### PR TITLE
[TICK-278]: feat/improve-sync-performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@iconscout/react-native-unicons": "^1.0.3",
     "@internxt/lib": "^1.1.5",
     "@internxt/sdk": "^0.3.6",
-    "@react-native-community/cameraroll": "4.1.2",
+    "@react-native-community/cameraroll": "github:internxt/react-native-cameraroll",
     "@react-native-community/masked-view": "0.1.10",
     "@react-navigation/bottom-tabs": "^6.0.0",
     "@react-navigation/material-top-tabs": "^6.0.2",

--- a/src/services/photos/PhotosCameraRollService.ts
+++ b/src/services/photos/PhotosCameraRollService.ts
@@ -50,15 +50,10 @@ export default class PhotosCameraRollService {
     const start = new Date().getTime();
 
     do {
-      const gS = new Date().getTime();
       const { edges, page_info } = await this.getPhotos({
         limit: slicesOf,
         cursor,
       });
-      const gE = new Date().getTime();
-      console.log(`elapsed ${((gE - gS) / 1000).toFixed(2)}s to retrieve ${edges.length} photos`)
-
-      console.log(`${slicesOf} more`)
 
       hasNextPage = page_info.has_next_page;
       cursor = page_info.end_cursor;
@@ -66,10 +61,6 @@ export default class PhotosCameraRollService {
       await this.localDatabaseService.bulkInsertTmpCameraRollRow(edges);
       count += edges.length;
     } while (hasNextPage);
-
-    const end = new Date().getTime();
-
-    console.log(`Synced ${count} photos in ${(end - start) / 1000} seconds`);
 
     return { count };
   }

--- a/src/services/photos/PhotosCameraRollService.ts
+++ b/src/services/photos/PhotosCameraRollService.ts
@@ -45,9 +45,7 @@ export default class PhotosCameraRollService {
 
     await this.localDatabaseService.cleanTmpCameraRollTable();
 
-    const slicesOf = Platform.OS === 'android' ? 100 : 10000;
-
-    const start = new Date().getTime();
+    const slicesOf = Platform.OS === 'android' ? 120 : 10000;
 
     do {
       const { edges, page_info } = await this.getPhotos({

--- a/src/services/photos/PhotosLocalDatabaseService/index.ts
+++ b/src/services/photos/PhotosLocalDatabaseService/index.ts
@@ -278,6 +278,42 @@ export default class PhotosLocalDatabaseService {
       .then(() => undefined);
   }
 
+  public async bulkInsertTmpCameraRollRow(edges: CameraRoll.PhotoIdentifier[]): Promise<void> {
+    const query = tmp_camera_roll.statements.bulkInsert(edges.length);
+    const values = [];
+
+    let edge: CameraRoll.PhotoIdentifier;
+
+    let start = new Date().getTime();
+    for (let i = 0; i < edges.length; i++) {
+      edge = edges[i];
+
+      values.push(
+        edge.node.group_name,
+        edge.node.timestamp * 1000,
+        edge.node.type,
+        edge.node.image.filename,
+        edge.node.image.fileSize,
+        edge.node.image.width,
+        edge.node.image.height,
+        edge.node.image.uri
+      );
+    }
+    let end = new Date().getTime();
+    let elapsed = (end - start);
+
+    console.log('elapsed on loop ' + elapsed + ' ms');
+
+    // console.log(query);
+    // console.log(values);
+
+    start = new Date().getTime();
+    await sqliteService.executeSql(PHOTOS_DB_NAME, query, values)
+    end = new Date().getTime();
+    elapsed = (end - start);
+    console.log('elapsed on insert ' + elapsed + ' ms');
+  }
+
   public async cleanTmpCameraRollTable(): Promise<void> {
     await sqliteService.executeSql(PHOTOS_DB_NAME, tmp_camera_roll.statements.cleanTable);
   }

--- a/src/services/photos/PhotosLocalDatabaseService/index.ts
+++ b/src/services/photos/PhotosLocalDatabaseService/index.ts
@@ -284,7 +284,6 @@ export default class PhotosLocalDatabaseService {
 
     let edge: CameraRoll.PhotoIdentifier;
 
-    let start = new Date().getTime();
     for (let i = 0; i < edges.length; i++) {
       edge = edges[i];
 
@@ -299,19 +298,8 @@ export default class PhotosLocalDatabaseService {
         edge.node.image.uri
       );
     }
-    let end = new Date().getTime();
-    let elapsed = (end - start);
 
-    console.log('elapsed on loop ' + elapsed + ' ms');
-
-    // console.log(query);
-    // console.log(values);
-
-    start = new Date().getTime();
-    await sqliteService.executeSql(PHOTOS_DB_NAME, query, values)
-    end = new Date().getTime();
-    elapsed = (end - start);
-    console.log('elapsed on insert ' + elapsed + ' ms');
+    await sqliteService.executeSql(PHOTOS_DB_NAME, query, values);
   }
 
   public async cleanTmpCameraRollTable(): Promise<void> {

--- a/src/services/photos/PhotosLocalDatabaseService/tables/tmp_camera_roll.ts
+++ b/src/services/photos/PhotosLocalDatabaseService/tables/tmp_camera_roll.ts
@@ -18,6 +18,17 @@ const statements = {
       group_name, timestamp, type, filename, fileSize, width, height, uri \
     ) \
     VALUES ( ?, ?, ?, ?, ?, ?, ?, ? );`,
+  bulkInsert: (size: number): string => {
+    let query = `INSERT INTO ${TABLE_NAME} (\
+      group_name, timestamp, type, filename, fileSize, width, height, uri \
+    ) VALUES `;
+
+    for (let i = 0; i < size; i++) {
+      query += `( ?, ?, ?, ?, ?, ?, ?, ? )${ i === (size - 1) ? ';' : ',' }`;
+    }
+
+    return query;
+  },
   count: (options: { from?: Date; to?: Date }): string => {
     const where = getWhereString(options);
     const query = `SELECT COUNT(*) AS count FROM ${TABLE_NAME} ${where};`;

--- a/src/services/photos/PhotosSyncService.ts
+++ b/src/services/photos/PhotosSyncService.ts
@@ -85,9 +85,12 @@ export default class PhotosSyncService {
 
       await this.deviceService.initialize();
 
+      console.log('.copyToLocalDatase() starts');
       const { count: cameraRollCount } = await this.cameraRollService.copyToLocalDatabase();
+      
       this.logService.info(`[SYNC] ${this.currentSyncId}: COPIED ${cameraRollCount} EDGES FROM CAMERA ROLL TO SQLITE`);
 
+      console.log('.calculateSyncInfo() starts');
       const syncInfo = await this.calculateSyncInfo();
       options.onStart?.(syncInfo);
       this.logService.info(

--- a/src/services/photos/PhotosSyncService.ts
+++ b/src/services/photos/PhotosSyncService.ts
@@ -85,12 +85,12 @@ export default class PhotosSyncService {
 
       await this.deviceService.initialize();
 
-      console.log('.copyToLocalDatase() starts');
+      const startLocalIndexingTime = new Date().getTime();
       const { count: cameraRollCount } = await this.cameraRollService.copyToLocalDatabase();
-      
-      this.logService.info(`[SYNC] ${this.currentSyncId}: COPIED ${cameraRollCount} EDGES FROM CAMERA ROLL TO SQLITE`);
+      const timeElapsedIndexing = ((new Date().getTime() - startLocalIndexingTime) / 1000);
 
-      console.log('.calculateSyncInfo() starts');
+      this.logService.info(`[SYNC] ${this.currentSyncId}: COPIED ${cameraRollCount} EDGES FROM CAMERA ROLL TO SQLITE IN ${timeElapsedIndexing.toFixed(2)}s`);
+
       const syncInfo = await this.calculateSyncInfo();
       options.onStart?.(syncInfo);
       this.logService.info(

--- a/src/services/photos/index.ts
+++ b/src/services/photos/index.ts
@@ -87,8 +87,6 @@ export class PhotosService {
   }
 
   public async initialize(): Promise<void> {
-    // await this.localDatabaseService.resetDatabase();
-
     await this.fileSystemService.initialize();
     await this.localDatabaseService.initialize();
     await this.userService.initialize();

--- a/src/services/photos/index.ts
+++ b/src/services/photos/index.ts
@@ -87,6 +87,8 @@ export class PhotosService {
   }
 
   public async initialize(): Promise<void> {
+    // await this.localDatabaseService.resetDatabase();
+
     await this.fileSystemService.initialize();
     await this.localDatabaseService.initialize();
     await this.userService.initialize();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1750,10 +1750,9 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@react-native-community/cameraroll@4.1.2":
+"@react-native-community/cameraroll@github:internxt/react-native-cameraroll":
   version "4.1.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cameraroll/-/cameraroll-4.1.2.tgz#489c6bb6137571540d93c543d5fcf8c652b548ec"
-  integrity sha512-jkdhMByMKD2CZ/5MPeBieYn8vkCfC4MOTouPpBpps3I8N6HUYJk+1JnDdktVYl2WINnqXpQptDA2YptVyifYAg==
+  resolved "https://codeload.github.com/internxt/react-native-cameraroll/tar.gz/fe28d99d7c210c6bfe7151eb02f6891be87a70bc"
 
 "@react-native-community/cli-debugger-ui@^4.13.1":
   version "4.13.1"


### PR DESCRIPTION
This PR improves local indexing performance on the Photos Sync module.

Mainly: 
- (1) Replaces inserting photos one-by-one for bulk inserts on SQLite.
- Provides a temporal fix for a buggy behavior of [react-native-camera-roll](https://github.com/react-native-cameraroll/react-native-cameraroll/issues/359) on Android when using cursors. (Kudos to @BohdanSol for the fork, great job!)
- Improves indexing time on iOS from several minutes to ~30 seconds due to (1) for 10,000 photos. (Tested on iPhone 11)

Advisable to double-check with detail @carlossalasamper 

Tested mainly local indexing with 10,000 photos for:
- iOS (iPhone 11): 30s 
- Android (Google Pixel 3): 8s