### PR TITLE
[_]: fix/ensure-create-entry-from-frame

### DIFF
--- a/src/@inxt-js/services/api.ts
+++ b/src/@inxt-js/services/api.ts
@@ -246,7 +246,7 @@ export class Bridge extends InxtApi {
   }
 
   createEntryFromFrame(bucketId: string, body: CreateEntryFromFrameBody, params?: AxiosRequestConfig): INXTRequest {
-    const targetUrl = `${this.url}/buckets/${bucketId}/files`;
+    const targetUrl = `${this.url}/buckets/${bucketId}/files/ensure`;
     const defParams: AxiosRequestConfig = {
       headers: {
         'Content-Type': 'application/octet-stream',

--- a/src/@inxt-js/services/request.ts
+++ b/src/@inxt-js/services/request.ts
@@ -248,7 +248,7 @@ export function createEntryFromFrame(
   params?: AxiosRequestConfig,
 ): Promise<CreateEntryFromFrameResponse | void> {
   const URL = config.bridgeUrl ? config.bridgeUrl : INXT_API_URL;
-  const targetUrl = `${URL}/buckets/${bucketId}/files`;
+  const targetUrl = `${URL}/buckets/${bucketId}/files/ensure`;
   const defParams: AxiosRequestConfig = {
     headers: {
       'Content-Type': 'application/octet-stream',

--- a/src/services/network/upload.ts
+++ b/src/services/network/upload.ts
@@ -180,7 +180,7 @@ function createBucketEntry(
   const newBucketEntry = generateBucketEntry(frameId, filename, index, hmac);
 
   return axios
-    .post<CreateEntryFromFrameResponse>(`${networkUrl}/buckets/${bucketId}/files`, newBucketEntry, options)
+    .post<CreateEntryFromFrameResponse>(`${networkUrl}/buckets/${bucketId}/files/ensure`, newBucketEntry, options)
     .then((res) => {
       return res.data.id;
     })


### PR DESCRIPTION
Uses an endpoint that double-checks the object existence in our storage before confirming the upload.