### PR TITLE
[DRIV-85] Add native encrypt decrypt ios

### DIFF
--- a/ios/Internxt.xcodeproj/project.pbxproj
+++ b/ios/Internxt.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		9439E20AFD5A4D67AD6AB52D /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 821BA930248741708194A7D2 /* GoogleService-Info.plist */; };
 		B18059E884C0ABDD17F3DC3D /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC715A2D49A985799AEE119 /* ExpoModulesProvider.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
-		F0AAA7CC7594339902E1BFBD /* libPods-Internxt.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 64DBC367941CDF397ADEE9F0 /* libPods-Internxt.a */; };
+		E96EC1CBEAE5B67BC94F2222 /* libPods-Internxt.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 353106A1707799798A7923F7 /* libPods-Internxt.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -27,9 +27,9 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Internxt/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Internxt/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = Internxt/main.m; sourceTree = "<group>"; };
-		2C6B5A22BCA166D1BC0583F6 /* Pods-Internxt.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.debug.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.debug.xcconfig"; sourceTree = "<group>"; };
-		64DBC367941CDF397ADEE9F0 /* libPods-Internxt.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Internxt.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		6C839AE00E2821BEE57166DA /* Pods-Internxt.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.release.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.release.xcconfig"; sourceTree = "<group>"; };
+		25BAF3532DE86F78E89AA448 /* Pods-Internxt.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.release.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.release.xcconfig"; sourceTree = "<group>"; };
+		353106A1707799798A7923F7 /* libPods-Internxt.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Internxt.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5DA1375B2B6A2A519AD06467 /* Pods-Internxt.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.debug.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.debug.xcconfig"; sourceTree = "<group>"; };
 		821BA930248741708194A7D2 /* GoogleService-Info.plist */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Internxt/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		978BA5A427DB8D7100384409 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = Internxt/SplashScreen.storyboard; sourceTree = "<group>"; };
@@ -44,7 +44,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F0AAA7CC7594339902E1BFBD /* libPods-Internxt.a in Frameworks */,
+				E96EC1CBEAE5B67BC94F2222 /* libPods-Internxt.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -73,7 +73,7 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				64DBC367941CDF397ADEE9F0 /* libPods-Internxt.a */,
+				353106A1707799798A7923F7 /* libPods-Internxt.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -129,8 +129,8 @@
 		D65327D7A22EEC0BE12398D9 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				2C6B5A22BCA166D1BC0583F6 /* Pods-Internxt.debug.xcconfig */,
-				6C839AE00E2821BEE57166DA /* Pods-Internxt.release.xcconfig */,
+				5DA1375B2B6A2A519AD06467 /* Pods-Internxt.debug.xcconfig */,
+				25BAF3532DE86F78E89AA448 /* Pods-Internxt.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -150,14 +150,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "Internxt" */;
 			buildPhases = (
-				0DAC5FAD77D9E87052F85B16 /* [CP] Check Pods Manifest.lock */,
+				C68062EEB8AC5556DBE72CA5 /* [CP] Check Pods Manifest.lock */,
 				FD10A7F022414F080027D42C /* Start Packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				366F96B5E706517ABBABADE2 /* [CP] Copy Pods Resources */,
 				C0ABA4564B7F48269ACCB374 /* Upload Debug Symbols to Sentry */,
+				9C5FA7DBA229355403D52C25 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -230,29 +230,7 @@
 			shellPath = /bin/sh;
 			shellScript = "export SENTRY_PROPERTIES=sentry.properties\nexport EXTRA_PACKAGER_ARGS=\"--sourcemap-output $DERIVED_FILE_DIR/main.jsbundle.map\"\nexport NODE_BINARY=node\n../node_modules/@sentry/cli/bin/sentry-cli react-native xcode ../node_modules/react-native/scripts/react-native-xcode.sh\n";
 		};
-		0DAC5FAD77D9E87052F85B16 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Internxt-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		366F96B5E706517ABBABADE2 /* [CP] Copy Pods Resources */ = {
+		9C5FA7DBA229355403D52C25 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -287,6 +265,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "export SENTRY_PROPERTIES=sentry.properties\n../node_modules/@sentry/cli/bin/sentry-cli upload-dsym";
+		};
+		C68062EEB8AC5556DBE72CA5 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Internxt-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 		FD10A7F022414F080027D42C /* Start Packager */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -326,7 +326,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2C6B5A22BCA166D1BC0583F6 /* Pods-Internxt.debug.xcconfig */;
+			baseConfigurationReference = 5DA1375B2B6A2A519AD06467 /* Pods-Internxt.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -362,7 +362,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6C839AE00E2821BEE57166DA /* Pods-Internxt.release.xcconfig */;
+			baseConfigurationReference = 25BAF3532DE86F78E89AA448 /* Pods-Internxt.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -44,14 +44,14 @@ PODS:
   - EXSplashScreen (0.14.2):
     - ExpoModulesCore
     - React-Core
-  - EXStructuredHeaders (2.2.1)
-  - EXUpdates (0.11.7):
+  - EXStructuredHeaders (2.1.1)
+  - EXUpdates (0.11.6):
     - EXManifests
     - ExpoModulesCore
     - EXStructuredHeaders
     - EXUpdatesInterface
     - React-Core
-  - EXUpdatesInterface (0.5.2)
+  - EXUpdatesInterface (0.5.1)
   - FBLazyVector (0.64.3)
   - FBReactNativeSpec (0.64.3):
     - RCT-Folly (= 2020.01.13.00)
@@ -149,17 +149,17 @@ PODS:
     - nanopb/encode (= 2.30908.0)
   - nanopb/decode (2.30908.0)
   - nanopb/encode (2.30908.0)
-  - Permission-AppTrackingTransparency (3.3.1):
+  - Permission-AppTrackingTransparency (3.2.0):
     - RNPermissions
-  - Permission-Camera (3.3.1):
+  - Permission-Camera (3.2.0):
     - RNPermissions
-  - Permission-FaceID (3.3.1):
+  - Permission-FaceID (3.2.0):
     - RNPermissions
-  - Permission-Notifications (3.3.1):
+  - Permission-Notifications (3.2.0):
     - RNPermissions
-  - Permission-PhotoLibrary (3.3.1):
+  - Permission-PhotoLibrary (3.2.0):
     - RNPermissions
-  - Permission-PhotoLibraryAddOnly (3.3.1):
+  - Permission-PhotoLibraryAddOnly (3.2.0):
     - RNPermissions
   - PromisesObjC (2.1.0)
   - RCT-Folly (2020.01.13.00):
@@ -359,7 +359,7 @@ PODS:
     - React-Core
   - react-native-document-picker (4.3.0):
     - React-Core
-  - react-native-image-picker (4.8.3):
+  - react-native-image-picker (4.2.0):
     - React-Core
   - react-native-image-resizer (1.4.5):
     - React-Core
@@ -437,32 +437,32 @@ PODS:
     - React-cxxreact (= 0.64.3)
     - React-jsi (= 0.64.3)
     - React-perflogger (= 0.64.3)
-  - ReactNativeLocalization (2.3.1):
+  - ReactNativeLocalization (2.1.7):
     - React-Core
   - rn-crypto (0.1.4):
     - IDZSwiftCommonCrypto (~> 0.13)
     - React-Core
   - rn-fetch-blob (0.11.2):
     - React-Core
-  - RNAnalytics (1.5.3):
+  - RNAnalytics (1.5.0):
     - Analytics
     - React-Core
-  - RNAnalyticsIntegration-Firebase (1.5.3):
+  - RNAnalyticsIntegration-Firebase (1.5.0):
     - Analytics
     - React-Core
     - RNAnalytics
     - Segment-Firebase (~> 2.7.7)
-  - RNCAsyncStorage (1.17.5):
+  - RNCAsyncStorage (1.17.0):
     - React-Core
-  - RNDeviceInfo (8.7.1):
+  - RNDeviceInfo (8.4.8):
     - React-Core
-  - RNFileViewer (2.1.5):
+  - RNFileViewer (2.1.4):
     - React-Core
-  - RNFS (2.20.0):
-    - React-Core
+  - RNFS (2.18.0):
+    - React
   - RNOS (1.2.6):
     - React
-  - RNPermissions (3.3.1):
+  - RNPermissions (3.2.0):
     - React-Core
   - RNScreens (3.10.2):
     - React-Core
@@ -470,7 +470,7 @@ PODS:
   - RNSentry (3.4.2):
     - React-Core
     - Sentry (= 7.11.0)
-  - RNShare (7.5.0):
+  - RNShare (7.3.3):
     - React-Core
   - RNSVG (12.1.1):
     - React
@@ -766,57 +766,48 @@ SPEC CHECKSUMS:
   Analytics: eefe524436f904b8bb3f8c8c3425280e43b34efc
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
-  EXApplication: 72d2781a562fc336305387b221cbd439b4da9a35
-  EXClipboard: 6df6a7e19d3b55bcddaec31e5a4d40a31695e9e7
-  EXConstants: 222a1dbfad69479d3fd1bc77187343d3933e2002
-  EXDevice: b9199fa42b07d507e2220f25d45c3993aefbe5ee
-  EXDocumentPicker: c02299939c9f942cc9e891504c0d813a72bc8cbe
-  EXErrorRecovery: 9d4f59e2f01ca204a069ad976218cc5f6573353a
-  EXFileSystem: 40a7f599cd63f4070d8c6dbbf4d4ad1cac90b556
-  EXFont: 621d92d8ac6702d02a5237602815c0e1b6d684e6
-  EXImagePicker: 1f46651412a153bc6e345f838e7082ab8724f5ad
-  EXJSONUtils: 827b0d129ac1ec5c7dabe61688efd305f27998c3
-  EXKeepAwake: f1ed9c7609cfe32a5519acd0f7d536cb59b8a656
-  EXLocalAuthentication: 85a6724381f1cbdec12f6183ecaaf1e2c7cd7b41
-  EXManifests: fec7979914efcd86ce824158170c123c197dca49
-  EXMediaLibrary: 6456b7ba46ccc32c3d16419f383761e40d283423
-  EXPermissions: 9c0075f11c72664778b9fc0df4af56ff87d62365
-  Expo: 866e4538335514b5dfa678bd437f9e2b9696570a
-  ExpoLinearGradient: 711337580a2ecebb43c5e9adf2723e279ff8f6a8
-  ExpoModulesCore: f16da48955ea71a71e423fba8a09d00a18946214
-  ExpoSystemUI: 850ed0ed44f6cc4e602e658b01214809397f659f
-  EXSplashScreen: c4333e4d7a89cc3f7452166527d207c725d3c2a5
-  EXStructuredHeaders: 71479c116081efdab342762b592c6d0954f5735a
-  EXUpdates: f0cb237532282b043aa656a3614c8e7cc83af6ab
-  EXUpdatesInterface: c2c085aaa6f5f2aecc3b377510e380306f5369a1
+  EXApplication: 54fe5bd6268d697771645e8f1aef8b806a65247a
+  EXClipboard: 8123fcda680538bb0e1f4e6511106553e52d3760
+  EXConstants: 88bf79622fbd9b476c96d8ec57fe97ca44fe8e3c
+  EXDevice: aa5e1edbf350481a948c3258b750dd11e6e4579e
+  EXDocumentPicker: d3eb6a207e1f370e496bea959b3ac145126560f5
+  EXErrorRecovery: b0d7582714a2cc896e94a2308a356f94dbf14ef7
+  EXFileSystem: 08a3033ac372b6346becf07839e1ccef26fb1058
+  EXFont: 2597c10ac85a69d348d44d7873eccf5a7576ef5e
+  EXImagePicker: bf4d62532cc2bf217edbe4abbb0014e73e079eac
+  EXJSONUtils: 5ee0d5cf76da70ad86f0be1a41cc70f47d69e06f
+  EXKeepAwake: bf48d7f740a5cd2befed6cf9a49911d385c6c47d
+  EXLocalAuthentication: 3c5f368ee954b79c3778158eb8000cbce4e2f8a2
+  EXManifests: d3464cd2278f4a19cd80c1aa673231570b534c11
+  EXMediaLibrary: 843669e1d9d38965057830138609ee99ef260cf1
+  EXPermissions: 2f8db9cfb1919d6c6776f462bb2c5a903e423b2a
+  Expo: 534e51e607aba8229293297da5585f4b26f50fa1
+  ExpoLinearGradient: fd591c223c81f6779036ed4cef4deb20ecb87c50
+  ExpoModulesCore: 32c0ccb47f477d330ee93db72505380adf0de09a
+  ExpoSystemUI: 182c672dd49bd2345023c2042257f68c075527cd
+  EXSplashScreen: 21669e598804ee810547dbb6692c8deb5dd8dbf3
+  EXStructuredHeaders: 4993087b2010dbcc510f5d92555b36f523425e8d
+  EXUpdates: bd5fa64f02685ed3e96be86b5ca350cdc2cd8d02
+  EXUpdatesInterface: a9814f422d3cd6e7cfd260d13c27786148ece20e
   FBLazyVector: c71c5917ec0ad2de41d5d06a5855f6d5eda06971
-<<<<<<< Updated upstream
-  FBReactNativeSpec: ca5494c0fafd3a0faa91831a0e6d393eee4975c8
-  Firebase: fb5114cd2bf96e2ff7bcb01d0d9a156cf5fd2f07
-  FirebaseAnalytics: 4ab446ce08a3fe52e8a4303dd997cf26276bf968
-  FirebaseCore: c5aab092d9c4b8efea894946166b04c9d9ef0e68
-  FirebaseCoreDiagnostics: 5daa63f1c1409d981a2d5007daa100b36eac6a34
-  FirebaseInstallations: caa7c8e0d3e2345b8829d2fa9ca1b4dfbf2fcc85
-=======
   FBReactNativeSpec: c9b7abcadfdd4c026d177c1d3dc6d95795238dac
   Firebase: 5f8193dff4b5b7c5d5ef72ae54bb76c08e2b841d
   FirebaseAnalytics: 7761cbadb00a717d8d0939363eb46041526474fa
   FirebaseCore: 5743c5785c074a794d35f2fff7ecc254a91e08b1
   FirebaseCoreDiagnostics: 92e07a649aeb66352b319d43bdd2ee3942af84cb
   FirebaseInstallations: 40bd9054049b2eae9a2c38ef1c3dd213df3605cd
->>>>>>> Stashed changes
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   GoogleAppMeasurement: 4c19f031220c72464d460c9daa1fb5d1acce958e
   GoogleDataTransport: 5fffe35792f8b96ec8d6775f5eccd83c998d5a3b
   GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
   IDZSwiftCommonCrypto: 00dd37cdfbd149312a7e5a582cf9909f8b129f44
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
-  Permission-AppTrackingTransparency: c6683b771e8892a434d340500fead09e8d73a444
-  Permission-Camera: 273b78e214eae8d734d1c497b67aa0030838c006
-  Permission-FaceID: ebdc76e0418fb61cc6ac5111bd5efda1bf58e72c
-  Permission-Notifications: 40b9694891df5c68f6b61ba5cfa3432de648c30d
-  Permission-PhotoLibrary: 4b514739911744def3b903a5a48a20037cd01795
-  Permission-PhotoLibraryAddOnly: ccc162c1f823021321536c58dc3431831ba82f22
+  Permission-AppTrackingTransparency: 95c9308dd40819fa9f6830751d0ef3ea11498723
+  Permission-Camera: 53efcbb755b0e8bdf253dbb27cc7559ccfce8480
+  Permission-FaceID: e3d306dc6284b8985beb608b033817900388cbb8
+  Permission-Notifications: bb420c3d28328df24de1b476b41ed8249ccf2537
+  Permission-PhotoLibrary: 7bec836dcdd04a0bfb200c314f1aae06d4476357
+  Permission-PhotoLibraryAddOnly: 06fb0cdb1d35683b235ad8c464ef0ecc88859ea3
   PromisesObjC: 99b6f43f9e1044bd87a95a60beff28c2c44ddb72
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: d34bf57e17cb6e3b2681f4809b13843c021feb6c
@@ -829,15 +820,15 @@ SPEC CHECKSUMS:
   React-jsi: a8b09c29521c798f1783348b37b511ba7b3dbeb3
   React-jsiexecutor: df6abc9fafbecb8e5b7a5fbc5e6d4bd017d594d5
   React-jsinspector: 34e23860273a23695342f58eed3ffd3ba10c31e0
-  react-native-cameraroll: 60ac50a5209777cbccfe8d7a62d0743a9da87060
-  react-native-document-picker: df3652604cb92ade18e3e280a562f23b4580f4bf
-  react-native-image-picker: eb0a159c2a00bcfb49f0469fcc6b164329e9d4ca
-  react-native-image-resizer: 506412a2bdd70dde64a61e13505ce10f61a04369
-  react-native-randombytes: 5fc412efe7b5c55b9002c0004d75fe5fabcaa507
+  react-native-cameraroll: 2957f2bce63ae896a848fbe0d5352c1bd4d20866
+  react-native-document-picker: 20f652c2402d3ddc81f396d8167c3bd978add4a2
+  react-native-image-picker: f7aa22adb4e0d1953eb515954f7318c38d726d8c
+  react-native-image-resizer: d9fb629a867335bdc13230ac2a58702bb8c8828f
+  react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
   react-native-receive-sharing-intent: 648f1eb35ae70886a8733d6be949042aa5111ffb
-  react-native-safe-area-context: 5cf05f49df9d17261e40e518481f2e334c6cd4b5
-  react-native-sqlite-storage: 6df009b8b67fe34c57c5fd06ee8fff7669fece6d
-  react-native-webview: fcadb5d977e7098e14eb3b27d339feae16c549ff
+  react-native-safe-area-context: 584dc04881deb49474363f3be89e4ca0e854c057
+  react-native-sqlite-storage: f6d515e1c446d1e6d026aa5352908a25d4de3261
+  react-native-webview: e89bf2dba26a04cda967814df3ed1be99f291233
   React-perflogger: cc76a4254d19640f1d8ad1c66fdee800414b805c
   React-RCTActionSheet: 7448f049318d8d7e8a9a1ebb742ada721757eea8
   React-RCTAnimation: fb9b3fa1a4a9f5e6ab01b3368693ce69860ba76a
@@ -850,26 +841,26 @@ SPEC CHECKSUMS:
   React-RCTVibration: c7f845861e79eae13dc1e8217a3cf47a3945b504
   React-runtimeexecutor: 493d9abb8b23c3f84e19ae221eeba92cadcb70dc
   ReactCommon: 8fea6422328e2fc093e25c9fac67adbcf0f04fb4
-  ReactNativeLocalization: be60e3a0e6e8db88d9f8190719ffb75e1cdab22a
-  rn-crypto: b9ea9d0b9eddbb05b411ab35d72dbb72781eff03
+  ReactNativeLocalization: 90a1181b7672309701dd7e5364fbf587319d41c6
+  rn-crypto: 684206bc83f4e6000a725492dbac51498a268c19
   rn-fetch-blob: f525a73a78df9ed5d35e67ea65e79d53c15255bc
-  RNAnalytics: 6fc4977ed662251d8a0066422aed1d1a5f697caf
-  RNAnalyticsIntegration-Firebase: 27eb53875cc0208cc64ec35f06fb0f9e3c012add
-  RNCAsyncStorage: e405f7684be5a2066f5418bb1a4729129ae4feb3
-  RNDeviceInfo: af47a7d1a09d64c8cbb8b0c883db9bca422a9813
-  RNFileViewer: ce7ca3ac370e18554d35d6355cffd7c30437c592
-  RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
+  RNAnalytics: a6dc48511d5d99b1ecaaf7157d8b5c618d15337e
+  RNAnalyticsIntegration-Firebase: 3d3d80be74a53031fc9524d5c5adef2907c28d8f
+  RNCAsyncStorage: 4efdcd2f7378421b29467c9de58f43552b60cf5b
+  RNDeviceInfo: 0400a6d0c94186d1120c3cbd97b23abc022187a9
+  RNFileViewer: 83cc066ad795b1f986791d03b56fe0ee14b6a69f
+  RNFS: 3ab21fa6c56d65566d1fb26c2228e2b6132e5e32
   RNOS: 6f2f9a70895bbbfbdad7196abd952e7b01d45027
-  RNPermissions: 7ad8d93b004e6bc85c89e27a102afcde90e07efa
+  RNPermissions: f7ebe52db07c00901127966ca080b4ec6a6ceb0a
   RNScreens: d6da2b9e29cf523832c2542f47bf1287318b1868
   RNSentry: 2cd1daa124b0d9fd0dfc2cb6094fdd168cb579bc
-  RNShare: 2e8e9dadea058057642a9351ca2878867ad4ad5c
+  RNShare: 3185c074441b7e8897014d95ba982434a0a024a1
   RNSVG: 551acb6562324b1d52a4e0758f7ca0ec234e278f
   Segment-Firebase: 2b07c895603aec168711922fe42a82984375d980
   Sentry: 0c5cd63d714187b4a39c331c1f0eb04ba7868341
-  TcpSockets: 8d839b9b14f6f344d98e4642ded13ab3112b462d
+  TcpSockets: 14306fb79f9750ea7d2ddd02d8bed182abb01797
   Yoga: e6ecf3fa25af9d4c87e94ad7d5d292eedef49749
 
 PODFILE CHECKSUM: 256c797d763c27da006439c23fb77784a964de5d
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -44,14 +44,14 @@ PODS:
   - EXSplashScreen (0.14.2):
     - ExpoModulesCore
     - React-Core
-  - EXStructuredHeaders (2.1.1)
-  - EXUpdates (0.11.6):
+  - EXStructuredHeaders (2.2.1)
+  - EXUpdates (0.11.7):
     - EXManifests
     - ExpoModulesCore
     - EXStructuredHeaders
     - EXUpdatesInterface
     - React-Core
-  - EXUpdatesInterface (0.5.1)
+  - EXUpdatesInterface (0.5.2)
   - FBLazyVector (0.64.3)
   - FBReactNativeSpec (0.64.3):
     - RCT-Folly (= 2020.01.13.00)
@@ -60,107 +60,108 @@ PODS:
     - React-Core (= 0.64.3)
     - React-jsi (= 0.64.3)
     - ReactCommon/turbomodule/core (= 0.64.3)
-  - Firebase (8.9.1):
-    - Firebase/Core (= 8.9.1)
-  - Firebase/Core (8.9.1):
+  - Firebase (8.15.0):
+    - Firebase/Core (= 8.15.0)
+  - Firebase/Core (8.15.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 8.9.1)
-  - Firebase/CoreOnly (8.9.1):
-    - FirebaseCore (= 8.9.1)
-  - FirebaseAnalytics (8.9.1):
-    - FirebaseAnalytics/AdIdSupport (= 8.9.1)
+    - FirebaseAnalytics (~> 8.15.0)
+  - Firebase/CoreOnly (8.15.0):
+    - FirebaseCore (= 8.15.0)
+  - FirebaseAnalytics (8.15.0):
+    - FirebaseAnalytics/AdIdSupport (= 8.15.0)
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
-    - GoogleUtilities/MethodSwizzler (~> 7.6)
-    - GoogleUtilities/Network (~> 7.6)
-    - "GoogleUtilities/NSData+zlib (~> 7.6)"
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
+    - GoogleUtilities/MethodSwizzler (~> 7.7)
+    - GoogleUtilities/Network (~> 7.7)
+    - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (~> 2.30908.0)
-  - FirebaseAnalytics/AdIdSupport (8.9.1):
+  - FirebaseAnalytics/AdIdSupport (8.15.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
-    - GoogleAppMeasurement (= 8.9.1)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
-    - GoogleUtilities/MethodSwizzler (~> 7.6)
-    - GoogleUtilities/Network (~> 7.6)
-    - "GoogleUtilities/NSData+zlib (~> 7.6)"
+    - GoogleAppMeasurement (= 8.15.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
+    - GoogleUtilities/MethodSwizzler (~> 7.7)
+    - GoogleUtilities/Network (~> 7.7)
+    - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (~> 2.30908.0)
-  - FirebaseCore (8.9.1):
+  - FirebaseCore (8.15.0):
     - FirebaseCoreDiagnostics (~> 8.0)
-    - GoogleUtilities/Environment (~> 7.6)
-    - GoogleUtilities/Logger (~> 7.6)
-  - FirebaseCoreDiagnostics (8.9.0):
+    - GoogleUtilities/Environment (~> 7.7)
+    - GoogleUtilities/Logger (~> 7.7)
+  - FirebaseCoreDiagnostics (8.15.0):
     - GoogleDataTransport (~> 9.1)
-    - GoogleUtilities/Environment (~> 7.6)
-    - GoogleUtilities/Logger (~> 7.6)
+    - GoogleUtilities/Environment (~> 7.7)
+    - GoogleUtilities/Logger (~> 7.7)
     - nanopb (~> 2.30908.0)
-  - FirebaseInstallations (8.9.0):
+  - FirebaseInstallations (8.15.0):
     - FirebaseCore (~> 8.0)
-    - GoogleUtilities/Environment (~> 7.6)
-    - GoogleUtilities/UserDefaults (~> 7.6)
+    - GoogleUtilities/Environment (~> 7.7)
+    - GoogleUtilities/UserDefaults (~> 7.7)
     - PromisesObjC (< 3.0, >= 1.2)
   - glog (0.3.5)
-  - GoogleAppMeasurement (8.9.1):
-    - GoogleAppMeasurement/AdIdSupport (= 8.9.1)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
-    - GoogleUtilities/MethodSwizzler (~> 7.6)
-    - GoogleUtilities/Network (~> 7.6)
-    - "GoogleUtilities/NSData+zlib (~> 7.6)"
+  - GoogleAppMeasurement (8.15.0):
+    - GoogleAppMeasurement/AdIdSupport (= 8.15.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
+    - GoogleUtilities/MethodSwizzler (~> 7.7)
+    - GoogleUtilities/Network (~> 7.7)
+    - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (8.9.1):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 8.9.1)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
-    - GoogleUtilities/MethodSwizzler (~> 7.6)
-    - GoogleUtilities/Network (~> 7.6)
-    - "GoogleUtilities/NSData+zlib (~> 7.6)"
+  - GoogleAppMeasurement/AdIdSupport (8.15.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 8.15.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
+    - GoogleUtilities/MethodSwizzler (~> 7.7)
+    - GoogleUtilities/Network (~> 7.7)
+    - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (8.9.1):
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
-    - GoogleUtilities/MethodSwizzler (~> 7.6)
-    - GoogleUtilities/Network (~> 7.6)
-    - "GoogleUtilities/NSData+zlib (~> 7.6)"
+  - GoogleAppMeasurement/WithoutAdIdSupport (8.15.0):
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
+    - GoogleUtilities/MethodSwizzler (~> 7.7)
+    - GoogleUtilities/Network (~> 7.7)
+    - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (~> 2.30908.0)
-  - GoogleDataTransport (9.1.2):
-    - GoogleUtilities/Environment (~> 7.2)
-    - nanopb (~> 2.30908.0)
+  - GoogleDataTransport (9.1.4):
+    - GoogleUtilities/Environment (~> 7.7)
+    - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/AppDelegateSwizzler (7.6.0):
+  - GoogleUtilities/AppDelegateSwizzler (7.7.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.6.0):
+  - GoogleUtilities/Environment (7.7.0):
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.6.0):
+  - GoogleUtilities/Logger (7.7.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (7.6.0):
+  - GoogleUtilities/MethodSwizzler (7.7.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (7.6.0):
+  - GoogleUtilities/Network (7.7.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.6.0)"
-  - GoogleUtilities/Reachability (7.6.0):
+  - "GoogleUtilities/NSData+zlib (7.7.0)"
+  - GoogleUtilities/Reachability (7.7.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (7.6.0):
+  - GoogleUtilities/UserDefaults (7.7.0):
     - GoogleUtilities/Logger
+  - IDZSwiftCommonCrypto (0.13.0)
   - nanopb (2.30908.0):
     - nanopb/decode (= 2.30908.0)
     - nanopb/encode (= 2.30908.0)
   - nanopb/decode (2.30908.0)
   - nanopb/encode (2.30908.0)
-  - Permission-AppTrackingTransparency (3.2.0):
+  - Permission-AppTrackingTransparency (3.3.1):
     - RNPermissions
-  - Permission-Camera (3.2.0):
+  - Permission-Camera (3.3.1):
     - RNPermissions
-  - Permission-FaceID (3.2.0):
+  - Permission-FaceID (3.3.1):
     - RNPermissions
-  - Permission-Notifications (3.2.0):
+  - Permission-Notifications (3.3.1):
     - RNPermissions
-  - Permission-PhotoLibrary (3.2.0):
+  - Permission-PhotoLibrary (3.3.1):
     - RNPermissions
-  - Permission-PhotoLibraryAddOnly (3.2.0):
+  - Permission-PhotoLibraryAddOnly (3.3.1):
     - RNPermissions
-  - PromisesObjC (2.0.0)
+  - PromisesObjC (2.1.0)
   - RCT-Folly (2020.01.13.00):
     - boost-for-react-native
     - DoubleConversion
@@ -358,7 +359,7 @@ PODS:
     - React-Core
   - react-native-document-picker (4.3.0):
     - React-Core
-  - react-native-image-picker (4.2.0):
+  - react-native-image-picker (4.8.3):
     - React-Core
   - react-native-image-resizer (1.4.5):
     - React-Core
@@ -436,31 +437,32 @@ PODS:
     - React-cxxreact (= 0.64.3)
     - React-jsi (= 0.64.3)
     - React-perflogger (= 0.64.3)
-  - ReactNativeLocalization (2.1.7):
+  - ReactNativeLocalization (2.3.1):
     - React-Core
-  - rn-crypto (0.1.3):
+  - rn-crypto (0.1.4):
+    - IDZSwiftCommonCrypto (~> 0.13)
     - React-Core
   - rn-fetch-blob (0.11.2):
     - React-Core
-  - RNAnalytics (1.5.0):
+  - RNAnalytics (1.5.3):
     - Analytics
     - React-Core
-  - RNAnalyticsIntegration-Firebase (1.5.0):
+  - RNAnalyticsIntegration-Firebase (1.5.3):
     - Analytics
     - React-Core
     - RNAnalytics
     - Segment-Firebase (~> 2.7.7)
-  - RNCAsyncStorage (1.17.0):
+  - RNCAsyncStorage (1.17.5):
     - React-Core
-  - RNDeviceInfo (8.4.8):
+  - RNDeviceInfo (8.7.1):
     - React-Core
-  - RNFileViewer (2.1.4):
+  - RNFileViewer (2.1.5):
     - React-Core
-  - RNFS (2.18.0):
-    - React
+  - RNFS (2.20.0):
+    - React-Core
   - RNOS (1.2.6):
     - React
-  - RNPermissions (3.2.0):
+  - RNPermissions (3.3.1):
     - React-Core
   - RNScreens (3.10.2):
     - React-Core
@@ -468,17 +470,17 @@ PODS:
   - RNSentry (3.4.2):
     - React-Core
     - Sentry (= 7.11.0)
-  - RNShare (7.3.3):
+  - RNShare (7.5.0):
     - React-Core
   - RNSVG (12.1.1):
     - React
-  - Segment-Firebase (2.7.8):
+  - Segment-Firebase (2.7.9):
     - Analytics
     - Firebase (~> 8.7)
     - Firebase/Core (~> 8.7)
     - FirebaseAnalytics (~> 8.7)
-    - Segment-Firebase/Core (= 2.7.8)
-  - Segment-Firebase/Core (2.7.8):
+    - Segment-Firebase/Core (= 2.7.9)
+  - Segment-Firebase/Core (2.7.9):
     - Analytics
     - Firebase (~> 8.7)
     - Firebase/Core (~> 8.7)
@@ -559,7 +561,7 @@ DEPENDENCIES:
   - React-runtimeexecutor (from `../node_modules/react-native/ReactCommon/runtimeexecutor`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - ReactNativeLocalization (from `../node_modules/react-native-localization`)
-  - rn-crypto (from `../node_modules/rn-crypto`)
+  - "rn-crypto (from `../node_modules/@internxt/rn-crypto`)"
   - rn-fetch-blob (from `../node_modules/rn-fetch-blob`)
   - "RNAnalytics (from `../node_modules/@segment/analytics-react-native`)"
   - "RNAnalyticsIntegration-Firebase (from `../node_modules/@segment/analytics-react-native-firebase`)"
@@ -588,6 +590,7 @@ SPEC REPOS:
     - GoogleAppMeasurement
     - GoogleDataTransport
     - GoogleUtilities
+    - IDZSwiftCommonCrypto
     - nanopb
     - PromisesObjC
     - Segment-Firebase
@@ -727,7 +730,7 @@ EXTERNAL SOURCES:
   ReactNativeLocalization:
     :path: "../node_modules/react-native-localization"
   rn-crypto:
-    :path: "../node_modules/rn-crypto"
+    :path: "../node_modules/@internxt/rn-crypto"
   rn-fetch-blob:
     :path: "../node_modules/rn-fetch-blob"
   RNAnalytics:
@@ -763,48 +766,58 @@ SPEC CHECKSUMS:
   Analytics: eefe524436f904b8bb3f8c8c3425280e43b34efc
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
-  EXApplication: 54fe5bd6268d697771645e8f1aef8b806a65247a
-  EXClipboard: 8123fcda680538bb0e1f4e6511106553e52d3760
-  EXConstants: 88bf79622fbd9b476c96d8ec57fe97ca44fe8e3c
-  EXDevice: aa5e1edbf350481a948c3258b750dd11e6e4579e
-  EXDocumentPicker: d3eb6a207e1f370e496bea959b3ac145126560f5
-  EXErrorRecovery: b0d7582714a2cc896e94a2308a356f94dbf14ef7
-  EXFileSystem: 08a3033ac372b6346becf07839e1ccef26fb1058
-  EXFont: 2597c10ac85a69d348d44d7873eccf5a7576ef5e
-  EXImagePicker: bf4d62532cc2bf217edbe4abbb0014e73e079eac
-  EXJSONUtils: 5ee0d5cf76da70ad86f0be1a41cc70f47d69e06f
-  EXKeepAwake: bf48d7f740a5cd2befed6cf9a49911d385c6c47d
-  EXLocalAuthentication: 3c5f368ee954b79c3778158eb8000cbce4e2f8a2
-  EXManifests: d3464cd2278f4a19cd80c1aa673231570b534c11
-  EXMediaLibrary: 843669e1d9d38965057830138609ee99ef260cf1
-  EXPermissions: 2f8db9cfb1919d6c6776f462bb2c5a903e423b2a
-  Expo: 534e51e607aba8229293297da5585f4b26f50fa1
-  ExpoLinearGradient: fd591c223c81f6779036ed4cef4deb20ecb87c50
-  ExpoModulesCore: 32c0ccb47f477d330ee93db72505380adf0de09a
-  ExpoSystemUI: 182c672dd49bd2345023c2042257f68c075527cd
-  EXSplashScreen: 21669e598804ee810547dbb6692c8deb5dd8dbf3
-  EXStructuredHeaders: 4993087b2010dbcc510f5d92555b36f523425e8d
-  EXUpdates: bd5fa64f02685ed3e96be86b5ca350cdc2cd8d02
-  EXUpdatesInterface: a9814f422d3cd6e7cfd260d13c27786148ece20e
+  EXApplication: 72d2781a562fc336305387b221cbd439b4da9a35
+  EXClipboard: 6df6a7e19d3b55bcddaec31e5a4d40a31695e9e7
+  EXConstants: 222a1dbfad69479d3fd1bc77187343d3933e2002
+  EXDevice: b9199fa42b07d507e2220f25d45c3993aefbe5ee
+  EXDocumentPicker: c02299939c9f942cc9e891504c0d813a72bc8cbe
+  EXErrorRecovery: 9d4f59e2f01ca204a069ad976218cc5f6573353a
+  EXFileSystem: 40a7f599cd63f4070d8c6dbbf4d4ad1cac90b556
+  EXFont: 621d92d8ac6702d02a5237602815c0e1b6d684e6
+  EXImagePicker: 1f46651412a153bc6e345f838e7082ab8724f5ad
+  EXJSONUtils: 827b0d129ac1ec5c7dabe61688efd305f27998c3
+  EXKeepAwake: f1ed9c7609cfe32a5519acd0f7d536cb59b8a656
+  EXLocalAuthentication: 85a6724381f1cbdec12f6183ecaaf1e2c7cd7b41
+  EXManifests: fec7979914efcd86ce824158170c123c197dca49
+  EXMediaLibrary: 6456b7ba46ccc32c3d16419f383761e40d283423
+  EXPermissions: 9c0075f11c72664778b9fc0df4af56ff87d62365
+  Expo: 866e4538335514b5dfa678bd437f9e2b9696570a
+  ExpoLinearGradient: 711337580a2ecebb43c5e9adf2723e279ff8f6a8
+  ExpoModulesCore: f16da48955ea71a71e423fba8a09d00a18946214
+  ExpoSystemUI: 850ed0ed44f6cc4e602e658b01214809397f659f
+  EXSplashScreen: c4333e4d7a89cc3f7452166527d207c725d3c2a5
+  EXStructuredHeaders: 71479c116081efdab342762b592c6d0954f5735a
+  EXUpdates: f0cb237532282b043aa656a3614c8e7cc83af6ab
+  EXUpdatesInterface: c2c085aaa6f5f2aecc3b377510e380306f5369a1
   FBLazyVector: c71c5917ec0ad2de41d5d06a5855f6d5eda06971
+<<<<<<< Updated upstream
   FBReactNativeSpec: ca5494c0fafd3a0faa91831a0e6d393eee4975c8
   Firebase: fb5114cd2bf96e2ff7bcb01d0d9a156cf5fd2f07
   FirebaseAnalytics: 4ab446ce08a3fe52e8a4303dd997cf26276bf968
   FirebaseCore: c5aab092d9c4b8efea894946166b04c9d9ef0e68
   FirebaseCoreDiagnostics: 5daa63f1c1409d981a2d5007daa100b36eac6a34
   FirebaseInstallations: caa7c8e0d3e2345b8829d2fa9ca1b4dfbf2fcc85
+=======
+  FBReactNativeSpec: c9b7abcadfdd4c026d177c1d3dc6d95795238dac
+  Firebase: 5f8193dff4b5b7c5d5ef72ae54bb76c08e2b841d
+  FirebaseAnalytics: 7761cbadb00a717d8d0939363eb46041526474fa
+  FirebaseCore: 5743c5785c074a794d35f2fff7ecc254a91e08b1
+  FirebaseCoreDiagnostics: 92e07a649aeb66352b319d43bdd2ee3942af84cb
+  FirebaseInstallations: 40bd9054049b2eae9a2c38ef1c3dd213df3605cd
+>>>>>>> Stashed changes
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
-  GoogleAppMeasurement: 837649ad3987936c232f6717c5680216f6243d24
-  GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
-  GoogleUtilities: 684ee790a24f73ebb2d1d966e9711c203f2a4237
+  GoogleAppMeasurement: 4c19f031220c72464d460c9daa1fb5d1acce958e
+  GoogleDataTransport: 5fffe35792f8b96ec8d6775f5eccd83c998d5a3b
+  GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
+  IDZSwiftCommonCrypto: 00dd37cdfbd149312a7e5a582cf9909f8b129f44
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
-  Permission-AppTrackingTransparency: 95c9308dd40819fa9f6830751d0ef3ea11498723
-  Permission-Camera: 53efcbb755b0e8bdf253dbb27cc7559ccfce8480
-  Permission-FaceID: e3d306dc6284b8985beb608b033817900388cbb8
-  Permission-Notifications: bb420c3d28328df24de1b476b41ed8249ccf2537
-  Permission-PhotoLibrary: 7bec836dcdd04a0bfb200c314f1aae06d4476357
-  Permission-PhotoLibraryAddOnly: 06fb0cdb1d35683b235ad8c464ef0ecc88859ea3
-  PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
+  Permission-AppTrackingTransparency: c6683b771e8892a434d340500fead09e8d73a444
+  Permission-Camera: 273b78e214eae8d734d1c497b67aa0030838c006
+  Permission-FaceID: ebdc76e0418fb61cc6ac5111bd5efda1bf58e72c
+  Permission-Notifications: 40b9694891df5c68f6b61ba5cfa3432de648c30d
+  Permission-PhotoLibrary: 4b514739911744def3b903a5a48a20037cd01795
+  Permission-PhotoLibraryAddOnly: ccc162c1f823021321536c58dc3431831ba82f22
+  PromisesObjC: 99b6f43f9e1044bd87a95a60beff28c2c44ddb72
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: d34bf57e17cb6e3b2681f4809b13843c021feb6c
   RCTTypeSafety: 8dab4933124ed39bb0c1d88d74d61b1eb950f28f
@@ -816,15 +829,15 @@ SPEC CHECKSUMS:
   React-jsi: a8b09c29521c798f1783348b37b511ba7b3dbeb3
   React-jsiexecutor: df6abc9fafbecb8e5b7a5fbc5e6d4bd017d594d5
   React-jsinspector: 34e23860273a23695342f58eed3ffd3ba10c31e0
-  react-native-cameraroll: 2957f2bce63ae896a848fbe0d5352c1bd4d20866
-  react-native-document-picker: 20f652c2402d3ddc81f396d8167c3bd978add4a2
-  react-native-image-picker: f7aa22adb4e0d1953eb515954f7318c38d726d8c
-  react-native-image-resizer: d9fb629a867335bdc13230ac2a58702bb8c8828f
-  react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
+  react-native-cameraroll: 60ac50a5209777cbccfe8d7a62d0743a9da87060
+  react-native-document-picker: df3652604cb92ade18e3e280a562f23b4580f4bf
+  react-native-image-picker: eb0a159c2a00bcfb49f0469fcc6b164329e9d4ca
+  react-native-image-resizer: 506412a2bdd70dde64a61e13505ce10f61a04369
+  react-native-randombytes: 5fc412efe7b5c55b9002c0004d75fe5fabcaa507
   react-native-receive-sharing-intent: 648f1eb35ae70886a8733d6be949042aa5111ffb
-  react-native-safe-area-context: 584dc04881deb49474363f3be89e4ca0e854c057
-  react-native-sqlite-storage: f6d515e1c446d1e6d026aa5352908a25d4de3261
-  react-native-webview: e89bf2dba26a04cda967814df3ed1be99f291233
+  react-native-safe-area-context: 5cf05f49df9d17261e40e518481f2e334c6cd4b5
+  react-native-sqlite-storage: 6df009b8b67fe34c57c5fd06ee8fff7669fece6d
+  react-native-webview: fcadb5d977e7098e14eb3b27d339feae16c549ff
   React-perflogger: cc76a4254d19640f1d8ad1c66fdee800414b805c
   React-RCTActionSheet: 7448f049318d8d7e8a9a1ebb742ada721757eea8
   React-RCTAnimation: fb9b3fa1a4a9f5e6ab01b3368693ce69860ba76a
@@ -837,24 +850,24 @@ SPEC CHECKSUMS:
   React-RCTVibration: c7f845861e79eae13dc1e8217a3cf47a3945b504
   React-runtimeexecutor: 493d9abb8b23c3f84e19ae221eeba92cadcb70dc
   ReactCommon: 8fea6422328e2fc093e25c9fac67adbcf0f04fb4
-  ReactNativeLocalization: 90a1181b7672309701dd7e5364fbf587319d41c6
-  rn-crypto: 10fb495ffa66c29a7578893b91d4156f8515125e
+  ReactNativeLocalization: be60e3a0e6e8db88d9f8190719ffb75e1cdab22a
+  rn-crypto: b9ea9d0b9eddbb05b411ab35d72dbb72781eff03
   rn-fetch-blob: f525a73a78df9ed5d35e67ea65e79d53c15255bc
-  RNAnalytics: a6dc48511d5d99b1ecaaf7157d8b5c618d15337e
-  RNAnalyticsIntegration-Firebase: 3d3d80be74a53031fc9524d5c5adef2907c28d8f
-  RNCAsyncStorage: 4efdcd2f7378421b29467c9de58f43552b60cf5b
-  RNDeviceInfo: 0400a6d0c94186d1120c3cbd97b23abc022187a9
-  RNFileViewer: 83cc066ad795b1f986791d03b56fe0ee14b6a69f
-  RNFS: 3ab21fa6c56d65566d1fb26c2228e2b6132e5e32
+  RNAnalytics: 6fc4977ed662251d8a0066422aed1d1a5f697caf
+  RNAnalyticsIntegration-Firebase: 27eb53875cc0208cc64ec35f06fb0f9e3c012add
+  RNCAsyncStorage: e405f7684be5a2066f5418bb1a4729129ae4feb3
+  RNDeviceInfo: af47a7d1a09d64c8cbb8b0c883db9bca422a9813
+  RNFileViewer: ce7ca3ac370e18554d35d6355cffd7c30437c592
+  RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
   RNOS: 6f2f9a70895bbbfbdad7196abd952e7b01d45027
-  RNPermissions: f7ebe52db07c00901127966ca080b4ec6a6ceb0a
+  RNPermissions: 7ad8d93b004e6bc85c89e27a102afcde90e07efa
   RNScreens: d6da2b9e29cf523832c2542f47bf1287318b1868
   RNSentry: 2cd1daa124b0d9fd0dfc2cb6094fdd168cb579bc
-  RNShare: 3185c074441b7e8897014d95ba982434a0a024a1
+  RNShare: 2e8e9dadea058057642a9351ca2878867ad4ad5c
   RNSVG: 551acb6562324b1d52a4e0758f7ca0ec234e278f
-  Segment-Firebase: e4515bc7e36d5f0435d122a8c225c43db1504c02
+  Segment-Firebase: 2b07c895603aec168711922fe42a82984375d980
   Sentry: 0c5cd63d714187b4a39c331c1f0eb04ba7868341
-  TcpSockets: 14306fb79f9750ea7d2ddd02d8bed182abb01797
+  TcpSockets: 8d839b9b14f6f344d98e4642ded13ab3112b462d
   Yoga: e6ecf3fa25af9d4c87e94ad7d5d292eedef49749
 
 PODFILE CHECKSUM: 256c797d763c27da006439c23fb77784a964de5d

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@burstware/react-native-portal": "^1.0.2",
     "@internxt/lib": "^1.1.5",
+    "@internxt/rn-crypto": "^0.1.4",
     "@internxt/sdk": "^0.8.1",
     "@react-native-async-storage/async-storage": "^1.17.0",
     "@react-native-community/cameraroll": "github:internxt/react-native-cameraroll",
@@ -114,7 +115,6 @@
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
     "reflect-metadata": "^0.1.13",
-    "rn-crypto": "^0.1.3",
     "rn-fetch-blob": "=0.11.2",
     "sentry-expo": "^4.0.0",
     "stream-browserify": "^1.0.0",

--- a/src/network/NetworkFacade.ts
+++ b/src/network/NetworkFacade.ts
@@ -15,6 +15,7 @@ import { ripemd160 } from '../@inxt-js/lib/crypto';
 import { Abortable } from '../types';
 import appService from '../services/AppService';
 import { getAuthFromCredentials, NetworkCredentials } from './requests';
+import fileSystemService from '../services/FileSystemService';
 
 export interface DownloadFileParams {
   toPath: string;

--- a/src/services/NetworkService/download.ts
+++ b/src/services/NetworkService/download.ts
@@ -11,7 +11,7 @@ import { FileId } from '@internxt/sdk/dist/photos';
 import fileSystemService from '../FileSystemService';
 import { NetworkCredentials } from '../../types';
 import { Platform } from 'react-native';
-import { decryptFile as nativeDecryptFile } from 'rn-crypto';
+import { decryptFile as nativeDecryptFile } from '@internxt/rn-crypto';
 
 type FileDecryptedURI = string;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2039,6 +2039,11 @@
   resolved "https://npm.pkg.github.com/download/@internxt/prettier-config/1.0.2/9a19de23e3330a81c0e2bace1a6a0325fc8633197cf677e44ea75e54df315b5e"
   integrity sha512-t4HiqvCbC7XgQepwWlIaFJe3iwW7HCf6xOSU9nKTV0tiGqOPz7xMtIgLEloQrDA34Cx4PkOYBXrvFPV6RxSFAA==
 
+"@internxt/rn-crypto@^0.1.4":
+  version "0.1.4"
+  resolved "https://npm.pkg.github.com/download/@internxt/rn-crypto/0.1.4/f250d9e178be8fcbf2b77b838dc21d35a0edd71abfc21a5230e3d57e40151b82#9959b498911e04648a1dfd86dec220aa5ab73065"
+  integrity sha512-6iFn6htJqw6INb+MS0fBip4071E1SYjEBsD+rOIb8dtfDKOlpEvxkxvHp8D0BOe3EHPSgBub9TohfQTv9qsP/w==
+
 "@internxt/sdk@^0.8.1":
   version "0.8.1"
   resolved "https://npm.pkg.github.com/download/@internxt/sdk/0.8.1/5b5e5c3def564d51b0636cca1a445ad6d1f6d08ea971ea96d71355b82c84c14f#701fa80d54de3eb191786b1ed2478c6ddfdbc33b"
@@ -10821,11 +10826,6 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
-
-rn-crypto@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/rn-crypto/-/rn-crypto-0.1.3.tgz#f8d783e34e56305551fa6802d88ffcab4a98a8fc"
-  integrity sha512-oBINRfNDg8BjPYafhl0OpzdxTFgGLcB48FBh2HC/O0UIo2BMSLB3ksXy9SFgQnz5i46EgCxQHp1DjPsxOkYbTw==
 
 rn-fetch-blob@=0.11.2:
   version "0.11.2"


### PR DESCRIPTION
This PR adds support for native encrypt/decrypt operations for iOS

This functionality is provided by [@internxt/rn-crypto](https://github.com/internxt/rn-crypto)

The encrypt/decrypt is now made on a background thread using a Swift OperationQueue which doesn't block the UI and let us encrypt/decrypt multiple files at the same time without frozing the UI.

Notes:
- There's still an operation blocking the UI thread which is coming from @inxt-js/lib/crypto.ts, from a function called GenerateFileKey, this function uses JS crypto which is not too performant so it still blocks briefly the UI thread 