### PR TITLE
[FIX]: Is logged initialization failing due to JS too fast

### DIFF
--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -11,7 +11,7 @@ import ForgotPasswordScreen from '../screens/ForgotPasswordScreen';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import PhotosPreviewScreen from '../screens/PhotosPreviewScreen';
 import { driveActions } from '../store/slices/drive';
-import { Alert, Platform } from 'react-native';
+import { Alert, Platform, View } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import analyticsService from '../services/AnalyticsService';
 import DebugScreen from '../screens/DebugScreen';
@@ -95,6 +95,9 @@ function AppNavigator(): JSX.Element {
     };
   }, []);
 
+  // We send null here when we don't know the isLoggedIn status yet, so we avoid
+  // redirects to the login screen even with the user logged
+  if (isLoggedIn == null) return <View></View>;
   return (
     <Stack.Navigator
       initialRouteName={initialRouteName}

--- a/src/services/photos/PhotosCommonService.ts
+++ b/src/services/photos/PhotosCommonService.ts
@@ -9,6 +9,7 @@ import { Platform } from 'react-native';
 import { items } from '@internxt/lib';
 import { createHash } from '@internxt/rn-crypto';
 import { SdkManager } from '../common/SdkManager';
+import * as crypto from 'react-native-crypto';
 enum HMAC {
   sha256 = 'sha256',
   sha512 = 'sha512',
@@ -59,7 +60,8 @@ export class PhotosCommonServices {
     timestamp: number,
     photoRef: PhotoFileSystemRef,
   ): Promise<Buffer> {
-    const hash = createHash(HMAC.sha256);
+    // Implementation for sha256 is failing on Android, fallback to JS hash until we fix that
+    const hash = Platform.OS === 'ios' ? createHash(HMAC.sha256) : crypto.createHash('sha256');
 
     // Add the userID to the hash
     hash.update(userId);

--- a/src/store/slices/auth/index.ts
+++ b/src/store/slices/auth/index.ts
@@ -18,7 +18,7 @@ import errorService from 'src/services/ErrorService';
 import { SdkManager } from 'src/services/common/SdkManager';
 
 export interface AuthState {
-  loggedIn: boolean;
+  loggedIn: boolean | null;
   token: string;
   photosToken: string;
   user: UserSettings | undefined;
@@ -27,7 +27,7 @@ export interface AuthState {
 }
 
 const initialState: AuthState = {
-  loggedIn: false,
+  loggedIn: null,
   token: '',
   photosToken: '',
   user: undefined,
@@ -52,6 +52,8 @@ export const initializeThunk = createAsyncThunk<void, void, { state: RootState }
       });
       dispatch(refreshUserThunk());
       dispatch(loadSecurityDetailsThunk());
+    } else {
+      dispatch(authActions.setLoggedIn(false));
     }
   },
 );
@@ -70,6 +72,8 @@ export const silentSignInThunk = createAsyncThunk<void, void, { state: RootState
         }),
       );
       authService.emitLoginEvent();
+    } else {
+      dispatch(authActions.setLoggedIn(false));
     }
   },
 );
@@ -102,7 +106,7 @@ export const signOutThunk = createAsyncThunk<void, void, { state: RootState }>(
 
     dispatch(photosThunks.clearPhotosThunk());
     dispatch(photosActions.resetState());
-
+    dispatch(authActions.setLoggedIn(false));
     authService.emitLogoutEvent();
   },
 );
@@ -235,6 +239,10 @@ export const authSlice = createSlice({
       state.user = action.payload.user;
       state.token = action.payload.token;
       state.photosToken = action.payload.photosToken;
+    },
+
+    setLoggedIn: (state, action: PayloadAction<boolean>) => {
+      state.loggedIn = action.payload;
     },
     updateUser(state, action: PayloadAction<Partial<UserSettings>>) {
       state.user && Object.assign(state.user, action.payload);


### PR DESCRIPTION
In Android devices, the isLoggedIn value was getting updated after we initialized the navigator, since the navigator loads an initialRoute once, if isLoggedIn is false, it redirects to the login screen