### PR TITLE
[FEATURE]: Removed encrypted files after upload fail/success

### DIFF
--- a/src/services/FileSystemService.ts
+++ b/src/services/FileSystemService.ts
@@ -129,6 +129,16 @@ class FileSystemService {
 
     return blob;
   }
+
+  public async getUsageStats() {
+    const tmpDir = await RNFS.stat(this.getTemporaryDir());
+    const documentsDir = await RNFS.stat(this.getDocumentsDir());
+
+    return {
+      tmp: { ...tmpDir, items: await RNFS.readDir(this.getTemporaryDir()) },
+      documents: { ...documentsDir, items: await RNFS.readDir(this.getDocumentsDir()) },
+    };
+  }
 }
 
 const fileSystemService = new FileSystemService();


### PR DESCRIPTION
This PR provides a cleanup function that gets executed right after an upload operation finish, doesn't matter if the operation success or fails. 

We do the cleanup on fail since we don't know why the operation is failing, if the operation is failing due to an encryption problem and we keep picking the old file, the upload will keep failing.