### PR TITLE
[_]: Runtime version for updates & release ID

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -31,9 +31,12 @@ export interface AppEnv {
   SENTRY_PROJECT: string;
   SENTRY_URL: string;
   SENTRY_AUTH_TOKEN: string;
+  RELEASE_ID: string;
 }
 
 const stage = AppStage.Production; // <- CHANGE STAGE
+
+const RELEASE_ID = `${packageJson.version} (${env[stage].REACT_NATIVE_APP_BUILD_NUMBER})`;
 
 const appConfig: ExpoConfig & { extra: AppEnv } = {
   name: 'Internxt',
@@ -41,6 +44,12 @@ const appConfig: ExpoConfig & { extra: AppEnv } = {
   entryPoint: './index.js',
   slug: 'drive-mobile',
   version: packageJson.version,
+  // Runtime version defines for which native version
+  // the updates will be comptaible, which means
+  // an update with runtimeVersion 1.1 won't be compatible
+  // with app version 1.0. We use here the package version,
+  // apps should be updated matching that.
+  runtimeVersion: packageJson.version,
   orientation: 'portrait',
   splash: {
     image: './assets/images/splash.png',
@@ -113,11 +122,13 @@ const appConfig: ExpoConfig & { extra: AppEnv } = {
           project: env[stage].SENTRY_PROJECT,
           authToken: env[stage].SENTRY_AUTH_TOKEN,
           url: env[stage].SENTRY_URL,
+          setCommits: true,
+          release: RELEASE_ID,
         },
       },
     ],
   },
-  extra: { NODE_ENV: stage, ...env[stage] },
+  extra: { NODE_ENV: stage, RELEASE_ID, ...env[stage] },
 };
 
 export default appConfig;

--- a/src/plugins/SentryPlugin.ts
+++ b/src/plugins/SentryPlugin.ts
@@ -6,7 +6,8 @@ const sentryPlugin: AppPlugin = {
   install(): void {
     Sentry.init({
       dsn: appService.constants.SENTRY_DSN,
-      debug: false,
+      debug: __DEV__,
+      release: appService.constants.RELEASE_ID,
     });
   },
 };


### PR DESCRIPTION
Right now, each update (update => expo publish) being released, was compatible with whatever app version it hits, with this, we can restrict which app versions will be updated with each publish

Also, for vissibility, a release ID has been added so we can identify each update in Sentry correctly