### PR TITLE
Adding Requirements in README.md and react-native-reanimated version changed and fixed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@
 </p>
 <p align="center" style="margin-top: 10px;">Internxt</p>
 
+## Requirements
+
+- JDK version: 11
+- SDK version: 29 or 30
+
+In case that you open the project in Android Studio:
+
+- NDK version: 21.1.6
+- CMake version: 3.10.2
+
 ## Setup
 
 Follow these steps before running the project.

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "react-native-os": "^1.2.6",
     "react-native-permissions": "^3.2.0",
     "react-native-randombytes": "^3.6.1",
-    "react-native-reanimated": "^2.10.0",
+    "react-native-reanimated": "~2.9.1",
     "react-native-receive-sharing-intent": "^1.1.0",
     "react-native-responsive-screen": "^1.4.1",
     "react-native-restart": "^0.0.24",

--- a/yarn.lock
+++ b/yarn.lock
@@ -836,6 +836,14 @@
     "@babel/helper-plugin-utils" "^7.16.7"
     "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
 
+"@babel/plugin-proposal-export-namespace-from@^7.17.12":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.18.9.tgz#5f7313ab348cdb19d590145f9247540e94761203"
+  integrity sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.9"
+    "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
+
 "@babel/plugin-proposal-json-strings@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.16.7.tgz#9732cb1d17d9a2626a08c5be25186c195b6fa6e8"
@@ -10967,11 +10975,12 @@ react-native-randombytes@^3.6.1:
     buffer "^4.9.1"
     sjcl "^1.0.3"
 
-react-native-reanimated@^2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.10.0.tgz#ed53be66bbb553b5b5e93e93ef4217c87b8c73db"
-  integrity sha512-jKm3xz5nX7ABtHzzuuLmawP0pFWP77lXNdIC6AWOceBs23OHUaJ29p4prxr/7Sb588GwTbkPsYkDqVFaE3ezNQ==
+react-native-reanimated@~2.9.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.9.1.tgz#d9a932e312c13c05b4f919e43ebbf76d996e0bc1"
+  integrity sha512-309SIhDBwY4F1n6e5Mr5D1uPZm2ESIcmZsGXHUu8hpKX4oIOlZj2MilTk+kHhi05LjChoJkcpfkstotCJmPRPg==
   dependencies:
+    "@babel/plugin-proposal-export-namespace-from" "^7.17.12"
     "@babel/plugin-transform-object-assign" "^7.16.7"
     "@babel/preset-typescript" "^7.16.7"
     "@types/invariant" "^2.2.35"


### PR DESCRIPTION
Requirements added in README.md with JDK, SDK, NDK and CMake version. Also the version of react-native-reanimated has been changed to 2.9.1 and it has been fixed.