### PR TITLE
[_]:(hotfix) Fix incorrect sorting for drive items

### DIFF
--- a/src/components/modals/SortModal/index.tsx
+++ b/src/components/modals/SortModal/index.tsx
@@ -9,6 +9,7 @@ import { SortDirection, SortType } from '../../../types/drive';
 import { BaseModalProps } from '../../../types/ui';
 import { useTailwind } from 'tailwind-rn';
 import useGetColor from '../../../hooks/useColor';
+import { TouchableOpacity } from 'react-native-gesture-handler';
 
 export type SortMode = {
   direction: SortDirection;
@@ -26,14 +27,14 @@ const SortModal: React.FC<SortModalProps> = (props) => {
   };
   const header = (
     <View>
-      <AppText numberOfLines={1} ellipsizeMode="middle" semibold style={tailwind('text-base text-neutral-500')}>
+      <AppText numberOfLines={1} ellipsizeMode="middle" semibold style={tailwind('text-lg text-neutral-500')}>
         {strings.screens.drive.sortBy}
       </AppText>
     </View>
   );
 
   return (
-    <BottomModal isOpen={props.isOpen} onClosed={onClosed} header={header} containerStyle={tailwind('pb-3 px-5')}>
+    <BottomModal isOpen={props.isOpen} onClosed={onClosed} header={header} containerStyle={tailwind('p-4')}>
       <SortModalItem
         isSelected={props.sortMode.direction === SortDirection.Asc && props.sortMode.type === SortType.Name}
         direction={SortDirection.Asc}
@@ -95,13 +96,12 @@ function SortModalItem(props: {
   onSortModeChange: (change: SortMode) => void;
 }) {
   const tailwind = useTailwind();
-  const getColor = useGetColor();
   const onPress = () => {
     props.onSortModeChange({ type: props.type, direction: props.direction });
   };
 
   return (
-    <TouchableHighlight underlayColor={getColor('text-neutral-30')} style={tailwind('rounded-lg')} onPress={onPress}>
+    <TouchableOpacity activeOpacity={0.65} style={tailwind('rounded-lg')} onPress={onPress}>
       <View
         style={[tailwind('items-center flex-row rounded-lg px-4 py-2.5'), props.isSelected && tailwind('bg-blue-10')]}
       >
@@ -121,7 +121,7 @@ function SortModalItem(props: {
           {props.advice}
         </AppText>
       </View>
-    </TouchableHighlight>
+    </TouchableOpacity>
   );
 }
 

--- a/src/screens/DriveScreen/index.tsx
+++ b/src/screens/DriveScreen/index.tsx
@@ -52,11 +52,8 @@ function DriveScreen({ navigation }: TabExplorerScreenProps<'Drive'>): JSX.Eleme
   const driveSortedItems = useMemo(
     () => [
       ...driveUploadingItems,
-      ...driveItems.sort(drive.file.getSortFunction(sortMode)).sort((a, b) => {
-        const aValue = a.data.fileId ? 1 : 0;
-        const bValue = b.data.fileId ? 1 : 0;
-        return aValue - bValue;
-      }),
+      ...driveItems.filter((item) => !item.data.fileId).sort(drive.file.getSortFunction(sortMode)),
+      ...driveItems.filter((item) => item.data.fileId).sort(drive.file.getSortFunction(sortMode)),
     ],
     [sortMode, driveUploadingItems, driveItems],
   );
@@ -83,7 +80,7 @@ function DriveScreen({ navigation }: TabExplorerScreenProps<'Drive'>): JSX.Eleme
 
   const onSortModeChange = (mode: SortMode) => {
     setSortMode(mode);
-    setSortModalOpen(false);
+    setTimeout(() => setSortModalOpen(false), 1);
   };
 
   const onCloseSortModal = () => {

--- a/src/screens/DriveScreen/index.tsx
+++ b/src/screens/DriveScreen/index.tsx
@@ -50,11 +50,10 @@ function DriveScreen({ navigation }: TabExplorerScreenProps<'Drive'>): JSX.Eleme
   const isRootFolder = currentFolderId === user?.root_folder_id;
   const screenTitle = !isRootFolder ? currentFolderName : strings.screens.drive.title;
   const driveSortedItems = useMemo(
-    () => [
-      ...driveUploadingItems,
-      ...driveItems.filter((item) => !item.data.fileId).sort(drive.file.getSortFunction(sortMode)),
-      ...driveItems.filter((item) => item.data.fileId).sort(drive.file.getSortFunction(sortMode)),
-    ],
+    () =>
+      driveUploadingItems
+        .concat(driveItems.filter((item) => !item.data.fileId).sort(drive.file.getSortFunction(sortMode)))
+        .concat(driveItems.filter((item) => item.data.fileId).sort(drive.file.getSortFunction(sortMode))),
     [sortMode, driveUploadingItems, driveItems],
   );
   const onCurrentFolderActionsButtonPressed = () => {

--- a/src/services/drive/file/driveFile.service.ts
+++ b/src/services/drive/file/driveFile.service.ts
@@ -163,14 +163,14 @@ class DriveFileService {
         sortFunction =
           direction === SortDirection.Asc
             ? (a: DriveListItem, b: DriveListItem) => {
-                const aName = a.data.name.toLowerCase();
-                const bName = b.data.name.toLowerCase();
+                const aName = Buffer.from(a.data.name.trim().toLowerCase()).toString('hex');
+                const bName = Buffer.from(b.data.name.trim().toLowerCase()).toString('hex');
 
                 return aName < bName ? -1 : aName > bName ? 1 : 0;
               }
             : (a: DriveListItem, b: DriveListItem) => {
-                const aName = a.data.name.toLowerCase();
-                const bName = b.data.name.toLowerCase();
+                const aName = Buffer.from(a.data.name.trim().toLowerCase()).toString('hex');
+                const bName = Buffer.from(b.data.name.trim().toLowerCase()).toString('hex');
 
                 return aName < bName ? 1 : aName > bName ? -1 : 0;
               };
@@ -179,10 +179,21 @@ class DriveFileService {
         sortFunction =
           direction === SortDirection.Asc
             ? (a: DriveListItem, b: DriveListItem) => {
-                return a.data?.size || 0 > (b.data?.size || 0) ? 1 : -1;
+                if (!a.data.size) return 0;
+                if (!b.data.size) return 0;
+
+                const sizeA = parseInt(a.data.size as string);
+                const sizeB = parseInt(b.data.size as string);
+
+                return sizeA > sizeB ? 1 : -1;
               }
             : (a: DriveListItem, b: DriveListItem) => {
-                return (a.data?.size || 0) < (b.data?.size || 0) ? 1 : -1;
+                if (!a.data.size) return 0;
+                if (!b.data.size) return 0;
+
+                const sizeA = parseInt(a.data.size as string);
+                const sizeB = parseInt(b.data.size as string);
+                return sizeA < sizeB ? 1 : -1;
               };
         break;
       case SortType.UpdatedAt:

--- a/src/types/drive.ts
+++ b/src/types/drive.ts
@@ -19,7 +19,7 @@ export type DriveItemFocused = {
   parentId?: number;
   fileId?: string;
   type?: string;
-  size?: number;
+  size?: string | number;
   updatedAt: string;
   folderId?: number;
   code?: string;
@@ -86,7 +86,7 @@ export type DriveItemDataProps = Pick<DriveItemData, 'id' | 'name' | 'updatedAt'
   code?: string;
 
   token?: string;
-  size?: number;
+  size?: string | number;
   type?: string;
   shareId?: string;
 };

--- a/src/types/prettysize.d.ts
+++ b/src/types/prettysize.d.ts
@@ -1,3 +1,3 @@
 declare module 'prettysize' {
-  export default function (bytes: number, removeSpace?: boolean): string;
+  export default function (bytes: number | string, removeSpace?: boolean): string;
 }


### PR DESCRIPTION
Some items were being sorted incorrectly in Drive.

What changed:

- The size being received was an string, so sorting by size was incorrect
- The name of the files has been converted to hex, so we can sort them in any language