### PR TITLE
[MT-58]:(feature) Account deactivated success screen

### DIFF
--- a/assets/lang/strings.ts
+++ b/assets/lang/strings.ts
@@ -132,6 +132,9 @@ const strings = new LocalizedStrings({
           ', so that you can sign up again. Please, if you still want to procede, enter your email below so that we can process the account removal.',
       },
       deactivation_screen: {
+        account_deleted: 'Account deleted',
+        account_deleted_advice:
+          'Your account and all its files, photos and backups has been successfully deleted, now you can sign up with the same email.',
         title: 'Deactivation email',
         subtitle_1:
           'Please check your email and follow the instructions to deactivate your account so you can start using Internxt again.',
@@ -786,6 +789,9 @@ const strings = new LocalizedStrings({
           ', por lo que podrás volver a registrarte con el mismo correo electrónico. Por favor, introduce tu correo electrónico para que podamos procesar el borrado de tu cuenta.',
       },
       deactivation_screen: {
+        account_deleted: 'Cuenta eliminada',
+        account_deleted_advice:
+          'Tu cuenta y todos sus archivos, fotos y backups han sido eliminadas correctamente. Ahora puedes crear una cuenta con el mismo email.',
         title: 'Email de desactivación',
         subtitle_1:
           'Por favor, comprueba el email que te hemos enviado y sigue las intrucciones para desactivar tu cuenta para que puedas seguir usando Internxt Drive.',

--- a/ios/Internxt.xcodeproj/project.pbxproj
+++ b/ios/Internxt.xcodeproj/project.pbxproj
@@ -258,7 +258,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export SENTRY_PROPERTIES=sentry.properties\n../node_modules/@sentry/cli/bin/sentry-cli upload-dsym";
+			shellScript = "export SENTRY_PROPERTIES=sentry.properties\n../node_modules/@sentry/cli/bin/sentry-cli upload-dsym\n";
 		};
 		F65F6FFF9D8FF066EC642431 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -327,7 +327,7 @@
 				CODE_SIGN_ENTITLEMENTS = Internxt/Internxt.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = JR4S3SY396;
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -363,7 +363,7 @@
 				CODE_SIGN_ENTITLEMENTS = Internxt/Internxt.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = JR4S3SY396;
 				INFOPLIST_FILE = Internxt/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,8 @@ import fileSystemService from './services/FileSystemService';
 import { referralsThunks } from './store/slices/referrals';
 import { storageThunks } from './store/slices/storage';
 import { PhotosContextProvider } from './contexts/Photos';
+import asyncStorageService from './services/AsyncStorageService';
+import { AsyncStorageKey } from './types';
 
 export default function App(): JSX.Element {
   const dispatch = useAppDispatch();
@@ -60,12 +62,6 @@ export default function App(): JSX.Element {
   const onPlansModalClosed = () => dispatch(uiActions.setIsPlansModalOpen(false));
   const onUserLoggedIn = () => {
     dispatch(appThunks.initializeThunk());
-    AppState.addEventListener('change', (state) => {
-      if (state === 'active') {
-        dispatch(referralsThunks.fetchReferralsThunk());
-        dispatch(storageThunks.loadLimitThunk());
-      }
-    });
   };
   const onUserLoggedOut = () => {
     /**

--- a/src/components/AppButton/index.tsx
+++ b/src/components/AppButton/index.tsx
@@ -8,7 +8,7 @@ import LoadingSpinner from '../LoadingSpinner';
 interface AppButtonProps {
   testID?: string;
   title: string | JSX.Element;
-  type: 'accept' | 'accept-2' | 'cancel' | 'cancel-2' | 'delete';
+  type: 'accept' | 'accept-2' | 'cancel' | 'cancel-2' | 'delete' | 'white';
   onPress: () => void;
   disabled?: boolean;
   loading?: boolean;
@@ -29,6 +29,21 @@ const AppButton = (props: AppButtonProps): JSX.Element => {
     cancel: tailwind('bg-gray-5'),
     'cancel-2': tailwind('bg-blue-10'),
     delete: props.disabled ? tailwind('bg-gray-40') : tailwind('bg-red-'),
+    white: {
+      ...tailwind('bg-white'),
+      ...({
+        borderColor: 'rgba(0,0,0,0.1)',
+        borderWidth: 1,
+        shadowColor: '#000000',
+        shadowOffset: {
+          width: 0,
+          height: 1,
+        },
+        shadowOpacity: 0.16,
+        shadowRadius: 1.51,
+        elevation: 2,
+      } as ViewStyle),
+    },
   }[props.type];
   const typeTextStyle = {
     accept: tailwind('text-white'),
@@ -36,6 +51,7 @@ const AppButton = (props: AppButtonProps): JSX.Element => {
     cancel: props.disabled ? tailwind('text-gray-40') : tailwind('text-gray-80'),
     'cancel-2': tailwind('text-blue-60'),
     delete: tailwind('text-white'),
+    white: tailwind('text-gray-80 border border-black-10'),
   }[props.type];
   const typeUnderlayColor = {
     accept: getColor('text-blue-70'),
@@ -43,6 +59,7 @@ const AppButton = (props: AppButtonProps): JSX.Element => {
     cancel: getColor('text-neutral-30'),
     'cancel-2': getColor('text-neutral-30'),
     delete: getColor('text-red-dark'),
+    white: getColor('text-gray-1'),
   }[props.type];
 
   const renderContent = () => {

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -16,6 +16,8 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import analyticsService from '../services/AnalyticsService';
 import DebugScreen from '../screens/DebugScreen';
 import { uiActions } from 'src/store/slices/ui';
+import { DeactivatedAccountScreen } from '../screens/DeactivatedAccountScreen';
+
 import { paymentsThunks } from 'src/store/slices/payments';
 import { storageThunks } from 'src/store/slices/storage';
 import { PhotosContext } from 'src/contexts/Photos';
@@ -35,7 +37,6 @@ function AppNavigator(): JSX.Element {
 
     if (isLoggedIn) {
       const comesFromCheckout = !!sessionId && event.url.includes('checkout');
-
       if (comesFromCheckout) {
         await analyticsService.trackPayment(sessionId as string);
         await AsyncStorage.removeItem('tmpCheckoutSessionId');
@@ -133,6 +134,7 @@ function AppNavigator(): JSX.Element {
       <Stack.Screen name="Debug" component={DebugScreen} />
       <Stack.Screen name="SignUp" component={SignUpScreen} />
       <Stack.Screen name="SignIn" component={SignInScreen} />
+      <Stack.Screen name="DeactivatedAccount" component={DeactivatedAccountScreen} />
       <Stack.Screen name="TabExplorer" component={AuthenticatedNavigator} />
       <Stack.Screen name="ForgotPassword" component={ForgotPasswordScreen} />
       <Stack.Screen name="PhotosPreview" component={PhotosPreviewScreen} />

--- a/src/screens/DeactivatedAccountScreen/DeactivatedAccountScreen.tsx
+++ b/src/screens/DeactivatedAccountScreen/DeactivatedAccountScreen.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import { RootStackScreenProps } from '../../types/navigation';
+import InternxtLogo from '../../../assets/logo.svg';
+import AppScreen from '../../components/AppScreen';
+import AppButton from '../../components/AppButton';
+import { useTailwind } from 'tailwind-rn';
+import { CheckCircle } from 'phosphor-react-native';
+import AppText from 'src/components/AppText';
+import strings from 'assets/lang/strings';
+import { Dimensions, View } from 'react-native';
+import AppVersionWidget from 'src/components/AppVersionWidget';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export function DeactivatedAccountScreen({ navigation }: RootStackScreenProps<'DeactivatedAccount'>): JSX.Element {
+  const tailwind = useTailwind();
+
+  const handleGoToSignIn = () => {
+    navigation.replace('SignIn');
+  };
+  const handleGoToSignUp = () => {
+    navigation.replace('SignUp');
+  };
+  const dimensions = Dimensions.get('screen');
+  return (
+    <AppScreen safeAreaTop safeAreaBottom style={tailwind('px-6 h-full items-center pt-20')}>
+      <LinearGradient
+        colors={['#F9F9FC', '#F9F9FC']}
+        locations={[0, 1]}
+        style={[tailwind('w-full h-full absolute'), { height: dimensions.height, width: dimensions.width }]}
+      />
+      <CheckCircle weight="thin" color={tailwind('text-primary').color as string} size={88} />
+      <AppText medium style={tailwind('text-center text-2xl mt-6')}>
+        {strings.screens.deactivation_screen.account_deleted}
+      </AppText>
+      <AppText style={tailwind('text-center text-lg mt-2')}>
+        {strings.screens.deactivation_screen.account_deleted_advice}
+      </AppText>
+      <AppButton
+        style={tailwind('w-full mt-8')}
+        title={strings.buttons.createAccount}
+        type="accept"
+        onPress={handleGoToSignUp}
+      />
+      <AppButton
+        style={tailwind('w-full mt-3')}
+        title={strings.buttons.sign_in}
+        type="white"
+        onPress={handleGoToSignIn}
+      />
+      <View style={tailwind('mt-auto')}>
+        <InternxtLogo width={90} style={tailwind('my-2')} />
+        <AppVersionWidget style={tailwind('mb-5')} />
+      </View>
+    </AppScreen>
+  );
+}

--- a/src/screens/DeactivatedAccountScreen/index.ts
+++ b/src/screens/DeactivatedAccountScreen/index.ts
@@ -1,0 +1,1 @@
+export * from './DeactivatedAccountScreen';

--- a/src/store/slices/auth/index.ts
+++ b/src/store/slices/auth/index.ts
@@ -193,6 +193,8 @@ export const deleteAccountThunk = createAsyncThunk<void, void, { state: RootStat
     const { user } = getState().auth;
 
     user && (await authService.deleteAccount(user.email));
+
+    asyncStorageService.saveItem(AsyncStorageKey.IsDeletingAccount, 'DELETING');
   },
 );
 

--- a/src/store/slices/referrals/index.ts
+++ b/src/store/slices/referrals/index.ts
@@ -1,18 +1,13 @@
 import { UserReferral } from '@internxt/sdk/dist/drive/referrals/types';
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import { RootState } from '../..';
-import strings from '../../../../assets/lang/strings';
-import notificationsService from '../../../services/NotificationsService';
 import usersReferralsService from '../../../services/UsersReferralsService';
-import { NotificationType } from '../../../types';
 
 export interface ReferralsState {
-  isReading: boolean;
   list: UserReferral[];
 }
 
 const initialState: ReferralsState = {
-  isReading: false,
   list: [],
 };
 
@@ -27,27 +22,6 @@ export const referralsSlice = createSlice({
   name: 'referrals',
   initialState,
   reducers: {},
-  extraReducers: (builder) => {
-    builder
-      .addCase(fetchReferralsThunk.pending, (state) => {
-        state.isReading = true;
-      })
-      .addCase(fetchReferralsThunk.fulfilled, (state, action) => {
-        state.isReading = false;
-        state.list = action.payload;
-      })
-      .addCase(fetchReferralsThunk.rejected, (state, action) => {
-        state.isReading = false;
-
-        notificationsService.show({
-          type: NotificationType.Error,
-          text1: strings.formatString(
-            strings.errors.fetchReferrals,
-            action.error.message || strings.errors.unknown,
-          ) as string,
-        });
-      });
-  },
 });
 
 export const referralsActions = referralsSlice.actions;

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -22,56 +22,12 @@
   right: -0.5rem
 }
 
-.bottom-3 {
-  bottom: 0.75rem
-}
-
-.left-3 {
-  left: 0.75rem
-}
-
-.right-3 {
-  right: 0.75rem
-}
-
-.bottom-14 {
-  bottom: 3.5rem
-}
-
-.top-1 {
-  top: 0.25rem
-}
-
-.bottom-2\.5 {
-  bottom: 0.625rem
-}
-
-.right-2\.5 {
-  right: 0.625rem
-}
-
-.bottom-2 {
-  bottom: 0.5rem
-}
-
-.right-2 {
-  right: 0.5rem
-}
-
-.bottom-1\.5 {
-  bottom: 0.375rem
-}
-
 .bottom-1 {
   bottom: 0.25rem
 }
 
-.left-2\.5 {
-  left: 0.625rem
-}
-
-.left-2 {
-  left: 0.5rem
+.right-1\.5 {
+  right: 0.375rem
 }
 
 .right-1 {
@@ -82,8 +38,12 @@
   left: 0.25rem
 }
 
-.right-1\.5 {
-  right: 0.375rem
+.bottom-14 {
+  bottom: 3.5rem
+}
+
+.top-1 {
+  top: 0.25rem
 }
 
 .z-10 {
@@ -264,6 +224,18 @@
   margin-top: 0.375rem
 }
 
+.mt-6 {
+  margin-top: 1.5rem
+}
+
+.mt-3 {
+  margin-top: 0.75rem
+}
+
+.mt-auto {
+  margin-top: auto
+}
+
 .mb-5 {
   margin-bottom: 1.25rem
 }
@@ -274,10 +246,6 @@
 
 .-ml-2 {
   margin-left: -0.5rem
-}
-
-.mt-3 {
-  margin-top: 0.75rem
 }
 
 .mt-14 {
@@ -338,10 +306,6 @@
 
 .mb-4 {
   margin-bottom: 1rem
-}
-
-.mt-6 {
-  margin-top: 1.5rem
 }
 
 .mb-7 {
@@ -653,12 +617,20 @@
   border-width: 0px
 }
 
+.border-2 {
+  border-width: 2px
+}
+
 .border-t {
   border-top-width: 1px
 }
 
 .border-b {
   border-bottom-width: 1px
+}
+
+.border-black-10 {
+  border-color: rgba(0,0,0,0.10)
 }
 
 .border-neutral-30 {
@@ -754,6 +726,11 @@
   background-color: rgb(255 13 0 / var(--tw-bg-opacity))
 }
 
+.bg-white {
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity))
+}
+
 .bg-gray-10 {
   --tw-bg-opacity: 1;
   background-color: rgb(229 229 235 / var(--tw-bg-opacity))
@@ -762,11 +739,6 @@
 .bg-neutral-30 {
   --tw-bg-opacity: 1;
   background-color: rgb(235 236 240 / var(--tw-bg-opacity))
-}
-
-.bg-white {
-  --tw-bg-opacity: 1;
-  background-color: rgb(255 255 255 / var(--tw-bg-opacity))
 }
 
 .bg-neutral-10 {
@@ -938,6 +910,11 @@
   padding-right: 2rem
 }
 
+.px-6 {
+  padding-left: 1.5rem;
+  padding-right: 1.5rem
+}
+
 .py-5 {
   padding-top: 1.25rem;
   padding-bottom: 1.25rem
@@ -946,11 +923,6 @@
 .px-10 {
   padding-left: 2.5rem;
   padding-right: 2.5rem
-}
-
-.px-6 {
-  padding-left: 1.5rem;
-  padding-right: 1.5rem
 }
 
 .py-6 {
@@ -1011,6 +983,10 @@
 
 .pb-1\.5 {
   padding-bottom: 0.375rem
+}
+
+.pt-20 {
+  padding-top: 5rem
 }
 
 .pr-4 {
@@ -1181,6 +1157,11 @@
 .text-red-dark {
   --tw-text-opacity: 1;
   color: rgb(230 11 0 / var(--tw-text-opacity))
+}
+
+.text-gray-1 {
+  --tw-text-opacity: 1;
+  color: rgb(249 249 252 / var(--tw-text-opacity))
 }
 
 .text-neutral-700 {

--- a/src/styles/tailwind.json
+++ b/src/styles/tailwind.json
@@ -29,69 +29,14 @@
 			"right": -8
 		}
 	},
-	"bottom-3": {
-		"style": {
-			"bottom": 12
-		}
-	},
-	"left-3": {
-		"style": {
-			"left": 12
-		}
-	},
-	"right-3": {
-		"style": {
-			"right": 12
-		}
-	},
-	"bottom-14": {
-		"style": {
-			"bottom": 56
-		}
-	},
-	"top-1": {
-		"style": {
-			"top": 4
-		}
-	},
-	"bottom-2.5": {
-		"style": {
-			"bottom": 10
-		}
-	},
-	"right-2.5": {
-		"style": {
-			"right": 10
-		}
-	},
-	"bottom-2": {
-		"style": {
-			"bottom": 8
-		}
-	},
-	"right-2": {
-		"style": {
-			"right": 8
-		}
-	},
-	"bottom-1.5": {
-		"style": {
-			"bottom": 6
-		}
-	},
 	"bottom-1": {
 		"style": {
 			"bottom": 4
 		}
 	},
-	"left-2.5": {
+	"right-1.5": {
 		"style": {
-			"left": 10
-		}
-	},
-	"left-2": {
-		"style": {
-			"left": 8
+			"right": 6
 		}
 	},
 	"right-1": {
@@ -104,9 +49,14 @@
 			"left": 4
 		}
 	},
-	"right-1.5": {
+	"bottom-14": {
 		"style": {
-			"right": 6
+			"bottom": 56
+		}
+	},
+	"top-1": {
+		"style": {
+			"top": 4
 		}
 	},
 	"z-10": {
@@ -340,6 +290,21 @@
 			"marginTop": 6
 		}
 	},
+	"mt-6": {
+		"style": {
+			"marginTop": 24
+		}
+	},
+	"mt-3": {
+		"style": {
+			"marginTop": 12
+		}
+	},
+	"mt-auto": {
+		"style": {
+			"marginTop": "auto"
+		}
+	},
 	"mb-5": {
 		"style": {
 			"marginBottom": 20
@@ -353,11 +318,6 @@
 	"-ml-2": {
 		"style": {
 			"marginLeft": -8
-		}
-	},
-	"mt-3": {
-		"style": {
-			"marginTop": 12
 		}
 	},
 	"mt-14": {
@@ -433,11 +393,6 @@
 	"mb-4": {
 		"style": {
 			"marginBottom": 16
-		}
-	},
-	"mt-6": {
-		"style": {
-			"marginTop": 24
 		}
 	},
 	"mb-7": {
@@ -854,6 +809,14 @@
 			"borderLeftWidth": 0
 		}
 	},
+	"border-2": {
+		"style": {
+			"borderTopWidth": 2,
+			"borderRightWidth": 2,
+			"borderBottomWidth": 2,
+			"borderLeftWidth": 2
+		}
+	},
 	"border-t": {
 		"style": {
 			"borderTopWidth": 1
@@ -862,6 +825,14 @@
 	"border-b": {
 		"style": {
 			"borderBottomWidth": 1
+		}
+	},
+	"border-black-10": {
+		"style": {
+			"borderTopColor": "rgba(0,0,0,0.10)",
+			"borderRightColor": "rgba(0,0,0,0.10)",
+			"borderBottomColor": "rgba(0,0,0,0.10)",
+			"borderLeftColor": "rgba(0,0,0,0.10)"
 		}
 	},
 	"border-neutral-30": {
@@ -1012,6 +983,12 @@
 			"backgroundColor": "rgb(255 13 0 / var(--tw-bg-opacity))"
 		}
 	},
+	"bg-white": {
+		"style": {
+			"--tw-bg-opacity": 1,
+			"backgroundColor": "rgb(255 255 255 / var(--tw-bg-opacity))"
+		}
+	},
 	"bg-gray-10": {
 		"style": {
 			"--tw-bg-opacity": 1,
@@ -1022,12 +999,6 @@
 		"style": {
 			"--tw-bg-opacity": 1,
 			"backgroundColor": "rgb(235 236 240 / var(--tw-bg-opacity))"
-		}
-	},
-	"bg-white": {
-		"style": {
-			"--tw-bg-opacity": 1,
-			"backgroundColor": "rgb(255 255 255 / var(--tw-bg-opacity))"
 		}
 	},
 	"bg-neutral-10": {
@@ -1256,6 +1227,12 @@
 			"paddingRight": 32
 		}
 	},
+	"px-6": {
+		"style": {
+			"paddingLeft": 24,
+			"paddingRight": 24
+		}
+	},
 	"py-5": {
 		"style": {
 			"paddingTop": 20,
@@ -1266,12 +1243,6 @@
 		"style": {
 			"paddingLeft": 40,
 			"paddingRight": 40
-		}
-	},
-	"px-6": {
-		"style": {
-			"paddingLeft": 24,
-			"paddingRight": 24
 		}
 	},
 	"py-6": {
@@ -1346,6 +1317,11 @@
 	"pb-1.5": {
 		"style": {
 			"paddingBottom": 6
+		}
+	},
+	"pt-20": {
+		"style": {
+			"paddingTop": 80
 		}
 	},
 	"pr-4": {
@@ -1554,6 +1530,12 @@
 		"style": {
 			"--tw-text-opacity": 1,
 			"color": "rgb(230 11 0 / var(--tw-text-opacity))"
+		}
+	},
+	"text-gray-1": {
+		"style": {
+			"--tw-text-opacity": 1,
+			"color": "rgb(249 249 252 / var(--tw-text-opacity))"
 		}
 	},
 	"text-neutral-700": {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -90,6 +90,7 @@ export enum AsyncStorageKey {
   LastUpdateCheck = 'lastUpdateCheck',
   Language = 'language',
   LastPhotosPagePulled = 'lastPhotosPagePulled',
+  IsDeletingAccount = 'isDeletingAccount',
 }
 
 export type ProgressCallback = (progress: number) => void;

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -14,6 +14,7 @@ export type RootStackParamList = {
   Debug: undefined;
   SignUp: undefined;
   SignIn: undefined;
+  DeactivatedAccount: undefined;
   TabExplorer: NavigatorScreenParams<TabExplorerStackParamList> & { showReferralsBanner?: boolean };
   ForgotPassword: undefined;
   PhotosPreview: { photoName: string };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,9 @@ module.exports = {
       current: 'currentColor',
       black: 'rgb(0,0,0)',
       'black-75': 'rgba(0,0,0,.75)',
+      'black-5': 'rgba(0,0,0,0.05)',
+      'black-10': 'rgba(0,0,0,0.10)',
+      'black-15': 'rgba(0,0,0,0.15)',
       white: 'rgb(255,255,255)',
       // NEW DESIGN SYSTEM
       primary: 'rgb(0,102,255)',


### PR DESCRIPTION
Mobile wasn't able to detect when an account has been successfully deleted/deactivated. This PR provides a mechanism to detect if the account has been deleted.

1- When the user press the "deactivate account button" we store a `isDeactivatingAccount` key in the async storage
2- If the user comes back to the app, and an API request throws a 401 and the key exists we assume the account has been deleted since the token is revoked, we then redirect the user to the new DeactivatedAccount screen
