### PR TITLE
[MT-53]: (feature) see drive thumbnails

### DIFF
--- a/src/components/DriveItemGrid/index.tsx
+++ b/src/components/DriveItemGrid/index.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { View, TouchableOpacity, TouchableHighlight, Animated, Easing, Image } from 'react-native';
+import { View, TouchableHighlight, Animated, Easing, Image } from 'react-native';
 
 import { FolderIcon, getFileTypeIcon } from '../../helpers';
 import globalStyle from '../../styles/global';
 import { useAppSelector } from '../../store/hooks';
-import { ArrowCircleUp, DotsThree } from 'phosphor-react-native';
+import { ArrowCircleUp } from 'phosphor-react-native';
 import { items } from '@internxt/lib';
 import AppText from '../AppText';
 
@@ -28,8 +28,7 @@ function DriveItemGrid(props: DriveItemProps): JSX.Element {
   const IconFile = getFileTypeIcon(props.data.type || '');
   const iconSize = 80;
 
-  const { isFolder, isUploading, isDownloading, onItemPressed, onItemLongPressed, onActionsButtonPressed } =
-    useDriveItem(props);
+  const { isFolder, isUploading, isDownloading, onItemPressed, onItemLongPressed } = useDriveItem(props);
 
   const maxThumbnailHeight = 96;
   const thumbnail = props.data.currentThumbnail || props.data.thumbnails ? props.data.thumbnails[0] : null;
@@ -37,17 +36,12 @@ function DriveItemGrid(props: DriveItemProps): JSX.Element {
   const getThumbnailWidth = () => {
     if (!thumbnailSize || !maxThumbnailWidth) return 0;
 
-    const thumbnailWidth = Math.floor(
-      thumbnailSize ? (thumbnailSize.width * maxThumbnailHeight) / thumbnailSize.height : 0,
-    );
-
+    const thumbnailWidth = thumbnailSize ? (thumbnailSize.width * maxThumbnailHeight) / thumbnailSize.height : 0;
     return thumbnailWidth > maxThumbnailWidth ? maxThumbnailWidth : thumbnailWidth;
   };
 
   const getThumbnailHeight = () => {
-    const thumbnailHeight = Math.floor(
-      thumbnailSize ? (thumbnailSize.height * getThumbnailWidth()) / thumbnailSize.width : 0,
-    );
+    const thumbnailHeight = thumbnailSize ? (thumbnailSize.height * getThumbnailWidth()) / thumbnailSize.width : 0;
 
     return thumbnailHeight > maxThumbnailHeight ? maxThumbnailHeight : thumbnailHeight;
   };

--- a/src/components/DriveItemGrid/index.tsx
+++ b/src/components/DriveItemGrid/index.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect } from 'react';
-import { View, TouchableOpacity, TouchableHighlight, Animated, Easing } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { View, TouchableOpacity, TouchableHighlight, Animated, Easing, Image } from 'react-native';
 
 import { FolderIcon, getFileTypeIcon } from '../../helpers';
 import globalStyle from '../../styles/global';
@@ -12,6 +12,9 @@ import { DriveItemProps } from '../../types/drive';
 import useDriveItem from '../../hooks/useDriveItem';
 import { useTailwind } from 'tailwind-rn';
 import useGetColor from '../../hooks/useColor';
+import drive from '@internxt-mobile/services/drive';
+import { time } from '@internxt-mobile/services/common/time';
+import prettysize from 'prettysize';
 
 function DriveItemGrid(props: DriveItemProps): JSX.Element {
   const tailwind = useTailwind();
@@ -19,10 +22,46 @@ function DriveItemGrid(props: DriveItemProps): JSX.Element {
   const { selectedItems } = useAppSelector((state) => state.drive);
   const isSelectionMode = selectedItems.length > 0;
   const spinValue = new Animated.Value(1);
+  const [thumbnailPath, setThumbnailPath] = useState<string | null>(null);
+  const [maxThumbnailWidth, setMaxThumbnailWidth] = useState<number | null>(null);
+  const [thumbnailSize, setThumbnailSize] = useState<{ width: number; height: number } | null>(null);
   const IconFile = getFileTypeIcon(props.data.type || '');
-  const iconSize = 64;
+  const iconSize = 80;
+
   const { isFolder, isUploading, isDownloading, onItemPressed, onItemLongPressed, onActionsButtonPressed } =
     useDriveItem(props);
+
+  const maxThumbnailHeight = 96;
+  const thumbnail = props.data.currentThumbnail || props.data.thumbnails ? props.data.thumbnails[0] : null;
+
+  const getThumbnailWidth = () => {
+    if (!thumbnailSize || !maxThumbnailWidth) return 0;
+
+    const thumbnailWidth = Math.floor(
+      thumbnailSize ? (thumbnailSize.width * maxThumbnailHeight) / thumbnailSize.height : 0,
+    );
+
+    return thumbnailWidth > maxThumbnailWidth ? maxThumbnailWidth : thumbnailWidth;
+  };
+
+  const getThumbnailHeight = () => {
+    const thumbnailHeight = Math.floor(
+      thumbnailSize ? (thumbnailSize.height * getThumbnailWidth()) / thumbnailSize.width : 0,
+    );
+
+    return thumbnailHeight > maxThumbnailHeight ? maxThumbnailHeight : thumbnailHeight;
+  };
+
+  useEffect(() => {
+    if (thumbnail && !thumbnailPath) {
+      drive.file.getThumbnail(props.data.currentThumbnail || props.data.thumbnails[0]).then((path) => {
+        Image.getSize(path, (width, height) => {
+          setThumbnailSize({ width, height });
+          setThumbnailPath(path);
+        });
+      });
+    }
+  }, [props.data]);
 
   useEffect(() => {
     Animated.loop(
@@ -35,23 +74,57 @@ function DriveItemGrid(props: DriveItemProps): JSX.Element {
     ).start();
   }, []);
 
+  const renderThumbnail = () => {
+    return (
+      <View
+        style={{
+          shadowColor: '#000',
+          shadowOffset: {
+            width: 0,
+            height: 1,
+          },
+          shadowOpacity: 0.2,
+          shadowRadius: 2.22,
+        }}
+      >
+        <Image
+          borderRadius={10}
+          source={{ uri: thumbnailPath as string }}
+          style={[
+            tailwind('rounded bg-debug'),
+            {
+              height: getThumbnailHeight(),
+              width: getThumbnailWidth() - 10,
+            },
+          ]}
+          resizeMode={'cover'}
+        />
+      </View>
+    );
+  };
   return (
     <TouchableHighlight
       disabled={isUploading || isDownloading}
       underlayColor={getColor('text-neutral-20')}
       onLongPress={onItemLongPressed}
       onPress={onItemPressed}
-      style={{ flex: 1 / 3 }}
+      onLayout={(event) => {
+        !maxThumbnailWidth && setMaxThumbnailWidth(Math.floor(event.nativeEvent.layout.width) - 8);
+      }}
+      style={[{ flex: 1 / 3 }, tailwind('p-2 mb-5 rounded-lg')]}
     >
-      <View style={tailwind('py-3.5')}>
+      <View>
         <View style={[tailwind('flex-grow overflow-hidden'), tailwind('flex-col items-center justify-center')]}>
-          {/* Icon */}
-          <View style={tailwind('w-full mb-1 items-center justify-center')}>
-            {isFolder ? (
-              <FolderIcon width={iconSize} height={iconSize} style={isUploading && tailwind('opacity-40')} />
-            ) : (
-              <IconFile width={iconSize} height={iconSize} />
-            )}
+          <View style={tailwind('w-full mb-1.5 items-center justify-center')}>
+            <View style={tailwind('h-24 flex items-center justify-center')}>
+              {isFolder ? (
+                <FolderIcon width={iconSize} height={iconSize} style={isUploading && tailwind('opacity-40')} />
+              ) : thumbnailPath ? (
+                renderThumbnail()
+              ) : (
+                <IconFile width={iconSize} height={iconSize} />
+              )}
+            </View>
 
             {isUploading && (
               <View style={tailwind('absolute top-0 bottom-0 w-full flex-row items-center justify-center')}>
@@ -65,10 +138,10 @@ function DriveItemGrid(props: DriveItemProps): JSX.Element {
             )}
           </View>
 
-          <View style={[tailwind('flex items-start justify-center items-center')]}>
+          <View style={[tailwind('flex items-start justify-center items-center mt-1.5')]}>
             <AppText
               style={[
-                tailwind('text-base text-neutral-500 text-center px-5'),
+                tailwind('text-base text-gray-100 text-center px-2.5 leading-5'),
                 isUploading && tailwind('opacity-40'),
                 globalStyle.fontWeight.medium,
               ]}
@@ -77,19 +150,14 @@ function DriveItemGrid(props: DriveItemProps): JSX.Element {
             >
               {items.getItemDisplayName(props.data)}
             </AppText>
+            <AppText style={tailwind('text-xs text-gray-50 mt-2')}>
+              {time.getFormattedDate(props.data.createdAt, time.formats.shortDate)}
+            </AppText>
+            {props.data.size ? (
+              <AppText style={tailwind('text-xs text-gray-50')}>{prettysize(props.data.size)}</AppText>
+            ) : null}
           </View>
         </View>
-
-        <TouchableOpacity
-          disabled={isUploading || isDownloading}
-          style={isSelectionMode && tailwind('hidden')}
-          onPress={onActionsButtonPressed}
-          onLongPress={onActionsButtonPressed}
-        >
-          <View style={[isUploading && tailwind('opacity-40'), tailwind('px-5 h-6 items-center justify-center')]}>
-            <DotsThree weight="bold" size={22} color={getColor('text-neutral-60')} />
-          </View>
-        </TouchableOpacity>
       </View>
     </TouchableHighlight>
   );

--- a/src/components/DriveItemSkinSkeleton/index.tsx
+++ b/src/components/DriveItemSkinSkeleton/index.tsx
@@ -1,15 +1,16 @@
+import { DriveListViewMode } from '@internxt-mobile/types/drive';
 import React, { useState } from 'react';
 import { View, Animated, Easing } from 'react-native';
 import { useTailwind } from 'tailwind-rn';
 
-export default function DriveItemSkinSkeleton(): JSX.Element {
+const DriveItemSkinSkeleton: React.FC<{ viewMode?: DriveListViewMode }> = ({ viewMode }) => {
   const tailwind = useTailwind();
   const [fadeAnim] = useState(new Animated.Value(1));
 
   Animated.loop(
     Animated.sequence([
       Animated.timing(fadeAnim, {
-        toValue: 0,
+        toValue: 0.4,
         duration: 1500,
         easing: Easing.linear,
         useNativeDriver: true,
@@ -23,15 +24,42 @@ export default function DriveItemSkinSkeleton(): JSX.Element {
     ]),
   ).start();
 
+  if (viewMode === DriveListViewMode.Grid) {
+    const renderGridItem = () => {
+      return (
+        <View style={[{ flex: 1 / 3 }, tailwind('items-center flex-col justify-center pt-6 mb-6')]}>
+          <View style={tailwind('w-20 h-20 rounded bg-gray-5 mb-4')}></View>
+          <View style={tailwind('w-full px-5 mb-1.5')}>
+            <View style={tailwind('w-full h-3.5 rounded bg-gray-5')}></View>
+          </View>
+          <View style={tailwind('w-full px-8 mb-1.5')}>
+            <View style={tailwind('w-full h-3 rounded bg-gray-5')}></View>
+          </View>
+          <View style={tailwind('w-full px-10 mb-1')}>
+            <View style={tailwind('w-full h-3 rounded bg-gray-5')}></View>
+          </View>
+        </View>
+      );
+    };
+    return (
+      <Animated.View style={[tailwind('flex-row'), { opacity: fadeAnim }]}>
+        {renderGridItem()}
+        {renderGridItem()}
+        {renderGridItem()}
+      </Animated.View>
+    );
+  }
   return (
     <Animated.View style={[tailwind('flex-row my-3 mx-5'), { opacity: fadeAnim }]}>
-      <View style={tailwind('bg-neutral-30 h-10 w-10 mr-4 rounded')} />
+      <View style={tailwind('bg-gray-5 h-10 w-10 mr-4 rounded')} />
 
       <View style={tailwind('flex-col flex-grow justify-center')}>
-        <View style={tailwind('h-3 w-2/6 mb-2 bg-neutral-30 rounded')} />
+        <View style={tailwind('h-3 w-2/6 mb-2 bg-gray-5 rounded')} />
 
-        <View style={tailwind('h-2.5 w-3/4 bg-neutral-10 rounded')} />
+        <View style={tailwind('h-2.5 w-3/4 bg-gray-5 rounded')} />
       </View>
     </Animated.View>
   );
-}
+};
+
+export default DriveItemSkinSkeleton;

--- a/src/components/DriveList/index.tsx
+++ b/src/components/DriveList/index.tsx
@@ -50,7 +50,7 @@ function DriveList(props: DriveListProps): JSX.Element {
 
   return (
     <FlatList
-      contentContainerStyle={[isEmptyFolder && tailwind('h-full justify-center')]}
+      contentContainerStyle={[isEmptyFolder ? tailwind('h-full justify-center') : tailwind('pt-5 px-1')]}
       key={props.viewMode}
       refreshControl={
         <RefreshControl
@@ -70,7 +70,7 @@ function DriveList(props: DriveListProps): JSX.Element {
         filesLoading ? (
           <View style={tailwind('h-full')}>
             {_.times(20, (n) => (
-              <DriveItemSkinSkeleton key={n} />
+              <DriveItemSkinSkeleton viewMode={props.viewMode} key={n} />
             ))}
           </View>
         ) : isRootFolder ? (

--- a/src/components/modals/MoveItemsModal/index.tsx
+++ b/src/components/modals/MoveItemsModal/index.tsx
@@ -78,6 +78,8 @@ function MoveItemsModal(): JSX.Element {
         .map<DriveListItem>((child) => ({
           status: DriveItemStatus.Idle,
           data: {
+            thumbnails: (child as DriveFileData).thumbnails,
+            currentThumbnail: null,
             createdAt: child.createdAt,
             updatedAt: child.updatedAt,
             name: child.name,
@@ -138,6 +140,11 @@ function MoveItemsModal(): JSX.Element {
               id: destinationFolderContentResponse.id,
               updatedAt: originFolderContentResponse.updatedAt,
               item: {
+                // TODO organize the Drive item types, we can't extend
+                // from one single type always and expect them to match
+                // the received object
+                thumbnails: [],
+                currentThumbnail: null,
                 name: originFolderContentResponse.name,
                 id: destinationFolderContentResponse.id,
                 parentId: originFolderContentResponse.parentId,

--- a/src/screens/drive/SharedScreen/SharedScreen.tsx
+++ b/src/screens/drive/SharedScreen/SharedScreen.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { View, ScrollView, RefreshControl } from 'react-native';
 import _ from 'lodash';
-
 import DriveItem from '../../../components/DriveItemTable';
 import DriveItemSkinSkeleton from '../../../components/DriveItemSkinSkeleton';
 import strings from '../../../../assets/lang/strings';
@@ -79,6 +78,8 @@ export const SharedScreen: React.FC<SharedScreenProps> = ({
               /** SDK types are wrong, should fix */
               token: sharedLink.token,
               shareId: sharedLink.id,
+              thumbnails: [],
+              currentThumbnail: null,
               code: (sharedLink as unknown as { code: string }).code,
               updatedAt: sharedLink.item.updatedAt,
               createdAt: sharedLink.item.createdAt,

--- a/src/services/common/time/time.service.ts
+++ b/src/services/common/time/time.service.ts
@@ -9,6 +9,7 @@ export type TimeInput = Date | number | string;
 export class TimeService {
   public formats = {
     dateAtTime: `dd LLL yyyy '${strings.generic.atTime}' HH:mm`,
+    shortDate: 'dd/LL/yyyy',
     duration: 'mm:ss',
   };
 

--- a/src/services/drive/constants.ts
+++ b/src/services/drive/constants.ts
@@ -1,0 +1,3 @@
+import RNFS from 'react-native-fs';
+export const DRIVE_ROOT_DIRECTORY = `${RNFS.DocumentDirectoryPath}/drive`;
+export const DRIVE_THUMBNAILS_DIRECTORY = `${DRIVE_ROOT_DIRECTORY}/thumbnails`;

--- a/src/services/drive/database/driveLocalDB.ts
+++ b/src/services/drive/database/driveLocalDB.ts
@@ -140,6 +140,8 @@ class DriveLocalDB {
         size: row.size as number,
         type: row.type || '',
         updatedAt: row.updated_at,
+        thumbnails: row.thumbnails,
+        currentThumbnail: row.currentThumbnail,
       };
       result = file;
     }

--- a/src/services/drive/index.ts
+++ b/src/services/drive/index.ts
@@ -6,6 +6,8 @@ import { driveLogger } from './logger';
 import { driveLocalDB } from './database';
 import { driveFileService } from './file';
 import { driveFolderService } from './folder';
+import fileSystemService from '../FileSystemService';
+import { DRIVE_ROOT_DIRECTORY, DRIVE_THUMBNAILS_DIRECTORY } from './constants';
 
 export default {
   logger: driveLogger,
@@ -16,4 +18,14 @@ export default {
   events: driveEvents,
   folder: driveFolderService,
   file: driveFileService,
+  clear: async () => {
+    await driveLocalDB.resetDatabase();
+    await fileSystemService.unlinkIfExists(DRIVE_ROOT_DIRECTORY);
+    driveLogger.info('Drive system clear');
+  },
+  start: async () => {
+    driveLogger.info('Drive system start');
+    await fileSystemService.mkdir(DRIVE_ROOT_DIRECTORY);
+    await fileSystemService.mkdir(DRIVE_THUMBNAILS_DIRECTORY);
+  },
 };

--- a/src/store/slices/app/index.ts
+++ b/src/store/slices/app/index.ts
@@ -1,3 +1,4 @@
+import drive from '@internxt-mobile/services/drive';
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import strings from 'assets/lang/strings';
 import languageService from 'src/services/LanguageService';
@@ -20,6 +21,7 @@ const initialState: AppState = {
 const initializeThunk = createAsyncThunk<void, void, { state: RootState }>(
   'app/initialize',
   async (_, { dispatch }) => {
+    await drive.start();
     dispatch(authThunks.initializeThunk());
     dispatch(driveThunks.initializeThunk());
     dispatch(paymentsThunks.initializeThunk());

--- a/src/store/slices/auth/index.ts
+++ b/src/store/slices/auth/index.ts
@@ -6,7 +6,7 @@ import authService from '../../../services/AuthService';
 import userService from '../../../services/UserService';
 import analytics, { AnalyticsEventKey } from '../../../services/AnalyticsService';
 import { AsyncStorageKey, DevicePlatform, NotificationType } from '../../../types';
-import { driveActions, driveThunks } from '../drive';
+import { driveActions } from '../drive';
 import { uiActions } from '../ui';
 import notificationsService from '../../../services/NotificationsService';
 import strings from '../../../../assets/lang/strings';
@@ -17,6 +17,7 @@ import errorService from 'src/services/ErrorService';
 import { SdkManager } from '@internxt-mobile/services/common';
 import UserService from '../../../services/UserService';
 import photos from '@internxt-mobile/services/photos';
+import drive from '@internxt-mobile/services/drive';
 
 export interface AuthState {
   loggedIn: boolean | null;
@@ -150,9 +151,9 @@ export const signOutThunk = createAsyncThunk<void, void, { state: RootState }>(
   async (_, { dispatch }) => {
     await authService.signout();
     await photos.clear();
+    await drive.clear();
     dispatch(uiActions.resetState());
     dispatch(authActions.resetState());
-    dispatch(driveThunks.clearLocalDatabaseThunk());
     dispatch(driveActions.resetState());
     dispatch(authActions.setLoggedIn(false));
     authService.emitLogoutEvent();

--- a/src/store/slices/drive/index.ts
+++ b/src/store/slices/drive/index.ts
@@ -449,13 +449,6 @@ const deleteItemsThunk = createAsyncThunk<void, { items: any[] }, { state: RootS
   },
 );
 
-const clearLocalDatabaseThunk = createAsyncThunk<void, void, { state: RootState }>(
-  'drive/clearLocalDatabase',
-  async () => {
-    drive.database.resetDatabase();
-  },
-);
-
 const loadUsageThunk = createAsyncThunk<number, void, { state: RootState }>('drive/loadUsage', async () => {
   return drive.usage.getUsage();
 });
@@ -734,6 +727,9 @@ export const driveSelectors = {
         status: DriveItemStatus.Uploading,
         progress: f.progress,
         data: {
+          // TODO: Organize Drive item types
+          thumbnails: [],
+          currentThumbnail: null,
           ...f,
         },
       })),
@@ -759,7 +755,6 @@ export const driveThunks = {
   createFolderThunk,
   moveItemThunk,
   deleteItemsThunk,
-  clearLocalDatabaseThunk,
   loadUsageThunk,
   getRecentsThunk,
 };

--- a/src/store/slices/ui/index.ts
+++ b/src/store/slices/ui/index.ts
@@ -98,10 +98,7 @@ export const uiSlice = createSlice({
     setShowMoveModal: (state, action: PayloadAction<boolean>) => {
       state.showMoveModal = action.payload;
     },
-    switchFileViewMode(state) {
-      state.fileViewMode =
-        state.fileViewMode === DriveListViewMode.List ? DriveListViewMode.Grid : DriveListViewMode.List;
-    },
+
     setBackButtonEnabled: (state, action: PayloadAction<boolean>) => {
       state.backButtonEnabled = action.payload;
     },

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -140,6 +140,11 @@
   margin-right: 1.5rem
 }
 
+.mx-2 {
+  margin-left: 0.5rem;
+  margin-right: 0.5rem
+}
+
 .ml-2 {
   margin-left: 0.5rem
 }
@@ -184,12 +189,24 @@
   margin-top: 2rem
 }
 
+.mb-5 {
+  margin-bottom: 1.25rem
+}
+
+.mb-1\.5 {
+  margin-bottom: 0.375rem
+}
+
 .ml-1\.5 {
   margin-left: 0.375rem
 }
 
 .ml-1 {
   margin-left: 0.25rem
+}
+
+.mt-1\.5 {
+  margin-top: 0.375rem
 }
 
 .mr-4 {
@@ -220,10 +237,6 @@
   margin-right: 0.375rem
 }
 
-.mt-1\.5 {
-  margin-top: 0.375rem
-}
-
 .mt-6 {
   margin-top: 1.5rem
 }
@@ -234,10 +247,6 @@
 
 .mt-auto {
   margin-top: auto
-}
-
-.mb-5 {
-  margin-bottom: 1.25rem
 }
 
 .mb-16 {
@@ -254,10 +263,6 @@
 
 .mb-6 {
   margin-bottom: 1.5rem
-}
-
-.mb-1\.5 {
-  margin-bottom: 0.375rem
 }
 
 .mt-4 {
@@ -348,8 +353,8 @@
   height: 0.75rem
 }
 
-.h-6 {
-  height: 1.5rem
+.h-24 {
+  height: 6rem
 }
 
 .h-10 {
@@ -374,10 +379,6 @@
 
 .h-28 {
   height: 7rem
-}
-
-.h-24 {
-  height: 6rem
 }
 
 .h-8 {
@@ -406,6 +407,10 @@
 
 .h-20 {
   height: 5rem
+}
+
+.h-3\.5 {
+  height: 0.875rem
 }
 
 .min-h-full {
@@ -584,6 +589,10 @@
   border-radius: 1.5rem
 }
 
+.rounded-sm {
+  border-radius: 0.125rem
+}
+
 .rounded-t-xl {
   border-top-left-radius: 0.75rem;
   border-top-right-radius: 0.75rem
@@ -615,10 +624,6 @@
 
 .border-0 {
   border-width: 0px
-}
-
-.border-2 {
-  border-width: 2px
 }
 
 .border-t {
@@ -797,6 +802,11 @@
   background-color: rgb(0 0 0 / var(--tw-bg-opacity))
 }
 
+.bg-debug {
+  --tw-bg-opacity: 1;
+  background-color: rgb(0 128 0 / var(--tw-bg-opacity))
+}
+
 .p-0 {
   padding: 0px
 }
@@ -905,6 +915,11 @@
   padding-bottom: 0px
 }
 
+.px-2\.5 {
+  padding-left: 0.625rem;
+  padding-right: 0.625rem
+}
+
 .px-8 {
   padding-left: 2rem;
   padding-right: 2rem
@@ -935,11 +950,6 @@
   padding-bottom: 1rem
 }
 
-.px-2\.5 {
-  padding-left: 0.625rem;
-  padding-right: 0.625rem
-}
-
 .py-10 {
   padding-top: 2.5rem;
   padding-bottom: 2.5rem
@@ -967,6 +977,10 @@
 
 .pl-5 {
   padding-left: 1.25rem
+}
+
+.pt-5 {
+  padding-top: 1.25rem
 }
 
 .pb-1 {
@@ -1045,6 +1059,14 @@
   padding-top: 0.75rem
 }
 
+.pt-6 {
+  padding-top: 1.5rem
+}
+
+.pt-10 {
+  padding-top: 2.5rem
+}
+
 .text-left {
   text-align: left
 }
@@ -1113,6 +1135,10 @@
 
 .font-semibold {
   font-weight: 600
+}
+
+.leading-5 {
+  line-height: 1.25rem
 }
 
 .text-white {
@@ -1244,6 +1270,16 @@
   color: rgb(166 200 255 / var(--tw-text-opacity))
 }
 
+.text-gray-100 {
+  --tw-text-opacity: 1;
+  color: rgb(24 24 27 / var(--tw-text-opacity))
+}
+
+.text-gray-50 {
+  --tw-text-opacity: 1;
+  color: rgb(142 142 148 / var(--tw-text-opacity))
+}
+
 .text-neutral-500 {
   --tw-text-opacity: 1;
   color: rgb(66 82 110 / var(--tw-text-opacity))
@@ -1279,11 +1315,6 @@
   color: rgb(255 204 0 / var(--tw-text-opacity))
 }
 
-.text-gray-50 {
-  --tw-text-opacity: 1;
-  color: rgb(142 142 148 / var(--tw-text-opacity))
-}
-
 .text-gray-20 {
   --tw-text-opacity: 1;
   color: rgb(209 209 215 / var(--tw-text-opacity))
@@ -1307,11 +1338,6 @@
 .text-red-70 {
   --tw-text-opacity: 1;
   color: rgb(162 25 31 / var(--tw-text-opacity))
-}
-
-.text-gray-100 {
-  --tw-text-opacity: 1;
-  color: rgb(24 24 27 / var(--tw-text-opacity))
 }
 
 .text-neutral-600 {

--- a/src/styles/tailwind.json
+++ b/src/styles/tailwind.json
@@ -185,6 +185,12 @@
 			"marginRight": 24
 		}
 	},
+	"mx-2": {
+		"style": {
+			"marginLeft": 8,
+			"marginRight": 8
+		}
+	},
 	"ml-2": {
 		"style": {
 			"marginLeft": 8
@@ -240,6 +246,16 @@
 			"marginTop": 32
 		}
 	},
+	"mb-5": {
+		"style": {
+			"marginBottom": 20
+		}
+	},
+	"mb-1.5": {
+		"style": {
+			"marginBottom": 6
+		}
+	},
 	"ml-1.5": {
 		"style": {
 			"marginLeft": 6
@@ -248,6 +264,11 @@
 	"ml-1": {
 		"style": {
 			"marginLeft": 4
+		}
+	},
+	"mt-1.5": {
+		"style": {
+			"marginTop": 6
 		}
 	},
 	"mr-4": {
@@ -285,11 +306,6 @@
 			"marginRight": 6
 		}
 	},
-	"mt-1.5": {
-		"style": {
-			"marginTop": 6
-		}
-	},
 	"mt-6": {
 		"style": {
 			"marginTop": 24
@@ -303,11 +319,6 @@
 	"mt-auto": {
 		"style": {
 			"marginTop": "auto"
-		}
-	},
-	"mb-5": {
-		"style": {
-			"marginBottom": 20
 		}
 	},
 	"mb-16": {
@@ -328,11 +339,6 @@
 	"mb-6": {
 		"style": {
 			"marginBottom": 24
-		}
-	},
-	"mb-1.5": {
-		"style": {
-			"marginBottom": 6
 		}
 	},
 	"mt-4": {
@@ -445,9 +451,9 @@
 			"height": 12
 		}
 	},
-	"h-6": {
+	"h-24": {
 		"style": {
-			"height": 24
+			"height": 96
 		}
 	},
 	"h-10": {
@@ -478,11 +484,6 @@
 	"h-28": {
 		"style": {
 			"height": 112
-		}
-	},
-	"h-24": {
-		"style": {
-			"height": 96
 		}
 	},
 	"h-8": {
@@ -518,6 +519,11 @@
 	"h-20": {
 		"style": {
 			"height": 80
+		}
+	},
+	"h-3.5": {
+		"style": {
+			"height": 14
 		}
 	},
 	"min-h-full": {
@@ -763,6 +769,14 @@
 			"borderBottomLeftRadius": 24
 		}
 	},
+	"rounded-sm": {
+		"style": {
+			"borderTopLeftRadius": 2,
+			"borderTopRightRadius": 2,
+			"borderBottomRightRadius": 2,
+			"borderBottomLeftRadius": 2
+		}
+	},
 	"rounded-t-xl": {
 		"style": {
 			"borderTopLeftRadius": 12,
@@ -807,14 +821,6 @@
 			"borderRightWidth": 0,
 			"borderBottomWidth": 0,
 			"borderLeftWidth": 0
-		}
-	},
-	"border-2": {
-		"style": {
-			"borderTopWidth": 2,
-			"borderRightWidth": 2,
-			"borderBottomWidth": 2,
-			"borderLeftWidth": 2
 		}
 	},
 	"border-t": {
@@ -1069,6 +1075,12 @@
 			"backgroundColor": "rgb(0 0 0 / var(--tw-bg-opacity))"
 		}
 	},
+	"bg-debug": {
+		"style": {
+			"--tw-bg-opacity": 1,
+			"backgroundColor": "rgb(0 128 0 / var(--tw-bg-opacity))"
+		}
+	},
 	"p-0": {
 		"style": {
 			"paddingTop": 0,
@@ -1221,6 +1233,12 @@
 			"paddingBottom": 0
 		}
 	},
+	"px-2.5": {
+		"style": {
+			"paddingLeft": 10,
+			"paddingRight": 10
+		}
+	},
 	"px-8": {
 		"style": {
 			"paddingLeft": 32,
@@ -1257,12 +1275,6 @@
 			"paddingBottom": 16
 		}
 	},
-	"px-2.5": {
-		"style": {
-			"paddingLeft": 10,
-			"paddingRight": 10
-		}
-	},
 	"py-10": {
 		"style": {
 			"paddingTop": 40,
@@ -1297,6 +1309,11 @@
 	"pl-5": {
 		"style": {
 			"paddingLeft": 20
+		}
+	},
+	"pt-5": {
+		"style": {
+			"paddingTop": 20
 		}
 	},
 	"pb-1": {
@@ -1394,6 +1411,16 @@
 			"paddingTop": 12
 		}
 	},
+	"pt-6": {
+		"style": {
+			"paddingTop": 24
+		}
+	},
+	"pt-10": {
+		"style": {
+			"paddingTop": 40
+		}
+	},
 	"text-left": {
 		"style": {
 			"textAlign": "left"
@@ -1477,6 +1504,11 @@
 	"font-semibold": {
 		"style": {
 			"fontWeight": "600"
+		}
+	},
+	"leading-5": {
+		"style": {
+			"lineHeight": 20
 		}
 	},
 	"text-white": {
@@ -1634,6 +1666,18 @@
 			"color": "rgb(166 200 255 / var(--tw-text-opacity))"
 		}
 	},
+	"text-gray-100": {
+		"style": {
+			"--tw-text-opacity": 1,
+			"color": "rgb(24 24 27 / var(--tw-text-opacity))"
+		}
+	},
+	"text-gray-50": {
+		"style": {
+			"--tw-text-opacity": 1,
+			"color": "rgb(142 142 148 / var(--tw-text-opacity))"
+		}
+	},
 	"text-neutral-500": {
 		"style": {
 			"--tw-text-opacity": 1,
@@ -1676,12 +1720,6 @@
 			"color": "rgb(255 204 0 / var(--tw-text-opacity))"
 		}
 	},
-	"text-gray-50": {
-		"style": {
-			"--tw-text-opacity": 1,
-			"color": "rgb(142 142 148 / var(--tw-text-opacity))"
-		}
-	},
 	"text-gray-20": {
 		"style": {
 			"--tw-text-opacity": 1,
@@ -1710,12 +1748,6 @@
 		"style": {
 			"--tw-text-opacity": 1,
 			"color": "rgb(162 25 31 / var(--tw-text-opacity))"
-		}
-	},
-	"text-gray-100": {
-		"style": {
-			"--tw-text-opacity": 1,
-			"color": "rgb(24 24 27 / var(--tw-text-opacity))"
 		}
 	},
 	"text-neutral-600": {

--- a/src/types/drive.ts
+++ b/src/types/drive.ts
@@ -1,4 +1,4 @@
-import { DriveFileData, DriveFolderData } from '@internxt/sdk/dist/drive/storage/types';
+import { DriveFileData, DriveFolderData, Thumbnail } from '@internxt/sdk/dist/drive/storage/types';
 
 export const UPLOAD_FILE_SIZE_LIMIT = 1024 * 1024 * 1024;
 
@@ -80,11 +80,13 @@ export enum SortType {
   UpdatedAt = 'updatedAt',
 }
 
-export type DriveItemDataProps = Pick<DriveItemData, 'id' | 'name' | 'updatedAt' | 'createdAt'> & {
+export type DriveItemDataProps = Pick<
+  DriveItemData,
+  'id' | 'name' | 'updatedAt' | 'createdAt' | 'currentThumbnail' | 'thumbnails'
+> & {
   fileId?: string;
   parentId?: number | null;
   code?: string;
-
   token?: string;
   size?: string | number;
   type?: string;
@@ -138,6 +140,8 @@ export interface SqliteDriveItemRow {
   type: string | null;
   created_at: string;
   updated_at: string;
+  thumbnails: Array<Thumbnail>;
+  currentThumbnail: Thumbnail | null;
 }
 
 export interface SqliteDriveFolderRecord {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -91,6 +91,7 @@ export enum AsyncStorageKey {
   Language = 'language',
   LastPhotosPagePulled = 'lastPhotosPagePulled',
   IsDeletingAccount = 'isDeletingAccount',
+  PreferredDriveViewMode = 'preferredDriveViewMode',
 }
 
 export type ProgressCallback = (progress: number) => void;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -197,6 +197,7 @@ module.exports = {
         800: 'rgb(23,43,77)',
         900: 'rgb(9,30,66)',
       },
+      debug: 'green',
     },
     extend: {
       fontSize: {


### PR DESCRIPTION
Branch coming from `feature/add-photos-analytics`

- Added thumbnails for files that has them only in Drive grid mode. 
- Last Drive view mode now is persisted when you return to the app.
- Added grid mode skeletons

