### PR TITLE
[_]:(hotfix) Avoid startup crash due to missing file

### DIFF
--- a/src/services/FileSystemService.ts
+++ b/src/services/FileSystemService.ts
@@ -76,6 +76,14 @@ class FileSystemService {
     const items = await RNFS.readDir(this.getTemporaryDir());
 
     items.forEach(async (item) => {
+      // Some library is writing this file
+      // in the tmp directory, on startup
+      // something is trying to pick the file,
+      // so we avoid deleting this file. Otherwise
+      // the app crashes on startup.
+      if (item.path.includes('NSIRD')) {
+        return;
+      }
       await this.unlink(item.path);
     });
   }


### PR DESCRIPTION
Some issues about this file missing on iOS has been found in Sentry, I believe the file contains some metadata about deleted stuff as stated here: https://discussions.apple.com/thread/252325852

Since the file is stored in the tmp dir, and we clean that dir on startup, we should prevent that file from being deleted. I think is the OS the one that is writing this file.

