### PR TITLE
[MT-78]: Expose .npmrc and use CI NPM_TOKEN env var

### DIFF
--- a/.github/workflows/lint-and-unit-tests.yml
+++ b/.github/workflows/lint-and-unit-tests.yml
@@ -1,8 +1,7 @@
-name: Staging CI
+name: Mobile - Lint and Unit Tests
 on:
   push:
-    # TMP for debugging
-    branches: ['*']
+    branches: ['**']
 jobs:
   build:
     # The type of runner that the job will run on

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ styles/tailwind.json
 .env.test.json
 .env.production.json
 .env.staging.json
-.npmrc
 google-services.json
 GoogleService-Info.plist
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,5 @@
 registry=https://registry.yarnpkg.com/
   
 @internxt:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=TOKEN
+//npm.pkg.github.com/:_authToken=$NPM_TOKEN
 always-auth=true

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Follow these steps before running the project.
 
 ### 1. Installation
 
-- Create a `.npmrc` file from the `.npmrc.template` example provided in the repo.
-- Replace `TOKEN` with your own [Github Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) with `read:packages` permission **ONLY**
+- Set your npm token as system env variable like export NPM_TOKEN=xxxx
+- Replace `xxxx` with your own [Github Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) with `read:packages` permission **ONLY**
 - Use `yarn` to install project dependencies.
 
 ### 2. Environment


### PR DESCRIPTION
Allow to run unit tests from Github Actions