### PR TITLE
[_]:(fix) Update GA node version and minimum node version

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.16.0]
       fail-fast: true
 
     steps:

--- a/package.json
+++ b/package.json
@@ -260,5 +260,8 @@
   "resolutions": {
     "@types/react": "17.0.0",
     "@types/react-dom": "17.0.0"
+  },
+  "engines": {
+    "node": ">=16.16.0"
   }
 }


### PR DESCRIPTION
Set minimum Node.JS version for Github Actions to 16.16.0 and engine option in package.json to 16.16.0