### PR TITLE
[_]:(fix) Avoid photo name collision in the local db

### DIFF
--- a/src/services/photos/database/photosLocalDB.ts
+++ b/src/services/photos/database/photosLocalDB.ts
@@ -119,26 +119,14 @@ export class PhotosLocalDB {
 
   public async savePhotosItem(photo: Photo) {
     this.log('Saving photos item');
-    const photoExists = await this.getSyncedPhotoByPhotoId(photo.id);
-    if (photoExists) {
-      this.log('Photos item already exists, skipping insert');
-      await sqliteService.executeSql(PHOTOS_DB_NAME, deviceSyncTable.statements.updatePhotoById, [
-        photo.name,
-        photo.hash,
-        new Date(photo.takenAt).getTime(),
-        JSON.stringify(photo),
-        photo.id,
-      ]);
-    } else {
-      this.log('Photos item saved into DB');
-      await sqliteService.executeSql(PHOTOS_DB_NAME, deviceSyncTable.statements.insert, [
-        photo.id,
-        photo.name,
-        photo.hash,
-        new Date(photo.takenAt).getTime(),
-        JSON.stringify(photo),
-      ]);
-    }
+    await sqliteService.executeSql(PHOTOS_DB_NAME, deviceSyncTable.statements.insert, [
+      photo.id,
+      photo.name,
+      photo.hash,
+      new Date(photo.takenAt).getTime(),
+      JSON.stringify(photo),
+    ]);
+    this.log('Photos item saved into DB');
   }
 
   private parseRow(row: Record<string, string>) {

--- a/src/services/photos/database/tables/deviceSync.ts
+++ b/src/services/photos/database/tables/deviceSync.ts
@@ -20,7 +20,7 @@ const statements = {
 
   dropTable: `DROP TABLE ${TABLE_NAME}`,
   cleanTable: `DELETE FROM ${TABLE_NAME};`,
-  insert: `INSERT INTO ${TABLE_NAME} (photo_id, photo_name, photo_hash, photo_taken_at, photo) VALUES (?,?,?,?,?);`,
+  insert: `REPLACE INTO ${TABLE_NAME} (photo_id, photo_name, photo_hash, photo_taken_at, photo) VALUES(?,?,?,?,?);`,
   deleteSyncedPhotoByPhotoId: `DELETE FROM ${TABLE_NAME} WHERE photo_id = ? `,
   getSyncedPhotos: `SELECT * FROM ${TABLE_NAME}`,
   getSyncedPhotoByName: `SELECT * FROM ${TABLE_NAME} WHERE photo_name = ?`,


### PR DESCRIPTION
Fixes a corner case where the same Photo can be inserted in the db twice, happens when:

1. We begin the sync process
2. We pull the photo from the server, but the photo in the device is already in the sync queue
3. The photo is already in the local db, but we check it agains the server since when we checked before against the local db, the Photo was not yet in the local DB
4. Photos server says the photo exists and gives us the Photo
5. We try to insert the Photo, but is alreay in the localDB causing a constraint violation in SQlite (not anymore with this PR)