### PR TITLE
[MT-111]:(fix) Fix not playable video previews

### DIFF
--- a/src/network/NetworkFacade.ts
+++ b/src/network/NetworkFacade.ts
@@ -84,7 +84,10 @@ export class NetworkFacade {
     const plainFilePath = filePath;
 
     const encryptedFilePath = fileSystemService.tmpFilePath(`${uuid.v4()}.enc`);
-
+    // Some Android devices doesn't create the file when encrypting, they wait for
+    // the file to exist, since we remove the file and the end anyways
+    // we create an empty one here
+    await fileSystemService.createEmptyFile(encryptedFilePath);
     const encryptFileFunction = Platform.OS === 'android' ? androidEncryptFileFromFs : iosEncryptFileFromFs;
     const stat = await RNFS.stat(plainFilePath);
     const fileSize = stat.size;

--- a/src/network/NetworkFacade.ts
+++ b/src/network/NetworkFacade.ts
@@ -84,10 +84,6 @@ export class NetworkFacade {
     const plainFilePath = filePath;
 
     const encryptedFilePath = fileSystemService.tmpFilePath(`${uuid.v4()}.enc`);
-    // Some Android devices doesn't create the file when encrypting, they wait for
-    // the file to exist, since we remove the file and the end anyways
-    // we create an empty one here
-    await fileSystemService.createEmptyFile(encryptedFilePath);
     const encryptFileFunction = Platform.OS === 'android' ? androidEncryptFileFromFs : iosEncryptFileFromFs;
     const stat = await RNFS.stat(plainFilePath);
     const fileSize = stat.size;
@@ -209,6 +205,8 @@ export class NetworkFacade {
           encryptedFileURI = path;
         } else {
           encryptedFileURI = fileSystemService.tmpFilePath(encryptedFileName);
+          // Create an empty file so RNFS can write to it directly
+          await fileSystemService.createEmptyFile(encryptedFileURI);
 
           downloadJob = RNFS.downloadFile({
             fromUrl: downloadables[0].url,
@@ -251,6 +249,11 @@ export class NetworkFacade {
         }
 
         params.downloadProgressCallback(1, totalBytes, totalBytes);
+
+        // The encrypted file should exists at this path and has size, otherwise something went wrong
+        const encryptedFileExists = await fileSystemService.fileExistsAndIsNotEmpty(encryptedFileURI);
+
+        if (!encryptedFileExists) throw new Error('An error ocurred while downloading the file');
 
         await decryptFileFromFs(
           encryptedFileURI,

--- a/src/screens/PhotosPreviewScreen/index.tsx
+++ b/src/screens/PhotosPreviewScreen/index.tsx
@@ -366,12 +366,7 @@ function PhotosPreviewScreen({ navigation, route }: RootStackScreenProps<'Photos
 
   return (
     <>
-      <AppScreen
-        statusBarHidden
-        statusBarStyle="light"
-        backgroundColor={getColor('text-black')}
-        style={{ ...tailwind('h-full') }}
-      >
+      <AppScreen statusBarStyle="dark" backgroundColor={getColor('text-black')} style={{ ...tailwind('h-full') }}>
         <PhotoPreviewHeader />
         {isVideo ? renderVideoViewer() : renderImageViewer()}
 

--- a/src/screens/SignInScreen/index.tsx
+++ b/src/screens/SignInScreen/index.tsx
@@ -18,11 +18,13 @@ import AppTextInput from '../../components/AppTextInput';
 import useGetColor from '../../hooks/useColor';
 import AppText from 'src/components/AppText';
 import validationService from '@internxt-mobile/services/ValidationService';
+import { useKeyboard } from '@internxt-mobile/hooks/useKeyboard';
 
 function SignInScreen({ navigation }: RootStackScreenProps<'SignIn'>): JSX.Element {
   const tailwind = useTailwind();
   const getColor = useGetColor();
   const dispatch = useAppDispatch();
+  const { keyboardShown } = useKeyboard();
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isLoading, setIsLoading] = useState(false);
@@ -241,8 +243,7 @@ function SignInScreen({ navigation }: RootStackScreenProps<'SignIn'>): JSX.Eleme
             />
           </View>
         </View>
-
-        <AppVersionWidget displayLogo style={tailwind('mb-5 mt-auto')} />
+        {keyboardShown ? null : <AppVersionWidget displayLogo style={tailwind('mb-5 mt-auto')} />}
       </ScrollView>
     </AppScreen>
   );

--- a/src/screens/SignUpScreen/index.tsx
+++ b/src/screens/SignUpScreen/index.tsx
@@ -8,9 +8,11 @@ import { useTailwind } from 'tailwind-rn';
 import AppButton from '../../components/AppButton';
 import SignUpForm from '../../components/forms/SignUpForm';
 import AppVersionWidget from 'src/components/AppVersionWidget';
+import { useKeyboard } from '@internxt-mobile/hooks/useKeyboard';
 
 function SignUpScreen({ navigation }: RootStackScreenProps<'SignUp'>): JSX.Element {
   const tailwind = useTailwind();
+  const { keyboardShown } = useKeyboard();
   const onGoToSignInButtonPressed = () => {
     navigation.canGoBack() ? navigation.goBack() : navigation.replace('SignIn');
   };
@@ -57,8 +59,8 @@ function SignUpScreen({ navigation }: RootStackScreenProps<'SignUp'>): JSX.Eleme
           onPress={onGoToSignInButtonPressed}
           title={strings.buttons.sign_in}
         />
+        {keyboardShown ? null : <AppVersionWidget displayLogo style={tailwind('mb-5 mt-auto')} />}
       </ScrollView>
-      <AppVersionWidget displayLogo style={tailwind('mb-5 mt-auto')} />
     </AppScreen>
   );
 }

--- a/src/screens/drive/DrivePreviewScreen/DrivePreviewScreen.tsx
+++ b/src/screens/drive/DrivePreviewScreen/DrivePreviewScreen.tsx
@@ -208,10 +208,8 @@ export const DrivePreviewScreen: React.FC<RootStackScreenProps<'DrivePreview'>> 
       );
     }
 
-    if (renderVideoPreview) {
-      return (
-        <DriveVideoPreview thumbnail={generatedThumbnail?.path} source={downloadingFile.downloadedFilePath as string} />
-      );
+    if (renderVideoPreview && downloadingFile.downloadedFilePath) {
+      return <DriveVideoPreview thumbnail={generatedThumbnail?.path} source={downloadingFile.downloadedFilePath} />;
     }
 
     if (renderPdfPreview) {

--- a/src/screens/drive/DrivePreviewScreen/DriveVideoPreview.tsx
+++ b/src/screens/drive/DrivePreviewScreen/DriveVideoPreview.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import { fs } from '@internxt-mobile/services/FileSystemService';
+import React, { useEffect, useState } from 'react';
 import { View } from 'react-native';
 import Animated, { FadeInDown } from 'react-native-reanimated';
 import { VideoViewer } from 'src/components/photos/VideoViewer';
@@ -11,12 +12,30 @@ export interface DriveVideoPreviewProps {
 }
 
 export const DriveVideoPreview: React.FC<DriveVideoPreviewProps> = (props) => {
+  const [videoHasLoadError, setVideoHasLoadError] = useState(false);
   const tailwind = useTailwind();
 
+  useEffect(() => {
+    setVideoHasLoadError(false);
+  }, [props.source]);
+
+  const handleOnVideoPlay = async () => {
+    // Fallback to display native file viewer if the native video player load fails
+    if (videoHasLoadError) {
+      await fs.showFileViewer(props.source);
+    }
+  };
   return (
     <Animated.View entering={FadeInDown.delay(150).duration(250)} style={tailwind('flex-1')}>
       <View style={tailwind('flex-1')}>
-        <VideoViewer thumbnail={props.thumbnail} source={props.source} />
+        <VideoViewer
+          thumbnail={props.thumbnail}
+          source={props.source}
+          onPlay={handleOnVideoPlay}
+          onVideoLoadError={() => {
+            setVideoHasLoadError(true);
+          }}
+        />
       </View>
     </Animated.View>
   );

--- a/src/services/FileSystemService.ts
+++ b/src/services/FileSystemService.ts
@@ -158,6 +158,16 @@ class FileSystemService {
     return FileViewer.open(fileInfo.uri, options);
   }
 
+  public async fileExistsAndIsNotEmpty(uri: string): Promise<boolean> {
+    try {
+      const stat = await this.statRNFS(uri);
+
+      return stat.isFile() && stat.size !== 0;
+    } catch {
+      return false;
+    }
+  }
+
   public async mkdir(uri: string) {
     await RNFS.mkdir(uri);
   }

--- a/src/services/photos/network/photosNetwork.service.ts
+++ b/src/services/photos/network/photosNetwork.service.ts
@@ -33,6 +33,7 @@ export class PhotosNetworkService {
       { sortBy: PhotosSortBy.UpdatedAt, sortType: 'ASC' },
       skip,
       limit,
+      false,
     );
 
     return { results };

--- a/src/store/slices/drive/index.ts
+++ b/src/store/slices/drive/index.ts
@@ -20,8 +20,6 @@ import {
 } from '../../../types/drive';
 import fileSystemService from '../../../services/FileSystemService';
 import { items } from '@internxt/lib';
-import network from '../../../network';
-import _ from 'lodash';
 import drive from '@internxt-mobile/services/drive';
 import authService from 'src/services/AuthService';
 import errorService from 'src/services/ErrorService';


### PR DESCRIPTION
Fix not playable videos for Drive previews.

In some cases the native video player is not able to reproduce the video, usually due to codec incompatibility. on iOS we use AVFoundation, on Android ExoPlayer.

**Solution**

We detect when we cannot load the video in the in app player, when that happens, and the user taps on the play button, we prompt the user the native OS video player 