### PR TITLE
[_]: Bump version to 1.5.28

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -154,8 +154,8 @@ android {
         applicationId 'com.internxt.cloud'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 75
-        versionName "1.5.27"
+        versionCode 76
+        versionName "1.5.28"
         testBuildType System.getProperty('testBuildType', 'debug')  // This will later be used to control the test apk build type
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
   </queries>
   <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:allowBackup="true" android:theme="@style/AppTheme" android:usesCleartextTraffic="true" android:requestLegacyExternalStorage="true" android:roundIcon="@mipmap/ic_launcher_round">
     <meta-data android:name="expo.modules.updates.ENABLED" android:value="true"/>
-    <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="1.5.26"/>
+    <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="1.5.28"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS" android:value="0"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="https://u.expo.dev/680f4feb-6315-4a50-93ec-36dcd0b831d2"/>

--- a/ios/Internxt/Info.plist
+++ b/ios/Internxt/Info.plist
@@ -17,7 +17,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.5.26</string>
+    <string>1.5.28</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/ios/Internxt/Supporting/Expo.plist
+++ b/ios/Internxt/Supporting/Expo.plist
@@ -16,7 +16,7 @@
       <string>production</string>
     </dict>
     <key>EXUpdatesRuntimeVersion</key>
-    <string>1.5.26</string>
+    <string>1.5.28</string>
     <key>EXUpdatesURL</key>
     <string>https://u.expo.dev/680f4feb-6315-4a50-93ec-36dcd0b831d2</string>
   </dict>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drive-mobile",
-  "version": "v1.5.27",
+  "version": "v1.5.28",
   "private": true,
   "license": "GNU",
   "scripts": {


### PR DESCRIPTION
- Fix download file to device storage on Android 12+
- Encrypt private key correctly when modifying password