### PR TITLE
[_]:(fix) Make Photos cache key more reliable by using the ID

### DIFF
--- a/src/services/photos/sync/devicePhotosScanner/devicePhotosScanner.ts
+++ b/src/services/photos/sync/devicePhotosScanner/devicePhotosScanner.ts
@@ -123,7 +123,7 @@ export class DevicePhotosScannerService extends RunnableService<DevicePhotosScan
       if (asset.filename.includes('.')) {
         name = asset.filename.split('.')[0];
       }
-      const assetKey = `${name}-${asset.creationTime.toString()}`;
+      const assetKey = `${name}-${asset.id}`;
       this.cachedDevicePhotos[assetKey] = asset;
     });
   }


### PR DESCRIPTION
This PR switches the cache key for storing the Photos items in the memory while retrieving them. Creation time key was used before, but in production some photos with null values there exists (still unknown why) making the previous key not reliable.