### PR TITLE
[PB-570]: Fix/invalidate file cache correctly

### DIFF
--- a/ios/Internxt.xcodeproj/project.pbxproj
+++ b/ios/Internxt.xcodeproj/project.pbxproj
@@ -11,8 +11,8 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		1479274634F84D1E9DCCE0B4 /* noop-file.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFCCFD5298584EE79685BC74 /* noop-file.swift */; };
-		2479B7AF1A28734A4CEA6D62 /* libPods-Internxt.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 33565C8ECECFE0F9E1666E95 /* libPods-Internxt.a */; };
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
+		7F8824649FC19E533C24B176 /* libPods-Internxt.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0668B92339B644FF56D08AB8 /* libPods-Internxt.a */; };
 		B18059E884C0ABDD17F3DC3D /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC715A2D49A985799AEE119 /* ExpoModulesProvider.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
 /* End PBXBuildFile section */
@@ -20,15 +20,15 @@
 /* Begin PBXFileReference section */
 		008F07F21AC5B25A0029DE68 /* main.jsbundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = main.jsbundle; sourceTree = "<group>"; };
 		03362DABC9FA4C02928C30A5 /* Internxt-Bridging-Header.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; name = "Internxt-Bridging-Header.h"; path = "Internxt/Internxt-Bridging-Header.h"; sourceTree = "<group>"; };
+		0668B92339B644FF56D08AB8 /* libPods-Internxt.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Internxt.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07F961A680F5B00A75B9A /* Internxt.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Internxt.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = Internxt/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.mm; path = Internxt/AppDelegate.mm; sourceTree = "<group>"; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Internxt/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Internxt/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = Internxt/main.m; sourceTree = "<group>"; };
-		262CC3B19AC923BAF2E0DEAA /* Pods-Internxt.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.release.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.release.xcconfig"; sourceTree = "<group>"; };
-		33565C8ECECFE0F9E1666E95 /* libPods-Internxt.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Internxt.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8824BD7A75B06A5E02BBDE4D /* Pods-Internxt.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.debug.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.debug.xcconfig"; sourceTree = "<group>"; };
+		7EE78F580B67F3F40FA65CC0 /* Pods-Internxt.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.debug.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.debug.xcconfig"; sourceTree = "<group>"; };
+		8D77959ABFFFABC656A246B1 /* Pods-Internxt.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.release.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.release.xcconfig"; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = Internxt/SplashScreen.storyboard; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
@@ -41,7 +41,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2479B7AF1A28734A4CEA6D62 /* libPods-Internxt.a in Frameworks */,
+				7F8824649FC19E533C24B176 /* libPods-Internxt.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -69,7 +69,7 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				33565C8ECECFE0F9E1666E95 /* libPods-Internxt.a */,
+				0668B92339B644FF56D08AB8 /* libPods-Internxt.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -124,8 +124,8 @@
 		D65327D7A22EEC0BE12398D9 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				8824BD7A75B06A5E02BBDE4D /* Pods-Internxt.debug.xcconfig */,
-				262CC3B19AC923BAF2E0DEAA /* Pods-Internxt.release.xcconfig */,
+				7EE78F580B67F3F40FA65CC0 /* Pods-Internxt.debug.xcconfig */,
+				8D77959ABFFFABC656A246B1 /* Pods-Internxt.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -145,14 +145,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "Internxt" */;
 			buildPhases = (
-				4DD8F6FF8D1F02CABA96BEB9 /* [CP] Check Pods Manifest.lock */,
+				D824CA3D9F87A0654082C467 /* [CP] Check Pods Manifest.lock */,
 				FD10A7F022414F080027D42C /* Start Packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				C0ABA4564B7F48269ACCB374 /* Upload Debug Symbols to Sentry */,
-				0C041770D811CE89DB35697C /* [CP] Copy Pods Resources */,
+				0EFAC58C8123D5B8291601C4 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -224,7 +224,7 @@
 			shellPath = /bin/sh;
 			shellScript = "export SENTRY_PROPERTIES=sentry.properties\nexport EXTRA_PACKAGER_ARGS=\"--sourcemap-output $DERIVED_FILE_DIR/main.jsbundle.map\"\nexport NODE_BINARY=node\n../node_modules/@sentry/cli/bin/sentry-cli react-native xcode ../node_modules/react-native/scripts/react-native-xcode.sh\n";
 		};
-		0C041770D811CE89DB35697C /* [CP] Copy Pods Resources */ = {
+		0EFAC58C8123D5B8291601C4 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -246,7 +246,21 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Internxt/Pods-Internxt-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		4DD8F6FF8D1F02CABA96BEB9 /* [CP] Check Pods Manifest.lock */ = {
+		C0ABA4564B7F48269ACCB374 /* Upload Debug Symbols to Sentry */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 12;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Upload Debug Symbols to Sentry";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export SENTRY_PROPERTIES=sentry.properties\n../node_modules/@sentry/cli/bin/sentry-cli upload-dsym\n";
+		};
+		D824CA3D9F87A0654082C467 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -267,20 +281,6 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
-		};
-		C0ABA4564B7F48269ACCB374 /* Upload Debug Symbols to Sentry */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 12;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Upload Debug Symbols to Sentry";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "export SENTRY_PROPERTIES=sentry.properties\n../node_modules/@sentry/cli/bin/sentry-cli upload-dsym\n";
 		};
 		FD10A7F022414F080027D42C /* Start Packager */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -320,7 +320,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8824BD7A75B06A5E02BBDE4D /* Pods-Internxt.debug.xcconfig */;
+			baseConfigurationReference = 7EE78F580B67F3F40FA65CC0 /* Pods-Internxt.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -357,7 +357,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 262CC3B19AC923BAF2E0DEAA /* Pods-Internxt.release.xcconfig */;
+			baseConfigurationReference = 8D77959ABFFFABC656A246B1 /* Pods-Internxt.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import fileSystemService from './services/FileSystemService';
 import { PhotosContextProvider } from './contexts/Photos';
 import errorService from './services/ErrorService';
-import { DriveContextProvider, removeOldItemsFromLocalDB } from './contexts/Drive/Drive.context';
+import { DriveContextProvider, getModifiedDriveItems } from './contexts/Drive/Drive.context';
 import { LockScreen } from './screens/common/LockScreen';
 import { logger } from './services/common';
 import { time } from './services/common/time';
@@ -78,7 +78,7 @@ export default function App(): JSX.Element {
   const onPlansModalClosed = () => dispatch(uiActions.setIsPlansModalOpen(false));
   const handleAppStateChange = (state: AppStateStatus) => {
     if (state === 'active') {
-      removeOldItemsFromLocalDB();
+      getModifiedDriveItems();
       dispatch(appActions.setLastScreenLock(Date.now()));
       dispatch(authThunks.refreshTokensThunk());
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,6 +78,7 @@ export default function App(): JSX.Element {
   const onPlansModalClosed = () => dispatch(uiActions.setIsPlansModalOpen(false));
   const handleAppStateChange = (state: AppStateStatus) => {
     if (state === 'active') {
+      // TODO: Check the cache and remove the items if they are old
       dispatch(appActions.setLastScreenLock(Date.now()));
       dispatch(authThunks.refreshTokensThunk());
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import fileSystemService from './services/FileSystemService';
 import { PhotosContextProvider } from './contexts/Photos';
 import errorService from './services/ErrorService';
-import { DriveContextProvider, getModifiedDriveItemsAndUpdateLocalCache } from './contexts/Drive/Drive.context';
+import { DriveContextProvider } from './contexts/Drive/Drive.context';
 import { LockScreen } from './screens/common/LockScreen';
 import { logger } from './services/common';
 import { time } from './services/common/time';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import fileSystemService from './services/FileSystemService';
 import { PhotosContextProvider } from './contexts/Photos';
 import errorService from './services/ErrorService';
-import { DriveContextProvider, getModifiedDriveItems } from './contexts/Drive/Drive.context';
+import { DriveContextProvider, getModifiedDriveItemsAndUpdateLocalCache } from './contexts/Drive/Drive.context';
 import { LockScreen } from './screens/common/LockScreen';
 import { logger } from './services/common';
 import { time } from './services/common/time';
@@ -78,7 +78,7 @@ export default function App(): JSX.Element {
   const onPlansModalClosed = () => dispatch(uiActions.setIsPlansModalOpen(false));
   const handleAppStateChange = (state: AppStateStatus) => {
     if (state === 'active') {
-      getModifiedDriveItems();
+      getModifiedDriveItemsAndUpdateLocalCache();
       dispatch(appActions.setLastScreenLock(Date.now()));
       dispatch(authThunks.refreshTokensThunk());
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,7 +78,6 @@ export default function App(): JSX.Element {
   const onPlansModalClosed = () => dispatch(uiActions.setIsPlansModalOpen(false));
   const handleAppStateChange = (state: AppStateStatus) => {
     if (state === 'active') {
-      getModifiedDriveItemsAndUpdateLocalCache();
       dispatch(appActions.setLastScreenLock(Date.now()));
       dispatch(authThunks.refreshTokensThunk());
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import fileSystemService from './services/FileSystemService';
 import { PhotosContextProvider } from './contexts/Photos';
 import errorService from './services/ErrorService';
-import { DriveContextProvider, checkIfItemsShouldBeDeletedFromLocalDB } from './contexts/Drive/Drive.context';
+import { DriveContextProvider, removeOldItemsFromLocalDB } from './contexts/Drive/Drive.context';
 import { LockScreen } from './screens/common/LockScreen';
 import { logger } from './services/common';
 import { time } from './services/common/time';
@@ -78,7 +78,7 @@ export default function App(): JSX.Element {
   const onPlansModalClosed = () => dispatch(uiActions.setIsPlansModalOpen(false));
   const handleAppStateChange = (state: AppStateStatus) => {
     if (state === 'active') {
-      checkIfItemsShouldBeDeletedFromLocalDB();
+      removeOldItemsFromLocalDB();
       dispatch(appActions.setLastScreenLock(Date.now()));
       dispatch(authThunks.refreshTokensThunk());
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import fileSystemService from './services/FileSystemService';
 import { PhotosContextProvider } from './contexts/Photos';
 import errorService from './services/ErrorService';
-import { DriveContextProvider } from './contexts/Drive/Drive.context';
+import { DriveContextProvider, checkIfItemsShouldBeDeletedFromLocalDB } from './contexts/Drive/Drive.context';
 import { LockScreen } from './screens/common/LockScreen';
 import { logger } from './services/common';
 import { time } from './services/common/time';
@@ -78,7 +78,7 @@ export default function App(): JSX.Element {
   const onPlansModalClosed = () => dispatch(uiActions.setIsPlansModalOpen(false));
   const handleAppStateChange = (state: AppStateStatus) => {
     if (state === 'active') {
-      // TODO: Check the cache and remove the items if they are old
+      checkIfItemsShouldBeDeletedFromLocalDB();
       dispatch(appActions.setLastScreenLock(Date.now()));
       dispatch(authThunks.refreshTokensThunk());
     }

--- a/src/contexts/Drive/Drive.context.tsx
+++ b/src/contexts/Drive/Drive.context.tsx
@@ -104,7 +104,10 @@ export const DriveContextProvider: React.FC<DriveContextProviderProps> = ({ chil
 
   const handleAppStateChange = async (state: AppStateStatus) => {
     if (state === 'active') {
-      if (currentFolderId.current) await loadFolderContent(currentFolderId.current, { pullFrom: ['network'] });
+      if (currentFolderId.current)
+        loadFolderContent(currentFolderId.current, { pullFrom: ['network'] }).catch((error) => {
+          errorService.reportError(error);
+        });
     }
   };
 

--- a/src/contexts/Drive/Drive.context.tsx
+++ b/src/contexts/Drive/Drive.context.tsx
@@ -49,7 +49,7 @@ const logger = new BaseLogger({
   tag: 'DRIVE_CONTEXT',
 });
 
-export const checkIfItemsShouldBeDeletedFromLocalDB = async () => {
+export const removeOldItemsFromLocalDB = async () => {
   const lastUpdatedAt = (await asyncStorageService.getItem(AsyncStorageKey.LastUpdatedAt)) || new Date().toISOString();
 
   const [modifiedFiles, modifiedFolders] = await Promise.all([
@@ -148,7 +148,7 @@ export const DriveContextProvider: React.FC<DriveContextProviderProps> = ({ chil
         logger.info(`FOLDER-${folderId} - FROM CACHE`);
 
         // Check if the items have been modified from another platform
-        checkIfItemsShouldBeDeletedFromLocalDB().catch((error) => {
+        removeOldItemsFromLocalDB().catch((error) => {
           errorService.reportError(error);
         });
 

--- a/src/contexts/Drive/Drive.context.tsx
+++ b/src/contexts/Drive/Drive.context.tsx
@@ -130,12 +130,14 @@ export const DriveContextProvider: React.FC<DriveContextProviderProps> = ({ chil
 
     folderContentFromDB?.files?.forEach((file: DriveFileData) => {
       const fileModified = parsedModifiedFiles?.find((item: DriveFileData) => item.id === file.id);
-      if (fileModified.status === 'TRASHED') {
-        driveLocalDB.deleteItem({ id: file.id });
-        // Remove item from the array
-        folderContentFromDB.files = folderContentFromDB.files.filter((item) => item.id !== file.id);
-      } else if (fileModified) {
-        file = fileModified;
+      if (fileModified) {
+        if (fileModified.status === 'TRASHED' || fileModified.status === 'REMOVED') {
+          driveLocalDB.deleteItem({ id: file.id });
+          // Remove item from the array
+          folderContentFromDB.files = folderContentFromDB.files.filter((item) => item.id !== file.id);
+        } else if (fileModified === 'EXISTS') {
+          file = fileModified;
+        }
       }
     });
 
@@ -143,7 +145,13 @@ export const DriveContextProvider: React.FC<DriveContextProviderProps> = ({ chil
       folderContentFromDB.children.forEach((folder: FolderContentChild) => {
         const folderModified = parsedModifiedFolders?.find((item: DriveFileData) => item.id === folder.id);
         if (folderModified) {
-          folder = folderModified;
+          if (folderModified.status === 'TRASHED' || folderModified.status === 'REMOVED') {
+            driveLocalDB.deleteItem({ id: folder.id });
+            // Remove item from the array
+            folderContentFromDB.children = folderContentFromDB.children.filter((item) => item.id !== folder.id);
+          } else if (folderModified.status === 'EXISTS') {
+            folder = folderModified;
+          }
         }
       });
     }

--- a/src/contexts/Drive/Drive.context.tsx
+++ b/src/contexts/Drive/Drive.context.tsx
@@ -88,7 +88,7 @@ export const DriveContextProvider: React.FC<DriveContextProviderProps> = ({ chil
   // 2.1 Get the recently modified files
   // 2.2 Get the recently modified folders
   // 3. Compare the recently modified items with the ones in the local cache (files or folders)
-  // 3. Remove the modified items from the local cache (files or folders)
+  // 4. Remove the modified items from the local cache (files or folders)
 
   const checkIfItemShouldBeUpdatedOrDeleted = async (folderContentFromDB: FolderContent) => {
     if (folderContentFromDB.files.length > 0) {

--- a/src/contexts/Drive/Drive.context.tsx
+++ b/src/contexts/Drive/Drive.context.tsx
@@ -61,23 +61,22 @@ export const removeOldItemsFromLocalDB = async () => {
       updatedAt: lastUpdatedAt,
       status: 'ALL',
     }),
-  ]);
+  ]).catch((error) => {
+    errorService.reportError(error);
+    return [[], []];
+  });
 
-  if (!modifiedFiles || !modifiedFolders) return;
+  if (!modifiedFiles || !modifiedFolders || (!modifiedFiles.length && !modifiedFolders.length)) return;
 
   const modifiedFilesIds = modifiedFiles.map((file) => file.id);
   const modifiedFoldersIds = modifiedFolders.map((folder) => folder.id);
 
-  modifiedFilesIds.forEach((fileId) => {
-    driveLocalDB.deleteItem({ id: fileId }).catch((error) => {
-      errorService.reportError(error);
-    });
+  modifiedFilesIds.forEach(async (fileId) => {
+    await driveLocalDB.deleteItem({ id: fileId });
   });
 
-  modifiedFoldersIds.forEach((folderId) => {
-    driveLocalDB.deleteFolderRecord(folderId).catch((error) => {
-      errorService.reportError(error);
-    });
+  modifiedFoldersIds.forEach(async (folderId) => {
+    await driveLocalDB.deleteFolderRecord(folderId);
   });
 
   // Get the last updatedAt date from the modified files and folders

--- a/src/contexts/Drive/Drive.context.tsx
+++ b/src/contexts/Drive/Drive.context.tsx
@@ -17,8 +17,6 @@ import { driveLocalDB } from '@internxt-mobile/services/drive/database';
 import { BaseLogger } from '@internxt-mobile/services/common';
 import { getHeaders } from 'src/helpers/headers';
 import { constants } from '@internxt-mobile/services/AppService';
-import moment from 'moment';
-import sentryService from '@internxt-mobile/services/SentryService';
 
 type DriveFoldersTree = {
   [folderId: number]:

--- a/src/contexts/Drive/Drive.context.tsx
+++ b/src/contexts/Drive/Drive.context.tsx
@@ -48,6 +48,52 @@ interface DriveContextProviderProps {
 const logger = new BaseLogger({
   tag: 'DRIVE_CONTEXT',
 });
+
+export const checkIfItemsShouldBeDeletedFromLocalDB = async () => {
+  const lastUpdatedAt = (await asyncStorageService.getItem(AsyncStorageKey.LastUpdatedAt)) || new Date().toISOString();
+
+  const [modifiedFiles, modifiedFolders] = await Promise.all([
+    driveFileService.getModifiedFiles({
+      updatedAt: lastUpdatedAt,
+      status: 'ALL',
+    }),
+    driveFolderService.getModifiedFolders({
+      updatedAt: lastUpdatedAt,
+      status: 'ALL',
+    }),
+  ]);
+
+  if (!modifiedFiles || !modifiedFolders) return;
+
+  const modifiedFilesIds = modifiedFiles.map((file) => file.id);
+  const modifiedFoldersIds = modifiedFolders.map((folder) => folder.id);
+
+  modifiedFilesIds.forEach((fileId) => {
+    driveLocalDB.deleteItem({ id: fileId }).catch((error) => {
+      errorService.reportError(error);
+    });
+  });
+
+  modifiedFoldersIds.forEach((folderId) => {
+    driveLocalDB.deleteFolderRecord(folderId).catch((error) => {
+      errorService.reportError(error);
+    });
+  });
+
+  // Get the last updatedAt date from the modified files and folders
+  let lastUpdatedAtFromModifiedFiles;
+  let lastUpdatedAtFromModifiedFolders;
+
+  if (modifiedFiles.length) lastUpdatedAtFromModifiedFiles = _.maxBy(modifiedFiles, 'updatedAt')?.updatedAt;
+  if (modifiedFolders.length)
+    lastUpdatedAtFromModifiedFolders = _.maxBy(modifiedFolders, 'updatedAt')?.updatedAt.toString();
+
+  // Get the most recent date
+  const newLastUpdatedAt = _.max([lastUpdatedAtFromModifiedFiles, lastUpdatedAtFromModifiedFolders]);
+
+  await asyncStorageService.saveItem(AsyncStorageKey.LastUpdatedAt, newLastUpdatedAt || new Date().toISOString());
+};
+
 export const DriveContextProvider: React.FC<DriveContextProviderProps> = ({ children, rootFolderId }) => {
   const [viewMode, setViewMode] = useState(DriveListViewMode.List);
   const [driveFoldersTree, setDriveFoldersTree] = useState<DriveFoldersTree>({});
@@ -79,54 +125,6 @@ export const DriveContextProvider: React.FC<DriveContextProviderProps> = ({ chil
     return driveUseCases.getFolderContent({ folderId });
   };
 
-  const checkIfItemShouldBeUpdatedOrDeleted = async () => {
-    const lastUpdatedAt =
-      (await asyncStorageService.getItem(AsyncStorageKey.LastUpdatedAt)) || new Date().toISOString();
-
-    const [modifiedFiles, modifiedFolders] = await Promise.all([
-      driveFileService.getModifiedFiles({
-        updatedAt: lastUpdatedAt,
-        status: 'ALL',
-      }),
-      driveFolderService.getModifiedFolders({
-        updatedAt: lastUpdatedAt,
-        status: 'ALL',
-      }),
-    ]);
-
-    if (!modifiedFiles || !modifiedFolders) return;
-
-    const modifiedFilesIds = modifiedFiles.map((file) => file.id);
-    const modifiedFoldersIds = modifiedFolders.map((folder) => folder.id);
-
-    modifiedFilesIds.forEach((fileId) => {
-      driveLocalDB.deleteItem({ id: fileId }).catch((error) => {
-        errorService.reportError(error);
-      });
-    });
-
-    modifiedFoldersIds.forEach((folderId) => {
-      driveLocalDB.deleteFolderRecord(folderId).catch((error) => {
-        errorService.reportError(error);
-      });
-    });
-
-    // Get the last updated at date from the modified files and folders
-    let lastUpdatedAtFromModifiedFiles;
-    let lastUpdatedAtFromModifiedFolders;
-
-    if (modifiedFiles.length) lastUpdatedAtFromModifiedFiles = _.maxBy(modifiedFiles, 'updatedAt')?.updatedAt;
-    if (modifiedFolders.length)
-      lastUpdatedAtFromModifiedFolders = _.maxBy(modifiedFolders, 'updatedAt')?.updatedAt.toString();
-
-    // Get the most recent date
-    const newLastUpdatedAt = _.max([lastUpdatedAtFromModifiedFiles, lastUpdatedAtFromModifiedFolders]);
-
-    await asyncStorageService.saveItem(AsyncStorageKey.LastUpdatedAt, newLastUpdatedAt || new Date().toISOString());
-
-    // Get the id of the files and folders that have been modified
-  };
-
   /**
    * load the folder content so
    * the next folder will be loaded quickly
@@ -150,7 +148,7 @@ export const DriveContextProvider: React.FC<DriveContextProviderProps> = ({ chil
         logger.info(`FOLDER-${folderId} - FROM CACHE`);
 
         // Check if the items have been modified from another platform
-        checkIfItemShouldBeUpdatedOrDeleted().catch((error) => {
+        checkIfItemsShouldBeDeletedFromLocalDB().catch((error) => {
           errorService.reportError(error);
         });
 

--- a/src/contexts/Drive/Drive.context.tsx
+++ b/src/contexts/Drive/Drive.context.tsx
@@ -57,7 +57,7 @@ export const DriveContextProvider: React.FC<DriveContextProviderProps> = ({ chil
   const [currentFolder, setCurrentFolder] = useState<FetchFolderContentResponseWithThumbnails | null>(null);
   const currentFolderId = useRef<number | null>(null);
   const onAppStateChangeListener = useRef<NativeEventSubscription | null>(null);
-  const handleAppStateChange = async (state: AppStateStatus) => {
+  const handleAppStateChange = (state: AppStateStatus) => {
     if (state === 'active' && currentFolderId.current) {
       loadFolderContent(currentFolderId.current, { pullFrom: ['network'] }).catch((error) => {
         errorService.reportError(error);

--- a/src/contexts/Drive/Drive.context.tsx
+++ b/src/contexts/Drive/Drive.context.tsx
@@ -49,7 +49,7 @@ const logger = new BaseLogger({
   tag: 'DRIVE_CONTEXT',
 });
 
-export const removeOldItemsFromLocalDB = async () => {
+export const getModifiedDriveItems = async () => {
   const lastUpdatedAt = (await asyncStorageService.getItem(AsyncStorageKey.LastUpdatedAt)) || new Date().toISOString();
 
   const [modifiedFiles, modifiedFolders] = await Promise.all([
@@ -147,7 +147,7 @@ export const DriveContextProvider: React.FC<DriveContextProviderProps> = ({ chil
         logger.info(`FOLDER-${folderId} - FROM CACHE`);
 
         // Check if the items have been modified from another platform
-        removeOldItemsFromLocalDB().catch((error) => {
+        getModifiedDriveItems().catch((error) => {
           errorService.reportError(error);
         });
 

--- a/src/contexts/Drive/Drive.context.tsx
+++ b/src/contexts/Drive/Drive.context.tsx
@@ -52,7 +52,7 @@ const logger = new BaseLogger({
 });
 
 export const getModifiedDriveItemsAndUpdateLocalCache = async () => {
-  const lastUpdatedAt = (await asyncStorageService.getItem(AsyncStorageKey.LastUpdatedAt)) || new Date().toISOString();
+  const lastUpdatedAt = (await asyncStorageService.getItem(AsyncStorageKey.LastUpdatedAt)) ?? new Date().toISOString();
 
   const [modifiedFiles, modifiedFolders] = await Promise.all([
     driveFileService.getModifiedFiles({
@@ -93,7 +93,7 @@ export const getModifiedDriveItemsAndUpdateLocalCache = async () => {
   // Get the most recent date
   const newLastUpdatedAt = _.max([lastUpdatedAtFromModifiedFiles, lastUpdatedAtFromModifiedFolders]);
 
-  await asyncStorageService.saveItem(AsyncStorageKey.LastUpdatedAt, newLastUpdatedAt || new Date().toISOString());
+  await asyncStorageService.saveItem(AsyncStorageKey.LastUpdatedAt, newLastUpdatedAt ?? new Date().toISOString());
 };
 
 export const DriveContextProvider: React.FC<DriveContextProviderProps> = ({ children, rootFolderId }) => {
@@ -112,7 +112,7 @@ export const DriveContextProvider: React.FC<DriveContextProviderProps> = ({ chil
     const listener = appService.onAppStateChange(handleAppStateChange);
 
     return () => {
-      listener && listener.remove();
+      if (listener) listener.remove();
     };
   }, []);
 

--- a/src/contexts/Drive/Drive.context.tsx
+++ b/src/contexts/Drive/Drive.context.tsx
@@ -49,7 +49,7 @@ const logger = new BaseLogger({
   tag: 'DRIVE_CONTEXT',
 });
 
-export const getModifiedDriveItems = async () => {
+export const getModifiedDriveItemsAndUpdateLocalCache = async () => {
   const lastUpdatedAt = (await asyncStorageService.getItem(AsyncStorageKey.LastUpdatedAt)) || new Date().toISOString();
 
   const [modifiedFiles, modifiedFolders] = await Promise.all([
@@ -84,6 +84,7 @@ export const getModifiedDriveItems = async () => {
   let lastUpdatedAtFromModifiedFolders;
 
   if (modifiedFiles.length) lastUpdatedAtFromModifiedFiles = _.maxBy(modifiedFiles, 'updatedAt')?.updatedAt;
+
   if (modifiedFolders.length)
     lastUpdatedAtFromModifiedFolders = _.maxBy(modifiedFolders, 'updatedAt')?.updatedAt.toString();
 
@@ -147,7 +148,7 @@ export const DriveContextProvider: React.FC<DriveContextProviderProps> = ({ chil
         logger.info(`FOLDER-${folderId} - FROM CACHE`);
 
         // Check if the items have been modified from another platform
-        getModifiedDriveItems().catch((error) => {
+        getModifiedDriveItemsAndUpdateLocalCache().catch((error) => {
           errorService.reportError(error);
         });
 

--- a/src/contexts/Drive/Drive.context.tsx
+++ b/src/contexts/Drive/Drive.context.tsx
@@ -97,7 +97,10 @@ export const DriveContextProvider: React.FC<DriveContextProviderProps> = ({ chil
   }) => {
     const query = `status=${status}&offset=${offset}&limit=${limit}${updatedAt && `&updatedAt=${updatedAt}`}`;
     const newToken = await asyncStorageService.getItem(AsyncStorageKey.PhotosToken);
-    const headers = await getHeaders(newToken as string);
+
+    if (!newToken) return;
+
+    const headers = await getHeaders(newToken);
 
     try {
       const modifiedItems = await fetch(`${constants.DRIVE_NEW_API_URL}/${itemsType}?${query}`, {
@@ -107,11 +110,12 @@ export const DriveContextProvider: React.FC<DriveContextProviderProps> = ({ chil
 
       return modifiedItems;
     } catch (error) {
-      console.log('ERROR: ', error);
+      errorService.reportError(error);
     }
   };
 
   const checkIfItemShouldBeUpdatedOrDeleted = async (folderContentFromDB: FolderContent) => {
+    // 1. Get the modified items from the server
     const [modifiedFiles, modifiedFolders] = await Promise.all([
       getModifiedItems({
         itemsType: 'files',
@@ -128,7 +132,16 @@ export const DriveContextProvider: React.FC<DriveContextProviderProps> = ({ chil
     const parsedModifiedFiles = await modifiedFiles?.json();
     const parsedModifiedFolders = await modifiedFolders?.json();
 
-    folderContentFromDB?.files?.forEach((file: DriveFileData) => {
+    if (
+      !parsedModifiedFiles ||
+      !parsedModifiedFolders ||
+      folderContentFromDB.children.length === 0 ||
+      folderContentFromDB.files.length === 0
+    ) {
+      return;
+    }
+
+    folderContentFromDB.files.forEach((file: DriveFileData) => {
       const fileModified = parsedModifiedFiles?.find((item: DriveFileData) => item.id === file.id);
       if (fileModified) {
         if (fileModified.status === 'TRASHED' || fileModified.status === 'REMOVED') {
@@ -141,20 +154,18 @@ export const DriveContextProvider: React.FC<DriveContextProviderProps> = ({ chil
       }
     });
 
-    if (folderContentFromDB.children.length > 0) {
-      folderContentFromDB.children.forEach((folder: FolderContentChild) => {
-        const folderModified = parsedModifiedFolders?.find((item: DriveFileData) => item.id === folder.id);
-        if (folderModified) {
-          if (folderModified.status === 'TRASHED' || folderModified.status === 'REMOVED') {
-            driveLocalDB.deleteItem({ id: folder.id });
-            // Remove item from the array
-            folderContentFromDB.children = folderContentFromDB.children.filter((item) => item.id !== folder.id);
-          } else if (folderModified.status === 'EXISTS') {
-            folder = folderModified;
-          }
+    folderContentFromDB.children.forEach((folder: FolderContentChild) => {
+      const folderModified = parsedModifiedFolders?.find((item: DriveFileData) => item.id === folder.id);
+      if (folderModified) {
+        if (folderModified.status === 'TRASHED' || folderModified.status === 'REMOVED') {
+          driveLocalDB.deleteItem({ id: folder.id });
+          // Remove item from the array
+          folderContentFromDB.children = folderContentFromDB.children.filter((item) => item.id !== folder.id);
+        } else if (folderModified.status === 'EXISTS') {
+          folder = folderModified;
         }
-      });
-    }
+      }
+    });
   };
 
   /**
@@ -179,6 +190,7 @@ export const DriveContextProvider: React.FC<DriveContextProviderProps> = ({ chil
       if (folderContentFromDB) {
         logger.info(`FOLDER-${folderId} - FROM CACHE`);
 
+        // Check if the items have been modified from another platform
         checkIfItemShouldBeUpdatedOrDeleted(folderContentFromDB)
           .then(() => {
             updateDriveFoldersTree({
@@ -188,7 +200,6 @@ export const DriveContextProvider: React.FC<DriveContextProviderProps> = ({ chil
             });
           })
           .catch((error) => {
-            console.log('ERROR: ', error);
             errorService.reportError(error);
           });
       }

--- a/src/contexts/Drive/helpers.ts
+++ b/src/contexts/Drive/helpers.ts
@@ -1,0 +1,52 @@
+import { driveFileService } from '@internxt-mobile/services/drive/file';
+import { driveFolderService } from '@internxt-mobile/services/drive/folder';
+import asyncStorageService from '@internxt-mobile/services/AsyncStorageService';
+import { AsyncStorageKey } from '@internxt-mobile/types/index';
+import { driveLocalDB } from '@internxt-mobile/services/drive/database';
+import errorService from '@internxt-mobile/services/ErrorService';
+import _ from 'lodash';
+
+export const getModifiedDriveItemsAndUpdateLocalCache = async () => {
+  const lastUpdatedAt = (await asyncStorageService.getItem(AsyncStorageKey.LastUpdatedAt)) ?? new Date().toISOString();
+
+  const [modifiedFiles, modifiedFolders] = await Promise.all([
+    driveFileService.getModifiedFiles({
+      updatedAt: lastUpdatedAt,
+      status: 'ALL',
+    }),
+    driveFolderService.getModifiedFolders({
+      updatedAt: lastUpdatedAt,
+      status: 'ALL',
+    }),
+  ]).catch((error) => {
+    errorService.reportError(error);
+    return [[], []];
+  });
+
+  if (!modifiedFiles || !modifiedFolders || (!modifiedFiles.length && !modifiedFolders.length)) return;
+
+  const modifiedFilesIds = modifiedFiles.map((file) => file.id);
+  const modifiedFoldersIds = modifiedFolders.map((folder) => folder.id);
+
+  for (const modifiedFileId of modifiedFilesIds) {
+    await driveLocalDB.deleteItem({ id: modifiedFileId });
+  }
+
+  for (const modifiedFolderId of modifiedFoldersIds) {
+    await driveLocalDB.deleteFolderRecord(modifiedFolderId);
+  }
+
+  // Get the last updatedAt date from the modified files and folders
+  let lastUpdatedAtFromModifiedFiles;
+  let lastUpdatedAtFromModifiedFolders;
+
+  if (modifiedFiles.length) lastUpdatedAtFromModifiedFiles = _.maxBy(modifiedFiles, 'updatedAt')?.updatedAt;
+
+  if (modifiedFolders.length)
+    lastUpdatedAtFromModifiedFolders = _.maxBy(modifiedFolders, 'updatedAt')?.updatedAt.toString();
+
+  // Get the most recent date
+  const newLastUpdatedAt = _.max([lastUpdatedAtFromModifiedFiles, lastUpdatedAtFromModifiedFolders]);
+
+  await asyncStorageService.saveItem(AsyncStorageKey.LastUpdatedAt, newLastUpdatedAt ?? new Date().toISOString());
+};

--- a/src/services/drive/file/driveFile.service.ts
+++ b/src/services/drive/file/driveFile.service.ts
@@ -14,7 +14,7 @@ import { getHeaders } from '../../../helpers/headers';
 import { constants } from '../../AppService';
 
 import { SdkManager } from '@internxt-mobile/services/common';
-import { DriveFileData, MoveFileResponse, Thumbnail } from '@internxt/sdk/dist/drive/storage/types';
+import { MoveFileResponse, Thumbnail } from '@internxt/sdk/dist/drive/storage/types';
 import { getEnvironmentConfig } from 'src/lib/network';
 import { DRIVE_THUMBNAILS_DIRECTORY } from '../constants';
 import fileSystemService, { fs } from '@internxt-mobile/services/FileSystemService';
@@ -24,7 +24,6 @@ import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import { driveFileCache } from './driveFileCache.service';
 import { Abortable, AsyncStorageKey } from '@internxt-mobile/types/index';
 import asyncStorageService from '@internxt-mobile/services/AsyncStorageService';
-import errorService from '@internxt-mobile/services/ErrorService';
 
 export type ArraySortFunction = (a: DriveListItem, b: DriveListItem) => number;
 export type DriveFileDownloadOptions = {
@@ -247,7 +246,8 @@ class DriveFileService {
     updatedAt?: string;
     status: 'ALL' | 'TRASHED' | 'REMOVED';
   }): Promise<GetModifiedFiles[] | undefined> {
-    const query = `status=${status}&offset=${offset}&limit=${limit}${updatedAt && `&updatedAt=${updatedAt}`}`;
+    const updatedAtDate = updatedAt && `&updatedAt=${updatedAt}`;
+    const query = `status=${status}&offset=${offset}&limit=${limit}${updatedAtDate}`;
     const newToken = await asyncStorageService.getItem(AsyncStorageKey.PhotosToken);
 
     if (!newToken) return;

--- a/src/services/drive/file/driveFile.service.ts
+++ b/src/services/drive/file/driveFile.service.ts
@@ -254,18 +254,14 @@ class DriveFileService {
 
     const headers = await getHeaders(newToken);
 
-    try {
-      const modifiedItems = await fetch(`${constants.DRIVE_NEW_API_URL}/files?${query}`, {
-        method: 'GET',
-        headers,
-      });
+    const modifiedItems = await fetch(`${constants.DRIVE_NEW_API_URL}/files?${query}`, {
+      method: 'GET',
+      headers,
+    });
 
-      const parsedModifiedFiles = await modifiedItems.json();
+    const parsedModifiedFiles = await modifiedItems.json();
 
-      return parsedModifiedFiles;
-    } catch (error) {
-      errorService.reportError(error);
-    }
+    return parsedModifiedFiles;
   }
 
   public async getThumbnail(thumbnail: Thumbnail) {

--- a/src/services/drive/file/driveFile.service.ts
+++ b/src/services/drive/file/driveFile.service.ts
@@ -6,6 +6,7 @@ import {
   DriveFileMetadataPayload,
   DriveItemData,
   DriveListItem,
+  GetModifiedFiles,
   SortDirection,
   SortType,
 } from '../../../types/drive';
@@ -13,7 +14,7 @@ import { getHeaders } from '../../../helpers/headers';
 import { constants } from '../../AppService';
 
 import { SdkManager } from '@internxt-mobile/services/common';
-import { MoveFileResponse, Thumbnail } from '@internxt/sdk/dist/drive/storage/types';
+import { DriveFileData, MoveFileResponse, Thumbnail } from '@internxt/sdk/dist/drive/storage/types';
 import { getEnvironmentConfig } from 'src/lib/network';
 import { DRIVE_THUMBNAILS_DIRECTORY } from '../constants';
 import fileSystemService, { fs } from '@internxt-mobile/services/FileSystemService';
@@ -21,7 +22,9 @@ import network from 'src/network';
 import { Image } from 'react-native';
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import { driveFileCache } from './driveFileCache.service';
-import { Abortable } from '@internxt-mobile/types/index';
+import { Abortable, AsyncStorageKey } from '@internxt-mobile/types/index';
+import asyncStorageService from '@internxt-mobile/services/AsyncStorageService';
+import errorService from '@internxt-mobile/services/ErrorService';
 
 export type ArraySortFunction = (a: DriveListItem, b: DriveListItem) => number;
 export type DriveFileDownloadOptions = {
@@ -231,6 +234,38 @@ class DriveFileService {
       },
       { headers: headersMap },
     );
+  }
+
+  public async getModifiedFiles({
+    limit = 50,
+    offset = 0,
+    updatedAt,
+    status,
+  }: {
+    limit?: number;
+    offset?: number;
+    updatedAt?: string;
+    status: 'ALL' | 'TRASHED' | 'REMOVED';
+  }): Promise<GetModifiedFiles[] | undefined> {
+    const query = `status=${status}&offset=${offset}&limit=${limit}${updatedAt && `&updatedAt=${updatedAt}`}`;
+    const newToken = await asyncStorageService.getItem(AsyncStorageKey.PhotosToken);
+
+    if (!newToken) return;
+
+    const headers = await getHeaders(newToken);
+
+    try {
+      const modifiedItems = await fetch(`${constants.DRIVE_NEW_API_URL}/files?${query}`, {
+        method: 'GET',
+        headers,
+      });
+
+      const parsedModifiedFiles = await modifiedItems.json();
+
+      return parsedModifiedFiles;
+    } catch (error) {
+      errorService.reportError(error);
+    }
   }
 
   public async getThumbnail(thumbnail: Thumbnail) {

--- a/src/services/drive/folder/driveFolder.service.ts
+++ b/src/services/drive/folder/driveFolder.service.ts
@@ -1,10 +1,5 @@
 import axios from 'axios';
-import {
-  DriveFileData,
-  DriveFolderData,
-  FetchFolderContentResponse,
-  MoveFolderPayload,
-} from '@internxt/sdk/dist/drive/storage/types';
+import { DriveFileData, MoveFolderPayload } from '@internxt/sdk/dist/drive/storage/types';
 
 import { getHeaders } from '../../../helpers/headers';
 import {
@@ -12,10 +7,13 @@ import {
   DriveItemStatus,
   DriveListItem,
   FetchFolderContentResponseWithThumbnails,
+  GetModifiedFolders,
 } from '../../../types/drive';
 import { constants } from '../../AppService';
-import { driveFileService } from '../file';
 import { SdkManager } from '@internxt-mobile/services/common';
+import asyncStorageService from '@internxt-mobile/services/AsyncStorageService';
+import { AsyncStorageKey } from '@internxt-mobile/types/index';
+import errorService from '@internxt-mobile/services/ErrorService';
 
 class DriveFolderService {
   private sdk: SdkManager;
@@ -101,6 +99,38 @@ class DriveFolderService {
     });
 
     return childsAsDriveListItems.concat(filesAsDriveListItems);
+  }
+
+  public async getModifiedFolders({
+    limit = 50,
+    offset = 0,
+    updatedAt,
+    status,
+  }: {
+    limit?: number;
+    offset?: number;
+    updatedAt: string;
+    status: 'ALL' | 'TRASHED' | 'REMOVED';
+  }): Promise<GetModifiedFolders[] | undefined> {
+    const query = `status=${status}&offset=${offset}&limit=${limit}${updatedAt && `&updatedAt=${updatedAt}`}`;
+    const newToken = await asyncStorageService.getItem(AsyncStorageKey.PhotosToken);
+
+    if (!newToken) return;
+
+    const headers = await getHeaders(newToken);
+
+    try {
+      const modifiedItems = await fetch(`${constants.DRIVE_NEW_API_URL}/folders?${query}`, {
+        method: 'GET',
+        headers,
+      });
+
+      const parsedModifiedFolders = await modifiedItems.json();
+
+      return parsedModifiedFolders;
+    } catch (error) {
+      errorService.reportError(error);
+    }
   }
 }
 

--- a/src/services/drive/folder/driveFolder.service.ts
+++ b/src/services/drive/folder/driveFolder.service.ts
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import { DriveFileData, MoveFolderPayload } from '@internxt/sdk/dist/drive/storage/types';
 
 import { getHeaders } from '../../../helpers/headers';
@@ -13,7 +12,6 @@ import { constants } from '../../AppService';
 import { SdkManager } from '@internxt-mobile/services/common';
 import asyncStorageService from '@internxt-mobile/services/AsyncStorageService';
 import { AsyncStorageKey } from '@internxt-mobile/types/index';
-import errorService from '@internxt-mobile/services/ErrorService';
 
 class DriveFolderService {
   private sdk: SdkManager;
@@ -112,7 +110,8 @@ class DriveFolderService {
     updatedAt: string;
     status: 'ALL' | 'TRASHED' | 'REMOVED';
   }): Promise<GetModifiedFolders[] | undefined> {
-    const query = `status=${status}&offset=${offset}&limit=${limit}${updatedAt && `&updatedAt=${updatedAt}`}`;
+    const updatedAtDate = updatedAt && `&updatedAt=${updatedAt}`;
+    const query = `status=${status}&offset=${offset}&limit=${limit}${updatedAtDate}`;
     const newToken = await asyncStorageService.getItem(AsyncStorageKey.PhotosToken);
 
     if (!newToken) return;

--- a/src/services/drive/folder/driveFolder.service.ts
+++ b/src/services/drive/folder/driveFolder.service.ts
@@ -119,18 +119,14 @@ class DriveFolderService {
 
     const headers = await getHeaders(newToken);
 
-    try {
-      const modifiedItems = await fetch(`${constants.DRIVE_NEW_API_URL}/folders?${query}`, {
-        method: 'GET',
-        headers,
-      });
+    const modifiedItems = await fetch(`${constants.DRIVE_NEW_API_URL}/folders?${query}`, {
+      method: 'GET',
+      headers,
+    });
 
-      const parsedModifiedFolders = await modifiedItems.json();
+    const parsedModifiedFolders = await modifiedItems.json();
 
-      return parsedModifiedFolders;
-    } catch (error) {
-      errorService.reportError(error);
-    }
+    return parsedModifiedFolders;
   }
 }
 

--- a/src/types/drive.ts
+++ b/src/types/drive.ts
@@ -21,6 +21,8 @@ export type DriveNavigationStack = DriveNavigationStackItem[];
 
 export type DriveItemData = DriveFileData & DriveFolderData;
 
+export type getModifiedItemsStatus = 'EXISTS' | 'TRASHED' | 'REMOVED';
+
 export type DriveItemFocused = {
   id: number;
   name: string;
@@ -36,6 +38,44 @@ export type DriveItemFocused = {
   isFromFolderActions?: boolean;
   isFolder: boolean;
 } | null;
+
+export interface GetModifiedFiles {
+  id: number;
+  uuid: string;
+  fileId: string;
+  name: string;
+  type: string;
+  size: string;
+  bucket: string;
+  folderId: number;
+  folder: null;
+  folderUuid: string;
+  encryptVersion: string;
+  userId: number;
+  modificationTime: Date;
+  createdAt: Date;
+  updatedAt: string;
+  plainName: string;
+  status: getModifiedItemsStatus;
+}
+
+export interface GetModifiedFolders {
+  type: string;
+  id: number;
+  parentId: number;
+  name: string;
+  parent: null;
+  bucket: null;
+  userId: number;
+  user: null;
+  encryptVersion: null;
+  createdAt: Date;
+  updatedAt: Date;
+  uuid: string;
+  plainName: string;
+  size: number;
+  status: string;
+}
 
 export interface DriveFolderMetadataPayload {
   itemName: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -95,6 +95,7 @@ export enum AsyncStorageKey {
   PhotosSyncEnabled = 'photosSyncEnabled',
   ScreenLockIsEnabled = 'screenLockIsEnabled',
   LastScreenLock = 'lastScreenLock',
+  LastUpdatedAt = 'lastUpdatedAt',
 }
 
 export type ProgressCallback = (progress: number) => void;


### PR DESCRIPTION
**PROBLEM:**
When an item is modified on another platform (renamed or moved to the trash), the old item still appears (with the old name or in the folder from which the item was deleted).

**FIX:**
Now, we check if the item has been modified and is cached, and if so, we remove the item from the local DB to replace it with the new one.