### PR TITLE
[PB-754]:(fix) Decrypt private key during login

### DIFF
--- a/src/components/PhotosSyncStatusWidget/index.tsx
+++ b/src/components/PhotosSyncStatusWidget/index.tsx
@@ -231,7 +231,7 @@ const PhotosSyncStatusWidget = () => {
         <View
           style={[
             tailwind(`w-full ${photosCtx.sync.status === PhotosSyncStatus.Paused ? 'bg-gray-50' : 'bg-primary'}`),
-            { width: isNaN(getProgressWidth()) ? 0 : getProgressWidth(), height: 3 },
+            { width: isFinite(getProgressWidth()) ? getProgressWidth() : 0, height: 3 },
           ]}
         />
       ) : (

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -11,6 +11,7 @@ import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import { SdkManager } from './common/sdk/SdkManager';
 import jwtDecode from 'jwt-decode';
 import errorService from './ErrorService';
+import { keysService } from './common/keys';
 interface RegisterParams {
   firstName: string;
   lastName: string;
@@ -85,6 +86,11 @@ class AuthService {
     );
 
     loginResult.user.mnemonic = decryptTextWithKey(loginResult.user.mnemonic, password);
+
+    if (loginResult.user.privateKey) {
+      const decryptedPrivateKey = keysService.decryptPrivateKey(loginResult.user.privateKey, password);
+      loginResult.user.privateKey = Buffer.from(decryptedPrivateKey).toString('base64');
+    }
 
     // Get the refreshed tokens, they contain expiration, the ones returned
     // on the login doesn't have expiration

--- a/src/services/common/keys/index.ts
+++ b/src/services/common/keys/index.ts
@@ -1,0 +1,1 @@
+export * from './keys.service';

--- a/src/services/common/keys/keys.service.ts
+++ b/src/services/common/keys/keys.service.ts
@@ -1,0 +1,9 @@
+import AesUtils from '../../../helpers/aesUtils';
+
+export class KeysService {
+  decryptPrivateKey(privateKey: string, password: string): string {
+    return AesUtils.decrypt(privateKey, password);
+  }
+}
+
+export const keysService = new KeysService();


### PR DESCRIPTION
This PR decrypts correctly the private key during login.

Due to not decoding the private key on mobile, the password modification was generating a new privateKey generated from the still encrypted privateKey instead of the plain one, now we decrypt the privateKey during login