### PR TITLE
[PB-2739]  bugfix/Unable to log in on some devices

### DIFF
--- a/src/screens/SignInScreen/index.tsx
+++ b/src/screens/SignInScreen/index.tsx
@@ -118,7 +118,7 @@ function SignInScreen({ navigation }: RootStackScreenProps<'SignIn'>): JSX.Eleme
 
       setIsLoading(false);
 
-      setErrors({ loginFailed: strings.errors.missingAuthCredentials });
+      setErrors({ loginFailed: castedError.message });
     }
   };
   const onGoToSignUpButtonPressed = () => {


### PR DESCRIPTION
- Display backend error message when login fails instead of generic message