### PR TITLE
[PB-3605] bugfix/When hide top bar returns to first page

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "react-native-logs": "^5.0.1",
     "react-native-modalbox": "^2.0.2",
     "react-native-network-bandwith-speed": "^3.0.0",
-    "react-native-pdf": "^6.6.2",
+    "react-native-pdf": "^6.7.6",
     "react-native-pdf-thumbnail": "^1.2.0",
     "react-native-permissions": "^3.2.0",
     "react-native-progress": "^5.0.0",

--- a/src/screens/drive/DrivePreviewScreen/DrivePreviewScreen.tsx
+++ b/src/screens/drive/DrivePreviewScreen/DrivePreviewScreen.tsx
@@ -225,7 +225,7 @@ export const DrivePreviewScreen: React.FC<RootStackScreenProps<'DrivePreview'>> 
             style={{ height: availableHeight }}
             onTap={() => setTopbarVisible(!topbarVisible)}
             width={dimensions.width}
-            height={availableHeight}
+            height={dimensions.height}
             source={downloadingFile.downloadedFilePath as string}
           />
         </View>


### PR DESCRIPTION
- Fixed move to page 1 on iOS when hide top bar in pdf preview