### PR TITLE
[PB-3737] feature/Handling of Existing Files During Uploads

### DIFF
--- a/assets/lang/strings.ts
+++ b/assets/lang/strings.ts
@@ -446,6 +446,11 @@ const strings = new LocalizedStrings({
       },
     },
     modals: {
+      duplicatedFiles: {
+        duplicateFilesTitle: 'Duplicate Files Found',
+        duplicateFilesMessage: 'The following files already exist: %s\n\nDo you want to upload them with a new name?',
+        duplicateFilesAction: 'Upload with new name',
+      },
       rename: {
         title: 'Rename',
         label: 'Name',
@@ -1147,6 +1152,11 @@ const strings = new LocalizedStrings({
       },
     },
     modals: {
+      duplicatedFiles: {
+        duplicateFilesTitle: 'Archivos duplicados encontrados',
+        duplicateFilesMessage: 'Los siguientes archivos ya existen: %s\n\n¿Quieres subirlos con un nuevo nombre?',
+        duplicateFilesAction: 'Subir con nuevo nombre',
+      },
       rename: {
         title: 'Renombrar',
         label: 'Nombre',

--- a/src/contexts/Drive/Drive.context.tsx
+++ b/src/contexts/Drive/Drive.context.tsx
@@ -9,7 +9,7 @@ import { AppStateStatus, NativeEventSubscription } from 'react-native';
 
 import { driveFolderService } from '@internxt-mobile/services/drive/folder';
 
-type DriveFoldersTreeNode = {
+export type DriveFoldersTreeNode = {
   name: string;
   parentId: string; //uuid of the parent folder
   id: number;
@@ -24,6 +24,7 @@ type DriveFoldersTreeNode = {
 type DriveFoldersTree = {
   [folderId: string]: DriveFoldersTreeNode;
 };
+
 export interface DriveContextType {
   driveFoldersTree: DriveFoldersTree;
   viewMode: DriveListViewMode;

--- a/src/network/upload.ts
+++ b/src/network/upload.ts
@@ -10,6 +10,7 @@ export interface UploadFileParams {
 
 const MAX_SIZE_FOR_SINGLE_UPLOAD = 100 * 1024 * 1024;
 const MULTIPART_PART_SIZE = 30 * 1024 * 1024;
+
 export async function uploadFile(
   filePath: string,
   bucketId: string,

--- a/src/services/drive/database/driveLocalDB.ts
+++ b/src/services/drive/database/driveLocalDB.ts
@@ -2,8 +2,6 @@ import { DriveFileData, DriveFolderData } from '@internxt/sdk/dist/drive/storage
 import {
   DRIVE_DB_NAME,
   DriveItemData,
-  FolderContent,
-  FolderContentChild,
   InsertSqliteDriveItemRowData,
   SqliteDriveFolderRecord,
   SqliteDriveItemRow,
@@ -231,49 +229,6 @@ class DriveLocalDB {
     }
 
     return result as DriveItemData;
-  }
-
-  async getFolderContent(folderId: number): Promise<FolderContent | null> {
-    const [items, folderContent] = await Promise.all([this.getDriveItems(folderId), this.getFolderRecord(folderId)]);
-    if (!folderContent) return null;
-
-    return {
-      name: folderContent.name,
-      icon: '',
-      parent_id: folderContent.parent_id,
-      parentId: folderContent.parent_id,
-      bucket: '-',
-      color: '',
-      createdAt: '-',
-      encrypt_version: '-',
-      id: folderId,
-      plain_name: folderContent.name,
-      updatedAt: folderContent.updated_at,
-      user_id: -1,
-      userId: -1,
-      // Añadir los UUIDs
-      uuid: folderContent.uuid ?? '',
-      parentUuid: folderContent.parent_uuid ?? '',
-      files: items.filter((item) => item.fileId),
-      children: items
-        .filter((item) => !item.fileId)
-        .map<FolderContentChild>((item) => {
-          return {
-            ...item,
-            parent_id: item.parentId ?? folderId,
-            parentId: item.parentId ?? folderId,
-            icon: item.icon ?? '-',
-            name: item.name,
-            plain_name: item.plain_name,
-            color: item.color ?? '-',
-            removed: false,
-            deleted: false,
-            // Incluir los UUIDs
-            uuid: item.uuid ?? '',
-            parentUuid: item.parentUuid ?? '',
-          } as FolderContentChild;
-        }),
-    };
   }
 }
 

--- a/src/services/drive/file/driveFile.service.ts
+++ b/src/services/drive/file/driveFile.service.ts
@@ -325,6 +325,10 @@ class DriveFileService {
   getName(filename: string, type?: string) {
     return filename + (type ? `.${type}` : '');
   }
+
+  public async checkFileExistence(parentFolderUuid: string, filesList: { plainName: string; type: string }[]) {
+    return this.sdk.storageV2.checkDuplicatedFiles({ folderUuid: parentFolderUuid, filesList });
+  }
 }
 
 export const driveFileService = new DriveFileService(SdkManager.getInstance());

--- a/src/services/drive/file/utils/checkDuplicatedFiles.ts
+++ b/src/services/drive/file/utils/checkDuplicatedFiles.ts
@@ -66,7 +66,7 @@ const parseFile = (file: File): FileInfo => {
   const { plainName, extension } = getFilenameAndExt(file.name);
   return {
     plainName,
-    type: extension || file.type || '',
+    type: extension ?? file.type ?? '',
     originalFile: file,
   };
 };

--- a/src/services/drive/file/utils/checkDuplicatedFiles.ts
+++ b/src/services/drive/file/utils/checkDuplicatedFiles.ts
@@ -1,0 +1,83 @@
+import { DriveFileData } from '@internxt/sdk/dist/drive/storage/types';
+import { driveFileService } from '../driveFile.service';
+
+export interface DuplicatedFilesResult {
+  duplicatedFilesResponse: DriveFileData[];
+  filesWithDuplicates: File[];
+  filesWithoutDuplicates: File[];
+}
+
+interface FileInfo {
+  plainName: string;
+  type: string;
+  originalFile: File;
+}
+
+export interface File {
+  name: string;
+  uri: string;
+  size: number;
+  type?: string;
+}
+
+export const checkDuplicatedFiles = async (files: File[], parentFolderUuid: string): Promise<DuplicatedFilesResult> => {
+  if (files.length === 0) {
+    return {
+      duplicatedFilesResponse: [],
+      filesWithDuplicates: [],
+      filesWithoutDuplicates: files,
+    };
+  }
+
+  const parsedFiles = files.map(parseFile);
+
+  const checkDuplicatedFileResponse = await driveFileService.checkFileExistence(
+    parentFolderUuid,
+    parsedFiles.map((f) => ({ plainName: f.plainName, type: f.type })),
+  );
+
+  const duplicatedFilesResponse = checkDuplicatedFileResponse.existentFiles;
+
+  const { filesWithDuplicates, filesWithoutDuplicates } = parsedFiles.reduce(
+    (acc, parsedFile) => {
+      const isDuplicated = duplicatedFilesResponse.some(
+        (duplicatedFile) =>
+          duplicatedFile.plainName === parsedFile.plainName && duplicatedFile.type === parsedFile.type,
+      );
+
+      if (isDuplicated) {
+        acc.filesWithDuplicates.push(parsedFile.originalFile);
+      } else {
+        acc.filesWithoutDuplicates.push(parsedFile.originalFile);
+      }
+
+      return acc;
+    },
+    { filesWithDuplicates: [], filesWithoutDuplicates: [] } as {
+      filesWithDuplicates: File[];
+      filesWithoutDuplicates: File[];
+    },
+  );
+
+  return { duplicatedFilesResponse, filesWithoutDuplicates, filesWithDuplicates };
+};
+
+const parseFile = (file: File): FileInfo => {
+  const { plainName, extension } = getFilenameAndExt(file.name);
+  return {
+    plainName,
+    type: extension || file.type || '',
+    originalFile: file,
+  };
+};
+
+const getFilenameAndExt = (filename: string): { plainName: string; extension: string } => {
+  const lastDotIndex = filename.lastIndexOf('.');
+  if (lastDotIndex === -1) {
+    return { plainName: filename, extension: '' };
+  }
+  return {
+    plainName: filename.substring(0, lastDotIndex),
+    extension: filename.substring(lastDotIndex + 1),
+  };
+};

--- a/src/services/drive/file/utils/getUniqueFilename.ts
+++ b/src/services/drive/file/utils/getUniqueFilename.ts
@@ -1,0 +1,38 @@
+import { items as itemsUtils } from '@internxt/lib';
+import { DriveFileData } from '@internxt/sdk/dist/drive/storage/types';
+import { driveFileService } from '../driveFile.service';
+
+export const getUniqueFilename = async (
+  filename: string,
+  extension: string,
+  duplicatedFiles: DriveFileData[],
+  parentFolderUuid: string,
+): Promise<string> => {
+  let isFileNewNameDuplicated = true;
+  let finalFilename = filename;
+  let currentDuplicatedFiles = duplicatedFiles;
+
+  do {
+    const currentFolderFilesToCheckDuplicates = currentDuplicatedFiles.map((file) => ({
+      name: file.plainName ?? file.name,
+      type: file.type,
+    }));
+
+    const [, , renamedFilename] = itemsUtils.renameIfNeeded(
+      currentFolderFilesToCheckDuplicates,
+      finalFilename,
+      extension,
+    );
+
+    finalFilename = renamedFilename;
+
+    const duplicatedFilesResponse = await driveFileService.checkFileExistence(parentFolderUuid, [
+      { plainName: renamedFilename, type: extension },
+    ]);
+
+    currentDuplicatedFiles = duplicatedFilesResponse.existentFiles;
+    isFileNewNameDuplicated = currentDuplicatedFiles.length > 0;
+  } while (isFileNewNameDuplicated);
+
+  return finalFilename;
+};

--- a/src/services/drive/file/utils/prepareFilesToUpload.ts
+++ b/src/services/drive/file/utils/prepareFilesToUpload.ts
@@ -1,0 +1,79 @@
+import { DriveFileData } from '@internxt/sdk/dist/drive/storage/types';
+import { DocumentPickerResponse } from 'react-native-document-picker';
+import { checkDuplicatedFiles } from './checkDuplicatedFiles';
+import { processDuplicateFiles } from './processDuplicateFiles';
+
+export interface FileToUpload {
+  name: string;
+  uri: string;
+  size: number;
+  type: string;
+  parentUuid: string;
+}
+
+const BATCH_SIZE = 200;
+
+export const prepareFilesToUpload = async ({
+  files,
+  parentFolderUuid,
+  disableDuplicatedNamesCheck = false,
+  disableExistenceCheck = false,
+}: {
+  files: DocumentPickerResponse[];
+  parentFolderUuid: string;
+  disableDuplicatedNamesCheck?: boolean;
+  disableExistenceCheck?: boolean;
+}): Promise<{ filesToUpload: FileToUpload[]; zeroLengthFilesNumber: number }> => {
+  let filesToUpload: FileToUpload[] = [];
+  let zeroLengthFilesNumber = 0;
+
+  const processFiles = async (
+    filesBatch: DocumentPickerResponse[],
+    disableDuplicatedNamesCheckOverride: boolean,
+    duplicatedFiles?: DriveFileData[],
+  ) => {
+    const { zeroLengthFiles, newFilesToUpload } = await processDuplicateFiles({
+      files: filesBatch,
+      existingFilesToUpload: filesToUpload,
+      parentFolderUuid,
+      disableDuplicatedNamesCheck: disableDuplicatedNamesCheckOverride,
+      duplicatedFiles,
+    });
+
+    filesToUpload = newFilesToUpload;
+    zeroLengthFilesNumber += zeroLengthFiles;
+  };
+
+  const processFilesBatch = async (filesBatch: DocumentPickerResponse[]) => {
+    if (disableExistenceCheck) {
+      await processFiles(filesBatch, true);
+    } else {
+      const mappedFiles = filesBatch.map((f) => ({
+        name: f.name,
+        uri: f.uri,
+        size: f.size,
+        type: f.type || '',
+      }));
+
+      const { duplicatedFilesResponse, filesWithoutDuplicates, filesWithDuplicates } = await checkDuplicatedFiles(
+        mappedFiles,
+        parentFolderUuid,
+      );
+
+      await processFiles(filesWithoutDuplicates as DocumentPickerResponse[], true);
+      await processFiles(
+        filesWithDuplicates as DocumentPickerResponse[],
+        disableDuplicatedNamesCheck,
+        duplicatedFilesResponse,
+      );
+    }
+  };
+
+  // Process files in batches
+  for (let i = 0; i < files.length; i += BATCH_SIZE) {
+    const batch = files.slice(i, i + BATCH_SIZE);
+    await processFilesBatch(batch);
+  }
+
+  return { filesToUpload, zeroLengthFilesNumber };
+};

--- a/src/services/drive/file/utils/prepareFilesToUpload.ts
+++ b/src/services/drive/file/utils/prepareFilesToUpload.ts
@@ -52,7 +52,7 @@ export const prepareFilesToUpload = async ({
         name: f.name,
         uri: f.uri,
         size: f.size,
-        type: f.type || '',
+        type: f.type ?? '',
       }));
 
       const { duplicatedFilesResponse, filesWithoutDuplicates, filesWithDuplicates } = await checkDuplicatedFiles(

--- a/src/services/drive/file/utils/processDuplicateFiles.ts
+++ b/src/services/drive/file/utils/processDuplicateFiles.ts
@@ -1,0 +1,60 @@
+import { DriveFileData } from '@internxt/sdk/dist/drive/storage/types';
+import { DocumentPickerResponse } from 'react-native-document-picker';
+import { getUniqueFilename } from './getUniqueFilename';
+import { FileToUpload } from './prepareFilesToUpload';
+
+interface ProcessDuplicateFilesParams {
+  files: DocumentPickerResponse[];
+  existingFilesToUpload: FileToUpload[];
+  parentFolderUuid: string;
+  disableDuplicatedNamesCheck?: boolean;
+  duplicatedFiles?: DriveFileData[];
+}
+
+export const processDuplicateFiles = async ({
+  files,
+  existingFilesToUpload,
+  parentFolderUuid,
+  disableDuplicatedNamesCheck,
+  duplicatedFiles,
+}: ProcessDuplicateFilesParams): Promise<{
+  newFilesToUpload: FileToUpload[];
+  zeroLengthFiles: number;
+}> => {
+  const zeroLengthFiles = files.filter((file) => file.size === 0).length;
+  const newFilesToUpload: FileToUpload[] = [...existingFilesToUpload];
+
+  const processFile = async (file: DocumentPickerResponse): Promise<void> => {
+    if (file.size === 0) return;
+
+    const { plainName, extension } = getFilenameAndExt(file.name);
+    let finalFilename = plainName;
+
+    if (!disableDuplicatedNamesCheck && duplicatedFiles) {
+      finalFilename = await getUniqueFilename(plainName, extension, duplicatedFiles, parentFolderUuid);
+    }
+
+    newFilesToUpload.push({
+      name: finalFilename,
+      size: file.size,
+      type: extension || file.type || '',
+      uri: file.uri,
+      parentUuid: parentFolderUuid,
+    });
+  };
+
+  await Promise.all(files.filter((file) => file.size > 0).map(processFile));
+
+  return { newFilesToUpload, zeroLengthFiles };
+};
+
+const getFilenameAndExt = (filename: string): { plainName: string; extension: string } => {
+  const lastDotIndex = filename.lastIndexOf('.');
+  if (lastDotIndex === -1) {
+    return { plainName: filename, extension: '' };
+  }
+  return {
+    plainName: filename.substring(0, lastDotIndex),
+    extension: filename.substring(lastDotIndex + 1),
+  };
+};

--- a/src/services/drive/file/utils/processDuplicateFiles.ts
+++ b/src/services/drive/file/utils/processDuplicateFiles.ts
@@ -37,7 +37,7 @@ export const processDuplicateFiles = async ({
     newFilesToUpload.push({
       name: finalFilename,
       size: file.size,
-      type: extension || file.type || '',
+      type: extension ?? file.type ?? '',
       uri: file.uri,
       parentUuid: parentFolderUuid,
     });

--- a/src/services/drive/file/utils/uploadFileUtils.ts
+++ b/src/services/drive/file/utils/uploadFileUtils.ts
@@ -70,7 +70,7 @@ export async function handleDuplicateFiles(
     name: file.name,
     uri: file.uri,
     size: file.size,
-    type: file.type || '',
+    type: file.type ?? '',
   }));
 
   const { filesWithoutDuplicates, filesWithDuplicates } = await checkDuplicatedFiles(mappedFiles, folderUuid);
@@ -216,7 +216,7 @@ export async function uploadSingleFile(
     uploadSuccess(file);
   } catch (e) {
     const err = e as Error;
-    errorService.reportError(err as Error, {
+    errorService.reportError(err, {
       extra: {
         fileId: file.id,
       },

--- a/src/services/drive/file/utils/uploadFileUtils.ts
+++ b/src/services/drive/file/utils/uploadFileUtils.ts
@@ -1,0 +1,234 @@
+import { Alert } from 'react-native';
+import { DocumentPickerResponse } from 'react-native-document-picker';
+import uuid from 'react-native-uuid';
+import strings from '../../../../../assets/lang/strings';
+import { isValidFilename } from '../../../../helpers';
+import { driveActions } from '../../../../store/slices/drive';
+import { UPLOAD_FILE_SIZE_LIMIT, UploadingFile } from '../../../../types/drive';
+import { checkDuplicatedFiles, File } from './checkDuplicatedFiles';
+import { FileToUpload, prepareFilesToUpload } from './prepareFilesToUpload';
+
+import errorService from '../../../ErrorService';
+
+import { Dispatch } from 'react';
+import { DriveFoldersTreeNode } from '../../../../contexts/Drive';
+import { NotificationType } from '../../../../types';
+import analyticsService, { DriveAnalyticsEvent } from '../../../AnalyticsService';
+import { logger } from '../../../common';
+import notificationsService from '../../../NotificationsService';
+
+/**
+ * Validate file names and filter out files exceeding the upload size limit.
+ *
+ * @param {DocumentPickerResponse[]} documents - Array of selected documents.
+ * @returns {{ filesToUpload: DocumentPickerResponse[], filesExcluded: DocumentPickerResponse[] }}
+ */
+export function validateAndFilterFiles(documents: DocumentPickerResponse[]) {
+  const filesToUpload: DocumentPickerResponse[] = [];
+  const filesExcluded: DocumentPickerResponse[] = [];
+
+  if (!documents.every((file) => isValidFilename(file.name))) {
+    throw new Error('Some file names are not valid');
+  }
+
+  for (const file of documents) {
+    if (file.size <= UPLOAD_FILE_SIZE_LIMIT) {
+      filesToUpload.push(file);
+    } else {
+      filesExcluded.push(file);
+    }
+  }
+
+  return { filesToUpload, filesExcluded };
+}
+
+/**
+ * Show an alert when some files exceed the upload size limit.
+ *
+ * @param {DocumentPickerResponse[]} filesExcluded - Files that were excluded due to size.
+ */
+export function showFileSizeAlert(filesExcluded: DocumentPickerResponse[]) {
+  if (filesExcluded.length === 0) return;
+
+  const messageKey = filesExcluded.length === 1 ? strings.messages.uploadFileLimit : strings.messages.uploadFilesLimit;
+  const alertText = strings.formatString(messageKey, filesExcluded.length).toString();
+  Alert.alert(strings.messages.limitPerFile, alertText);
+}
+
+/**
+ * Handle duplicate files by checking for existing files in the target folder and optionally prompting the user.
+ *
+ * @param {DocumentPickerResponse[]} files - Files to check for duplication.
+ * @param {string} folderUuid - UUID of the destination folder.
+ * @returns {Promise<DocumentPickerResponse[]>} - Files to proceed with after handling duplicates.
+ */
+export async function handleDuplicateFiles(
+  files: DocumentPickerResponse[],
+  folderUuid: string,
+): Promise<DocumentPickerResponse[]> {
+  const mappedFiles = files.map((file) => ({
+    name: file.name,
+    uri: file.uri,
+    size: file.size,
+    type: file.type || '',
+  }));
+
+  const { filesWithoutDuplicates, filesWithDuplicates } = await checkDuplicatedFiles(mappedFiles, folderUuid);
+
+  let filesToProcess = [...filesWithoutDuplicates] as DocumentPickerResponse[];
+
+  if (filesWithDuplicates.length > 0) {
+    const shouldUploadDuplicates = await askUserAboutDuplicates(filesWithDuplicates);
+
+    if (shouldUploadDuplicates) {
+      filesToProcess = [...filesToProcess, ...(filesWithDuplicates as DocumentPickerResponse[])];
+    }
+  }
+
+  return filesToProcess;
+}
+
+/**
+ * Prompt the user about uploading duplicate files.
+ *
+ * @param {File[]} filesWithDuplicates - Array of duplicate file metadata.
+ * @returns {Promise<boolean>} - Whether the user chooses to upload duplicates.
+ */
+export async function askUserAboutDuplicates(filesWithDuplicates: File[]): Promise<boolean> {
+  const duplicatedFileNames = filesWithDuplicates.map((f) => f.name).join(', ');
+  const message = strings.modals.duplicatedFiles.duplicateFilesMessage.replace('%s', duplicatedFileNames);
+
+  return new Promise<boolean>((resolve) => {
+    Alert.alert(
+      strings.modals.duplicatedFiles.duplicateFilesTitle,
+      message,
+      [
+        {
+          text: strings.buttons.cancel,
+          onPress: () => resolve(false),
+          style: 'cancel',
+        },
+        {
+          text: strings.modals.duplicatedFiles.duplicateFilesAction,
+          onPress: () => resolve(true),
+        },
+      ],
+      { cancelable: false },
+    );
+  });
+}
+
+/**
+ * Prepare files to be uploaded by resolving metadata and paths.
+ *
+ * @param {DocumentPickerResponse[]} files - Files to prepare.
+ * @param {string} folderUuid - UUID of the destination folder.
+ * @returns {Promise<FileToUpload[]>} - Prepared file objects ready for upload.
+ */
+export async function prepareUploadFiles(files: DocumentPickerResponse[], folderUuid: string): Promise<FileToUpload[]> {
+  const { filesToUpload: preparedFiles } = await prepareFilesToUpload({
+    files,
+    parentFolderUuid: folderUuid,
+    disableDuplicatedNamesCheck: false,
+    disableExistenceCheck: false,
+  });
+
+  return preparedFiles;
+}
+
+/**
+ * Convert prepared files into UploadingFile format.
+ *
+ * @param {FileToUpload[]} preparedFiles - Files returned from preparation step.
+ * @param {DriveFoldersTreeNode} focusedFolder - Folder context in which files are being uploaded.
+ * @returns {UploadingFile[]} - Files formatted for upload state tracking.
+ */
+export function createUploadingFiles(
+  preparedFiles: FileToUpload[],
+  focusedFolder: DriveFoldersTreeNode,
+): UploadingFile[] {
+  const formattedFiles: UploadingFile[] = [];
+
+  for (const preparedFile of preparedFiles) {
+    const fileToUpload: UploadingFile = {
+      id: new Date().getTime() + Math.random(),
+      uuid: uuid.v4().toString(),
+      uri: preparedFile.uri,
+      name: preparedFile.name,
+      type: preparedFile.type,
+      parentId: focusedFolder.id,
+      parentUuid: focusedFolder.uuid,
+      createdAt: new Date().toString(),
+      updatedAt: new Date().toString(),
+      size: preparedFile.size,
+      progress: 0,
+      uploaded: false,
+    };
+
+    formattedFiles.push(fileToUpload);
+  }
+
+  return formattedFiles;
+}
+
+/**
+ * Initialize the upload process for each file, including tracking and dispatching actions.
+ *
+ * @param {UploadingFile[]} files - Files to upload.
+ * @param {Function} dispatch - Redux dispatch function.
+ */
+export function initializeUploads(files: UploadingFile[], dispatch: Dispatch<any>) {
+  for (const file of files) {
+    trackUploadStart(file);
+    dispatch(driveActions.uploadFileStart(file.name));
+    dispatch(driveActions.addUploadingFile({ ...file }));
+  }
+}
+
+async function trackUploadStart(file: UploadingFile) {
+  await analyticsService.track(DriveAnalyticsEvent.FileUploadStarted, { size: file.size, type: file.type });
+}
+async function trackUploadError(file: UploadingFile, err: Error) {
+  await analyticsService.track(DriveAnalyticsEvent.FileUploadError, {
+    message: err.message,
+    size: file.size,
+    type: file.type,
+  });
+}
+
+/**
+ * Upload a single file, handle errors, and update Redux state accordingly.
+ *
+ * @param {UploadingFile} file - The file to upload.
+ * @param {Function} dispatch - Redux dispatch function.
+ * @param {(uploadingFile: UploadingFile, fileType: 'document' | 'image') => Promise<void>} uploadFile - Upload function.
+ * @param {(file: UploadingFile) => void} uploadSuccess - Callback for successful upload.
+ */
+export async function uploadSingleFile(
+  file: UploadingFile,
+  dispatch: Dispatch<any>,
+  uploadFile: (uploadingFile: UploadingFile, fileType: 'document' | 'image') => Promise<void>,
+  uploadSuccess: (file: UploadingFile) => void,
+) {
+  try {
+    console.log('Uploading file: ', file);
+    await uploadFile(file, 'document');
+    uploadSuccess(file);
+  } catch (e) {
+    const err = e as Error;
+    errorService.reportError(err as Error, {
+      extra: {
+        fileId: file.id,
+      },
+    });
+    trackUploadError(file, err);
+    dispatch(driveActions.uploadFileFailed({ errorMessage: err.message, id: file.id }));
+    logger.error('File upload process failed: ', JSON.stringify(err));
+    notificationsService.show({
+      type: NotificationType.Error,
+      text1: strings.formatString(strings.errors.uploadFile, err.message) as string,
+    });
+  } finally {
+    dispatch(driveActions.uploadFileFinished());
+  }
+}


### PR DESCRIPTION
- Added logic to handle if file already exists
- It solves the problem with the pagination, as it is possible that not all the files are uploaded, it makes a request to the server to check if the file already exists before uploading it, this way we avoid the error of trying to upload a heavy file that already exists and you get an error at the end after the wait.