### PR TITLE
[PB-4530-4531] feature/Prevent screen captures and recording

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -54,6 +54,8 @@ PODS:
     - ExpoModulesCore
   - ExpoSystemUI (2.9.4):
     - ExpoModulesCore
+  - EXScreenCapture (5.8.1):
+    - ExpoModulesCore
   - EXSplashScreen (0.26.5):
     - ExpoModulesCore
     - glog
@@ -1222,6 +1224,7 @@ DEPENDENCIES:
   - ExpoModulesCore (from `../node_modules/expo-modules-core`)
   - ExpoSharing (from `../node_modules/expo-sharing/ios`)
   - ExpoSystemUI (from `../node_modules/expo-system-ui/ios`)
+  - EXScreenCapture (from `../node_modules/expo-screen-capture/ios`)
   - EXSplashScreen (from `../node_modules/expo-splash-screen/ios`)
   - EXStructuredHeaders (from `../node_modules/expo-structured-headers/ios`)
   - EXUpdates (from `../node_modules/expo-updates/ios`)
@@ -1363,6 +1366,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/expo-sharing/ios"
   ExpoSystemUI:
     :path: "../node_modules/expo-system-ui/ios"
+  EXScreenCapture:
+    :path: "../node_modules/expo-screen-capture/ios"
   EXSplashScreen:
     :path: "../node_modules/expo-splash-screen/ios"
   EXStructuredHeaders:
@@ -1540,6 +1545,7 @@ SPEC CHECKSUMS:
   ExpoModulesCore: 421e9c6bcb63baf153a5ec22b2b4319addfe331c
   ExpoSharing: 752ad6ae2b693de9cd4e7fddb78297bdc658b815
   ExpoSystemUI: 735278045c1a28de0018a300bb5abb3f9090652b
+  EXScreenCapture: 7a491c16de021638078f50281d411e3352bb28c2
   EXSplashScreen: fb4d80520d2348d57879e7a272415438bbcdffd3
   EXStructuredHeaders: 5b0f47259db047dc1fdfa84752e292c2bfa68ecd
   EXUpdates: 4aa99ef9610e0d6fbf80d7f2b3f169b527f24a1d

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "expo-local-authentication": "~13.8.0",
     "expo-media-library": "~15.9.2",
     "expo-navigation-bar": "~2.8.1",
+    "expo-screen-capture": "~5.8.1",
     "expo-sharing": "~11.10.0",
     "expo-splash-screen": "~0.26.5",
     "expo-status-bar": "~1.11.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,6 @@
 import * as NavigationBar from 'expo-navigation-bar';
+import { usePreventScreenCapture } from 'expo-screen-capture';
+
 import { useEffect, useState } from 'react';
 import {
   Appearance,
@@ -50,6 +52,7 @@ export default function App(): JSX.Element {
   const { user } = useAppSelector((state) => state.auth);
   const { screenLocked, lastScreenLock, initialScreenLocked } = useAppSelector((state) => state.app);
   const { color: whiteColor } = tailwind('text-white');
+  usePreventScreenCapture();
 
   useEffect(() => {
     const initializeTheme = async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6468,6 +6468,11 @@ expo-navigation-bar@~2.8.1:
     "@react-native/normalize-color" "^2.0.0"
     debug "^4.3.2"
 
+expo-screen-capture@~5.8.1:
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/expo-screen-capture/-/expo-screen-capture-5.8.1.tgz#38fdf1523f461612cfc9be0ef36273611086421d"
+  integrity sha512-dWlU5botnVfxnF/CzerZzxmVH7lDXWNXQjPUKNHO8dKZv/N41Zjo7TuKbdYGMSUybJlXfi0nP/EU6JzXc2d2rw==
+
 expo-sharing@~11.10.0:
   version "11.10.0"
   resolved "https://registry.yarnpkg.com/expo-sharing/-/expo-sharing-11.10.0.tgz#0e85197ee4d2634b00fe201e571fbdc64cf83eef"


### PR DESCRIPTION
- Add expo-screen-capture dependency and implement screen capture prevention in App component (only works on Android)

**Note:** ⚠️ 
- In draft until the screenshot and video recording prevention on iOS is tested and verified to work