### PR TITLE
[PB-4534] feature/Remove unnecessary permissions

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,8 +3,6 @@
   <uses-permission android:name="android.permission.DETECT_SCREEN_CAPTURE"/>
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-  <uses-permission android:name="android.permission.RECORD_AUDIO"/>
-  <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
   <uses-permission android:name="android.permission.USE_BIOMETRIC"/>
   <uses-permission android:name="android.permission.USE_FINGERPRINT"/>
   <uses-permission android:name="android.permission.VIBRATE"/>

--- a/ios/Internxt/Info.plist
+++ b/ios/Internxt/Info.plist
@@ -47,8 +47,6 @@
     <string>Allow $(PRODUCT_NAME) to access your camera to upload a newly captured photo to the storage service</string>
     <key>NSFaceIDUsageDescription</key>
     <string>Protect the app access to secure the available files</string>
-    <key>NSMicrophoneUsageDescription</key>
-    <string>Allow $(PRODUCT_NAME) to access your microphone</string>
     <key>NSPhotoLibraryAddUsageDescription</key>
     <string>Allow $(PRODUCT_NAME) to save/download photos from the storage service</string>
     <key>NSPhotoLibraryUsageDescription</key>


### PR DESCRIPTION
**Reduce app permissions to follow principle of least privilege**
Removes unnecessary permissions identified in security audit SECURITUM-2414556-006:

**Android:**
- android.permission.RECORD_AUDIO
- android.permission.SYSTEM_ALERT_WINDOW

**iOS:**
- NSMicrophoneUsageDescription

These permissions were not essential for core app functionality and their removal improves user privacy and security posture