### PR TITLE
[PB-4583] bugfix/Rename item

### DIFF
--- a/src/contexts/Drive/Drive.context.tsx
+++ b/src/contexts/Drive/Drive.context.tsx
@@ -32,6 +32,7 @@ export interface DriveContextType {
   toggleViewMode: () => void;
   loadFolderContent: (folderUuid: string, options?: LoadFolderContentOptions) => Promise<void>;
   focusedFolder: DriveFoldersTreeNode | null;
+  updateItemInTree: (folderId: string, itemId: number, updates: { name?: string; plainName?: string }) => void;
 }
 
 type LoadFolderContentOptions = {
@@ -321,6 +322,24 @@ export const DriveContextProvider: React.FC<DriveContextProviderProps> = ({ chil
     });
   };
 
+  const updateItemInTree = (folderId: string, itemId: number, updates: { name?: string; plainName?: string }) => {
+    setDriveFoldersTree((prevTree) => {
+      const folder = prevTree[folderId];
+      if (!folder) return prevTree;
+
+      return {
+        ...prevTree,
+        [folderId]: {
+          ...folder,
+          files: folder.files.map((file) => (file.id === itemId ? { ...file, ...updates } : file)),
+          folders: folder.folders.map((folderItem) =>
+            folderItem.id === itemId ? { ...folderItem, ...updates } : folderItem,
+          ),
+        },
+      };
+    });
+  };
+
   const handleToggleViewMode = () => {
     const newViewMode = viewMode === DriveListViewMode.List ? DriveListViewMode.Grid : DriveListViewMode.List;
     setViewMode(newViewMode);
@@ -337,6 +356,7 @@ export const DriveContextProvider: React.FC<DriveContextProviderProps> = ({ chil
         // Default current folder is the root folder
         focusedFolder: currentFolder,
         rootFolderId: rootFolderId ?? '',
+        updateItemInTree,
       }}
     >
       {children}


### PR DESCRIPTION
**Bug:**
- UI not reflecting renamed items correctly after items fetch

**Fix applied:** 
- Optimistic updates: Item names update instantly in UI and local state
- Auto rollback: Reverts all changes if rename call to API fails