### PR TITLE
[PB-6305]  feature/Move Settings to header and add Photos tab selector

### DIFF
--- a/assets/lang/strings.ts
+++ b/assets/lang/strings.ts
@@ -41,7 +41,7 @@ const translations = {
       Drive: 'Drive',
       Add: 'Add',
       Shared: 'Shared',
-      Settings: 'Settings',
+      Photos: 'Photos',
     },
     subscriptions: {
       free: 'Free plan',
@@ -161,6 +161,11 @@ const translations = {
       },
       home: {
         title: 'Home',
+      },
+      photos: {
+        title: 'Photos',
+        emptyTitle: 'No photos to show',
+        emptySubtitle: 'Take a photo or video to start backing up',
       },
       forgot_password: {
         title: 'Delete account',
@@ -887,7 +892,7 @@ const translations = {
       Drive: 'Drive',
       Add: 'Añadir',
       Shared: 'Compartido',
-      Settings: 'Ajustes',
+      Photos: 'Fotos',
     },
     subscriptions: {
       free: 'Plan gratuito',
@@ -1008,6 +1013,11 @@ const translations = {
       },
       home: {
         title: 'Inicio',
+      },
+      photos: {
+        title: 'Fotos',
+        emptyTitle: 'No hay fotos que mostrar',
+        emptySubtitle: 'Haz una foto o vídeo para empezar el backup',
       },
       forgot_password: {
         title: 'Borrar cuenta',

--- a/src/components/AppScreenTitle/index.tsx
+++ b/src/components/AppScreenTitle/index.tsx
@@ -1,6 +1,6 @@
 import { StyleProp, TextStyle, TouchableOpacity, View } from 'react-native';
 
-import { CaretLeft } from 'phosphor-react-native';
+import { CaretLeftIcon } from 'phosphor-react-native';
 import { useTailwind } from 'tailwind-rn';
 import useGetColor from '../../hooks/useColor';
 import AppText from '../AppText';
@@ -11,6 +11,7 @@ interface AppScreenTitleProps {
   containerStyle?: StyleProp<TextStyle>;
   centerText?: boolean;
   showBackButton?: boolean;
+  compactBackButton?: boolean;
   rightSlot?: JSX.Element;
   onBackButtonPressed?: () => void;
 }
@@ -20,12 +21,15 @@ const defaultProps: Partial<AppScreenTitleProps> = {
   showBackButton: true,
 };
 
+const BACK_BUTTON_HIT_SLOP = { top: 10, bottom: 10, left: 10, right: 10 };
+
 const AppScreenTitle = ({
   text,
   textStyle,
   containerStyle,
   centerText = defaultProps.centerText,
   showBackButton = defaultProps.showBackButton,
+  compactBackButton = false,
   rightSlot,
   onBackButtonPressed,
 }: AppScreenTitleProps): JSX.Element => {
@@ -45,9 +49,14 @@ const AppScreenTitle = ({
       ]}
     >
       {showBackButton && (
-        <TouchableOpacity style={tailwind('flex-1')} disabled={!onBackButtonPressed} onPress={onBackButtonPressed}>
+        <TouchableOpacity
+          style={compactBackButton ? tailwind('mr-2') : tailwind('flex-1')}
+          hitSlop={compactBackButton ? BACK_BUTTON_HIT_SLOP : undefined}
+          disabled={!onBackButtonPressed}
+          onPress={onBackButtonPressed}
+        >
           <View style={[tailwind('flex justify-center'), !onBackButtonPressed && tailwind('opacity-50')]}>
-            <CaretLeft weight="bold" color={getColor('text-primary')} size={24} />
+            <CaretLeftIcon weight="bold" color={getColor('text-primary')} size={24} />
           </View>
         </TouchableOpacity>
       )}
@@ -60,11 +69,9 @@ const AppScreenTitle = ({
         >
           {text}
         </AppText>
-
-        {rightSlot}
       </View>
 
-      {showBackButton && <View style={tailwind('flex-1')} />}
+      {rightSlot ? rightSlot : showBackButton && !compactBackButton && <View style={tailwind('flex-1')} />}
     </View>
   );
 };

--- a/src/components/BottomTabNavigator/index.tsx
+++ b/src/components/BottomTabNavigator/index.tsx
@@ -1,8 +1,7 @@
 import { BottomTabBarProps } from '@react-navigation/bottom-tabs/lib/typescript/src/types';
 import { Text, TouchableWithoutFeedback, View } from 'react-native';
 
-import { FolderSimple, Gear, House, PlusCircle, Users } from 'phosphor-react-native';
-import { storageThunks } from 'src/store/slices/storage';
+import { FolderSimpleIcon, HouseIcon, ImageIcon, PlusCircleIcon, UsersIcon } from 'phosphor-react-native';
 import { useTailwind } from 'tailwind-rn';
 import strings from '../../../assets/lang/strings';
 import useGetColor from '../../hooks/useColor';
@@ -18,11 +17,11 @@ function BottomTabNavigator(props: BottomTabBarProps): JSX.Element {
   useLanguage();
 
   const tabs = {
-    Home: { label: strings.tabs.Home, icon: House },
-    Drive: { label: strings.tabs.Drive, icon: FolderSimple },
-    Add: { label: strings.tabs.Add, icon: PlusCircle },
-    Shared: { label: strings.tabs.Shared, icon: Users },
-    Settings: { label: strings.tabs.Settings, icon: Gear },
+    Home: { label: strings.tabs.Home, icon: HouseIcon },
+    Drive: { label: strings.tabs.Drive, icon: FolderSimpleIcon },
+    Add: { label: strings.tabs.Add, icon: PlusCircleIcon },
+    Shared: { label: strings.tabs.Shared, icon: UsersIcon },
+    Photos: { label: strings.tabs.Photos, icon: ImageIcon },
   };
 
   const items = props.state.routes
@@ -32,12 +31,8 @@ function BottomTabNavigator(props: BottomTabBarProps): JSX.Element {
       const label = tabs[route.name as keyof typeof tabs].label;
       const isFocused = props.state.index === index;
       const isAddRoute = route.name === 'Add';
-      const isSettingsRoute = route.name === 'Settings';
 
       const onPress = () => {
-        if (isSettingsRoute) {
-          dispatch(storageThunks.loadStorageUsageThunk());
-        }
         if (isAddRoute) {
           return dispatch(uiActions.setShowUploadFileModal(true));
         }
@@ -59,8 +54,8 @@ function BottomTabNavigator(props: BottomTabBarProps): JSX.Element {
       const iconColor = isAddRoute
         ? getColor('text-white')
         : isFocused
-        ? getColor('text-primary')
-        : getColor('text-gray-50');
+          ? getColor('text-primary')
+          : getColor('text-gray-50');
 
       const Icon = tabs[route.name as keyof typeof tabs].icon;
 

--- a/src/hooks/useProfileAvatar.spec.ts
+++ b/src/hooks/useProfileAvatar.spec.ts
@@ -1,0 +1,126 @@
+import { imageService } from '@internxt-mobile/services/common';
+import errorService from '@internxt-mobile/services/ErrorService';
+import { fs } from '@internxt-mobile/services/FileSystemService';
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { useAppSelector } from '../store/hooks';
+import { useProfileAvatar } from './useProfileAvatar';
+
+jest.mock('../store/hooks', () => ({
+  useAppSelector: jest.fn(),
+}));
+
+jest.mock('@internxt-mobile/services/common', () => ({
+  imageService: {
+    getCachedImage: jest.fn(),
+  },
+  PROFILE_PICTURE_CACHE_KEY: 'profile_picture',
+}));
+
+jest.mock('@internxt-mobile/services/ErrorService', () => ({
+  __esModule: true,
+  default: { reportError: jest.fn() },
+}));
+
+jest.mock('@internxt-mobile/services/FileSystemService', () => ({
+  fs: { pathToUri: jest.fn((path: string) => `file://${path}`) },
+}));
+
+const mockUseAppSelector = useAppSelector as jest.Mock;
+const mockGetCachedImage = imageService.getCachedImage as jest.Mock;
+const mockPathToUri = fs.pathToUri as jest.Mock;
+const mockReportError = errorService.reportError as jest.Mock;
+
+const setupUser = (avatar: string | null | undefined) => {
+  mockUseAppSelector.mockImplementation((selector: (s: { auth: { user: unknown } }) => unknown) =>
+    selector({ auth: { user: avatar !== undefined ? { avatar } : undefined } }),
+  );
+};
+
+const CACHE_KEY = 'profile_picture';
+const AVATAR_URL = 'https://example.com/avatar.jpg';
+const CACHED_PATH = '/cache/avatar.jpg';
+const CACHED_URI = 'file:///cache/avatar.jpg';
+
+describe('useProfileAvatar', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPathToUri.mockImplementation((path: string) => `file://${path}`);
+  });
+
+  describe('when user has no avatar', () => {
+    it('returns undefined when user is undefined', async () => {
+      setupUser(undefined);
+
+      const { result } = renderHook(() => useProfileAvatar());
+
+      expect(result.current).toBeUndefined();
+      expect(mockGetCachedImage).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined when user.avatar is null', async () => {
+      setupUser(null);
+
+      const { result } = renderHook(() => useProfileAvatar());
+
+      expect(result.current).toBeUndefined();
+      expect(mockGetCachedImage).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined when user.avatar is empty string', async () => {
+      setupUser('');
+
+      const { result } = renderHook(() => useProfileAvatar());
+
+      expect(result.current).toBeUndefined();
+      expect(mockGetCachedImage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when user has an avatar', () => {
+    it('returns cached URI when a local cache hit exists', async () => {
+      setupUser(AVATAR_URL);
+      mockGetCachedImage.mockResolvedValue(CACHED_PATH);
+
+      const { result } = renderHook(() => useProfileAvatar());
+
+      await waitFor(() => expect(result.current).toBe(CACHED_URI));
+
+      expect(mockGetCachedImage).toHaveBeenCalledWith(CACHE_KEY);
+      expect(mockPathToUri).toHaveBeenCalledWith(CACHED_PATH);
+    });
+
+    it('returns remote avatar URL when there is no cache hit', async () => {
+      setupUser(AVATAR_URL);
+      mockGetCachedImage.mockResolvedValue(null);
+
+      const { result } = renderHook(() => useProfileAvatar());
+
+      await waitFor(() => expect(result.current).toBe(AVATAR_URL));
+
+      expect(mockGetCachedImage).toHaveBeenCalledWith(CACHE_KEY);
+      expect(mockPathToUri).not.toHaveBeenCalled();
+    });
+
+    it('falls back to remote avatar URL when getCachedImage rejects', async () => {
+      setupUser(AVATAR_URL);
+      const error = new Error('cache read failed');
+      mockGetCachedImage.mockRejectedValue(error);
+
+      const { result } = renderHook(() => useProfileAvatar());
+
+      await waitFor(() => expect(result.current).toBe(AVATAR_URL));
+
+      expect(mockReportError).toHaveBeenCalledWith(error);
+    });
+
+    it('reports the error via errorService on cache failure', async () => {
+      setupUser(AVATAR_URL);
+      const error = new Error('disk error');
+      mockGetCachedImage.mockRejectedValue(error);
+
+      renderHook(() => useProfileAvatar());
+
+      await waitFor(() => expect(mockReportError).toHaveBeenCalledWith(error));
+    });
+  });
+});

--- a/src/hooks/useProfileAvatar.ts
+++ b/src/hooks/useProfileAvatar.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import { imageService, PROFILE_PICTURE_CACHE_KEY } from '@internxt-mobile/services/common';
+import errorService from '@internxt-mobile/services/ErrorService';
+import { fs } from '@internxt-mobile/services/FileSystemService';
+import { useAppSelector } from '../store/hooks';
+
+export const useProfileAvatar = (): string | undefined => {
+  const { user } = useAppSelector((state) => state.auth);
+  const [profileAvatar, setProfileAvatar] = useState<string>();
+
+  useEffect(() => {
+    if (!user?.avatar) {
+      return setProfileAvatar(undefined);
+    }
+
+    imageService
+      .getCachedImage(PROFILE_PICTURE_CACHE_KEY)
+      .then((cachedImage) => {
+        if (!user.avatar) return;
+        if (cachedImage) {
+          setProfileAvatar(fs.pathToUri(cachedImage));
+        } else {
+          setProfileAvatar(user.avatar);
+        }
+      })
+      .catch((err) => {
+        errorService.reportError(err);
+        if (user?.avatar) {
+          setProfileAvatar(user.avatar);
+        }
+      });
+  }, [user?.avatar]);
+
+  return profileAvatar;
+};

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -14,6 +14,7 @@ import { DeactivatedAccountScreen } from '../screens/DeactivatedAccountScreen';
 import DebugScreen from '../screens/DebugScreen';
 import { TrashScreen } from '../screens/common/TrashScreen';
 import { DrivePreviewScreen } from '../screens/drive/DrivePreviewScreen';
+import { SettingsNavigator } from './SettingsNavigator';
 import ShareExtensionView from '../shareExtension/ShareExtensionView.android';
 import { useIosPendingShareHandoff } from '../shareExtension/hooks/useIosPendingShareHandoff';
 import { useAndroidShareIntent } from '../shareExtension/useAndroidShareIntent';
@@ -43,6 +44,7 @@ function AppNavigator({ navigationContainerRef }: Readonly<Props>): JSX.Element 
       <Stack.Screen name="DeactivatedAccount" component={DeactivatedAccountScreen} />
       <Stack.Screen name="TabExplorer" component={AuthenticatedNavigator} />
       <Stack.Screen name="Trash" component={TrashScreen} />
+      <Stack.Screen name="Settings" component={SettingsNavigator} />
       <Stack.Screen
         name="DrivePreview"
         component={DrivePreviewScreen}

--- a/src/navigation/TabExplorerNavigator.tsx
+++ b/src/navigation/TabExplorerNavigator.tsx
@@ -21,12 +21,12 @@ import useGetColor from '../hooks/useColor';
 import { SharedScreen } from '../screens/drive/SharedScreen/SharedScreen';
 import EmptyScreen from '../screens/EmptyScreen';
 import HomeScreen from '../screens/HomeScreen';
+import PhotosScreen from '../screens/PhotosScreen';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { uiActions } from '../store/slices/ui';
 import { AsyncStorageKey } from '../types';
 import { RootStackScreenProps, TabExplorerStackParamList } from '../types/navigation';
 import { DriveNavigator } from './DriveNavigator';
-import { SettingsNavigator } from './SettingsNavigator';
 
 const Tab = createBottomTabNavigator<TabExplorerStackParamList>();
 
@@ -77,7 +77,7 @@ export default function TabExplorerNavigator(props: RootStackScreenProps<'TabExp
         <Tab.Screen name="Drive" component={DriveNavigator} options={{ lazy: false }} />
         <Tab.Screen name="Add" component={EmptyScreen} />
         <Tab.Screen name="Shared" component={SharedScreen} options={{ lazy: false }} />
-        <Tab.Screen name="Settings" component={SettingsNavigator} options={{ lazy: false }} />
+        <Tab.Screen name="Photos" component={PhotosScreen} />
       </Tab.Navigator>
 
       <AddModal />

--- a/src/screens/DebugScreen/index.tsx
+++ b/src/screens/DebugScreen/index.tsx
@@ -1,21 +1,17 @@
-import React from 'react';
-
-import strings from '../../../assets/lang/strings';
-import ScreenTitle from '../../components/AppScreenTitle';
-import AppScreen from '../../components/AppScreen';
-import DebugNotificationsWidget from '../../components/DebugNotificationsWidget';
-import DebugInternetWidget from '../../components/DebugInternetWidget';
-import DebugUploadWidget from '../../components/DebugUploadWidget';
-import DebugDownloadWidget from '../../components/DebugDownloadWidget';
-import { RootStackScreenProps } from '../../types/navigation';
-import { useTailwind } from 'tailwind-rn';
-import useGetColor from '../../hooks/useColor';
-import { DebugDeviceStorageWidget } from 'src/components/DebugDeviceStorageWidget';
 import { ScrollView } from 'react-native';
+import { DebugDeviceStorageWidget } from 'src/components/DebugDeviceStorageWidget';
+import { useTailwind } from 'tailwind-rn';
+import strings from '../../../assets/lang/strings';
+import AppScreen from '../../components/AppScreen';
+import ScreenTitle from '../../components/AppScreenTitle';
+import DebugDownloadWidget from '../../components/DebugDownloadWidget';
+import DebugInternetWidget from '../../components/DebugInternetWidget';
+import DebugNotificationsWidget from '../../components/DebugNotificationsWidget';
+import DebugUploadWidget from '../../components/DebugUploadWidget';
+import { RootStackScreenProps } from '../../types/navigation';
 
 function DebugScreen({ navigation }: RootStackScreenProps<'Debug'>): JSX.Element {
   const tailwind = useTailwind();
-  const getColor = useGetColor();
   const onBackButtonPressed = () => navigation.goBack();
 
   return (

--- a/src/screens/HomeScreen/index.tsx
+++ b/src/screens/HomeScreen/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useState } from 'react';
 import strings from '../../../assets/lang/strings';
 
 import ScreenTitle from '../../components/AppScreenTitle';
@@ -11,13 +11,19 @@ import { useUseCase } from '@internxt-mobile/hooks/common';
 import * as useCases from '@internxt-mobile/useCases/drive';
 import { SearchInput } from 'src/components/SearchInput';
 import { useLanguage } from '../../hooks/useLanguage';
+import { useEffect } from 'react';
+import { TouchableOpacity } from 'react-native';
+import { TabExplorerScreenProps } from '../../types/navigation';
+import UserProfilePicture from '../../components/UserProfilePicture';
+import { useProfileAvatar } from '../../hooks/useProfileAvatar';
 
 enum HomeTab {
   Recents = 'recents',
 }
 
-const HomeScreen = (): JSX.Element => {
+const HomeScreen = (props: TabExplorerScreenProps<'Home'>): JSX.Element => {
   const tailwind = useTailwind();
+  const profileAvatar = useProfileAvatar();
   useLanguage();
   const [searchText, setSearchText] = useState('');
 
@@ -65,13 +71,18 @@ const HomeScreen = (): JSX.Element => {
   ];
   const onTabChanged = (tabId: string) => {
     setCurrentTab(tabId as HomeTab);
-
     setSearchText('');
   };
 
+  const avatarSlot = (
+    <TouchableOpacity onPress={() => props.navigation.navigate('Settings')}>
+      <UserProfilePicture uri={profileAvatar} size={36} />
+    </TouchableOpacity>
+  );
+
   return (
     <AppScreen safeAreaTop style={tailwind('flex-1 flex-grow')}>
-      <ScreenTitle text={strings.screens.home.title} showBackButton={false} />
+      <ScreenTitle text={strings.screens.home.title} showBackButton={false} rightSlot={avatarSlot} />
       <SearchInput value={searchText} onChangeText={setSearchText} placeholder={searchPlaceholder} />
       <Tabs value={currentTab} onTabChanged={onTabChanged} tabs={tabs} />
     </AppScreen>

--- a/src/screens/PhotosScreen/index.tsx
+++ b/src/screens/PhotosScreen/index.tsx
@@ -1,0 +1,31 @@
+import { ImageIcon } from 'phosphor-react-native';
+import { View } from 'react-native';
+import AppScreen from 'src/components/AppScreen';
+import AppScreenTitle from 'src/components/AppScreenTitle';
+import AppText from 'src/components/AppText';
+import useGetColor from 'src/hooks/useColor';
+import { useTailwind } from 'tailwind-rn';
+import strings from '../../../assets/lang/strings';
+
+const PhotosScreen = (): JSX.Element => {
+  const tailwind = useTailwind();
+  const getColor = useGetColor();
+
+  return (
+    <AppScreen safeAreaTop style={tailwind('flex-1')}>
+      <AppScreenTitle text={strings.screens.photos.title} showBackButton={false} />
+
+      <View style={tailwind('flex-1 items-center justify-center px-10')}>
+        <ImageIcon size={64} color={getColor('text-primary')} />
+        <AppText medium style={[tailwind('text-xl mt-5 text-center'), { color: getColor('text-gray-100') }]}>
+          {strings.screens.photos.emptyTitle}
+        </AppText>
+        <AppText style={[tailwind('text-base mt-1 text-center'), { color: getColor('text-gray-50') }]}>
+          {strings.screens.photos.emptySubtitle}
+        </AppText>
+      </View>
+    </AppScreen>
+  );
+};
+
+export default PhotosScreen;

--- a/src/screens/SettingsScreen/index.tsx
+++ b/src/screens/SettingsScreen/index.tsx
@@ -1,16 +1,16 @@
 import {
-  Bug,
-  CaretRight,
-  FileText,
-  FolderSimple,
-  Info,
-  Moon,
-  Question,
-  Shield,
-  Translate,
-  Trash,
+  BugIcon,
+  CaretRightIcon,
+  FileTextIcon,
+  FolderSimpleIcon,
+  InfoIcon,
+  MoonIcon,
+  QuestionIcon,
+  ShieldIcon,
+  TranslateIcon,
+  TrashIcon,
 } from 'phosphor-react-native';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { Linking, Platform, ScrollView, View } from 'react-native';
 import AppSwitch from '../../components/AppSwitch';
 
@@ -26,6 +26,7 @@ import SettingsGroup from '../../components/SettingsGroup';
 import UserProfilePicture from '../../components/UserProfilePicture';
 import useGetColor from '../../hooks/useColor';
 import { useLanguage } from '../../hooks/useLanguage';
+import { useProfileAvatar } from '../../hooks/useProfileAvatar';
 import { useScreenProtection } from '../../hooks/useScreenProtection';
 import appService from '../../services/AppService';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
@@ -33,8 +34,7 @@ import { authSelectors } from '../../store/slices/auth';
 import { uiActions } from '../../store/slices/ui';
 import { SettingsScreenProps } from '../../types/navigation';
 
-import { imageService, logger, PROFILE_PICTURE_CACHE_KEY } from '@internxt-mobile/services/common';
-import errorService from '@internxt-mobile/services/ErrorService';
+import { logger } from '@internxt-mobile/services/common';
 import { fs } from '@internxt-mobile/services/FileSystemService';
 import { notifications } from '@internxt-mobile/services/NotificationsService';
 
@@ -54,33 +54,9 @@ function SettingsScreen({ navigation }: SettingsScreenProps<'SettingsHome'>): JS
   useLanguage();
 
   const showBilling = useAppSelector(paymentsSelectors.shouldShowBilling);
-  const { user } = useAppSelector((state) => state.auth);
   const usagePercent = useAppSelector(storageSelectors.usagePercent);
-  const [profileAvatar, setProfileAvatar] = useState<string>();
+  const profileAvatar = useProfileAvatar();
   const userFullName = useAppSelector(authSelectors.userFullName);
-
-  useEffect(() => {
-    if (!user?.avatar) {
-      return setProfileAvatar(undefined);
-    }
-
-    imageService
-      .getCachedImage(PROFILE_PICTURE_CACHE_KEY)
-      .then((cachedImage) => {
-        if (!user.avatar) return;
-        if (cachedImage) {
-          setProfileAvatar(fs.pathToUri(cachedImage));
-        } else if (user?.avatar) {
-          setProfileAvatar(user?.avatar);
-        }
-      })
-      .catch((err) => {
-        errorService.reportError(err);
-        if (user?.avatar) {
-          setProfileAvatar(user.avatar);
-        }
-      });
-  }, [user?.avatar]);
 
   const handleDarkModeToggle = async (value: boolean) => {
     const newTheme = value ? 'dark' : 'light';
@@ -158,7 +134,9 @@ function SettingsScreen({ navigation }: SettingsScreenProps<'SettingsHome'>): JS
         <AppScreenTitle
           text={strings.screens.SettingsScreen.title}
           containerStyle={{ backgroundColor: getColor('bg-surface') }}
-          showBackButton={false}
+          showBackButton={navigation.canGoBack()}
+          compactBackButton
+          onBackButtonPressed={() => navigation.goBack()}
           rightSlot={
             <View style={tailwind('flex-grow items-end justify-center')}>
               <AppVersionWidget />
@@ -190,7 +168,7 @@ function SettingsScreen({ navigation }: SettingsScreenProps<'SettingsHome'>): JS
                       </View>
 
                       <View style={tailwind('items-end')}>
-                        <CaretRight color={getColor('text-gray-40')} size={20} />
+                        <CaretRightIcon color={getColor('text-gray-40')} size={20} />
                       </View>
                     </View>
                   ),
@@ -224,7 +202,7 @@ function SettingsScreen({ navigation }: SettingsScreenProps<'SettingsHome'>): JS
                   key: 'storage',
                   template: (
                     <View style={[tailwind('flex-row items-center px-4 py-3')]}>
-                      <FolderSimple size={24} color={getColor('text-primary')} style={tailwind('mr-3')} />
+                      <FolderSimpleIcon size={24} color={getColor('text-primary')} style={tailwind('mr-3')} />
                       <View style={tailwind('flex-grow justify-center')}>
                         <AppText style={[tailwind('text-lg')]}>{strings.screens.SettingsScreen.storage}</AppText>
                       </View>
@@ -234,7 +212,7 @@ function SettingsScreen({ navigation }: SettingsScreenProps<'SettingsHome'>): JS
                             {strings.formatString(strings.generic.usagePercent, usagePercent)}
                           </AppText>
                         ) : null}
-                        <CaretRight color={getColor('text-gray-40')} size={20} />
+                        <CaretRightIcon color={getColor('text-gray-40')} size={20} />
                       </View>
                     </View>
                   ),
@@ -244,14 +222,14 @@ function SettingsScreen({ navigation }: SettingsScreenProps<'SettingsHome'>): JS
                   key: 'trash',
                   template: (
                     <View style={[tailwind('flex-row items-center  px-4 py-3')]}>
-                      <Trash size={24} color={getColor('text-primary')} style={tailwind('mr-3')} />
+                      <TrashIcon size={24} color={getColor('text-primary')} style={tailwind('mr-3')} />
                       <View style={tailwind('flex-grow justify-center')}>
                         <AppText style={[tailwind('text-lg')]}>{strings.screens.SettingsScreen.trash}</AppText>
                       </View>
                       <View style={tailwind('flex-row items-center')}>
                         {/* Disabled until we can get the Trash size */}
                         {/* <AppText style={tailwind('text-gray-40 mr-2.5')}>{prettysize(0)}</AppText> */}
-                        <CaretRight color={getColor('text-gray-40')} size={20} />
+                        <CaretRightIcon color={getColor('text-gray-40')} size={20} />
                       </View>
                     </View>
                   ),
@@ -261,7 +239,7 @@ function SettingsScreen({ navigation }: SettingsScreenProps<'SettingsHome'>): JS
                   key: 'language',
                   template: (
                     <View style={[tailwind('flex-row items-center  px-4 py-3')]}>
-                      <Translate size={24} color={getColor('text-primary')} style={tailwind('mr-3')} />
+                      <TranslateIcon size={24} color={getColor('text-primary')} style={tailwind('mr-3')} />
                       <View style={tailwind('flex-grow justify-center')}>
                         <AppText style={[tailwind('text-lg')]}>{strings.screens.SettingsScreen.language}</AppText>
                       </View>
@@ -269,7 +247,7 @@ function SettingsScreen({ navigation }: SettingsScreenProps<'SettingsHome'>): JS
                         <AppText style={[tailwind('mr-2.5'), { color: getColor('text-gray-40') }]}>
                           {strings.languages[strings.getLanguage() as Language]}
                         </AppText>
-                        <CaretRight color={getColor('text-gray-40')} size={20} />
+                        <CaretRightIcon color={getColor('text-gray-40')} size={20} />
                       </View>
                     </View>
                   ),
@@ -279,7 +257,7 @@ function SettingsScreen({ navigation }: SettingsScreenProps<'SettingsHome'>): JS
                   key: 'dark-mode',
                   template: (
                     <View style={[tailwind('flex-row items-center px-4 py-3')]}>
-                      <Moon size={24} color={getColor('text-primary')} style={tailwind('mr-3')} />
+                      <MoonIcon size={24} color={getColor('text-primary')} style={tailwind('mr-3')} />
                       <View style={tailwind('flex-grow justify-center')}>
                         <AppText style={[tailwind('text-lg')]}>{strings.screens.SettingsScreen.darkMode}</AppText>
                         <AppText style={[tailwind('text-sm'), { color: getColor('text-gray-40') }]}>
@@ -306,7 +284,7 @@ function SettingsScreen({ navigation }: SettingsScreenProps<'SettingsHome'>): JS
                   key: 'screen-protection',
                   template: (
                     <View style={[tailwind('flex-row items-center px-4 py-3')]}>
-                      <Shield size={24} color={getColor('text-primary')} style={tailwind('mr-3')} />
+                      <ShieldIcon size={24} color={getColor('text-primary')} style={tailwind('mr-3')} />
                       <View style={tailwind('flex-grow justify-center')}>
                         <AppText style={[tailwind('text-lg')]}>
                           {strings.screens.SettingsScreen.screenProtection}
@@ -342,12 +320,12 @@ function SettingsScreen({ navigation }: SettingsScreenProps<'SettingsHome'>): JS
                   key: 'support',
                   template: (
                     <View style={[tailwind('flex-row items-center px-4 py-3')]}>
-                      <Question size={24} color={getColor('text-primary')} style={tailwind('mr-3')} />
+                      <QuestionIcon size={24} color={getColor('text-primary')} style={tailwind('mr-3')} />
                       <View style={tailwind('flex-grow justify-center')}>
                         <AppText style={[tailwind('text-lg')]}>{strings.screens.SettingsScreen.support}</AppText>
                       </View>
                       <View style={tailwind('justify-center')}>
-                        <CaretRight color={getColor('text-gray-40')} size={20} />
+                        <CaretRightIcon color={getColor('text-gray-40')} size={20} />
                       </View>
                     </View>
                   ),
@@ -357,12 +335,12 @@ function SettingsScreen({ navigation }: SettingsScreenProps<'SettingsHome'>): JS
                   key: 'more-information',
                   template: (
                     <View style={[tailwind('flex-row items-center px-4 py-3')]}>
-                      <Info size={24} color={getColor('text-primary')} style={tailwind('mr-3')} />
+                      <InfoIcon size={24} color={getColor('text-primary')} style={tailwind('mr-3')} />
                       <View style={tailwind('flex-grow justify-center')}>
                         <AppText style={[tailwind('text-lg')]}>{strings.screens.SettingsScreen.more}</AppText>
                       </View>
                       <View style={tailwind('justify-center')}>
-                        <CaretRight color={getColor('text-gray-40')} size={20} />
+                        <CaretRightIcon color={getColor('text-gray-40')} size={20} />
                       </View>
                     </View>
                   ),
@@ -373,12 +351,12 @@ function SettingsScreen({ navigation }: SettingsScreenProps<'SettingsHome'>): JS
                   loading: gettingLogs,
                   template: (
                     <View style={[tailwind('flex-row items-center px-4 py-3')]}>
-                      <FileText size={24} color={getColor('text-primary')} style={tailwind('mr-3')} />
+                      <FileTextIcon size={24} color={getColor('text-primary')} style={tailwind('mr-3')} />
                       <View style={tailwind('flex-grow justify-center')}>
                         <AppText style={[tailwind('text-lg')]}>{strings.screens.SettingsScreen.saveLogs}</AppText>
                       </View>
                       <View style={tailwind('justify-center')}>
-                        <CaretRight color={getColor('text-gray-40')} size={20} />
+                        <CaretRightIcon color={getColor('text-gray-40')} size={20} />
                       </View>
                     </View>
                   ),
@@ -400,7 +378,7 @@ function SettingsScreen({ navigation }: SettingsScreenProps<'SettingsHome'>): JS
                         </AppText>
                       </View>
                       <View style={tailwind('justify-center')}>
-                        <CaretRight color={getColor('text-gray-40')} size={20} />
+                        <CaretRightIcon color={getColor('text-gray-40')} size={20} />
                       </View>
                     </View>
                   ),
@@ -418,12 +396,12 @@ function SettingsScreen({ navigation }: SettingsScreenProps<'SettingsHome'>): JS
                     key: 'debug',
                     template: (
                       <View style={[tailwind('flex-row items-center px-4 py-3')]}>
-                        <Bug size={24} color={getColor('text-primary')} style={tailwind('mr-3')} />
+                        <BugIcon size={24} color={getColor('text-primary')} style={tailwind('mr-3')} />
                         <View style={tailwind('flex-grow justify-center')}>
                           <AppText style={[tailwind('text-lg')]}>{strings.screens.DebugScreen.title}</AppText>
                         </View>
                         <View style={tailwind('justify-center')}>
-                          <CaretRight color={getColor('text-gray-40')} size={20} />
+                          <CaretRightIcon color={getColor('text-gray-40')} size={20} />
                         </View>
                       </View>
                     ),

--- a/src/screens/common/TrashScreen/TrashScreenHeader.tsx
+++ b/src/screens/common/TrashScreen/TrashScreenHeader.tsx
@@ -21,7 +21,7 @@ export const TrashScreenHeader: React.FC<TrashScreenHeaderProps> = (props) => {
   return (
     <View style={tailwind('flex justify-evenly flex-row pt-4 pb-2 ')}>
       <View style={tailwind('flex-1')}>
-        <BackButton onPress={props.onBackButtonPress} label={strings.tabs.Settings} />
+        <BackButton onPress={props.onBackButtonPress} label={strings.screens.SettingsScreen.title} />
       </View>
       <View style={tailwind('flex-1')}>
         <AppText medium style={[tailwind('text-center text-xl'), { color: getColor('text-gray-100') }]}>

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -27,6 +27,7 @@ export type RootStackParamList = {
   TabExplorer: NavigatorScreenParams<TabExplorerStackParamList>;
   Trash: undefined;
   DrivePreview: undefined;
+  Settings: undefined;
   AndroidShare: { files: SharedFile[] } | undefined;
   LargeShareUpload: { metadata: PendingShareMetadata };
 };
@@ -46,7 +47,7 @@ export type TabExplorerStackParamList = {
   Drive: { sharedFolderId: number } | undefined;
   Add: undefined;
   Shared: undefined;
-  Settings: undefined;
+  Photos: undefined;
 };
 
 export type DriveStackParamList = {


### PR DESCRIPTION
 - Show the user's profile avatar in the Home screen header (tapping it navigates to Settings)
 - Extract avatar loading logic into a shared useProfileAvatar hook, removing duplication between Home and Settings screens
 - Add unit tests for useProfileAvatar
 - Update deprecated phosphor-react-native icons in Settings to the new *Icon naming convention