### PR TITLE
[PB-5924]: scaffold DocumentsProvider for SAF file picker integration

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -187,4 +187,7 @@ dependencies {
     } else {
         implementation jscFlavor
     }
+
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("androidx.security:security-crypto:1.1.0-alpha06")
 }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -12,3 +12,4 @@
 -keep class com.facebook.react.turbomodule.** { *; }
 
 # Add any project specific keep options here:
+-keep class com.internxt.cloud.documents.** { *; }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -48,5 +48,17 @@
       </intent-filter>
     </activity>
     <provider android:name="io.sentry.android.core.SentryInitProvider" android:authorities="${applicationId}.SentryInitProvider" tools:node="remove"/>
+    <provider
+      android:name="com.internxt.cloud.documents.InternxtDocumentsProvider"
+      android:authorities="com.internxt.cloud.documents"
+      android:exported="true"
+      android:grantUriPermissions="true"
+      android:permission="android.permission.MANAGE_DOCUMENTS"
+      android:label="@string/documents_provider_label"
+      android:icon="@mipmap/ic_launcher">
+      <intent-filter>
+        <action android:name="android.content.action.DOCUMENTS_PROVIDER"/>
+      </intent-filter>
+    </provider>
   </application>
 </manifest>

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -1,0 +1,75 @@
+package com.internxt.cloud.documents
+
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.os.CancellationSignal
+import android.os.ParcelFileDescriptor
+import android.provider.DocumentsContract.Document
+import android.provider.DocumentsContract.Root
+import android.provider.DocumentsProvider
+import com.internxt.cloud.R
+
+class InternxtDocumentsProvider : DocumentsProvider() {
+
+    override fun onCreate(): Boolean = true
+
+    override fun queryRoots(projection: Array<String>?): Cursor {
+        val cursor = MatrixCursor(resolveRootProjection(projection))
+        cursor.newRow().apply {
+            add(Root.COLUMN_ROOT_ID, ROOT_ID)
+            add(Root.COLUMN_DOCUMENT_ID, ROOT_DOCUMENT_ID)
+            add(Root.COLUMN_TITLE, context?.getString(R.string.documents_provider_label))
+            add(Root.COLUMN_FLAGS, 0)
+            add(Root.COLUMN_ICON, R.mipmap.ic_launcher)
+        }
+        return cursor
+    }
+
+    override fun queryDocument(documentId: String?, projection: Array<String>?): Cursor =
+        MatrixCursor(resolveDocumentProjection(projection))
+
+    override fun queryChildDocuments(
+        parentDocumentId: String?,
+        projection: Array<String>?,
+        sortOrder: String?
+    ): Cursor = MatrixCursor(resolveDocumentProjection(projection))
+
+    override fun openDocument(
+        documentId: String?,
+        mode: String?,
+        signal: CancellationSignal?
+    ): ParcelFileDescriptor {
+        throw UnsupportedOperationException("Not implemented yet")
+    }
+
+    private fun resolveRootProjection(projection: Array<String>?): Array<String> =
+        projection ?: DEFAULT_ROOT_PROJECTION
+
+    private fun resolveDocumentProjection(projection: Array<String>?): Array<String> =
+        projection ?: DEFAULT_DOCUMENT_PROJECTION
+
+    companion object {
+        const val AUTHORITY = "com.internxt.cloud.documents"
+        private const val ROOT_ID = "root"
+        private const val ROOT_DOCUMENT_ID = "root"
+
+        private val DEFAULT_ROOT_PROJECTION = arrayOf(
+            Root.COLUMN_ROOT_ID,
+            Root.COLUMN_FLAGS,
+            Root.COLUMN_ICON,
+            Root.COLUMN_TITLE,
+            Root.COLUMN_SUMMARY,
+            Root.COLUMN_DOCUMENT_ID,
+            Root.COLUMN_AVAILABLE_BYTES
+        )
+
+        private val DEFAULT_DOCUMENT_PROJECTION = arrayOf(
+            Document.COLUMN_DOCUMENT_ID,
+            Document.COLUMN_MIME_TYPE,
+            Document.COLUMN_DISPLAY_NAME,
+            Document.COLUMN_LAST_MODIFIED,
+            Document.COLUMN_FLAGS,
+            Document.COLUMN_SIZE
+        )
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
   <string name="app_name">Internxt</string>
+  <string name="documents_provider_label">Internxt Drive</string>
   <string name="expo_system_ui_user_interface_style" translatable="false">automatic</string>
   <string name="expo_runtime_version">1.8.8</string>
   <string name="expo_splash_screen_resize_mode" translatable="false">contain</string>


### PR DESCRIPTION
Registers InternxtDocumentsProvider in the manifest under MANAGE_DOCUMENTS so Internxt Drive appears as a source in the Android system file picker. Provider returns a single empty root as a stub; real roots, children and file streaming will land in follow-up tickets. Adds OkHttp and security-crypto dependencies for upcoming auth/networking work.