### PR TITLE
[PB-6219]: use fingerprint policy for runtimeVersion to prevent update check failures

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -34,7 +34,9 @@ const appConfig: ExpoConfig & { extra: AppEnv & { NODE_ENV: AppStage; RELEASE_ID
   },
 
   assetBundlePatterns: ['**/*'],
-  runtimeVersion: packageVersion,
+  runtimeVersion: {
+    policy: 'fingerprint',
+  },
   ios: {
     jsEngine: 'hermes',
     icon: './assets/icon-ios.png',

--- a/src/helpers/update.ts
+++ b/src/helpers/update.ts
@@ -29,6 +29,7 @@ export const getRemoteUpdateIfAvailable = async () => {
     }
     await Updates.reloadAsync();
   } catch (e) {
+    logger.warn(`Failed to check for remote updates (runtimeVersion: ${Updates.runtimeVersion}): ${e}`);
     errorService.reportError(e, {
       extra: {
         currentRuntimeVersion: Updates.runtimeVersion,


### PR DESCRIPTION
Previously, runtimeVersion was set to the package.json version (e.g. "1.8.6"). This meant every version bump changed the runtimeVersion, causing users on older binaries to fail when calling checkForUpdateAsync — the Expo update server had no OTA update for their outdated runtimeVersion, rejecting the request with "Failed to check for update".

Switching to the fingerprint policy generates a hash based on native dependencies, so runtimeVersion only changes when native code changes — not on JS-only version bumps. This allows OTA updates to reach all compatible binaries regardless of package version.

Also added a logger.warn before the Sentry report for better diagnostics.

See: https://docs.expo.dev/eas-update/runtime-versions/#fingerprint-runtime-version-policy