### PR TITLE
[PB-5877] feature/Enable folder uploads

### DIFF
--- a/assets/lang/strings.ts
+++ b/assets/lang/strings.ts
@@ -353,6 +353,7 @@ const translations = {
         errorPrep: 'Could not prepare the file for upload.',
         errorFileTooLarge: 'The maximum upload size is 300 MB at a time.',
         errorFileAlreadyExists: 'A file with this name already exists in this folder.',
+        errorPaymentRequired: 'Uploading empty files requires a paid plan.',
         uploading: 'Uploading…',
         preparing: 'Preparing…',
         cancelUploadTitle: 'Cancel upload?',
@@ -672,6 +673,11 @@ const translations = {
           'You have currently used 3GB of storage. To start uploading more files, please upgrade your storage plan.',
         advice: 'Get a higher plan or remove files you will no longer use in order to upload or sync your files again.',
       },
+      EmptyFileNotAllowedModal: {
+        title: 'Empty files not supported',
+        message:
+          'Uploading empty files is only available for some plans. Please upgrade your plan to use this feature.',
+      },
       ComingSoonModal: {
         title: 'Coming soon!',
         subtitle: 'Our fantastic devs are working on it, so stay tuned!',
@@ -741,7 +747,9 @@ const translations = {
       limitPerFile: 'Max upload size per file reached',
       folderUploadCompleted: 'Successfully uploaded {0} files to "{1}"',
       folderUploadPartial: '{0} of {1} files uploaded ({2} failed)',
+      folderUploadPartialWithSkipped: '{0} of {1} files uploaded ({2} failed, {3} skipped)',
       folderUploadCancelled: 'Folder upload cancelled',
+      emptyFileSkippedDuringFolderUpload: 'Empty files were skipped (upgrade your plan to upload them)',
     },
     errors: {
       runtimeLogsMissing: 'The logs file is missing or empty',
@@ -1197,6 +1205,7 @@ const translations = {
         errorPrep: 'No se pudo preparar el archivo para la subida.',
         errorFileTooLarge: 'El tamaño máximo de subida es de 300 MB a la vez.',
         errorFileAlreadyExists: 'Ya existe un archivo con este nombre en esta carpeta.',
+        errorPaymentRequired: 'La subida de archivos vacíos requiere un plan de pago.',
         uploading: 'Subiendo…',
         preparing: 'Preparando…',
         cancelUploadTitle: '¿Cancelar la subida?',
@@ -1518,6 +1527,11 @@ const translations = {
         advice:
           'Mejora tu plan o borra los archivos que no vayas a usar para subir o sincronizar tus archivos de nuevo.',
       },
+      EmptyFileNotAllowedModal: {
+        title: 'Archivos vacíos no permitidos',
+        message:
+          'La subida de archivos vacíos solo está disponible en algunos planes. Actualiza tu plan para usar esta función.',
+      },
       ComingSoonModal: {
         title: '¡Próximamente!',
         subtitle: 'Nuestros fantásticos programadores están trabajando en ello, así que mantente al tanto!',
@@ -1590,7 +1604,9 @@ const translations = {
       limitPerFile: 'Tamaño máximo por archivo alcanzado',
       folderUploadCompleted: '{0} archivos subidos correctamente a "{1}"',
       folderUploadPartial: '{0} de {1} archivos subidos ({2} fallaron)',
+      folderUploadPartialWithSkipped: '{0} de {1} archivos subidos ({2} fallaron, {3} omitidos)',
       folderUploadCancelled: 'Subida de carpeta cancelada',
+      emptyFileSkippedDuringFolderUpload: 'Se han omitido archivos vacíos (actualiza tu plan para subirlos)',
     },
     errors: {
       runtimeLogsMissing: 'El archivo no se encuentra o está vacío',

--- a/src/components/modals/AddModal/hooks/useFolderUpload.ts
+++ b/src/components/modals/AddModal/hooks/useFolderUpload.ts
@@ -5,6 +5,7 @@ import uuid from 'react-native-uuid';
 
 import { useDrive } from '@internxt-mobile/hooks/drive';
 import { logger } from '@internxt-mobile/services/common';
+import { EmptyFileNotAllowedError } from '@internxt-mobile/services/drive/file/utils/emptyFileErrors';
 import errorService from '@internxt-mobile/services/ErrorService';
 import { DriveFileData } from '@internxt-mobile/types/drive/file';
 import strings from '../../../../../assets/lang/strings';
@@ -33,12 +34,12 @@ import { NameCollisionAction } from '../../NameCollisionModal';
 const noopProgress: ProgressCallback = () => {};
 
 const showFolderUploadResult = (
-  result: { cancelled: boolean; failedFiles: number; uploadedFiles: number; totalFiles: number },
+  result: { cancelled: boolean; failedFiles: number; uploadedFiles: number; totalFiles: number; skippedFiles: number },
   folderName: string,
 ) => {
   if (result.cancelled) {
     notificationsService.show({ type: NotificationType.Info, text1: strings.messages.folderUploadCancelled });
-  } else if (result.failedFiles === 0) {
+  } else if (result.failedFiles === 0 && result.skippedFiles === 0) {
     notificationsService.show({
       type: NotificationType.Success,
       text1: strings.formatString(strings.messages.folderUploadCompleted, result.uploadedFiles, folderName) as string,
@@ -47,10 +48,11 @@ const showFolderUploadResult = (
     notificationsService.show({
       type: NotificationType.Warning,
       text1: strings.formatString(
-        strings.messages.folderUploadPartial,
+        strings.messages.folderUploadPartialWithSkipped,
         result.uploadedFiles,
         result.totalFiles,
         result.failedFiles,
+        result.skippedFiles,
       ) as string,
     });
   }
@@ -70,6 +72,7 @@ type UploadFileEntryFn = (
   progressCallback: ProgressCallback,
   modificationTime?: string,
   creationTime?: string,
+  signal?: AbortSignal,
 ) => Promise<DriveFileData>;
 
 export interface FolderUploadCollisionModalState {
@@ -118,10 +121,29 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
   const handleUploadFolder = async () => {
     dispatch(uiActions.setShowUploadFileModal(false));
 
-    const uploadFolderFileIOS = async (fileNode: FolderTreeNode, parentUuid: string): Promise<void> => {
+    let hasShownEmptyFileNotice = false;
+
+    const handleEmptyFileSkipped = () => {
+      if (!hasShownEmptyFileNotice) {
+        hasShownEmptyFileNotice = true;
+        notificationsService.show({
+          type: NotificationType.Warning,
+          text1: strings.messages.emptyFileSkippedDuringFolderUpload,
+        });
+      }
+    };
+
+    const uploadFolderFileIOS = async (fileNode: FolderTreeNode, parentUuid: string, signal: AbortSignal): Promise<void> => {
       const filePath = fileNode.uri.replace('file://', '');
       const { extension, plainName } = getFileExtensionAndPlainName(fileNode.name);
-      await uploadAndCreateFileEntry(filePath, plainName, extension, parentUuid, noopProgress);
+      try {
+        await uploadAndCreateFileEntry(filePath, plainName, extension, parentUuid, noopProgress, undefined, undefined, signal);
+      } catch (err) {
+        if (err instanceof EmptyFileNotAllowedError) {
+          handleEmptyFileSkipped();
+        }
+        throw err;
+      }
     };
 
     const uploadFolderFileAndroid = async (
@@ -137,7 +159,12 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
       try {
         await StorageAccessFramework.copyAsync({ from: fileNode.uri, to: tempUri });
         if (signal.aborted) return;
-        await uploadAndCreateFileEntry(tempPath, plainName, extension, parentUuid, noopProgress);
+        await uploadAndCreateFileEntry(tempPath, plainName, extension, parentUuid, noopProgress, undefined, undefined, signal);
+      } catch (err) {
+        if (err instanceof EmptyFileNotAllowedError) {
+          handleEmptyFileSkipped();
+        }
+        throw err;
       } finally {
         await fileSystemService.unlinkIfExists(tempPath).catch((e) => {
           logger.warn('[useFolderUpload] Failed to unlink temp file: ' + (e as Error).message);
@@ -231,7 +258,7 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
           if (Platform.OS === 'android' && fileNode.uri.startsWith('content://')) {
             await uploadFolderFileAndroid(fileNode, parentUuid, signal, uploadId);
           } else {
-            await uploadFolderFileIOS(fileNode, parentUuid);
+            await uploadFolderFileIOS(fileNode, parentUuid, signal);
           }
         },
       });

--- a/src/components/modals/AddModal/index.tsx
+++ b/src/components/modals/AddModal/index.tsx
@@ -21,6 +21,7 @@ import { Alert, PermissionsAndroid, Platform, TouchableHighlight, View } from 'r
 import { useDrive } from '@internxt-mobile/hooks/drive';
 import { imageService, logger } from '@internxt-mobile/services/common';
 import { uploadService } from '@internxt-mobile/services/common/network/upload/upload.service';
+import { EmptyFileNotAllowedError, isEmptyFilePlanError } from '@internxt-mobile/services/drive/file/utils/emptyFileErrors';
 import drive from '@internxt-mobile/services/drive';
 import {
   generateFileName,
@@ -184,6 +185,7 @@ function AddModal(): JSX.Element {
     progressCallback: ProgressCallback,
     modificationTime?: string,
     creationTime?: string,
+    signal?: AbortSignal,
   ) {
     if (!user) {
       throw new Error('User not found in Redux state');
@@ -195,6 +197,33 @@ function AddModal(): JSX.Element {
     checkFileSizeLimitToUpload(fileStat.size, fileName);
 
     const fileSize = fileStat.size;
+
+    const modTimestamp = modificationTime ?? fileStat.mtime;
+    const modificationTimeISO = modTimestamp ? new Date(modTimestamp).toISOString() : undefined;
+    const createTimestamp = creationTime ?? fileStat.ctime;
+    const creationTimeISO = createTimestamp ? new Date(createTimestamp).toISOString() : undefined;
+
+    if (fileSize === 0) {
+      const emptyEntry: FileEntryByUuid = {
+        type: fileExtension,
+        size: 0,
+        plainName: fileName,
+        bucket,
+        folderUuid: currentFolderId,
+        encryptVersion: EncryptionVersion.Aes03,
+        modificationTime: modificationTimeISO,
+        creationTime: creationTimeISO,
+      };
+      try {
+        const entry = await uploadService.createFileEntry(emptyEntry);
+        drive.events.emit({ event: DriveEventKey.UploadCompleted });
+        return { ...entry, thumbnails: [] } as DriveFileData;
+      } catch (err) {
+        if (isEmptyFilePlanError(err)) throw new EmptyFileNotAllowedError();
+        throw err;
+      }
+    }
+
     const fileId = await network.uploadFile(
       filePath,
       bucket,
@@ -206,6 +235,7 @@ function AddModal(): JSX.Element {
       },
       {
         notifyProgress: progressCallback,
+        signal,
       },
     );
     logger.info('File uploaded with fileId: ', fileId);
@@ -215,11 +245,6 @@ function AddModal(): JSX.Element {
 
     const folderId = currentFolderId;
     const plainName = fileName;
-    const modTimestamp = modificationTime ?? fileStat.mtime;
-    const modificationTimeISO = modTimestamp ? new Date(modTimestamp).toISOString() : undefined;
-
-    const createTimestamp = creationTime ?? fileStat.ctime;
-    const creationTimeISO = createTimestamp ? new Date(createTimestamp).toISOString() : undefined;
 
     const fileEntryByUuid: FileEntryByUuid = {
       fileId: fileId,

--- a/src/components/modals/EmptyFileNotAllowedModal/index.tsx
+++ b/src/components/modals/EmptyFileNotAllowedModal/index.tsx
@@ -1,0 +1,44 @@
+import strings from 'assets/lang/strings';
+import { View } from 'react-native';
+import AppButton from 'src/components/AppButton';
+import AppText from 'src/components/AppText';
+import useGetColor from 'src/hooks/useColor';
+import { useAppDispatch, useAppSelector } from 'src/store/hooks';
+import { uiActions } from 'src/store/slices/ui';
+import { useTailwind } from 'tailwind-rn';
+import CenterModal from '../CenterModal';
+
+function EmptyFileNotAllowedModal(): JSX.Element {
+  const tailwind = useTailwind();
+  const getColor = useGetColor();
+  const dispatch = useAppDispatch();
+  const isOpen = useAppSelector((state) => state.ui.showEmptyFileNotAllowedModal);
+
+  const handleClose = () => {
+    dispatch(uiActions.setShowEmptyFileNotAllowedModal(false));
+  };
+
+  return (
+    <CenterModal isOpen={isOpen} onClosed={handleClose} style={{ overflow: 'hidden' }}>
+      <View style={[tailwind('px-4 py-4'), { backgroundColor: getColor('bg-surface') }]}>
+        <AppText medium style={[tailwind('text-xl mb-2'), { color: getColor('text-gray-100') }]}>
+          {strings.modals.EmptyFileNotAllowedModal.title}
+        </AppText>
+        <AppText
+          style={[
+            tailwind('mb-6'),
+            {
+              color: getColor('text-gray-60'),
+              lineHeight: (tailwind('text-base').fontSize as number) * 1.4,
+            },
+          ]}
+        >
+          {strings.modals.EmptyFileNotAllowedModal.message}
+        </AppText>
+        <AppButton title={strings.buttons.close} type="accept" onPress={handleClose} />
+      </View>
+    </CenterModal>
+  );
+}
+
+export default EmptyFileNotAllowedModal;

--- a/src/navigation/TabExplorerNavigator.tsx
+++ b/src/navigation/TabExplorerNavigator.tsx
@@ -15,6 +15,7 @@ import DriveItemInfoModal from '../components/modals/DriveItemInfoModal';
 import DriveRenameModal from '../components/modals/DriveRenameModal';
 import MoveItemsModal from '../components/modals/MoveItemsModal';
 import RunOutOfStorageModal from '../components/modals/RunOutOfStorageModal';
+import EmptyFileNotAllowedModal from '../components/modals/EmptyFileNotAllowedModal';
 import { SharedLinkInfoModal } from '../components/modals/SharedLinkInfoModal';
 import SignOutModal from '../components/modals/SignOutModal';
 import useGetColor from '../hooks/useColor';
@@ -86,6 +87,7 @@ export default function TabExplorerNavigator(props: RootStackScreenProps<'TabExp
       <MoveItemsModal />
       <DriveRenameModal />
       <RunOutOfStorageModal />
+      <EmptyFileNotAllowedModal />
       <SignOutModal />
       <SecurityModal isOpen={isSecurityModalOpen} onClose={onSecurityModalClosed} />
     </View>

--- a/src/network/NetworkFacade.ts
+++ b/src/network/NetworkFacade.ts
@@ -1,4 +1,5 @@
 import * as RNFS from '@dr.pogodin/react-native-fs';
+import { AbortError } from './errors';
 import { logger } from '@internxt-mobile/services/common';
 import { decryptFile, encryptFile, encryptFileToChunks, joinFiles } from '@internxt/rn-crypto';
 import { ALGORITHMS, Network } from '@internxt/sdk/dist/network';
@@ -108,6 +109,9 @@ export class NetworkFacade {
     const fileSize = stat.size;
     const shouldEnableEncryptionProgress = fileSize >= MINIMUM_SIZE_FOR_ENCRYPTION_PROGRESS;
 
+    let activeFetchTask: ReturnType<typeof ReactNativeBlobUtil.fetch> | null = null;
+    let aborted = false;
+
     const uploadFilePromise = uploadFile(
       this.network,
       this.cryptoLib,
@@ -136,7 +140,9 @@ export class NetworkFacade {
         fileHash = ripemd160(Buffer.from(await RNFS.hash(encryptedFilePath, 'sha256'), 'hex')).toString('hex');
       },
       async (url: string) => {
-        await ReactNativeBlobUtil.fetch(
+        if (aborted) throw new AbortError();
+
+        const fetchTask = ReactNativeBlobUtil.fetch(
           'PUT',
           url,
           {
@@ -153,6 +159,13 @@ export class NetworkFacade {
             updateProgress(uploadProgress);
           }
         });
+
+        activeFetchTask = fetchTask;
+        try {
+          await fetchTask;
+        } finally {
+          activeFetchTask = null;
+        }
 
         return fileHash;
       },
@@ -174,7 +187,12 @@ export class NetworkFacade {
       }
     };
 
-    return [wrapUploadWithCleanup(), () => null];
+    const abortable: Abortable = () => {
+      aborted = true;
+      activeFetchTask?.cancel?.();
+    };
+
+    return [wrapUploadWithCleanup(), abortable];
   }
 
   async uploadMultipart(
@@ -185,6 +203,23 @@ export class NetworkFacade {
   ): Promise<string> {
     const CONCURRENT_UPLOADS = 6;
     const limit = pLimit(CONCURRENT_UPLOADS);
+    const activeFetchTasks = new Set<ReturnType<typeof ReactNativeBlobUtil.fetch>>();
+    let aborted = false;
+
+    const abortHandler = () => {
+      aborted = true;
+      limit.clearQueue();
+      activeFetchTasks.forEach((t) => t.cancel?.());
+      activeFetchTasks.clear();
+    };
+
+    if (options.abortController) {
+      if (options.abortController.aborted) {
+        abortHandler();
+      } else {
+        options.abortController.addEventListener('abort', abortHandler, { once: true });
+      }
+    }
 
     const uploadState = {
       partsUploadedBytes: {} as Record<number, number>,
@@ -194,8 +229,9 @@ export class NetworkFacade {
 
     const fileInfo = await this.getFileInfo(filePath, options.partSize);
     const encryptedPartPaths = this.createEncryptedPartPaths(fileInfo.parts);
+    const abortCtx = { isAborted: () => aborted, activeFetchTasks };
     const uploadMultipart = async (urls: string[]) => {
-      await this.processUploadParts(urls, encryptedPartPaths, uploadState, limit, fileInfo.size, options);
+      await this.processUploadParts(urls, encryptedPartPaths, uploadState, limit, fileInfo.size, options, abortCtx);
       uploadState.fileHash = await this.calculateFileHash(encryptedPartPaths);
 
       return {
@@ -216,6 +252,7 @@ export class NetworkFacade {
       );
     } finally {
       await this.cleanupEncryptedFiles(encryptedPartPaths);
+      options.abortController?.removeEventListener('abort', abortHandler);
     }
   }
 
@@ -260,30 +297,16 @@ export class NetworkFacade {
     limit: LimitFunction,
     fileSize: number,
     options: UploadMultipartOptions,
+    abortCtx: { isAborted: () => boolean; activeFetchTasks: Set<ReturnType<typeof ReactNativeBlobUtil.fetch>> },
   ): Promise<void> {
     const uploadWithRetry = async (path: string, url: string, index: number): Promise<PartInfo> => {
       try {
-        const result = await this.uploadPart(
-          url,
-          path,
-          index,
-          uploadState.partsUploadedBytes,
-          fileSize,
-          options.uploadingCallback,
-        );
-        return result;
+        return await this.uploadPart(url, path, index, uploadState.partsUploadedBytes, fileSize, options.uploadingCallback, abortCtx);
       } catch (error) {
+        if ((error as Error)?.name === AbortError.errorName) throw error;
         logger.error(`First attempt failed for part ${index + 1}, retrying...`);
         try {
-          const retryResult = await this.uploadPart(
-            url,
-            path,
-            index,
-            uploadState.partsUploadedBytes,
-            fileSize,
-            options.uploadingCallback,
-          );
-          return retryResult;
+          return await this.uploadPart(url, path, index, uploadState.partsUploadedBytes, fileSize, options.uploadingCallback, abortCtx);
         } catch (retryError) {
           logger.error(`Retry failed for part ${index + 1}`);
           throw retryError;
@@ -309,17 +332,22 @@ export class NetworkFacade {
     partsUploadedBytes: Record<number, number>,
     fileSize: number,
     progressCallback?: (progress: number) => void,
+    abortCtx?: { isAborted: () => boolean; activeFetchTasks: Set<ReturnType<typeof ReactNativeBlobUtil.fetch>> },
   ): Promise<PartInfo> {
-    try {
-      const response = await ReactNativeBlobUtil.fetch(
-        'PUT',
-        url,
-        { 'Content-Type': 'application/octet-stream' },
-        ReactNativeBlobUtil.wrap(encryptedPartPath),
-      ).uploadProgress({ interval: 150 }, (sent: number) => {
-        this.updateUploadProgress(index, parseInt(sent.toString()), partsUploadedBytes, fileSize, progressCallback);
-      });
+    if (abortCtx?.isAborted()) throw new AbortError();
 
+    const fetchTask = ReactNativeBlobUtil.fetch(
+      'PUT',
+      url,
+      { 'Content-Type': 'application/octet-stream' },
+      ReactNativeBlobUtil.wrap(encryptedPartPath),
+    ).uploadProgress({ interval: 150 }, (sent: number) => {
+      this.updateUploadProgress(index, parseInt(sent.toString()), partsUploadedBytes, fileSize, progressCallback);
+    });
+
+    abortCtx?.activeFetchTasks.add(fetchTask);
+    try {
+      const response = await fetchTask;
       const etag = Platform.OS === 'android' ? response.info().headers.ETag : response.info().headers.Etag;
       if (!etag) throw new Error('Missing ETag in upload response');
 
@@ -328,8 +356,11 @@ export class NetworkFacade {
         ETag: etag,
       };
     } catch (error) {
+      if (abortCtx?.isAborted()) throw new AbortError();
       logger.error(`Error uploading part ${index + 1}:`, error);
       throw error;
+    } finally {
+      abortCtx?.activeFetchTasks.delete(fetchTask);
     }
   }
 

--- a/src/network/errors.ts
+++ b/src/network/errors.ts
@@ -1,0 +1,8 @@
+export class AbortError extends Error {
+  static readonly errorName = 'AbortError';
+
+  constructor(message = 'Upload cancelled') {
+    super(message);
+    this.name = AbortError.errorName;
+  }
+}

--- a/src/network/upload.ts
+++ b/src/network/upload.ts
@@ -2,6 +2,7 @@ import * as RNFS from '@dr.pogodin/react-native-fs';
 import { logger } from '../services/common';
 import { withRateLimitRetry } from '../services/common/rate-limit';
 import { Abortable } from '../types';
+import { AbortError } from './errors';
 import { getNetwork } from './NetworkFacade';
 import { NetworkCredentials } from './requests';
 
@@ -28,7 +29,7 @@ export async function uploadFile(
 
   const useMultipart = fileSize > MAX_SIZE_FOR_SINGLE_UPLOAD;
 
-  const uploadAbortController = new AbortController();
+  const isAborted = () => params.signal?.aborted === true;
 
   async function retryUpload(): Promise<string> {
     const MAX_TRIES = 3;
@@ -38,11 +39,13 @@ export async function uploadFile(
     for (let attempt = 1; attempt <= MAX_TRIES; attempt++) {
       try {
         const result = await withRateLimitRetry(async () => {
+          if (isAborted()) throw new AbortError();
+
           if (useMultipart) {
-            return await network.uploadMultipart(bucketId, mnemonic, filePath, {
+            return network.uploadMultipart(bucketId, mnemonic, filePath, {
               partSize: MULTIPART_PART_SIZE,
               uploadingCallback: params.notifyProgress,
-              abortController: uploadAbortController.signal,
+              abortController: params.signal,
             });
           }
 
@@ -54,11 +57,16 @@ export async function uploadFile(
             onAbortableReady(abortable);
           }
 
-          return await promise;
+          params.signal?.addEventListener('abort', () => abortable(), { once: true });
+          if (isAborted()) abortable();
+
+          return promise;
         }, 'Upload');
 
         return result;
       } catch (err) {
+        if ((err as Error)?.name === AbortError.errorName) throw err;
+
         logger.error(`Upload attempt ${attempt} of ${MAX_TRIES} failed:`, err);
 
         const lastTryFailed = attempt === MAX_TRIES;

--- a/src/services/drive/file/utils/emptyFileErrors.ts
+++ b/src/services/drive/file/utils/emptyFileErrors.ts
@@ -1,0 +1,13 @@
+export class EmptyFileNotAllowedError extends Error {
+  constructor() {
+    super('Empty files require a paid plan');
+    this.name = 'EmptyFileNotAllowedError';
+    Object.setPrototypeOf(this, EmptyFileNotAllowedError.prototype);
+  }
+}
+
+export const isEmptyFilePlanError = (error: unknown): boolean => {
+  const err = error as { status?: unknown; response?: { status?: unknown } };
+  const status = Number(err?.status ?? err?.response?.status);
+  return status === 402;
+};

--- a/src/services/drive/file/utils/uploadFileUtils.ts
+++ b/src/services/drive/file/utils/uploadFileUtils.ts
@@ -20,9 +20,11 @@ import { Dispatch } from 'react';
 import { Action } from 'redux';
 import { DriveFoldersTreeNode } from '../../../../contexts/Drive';
 import { getEnvironmentConfigFromUser } from '../../../../lib/network';
+import { uiActions } from '../../../../store/slices/ui';
 import analyticsService, { DriveAnalyticsEvent } from '../../../AnalyticsService';
 import { logger } from '../../../common';
 import { uploadService } from '../../../common/network/upload/upload.service';
+import { EmptyFileNotAllowedError, isEmptyFilePlanError } from './emptyFileErrors';
 import { BucketNotFoundError } from './upload.errors';
 
 /**
@@ -232,7 +234,12 @@ export async function createEmptyFileEntry(bucketId: string, file: UploadingFile
     creationTime: creationTimeISO,
   };
 
-  return uploadService.createFileEntry(fileEntry);
+  try {
+    return await uploadService.createFileEntry(fileEntry);
+  } catch (err) {
+    if (isEmptyFilePlanError(err)) throw new EmptyFileNotAllowedError();
+    throw err;
+  }
 }
 
 /**
@@ -265,6 +272,11 @@ export async function uploadSingleFile(
     }
     uploadSuccess(file);
   } catch (e) {
+    if (e instanceof EmptyFileNotAllowedError) {
+      dispatch(uiActions.setShowEmptyFileNotAllowedModal(true));
+      dispatch(driveActions.uploadFileFinished());
+      return;
+    }
     const err = e as Error;
     errorService.reportError(err, {
       extra: {
@@ -280,3 +292,4 @@ export async function uploadSingleFile(
     dispatch(driveActions.uploadFileFinished());
   }
 }
+

--- a/src/services/drive/folder/folderOrchestration.service.spec.ts
+++ b/src/services/drive/folder/folderOrchestration.service.spec.ts
@@ -1,5 +1,5 @@
-import { uploadFolderContents, getMaxDepth } from './folderOrchestration.service';
 import { FolderTree, FolderTreeNode } from '../../../types/drive/folderUpload';
+import { getMaxDepth, uploadFolderContents } from './folderOrchestration.service';
 
 const mockCreateFolder = jest.fn();
 const mockCheckDuplicatedFolders = jest.fn();
@@ -46,19 +46,19 @@ const makeSignal = (aborted = false): AbortSignal => {
 };
 
 describe('getMaxDepth', () => {
-  it('when dirs is empty, then returns 0', () => {
+  test('when dirs is empty, then returns 0', () => {
     expect(getMaxDepth([])).toBe(0);
   });
 
-  it('when dirs has a single flat entry, then returns 1', () => {
+  test('when dirs has a single flat entry, then returns 1', () => {
     expect(getMaxDepth([makeDir('photos')])).toBe(1);
   });
 
-  it('when dirs has two entries one level deep, then returns 2', () => {
+  test('when dirs has two entries one level deep, then returns 2', () => {
     expect(getMaxDepth([makeDir('photos'), makeDir('photos/vacation')])).toBe(2);
   });
 
-  it('when dirs has three levels of nesting, then returns 3', () => {
+  test('when dirs has three levels of nesting, then returns 3', () => {
     expect(getMaxDepth([makeDir('a'), makeDir('a/b'), makeDir('a/b/c')])).toBe(3);
   });
 });
@@ -75,7 +75,7 @@ describe('uploadFolderContents', () => {
   });
 
   describe('folder tree is mapped and uploaded correctly', () => {
-    it('when tree is empty, then returns all-zero counts', async () => {
+    test('when tree is empty, then returns all-zero counts', async () => {
       const result = await uploadFolderContents({
         tree: makeTree([], []),
         rootParentUuid: ROOT,
@@ -85,14 +85,19 @@ describe('uploadFolderContents', () => {
       });
 
       expect(result).toEqual({
-        totalFiles: 0, uploadedFiles: 0, failedFiles: 0,
-        totalFolders: 0, createdFolders: 0, failedFolders: 0,
+        totalFiles: 0,
+        uploadedFiles: 0,
+        failedFiles: 0,
+        skippedFiles: 0,
+        totalFolders: 0,
+        createdFolders: 0,
+        failedFolders: 0,
         cancelled: false,
       });
       expect(uploadFile).not.toHaveBeenCalled();
     });
 
-    it('when tree has only root-level files, then uploads all files to rootParentUuid', async () => {
+    test('when tree has only root-level files, then uploads all files to rootParentUuid', async () => {
       const files = [makeFile('a.jpg', ''), makeFile('b.jpg', ''), makeFile('c.jpg', '')];
 
       const result = await uploadFolderContents({
@@ -104,8 +109,13 @@ describe('uploadFolderContents', () => {
       });
 
       expect(result).toEqual({
-        totalFiles: 3, uploadedFiles: 3, failedFiles: 0,
-        totalFolders: 0, createdFolders: 0, failedFolders: 0,
+        totalFiles: 3,
+        uploadedFiles: 3,
+        failedFiles: 0,
+        skippedFiles: 0,
+        totalFolders: 0,
+        createdFolders: 0,
+        failedFolders: 0,
         cancelled: false,
       });
       expect(uploadFile).toHaveBeenCalledTimes(3);
@@ -114,7 +124,7 @@ describe('uploadFolderContents', () => {
       });
     });
 
-    it('when tree has one subfolder with one file, then creates the folder and uploads the file to it', async () => {
+    test('when tree has one subfolder with one file, then creates the folder and uploads the file to it', async () => {
       // Arrange
       mockCreateFolder.mockResolvedValue({ uuid: 'photos-uuid' });
       const dirs = [makeDir('photos')];
@@ -135,11 +145,9 @@ describe('uploadFolderContents', () => {
       expect(uploadFile).toHaveBeenCalledWith(files[0], 'photos-uuid', expect.any(AbortSignal));
     });
 
-    it('when tree has two levels of nested dirs with files, then creates folders in order and routes files to correct parent UUIDs', async () => {
+    test('when tree has two levels of nested dirs with files, then creates folders in order and routes files to correct parent UUIDs', async () => {
       // Arrange
-      mockCreateFolder
-        .mockResolvedValueOnce({ uuid: 'photos-uuid' })
-        .mockResolvedValueOnce({ uuid: 'vacation-uuid' });
+      mockCreateFolder.mockResolvedValueOnce({ uuid: 'photos-uuid' }).mockResolvedValueOnce({ uuid: 'vacation-uuid' });
       const dirs = [makeDir('photos'), makeDir('photos/vacation')];
       const files = [makeFile('root.jpg', ''), makeFile('photo.jpg', 'photos'), makeFile('vac.jpg', 'photos/vacation')];
 
@@ -154,8 +162,13 @@ describe('uploadFolderContents', () => {
 
       // Assert
       expect(result).toEqual({
-        totalFiles: 3, uploadedFiles: 3, failedFiles: 0,
-        totalFolders: 2, createdFolders: 2, failedFolders: 0,
+        totalFiles: 3,
+        uploadedFiles: 3,
+        failedFiles: 0,
+        skippedFiles: 0,
+        totalFolders: 2,
+        createdFolders: 2,
+        failedFolders: 0,
         cancelled: false,
       });
       expect(mockCreateFolder).toHaveBeenCalledWith(ROOT, 'photos');
@@ -165,11 +178,9 @@ describe('uploadFolderContents', () => {
       expect(uploadFile).toHaveBeenCalledWith(files[2], 'vacation-uuid', expect.any(AbortSignal));
     });
 
-    it('when tree has nested dirs but no files, then creates all folders and does not upload any file', async () => {
+    test('when tree has nested dirs but no files, then creates all folders and does not upload any file', async () => {
       // Arrange
-      mockCreateFolder
-        .mockResolvedValueOnce({ uuid: 'a-uuid' })
-        .mockResolvedValueOnce({ uuid: 'ab-uuid' });
+      mockCreateFolder.mockResolvedValueOnce({ uuid: 'a-uuid' }).mockResolvedValueOnce({ uuid: 'ab-uuid' });
 
       // Act
       const result = await uploadFolderContents({
@@ -182,8 +193,13 @@ describe('uploadFolderContents', () => {
 
       // Assert
       expect(result).toEqual({
-        totalFiles: 0, uploadedFiles: 0, failedFiles: 0,
-        totalFolders: 2, createdFolders: 2, failedFolders: 0,
+        totalFiles: 0,
+        uploadedFiles: 0,
+        failedFiles: 0,
+        skippedFiles: 0,
+        totalFolders: 2,
+        createdFolders: 2,
+        failedFolders: 0,
         cancelled: false,
       });
       expect(mockCreateFolder).toHaveBeenCalledWith(ROOT, 'a');
@@ -193,7 +209,7 @@ describe('uploadFolderContents', () => {
   });
 
   describe('destination folder already exists on the server', () => {
-    it('when createFolder returns 409, then calls checkDuplicatedFolders and uploads to the existing UUID', async () => {
+    test('when createFolder returns 409, then calls checkDuplicatedFolders and uploads to the existing UUID', async () => {
       // Arrange
       mockCreateFolder.mockRejectedValueOnce({ status: 409, message: 'Already exists' });
       mockCheckDuplicatedFolders.mockResolvedValueOnce({
@@ -214,7 +230,7 @@ describe('uploadFolderContents', () => {
       expect(uploadFile).toHaveBeenCalledWith(expect.anything(), 'existing-uuid', expect.any(AbortSignal));
     });
 
-    it('when folder name has special characters and createFolder returns 409, then passes the name directly to checkDuplicatedFolders', async () => {
+    test('when folder name has special characters and createFolder returns 409, then passes the name directly to checkDuplicatedFolders', async () => {
       // Arrange
       mockCreateFolder.mockRejectedValueOnce({ status: 409 });
       mockCheckDuplicatedFolders.mockResolvedValueOnce({
@@ -235,7 +251,7 @@ describe('uploadFolderContents', () => {
       expect(uploadFile).toHaveBeenCalledWith(expect.anything(), 'cafe-uuid', expect.any(AbortSignal));
     });
 
-    it('when createFolder returns 409 and checkDuplicatedFolders returns empty, then counts the dependent file as failed', async () => {
+    test('when createFolder returns 409 and checkDuplicatedFolders returns empty, then counts the dependent file as failed', async () => {
       // Arrange
       mockCreateFolder.mockRejectedValueOnce({ status: 409 });
       mockCheckDuplicatedFolders.mockResolvedValueOnce({ existentFolders: [] });
@@ -254,7 +270,7 @@ describe('uploadFolderContents', () => {
       expect(result.uploadedFiles).toBe(0);
     });
 
-    it('when createFolder returns a non-409 error, then does not call checkDuplicatedFolders', async () => {
+    test('when createFolder returns a non-409 error, then does not call checkDuplicatedFolders', async () => {
       // Arrange
       mockCreateFolder.mockRejectedValueOnce({ status: 500, message: 'Internal Server Error' });
 
@@ -274,7 +290,7 @@ describe('uploadFolderContents', () => {
   });
 
   describe('a file failure does not abort the rest of the upload', () => {
-    it('when one file upload fails, then counts it as failed and continues uploading the rest', async () => {
+    test('when one file upload fails, then counts it as failed and continues uploading the rest', async () => {
       // Arrange
       uploadFile.mockRejectedValueOnce(new Error('Network error')).mockResolvedValue(undefined);
       const files = [makeFile('a.jpg', ''), makeFile('b.jpg', ''), makeFile('c.jpg', '')];
@@ -294,7 +310,7 @@ describe('uploadFolderContents', () => {
       expect(result.cancelled).toBe(false);
     });
 
-    it('when all file uploads fail, then counts all as failed and does not mark as cancelled', async () => {
+    test('when all file uploads fail, then counts all as failed and does not mark as cancelled', async () => {
       // Arrange
       uploadFile.mockRejectedValue(new Error('Network error'));
       const files = [makeFile('a.jpg', ''), makeFile('b.jpg', '')];
@@ -316,7 +332,7 @@ describe('uploadFolderContents', () => {
   });
 
   describe('progress is reported as files are processed', () => {
-    it('when files succeed and fail, then calls onProgress once per file', async () => {
+    test('when files succeed and fail, then calls onProgress once per file', async () => {
       uploadFile.mockRejectedValueOnce(new Error('fail')).mockResolvedValue(undefined);
       const files = [makeFile('a.jpg', ''), makeFile('b.jpg', ''), makeFile('c.jpg', '')];
 
@@ -331,7 +347,7 @@ describe('uploadFolderContents', () => {
       expect(onProgress).toHaveBeenCalledTimes(3);
     });
 
-    it('when all files succeed, then last onProgress call reports the total uploaded count', async () => {
+    test('when all files succeed, then last onProgress call reports the total uploaded count', async () => {
       const files = [makeFile('a.jpg', ''), makeFile('b.jpg', '')];
 
       await uploadFolderContents({
@@ -347,7 +363,7 @@ describe('uploadFolderContents', () => {
   });
 
   describe('upload is stopped when a cancellation signal is received', () => {
-    it('when signal is already aborted before calling, then returns cancelled=true without uploading any file', async () => {
+    test('when signal is already aborted before calling, then returns cancelled=true without uploading any file', async () => {
       const result = await uploadFolderContents({
         tree: makeTree([], [makeFile('a.jpg', ''), makeFile('b.jpg', '')]),
         rootParentUuid: ROOT,
@@ -361,7 +377,7 @@ describe('uploadFolderContents', () => {
       expect(uploadFile).not.toHaveBeenCalled();
     });
 
-    it('when uploadFile throws AbortError, then sets cancelled=true and does not increment failedFiles', async () => {
+    test('when uploadFile throws AbortError, then sets cancelled=true and does not increment failedFiles', async () => {
       // Arrange
       const abortError = new Error('Aborted');
       abortError.name = 'AbortError';
@@ -381,7 +397,7 @@ describe('uploadFolderContents', () => {
       expect(result.cancelled).toBe(true);
     });
 
-    it('when signal is aborted after first upload, then does not start more than the concurrent limit', async () => {
+    test('when signal is aborted after first upload, then does not start more than the concurrent limit', async () => {
       // Arrange
       const abortController = new AbortController();
       let callCount = 0;
@@ -408,7 +424,7 @@ describe('uploadFolderContents', () => {
       expect(uploadFile.mock.calls.length).toBeLessThanOrEqual(3);
     });
 
-    it('when signal is pre-aborted and tree is empty, then returns all-zero counts with cancelled=true', async () => {
+    test('when signal is pre-aborted and tree is empty, then returns all-zero counts with cancelled=true', async () => {
       const result = await uploadFolderContents({
         tree: makeTree([], []),
         rootParentUuid: ROOT,
@@ -418,15 +434,20 @@ describe('uploadFolderContents', () => {
       });
 
       expect(result).toEqual({
-        totalFiles: 0, uploadedFiles: 0, failedFiles: 0,
-        totalFolders: 0, createdFolders: 0, failedFolders: 0,
+        totalFiles: 0,
+        uploadedFiles: 0,
+        failedFiles: 0,
+        skippedFiles: 0,
+        totalFolders: 0,
+        createdFolders: 0,
+        failedFolders: 0,
         cancelled: true,
       });
     });
   });
 
   describe('simultaneous uploads do not interfere with each other', () => {
-    it('when two uploads run concurrently with independent signals, then both complete with their own file counts', async () => {
+    test('when two uploads run concurrently with independent signals, then both complete with their own file counts', async () => {
       // Arrange
       const onProgressA = jest.fn();
       const onProgressB = jest.fn();
@@ -453,20 +474,30 @@ describe('uploadFolderContents', () => {
 
       // Assert
       expect(resultA).toEqual({
-        totalFiles: 2, uploadedFiles: 2, failedFiles: 0,
-        totalFolders: 0, createdFolders: 0, failedFolders: 0,
+        totalFiles: 2,
+        uploadedFiles: 2,
+        failedFiles: 0,
+        skippedFiles: 0,
+        totalFolders: 0,
+        createdFolders: 0,
+        failedFolders: 0,
         cancelled: false,
       });
       expect(resultB).toEqual({
-        totalFiles: 3, uploadedFiles: 3, failedFiles: 0,
-        totalFolders: 0, createdFolders: 0, failedFolders: 0,
+        totalFiles: 3,
+        uploadedFiles: 3,
+        failedFiles: 0,
+        skippedFiles: 0,
+        totalFolders: 0,
+        createdFolders: 0,
+        failedFolders: 0,
         cancelled: false,
       });
       expect(uploadFileA).toHaveBeenCalledTimes(2);
       expect(uploadFileB).toHaveBeenCalledTimes(3);
     });
 
-    it('when signal A is aborted mid-upload, then upload B completes successfully', async () => {
+    test('when signal A is aborted mid-upload, then upload B completes successfully', async () => {
       // Arrange
       const firstUploadController = new AbortController();
       const uploadFileA = jest.fn().mockImplementation(async () => {

--- a/src/services/drive/folder/folderOrchestration.service.ts
+++ b/src/services/drive/folder/folderOrchestration.service.ts
@@ -1,5 +1,7 @@
 import { logger } from '@internxt-mobile/services/common';
+import { EmptyFileNotAllowedError } from '@internxt-mobile/services/drive/file/utils/emptyFileErrors';
 import pLimit from 'p-limit';
+import { AbortError } from '../../../network/errors';
 import { FolderTree, FolderTreeNode, FolderUploadResult, UploadFileCallback } from '../../../types/drive/folderUpload';
 import { HTTP_CONFLICT, HTTP_NOT_FOUND } from '../../common/httpStatusCodes';
 import { driveFolderService } from './driveFolder.service';
@@ -111,13 +113,13 @@ export const uploadFolderContents = async ({
       continue;
     }
     const folderPromise = parentPromise.then(async (parentUuid) => {
-      if (signal.aborted) throw new DOMException('Upload cancelled', 'AbortError');
+      if (signal.aborted) throw new AbortError();
       const uuid = await createFolderWithMerge(parentUuid, directory.name);
       createdFolders++;
       return uuid;
     });
     folderPromise.catch((err) => {
-      if ((err as Error)?.name !== 'AbortError') failedFolders++;
+      if ((err as Error)?.name !== AbortError.errorName) failedFolders++;
     });
     folderCreationPromises.set(directory.relativePath, folderPromise);
   }
@@ -128,6 +130,7 @@ export const uploadFolderContents = async ({
       totalFiles: 0,
       uploadedFiles: 0,
       failedFiles: 0,
+      skippedFiles: 0,
       totalFolders,
       createdFolders,
       failedFolders,
@@ -137,6 +140,7 @@ export const uploadFolderContents = async ({
 
   let uploadedFiles = 0;
   let failedFiles = 0;
+  let skippedFiles = 0;
   let wasCancelled = false;
   const uploadLimit = pLimit(FOLDER_UPLOAD_CONCURRENCY);
 
@@ -168,8 +172,11 @@ export const uploadFolderContents = async ({
           logger.info(TAG, `created: "${file.relativePath}" (${uploadedFiles}/${totalFiles})`);
         } catch (err) {
           const error = err as Error;
-          if (error.name === 'AbortError') {
+          if (error.name === AbortError.errorName) {
             wasCancelled = true;
+          } else if (err instanceof EmptyFileNotAllowedError) {
+            skippedFiles++;
+            logger.info(TAG, `skipped empty file: "${file.relativePath}" (plan restriction)`);
           } else {
             failedFiles++;
             logger.error(TAG, `failed creation: "${file.relativePath}": ${error.message}`);
@@ -185,6 +192,7 @@ export const uploadFolderContents = async ({
     totalFiles,
     uploadedFiles,
     failedFiles,
+    skippedFiles,
     totalFolders,
     createdFolders,
     failedFolders,

--- a/src/shareExtension/ShareExtensionView.android.tsx
+++ b/src/shareExtension/ShareExtensionView.android.tsx
@@ -22,6 +22,7 @@ const ShareExtensionView = ({ navigation, route }: RootStackScreenProps<'Android
     uploadError,
     progress: uploadProgress,
     thumbnailUri,
+    uploadedCount,
     collisionState,
     uploadFiles,
     handleCollisionAction,
@@ -77,6 +78,7 @@ const ShareExtensionView = ({ navigation, route }: RootStackScreenProps<'Android
         uploadError={uploadError}
         uploadProgress={uploadProgress}
         thumbnailUri={thumbnailUri}
+        uploadedCount={uploadedCount}
         collisionState={collisionState}
         onClose={handleClose}
         onSave={handleSave}

--- a/src/shareExtension/ShareExtensionView.ios.tsx
+++ b/src/shareExtension/ShareExtensionView.ios.tsx
@@ -51,6 +51,7 @@ const ShareExtensionView = ({
     uploadError,
     progress: uploadProgress,
     thumbnailUri,
+    uploadedCount,
     collisionState,
     uploadFiles,
     handleCollisionAction,
@@ -91,6 +92,7 @@ const ShareExtensionView = ({
       uploadError={uploadError}
       uploadProgress={uploadProgress}
       thumbnailUri={thumbnailUri}
+      uploadedCount={uploadedCount}
       collisionState={collisionState}
       onClose={close}
       onSave={handleSave}

--- a/src/shareExtension/components/UploadSuccessCard.tsx
+++ b/src/shareExtension/components/UploadSuccessCard.tsx
@@ -13,6 +13,7 @@ interface UploadSuccessCardProps {
   sharedFiles: SharedFile[];
   uploadedFileName: string;
   thumbnailUri?: string | null;
+  uploadedCount?: number;
   onClose: () => void;
   onViewInFolder: () => void;
 }
@@ -21,6 +22,7 @@ export const UploadSuccessCard = ({
   sharedFiles,
   uploadedFileName,
   thumbnailUri,
+  uploadedCount,
   onClose,
   onViewInFolder,
 }: UploadSuccessCardProps) => {
@@ -37,7 +39,8 @@ export const UploadSuccessCard = ({
     }).start();
   }, [slideAnim]);
 
-  const isSingleFile = sharedFiles.length === 1;
+  const displayCount = uploadedCount ?? sharedFiles.length;
+  const isSingleFile = displayCount === 1;
   const firstFile = sharedFiles[0];
   const fileExtension = firstFile ? getSharedFileExtension(firstFile) : '';
   const isImage = firstFile?.mimeType?.startsWith('image/') ?? false;
@@ -51,7 +54,7 @@ export const UploadSuccessCard = ({
 
   const fileName = isSingleFile
     ? uploadedFileName
-    : strings.formatString(shareExtensionTrans.itemsUploaded, sharedFiles.length).toString();
+    : strings.formatString(shareExtensionTrans.itemsUploaded, displayCount).toString();
 
   const formattedSize = totalSizeOrNull === null ? null : formatBytes(totalSizeOrNull);
   const sizeAndFormat = isSingleFile

--- a/src/shareExtension/errors.ts
+++ b/src/shareExtension/errors.ts
@@ -1,3 +1,5 @@
+import { EmptyFileNotAllowedError, isEmptyFilePlanError } from '../services/drive/file/utils/emptyFileErrors';
+
 export class HttpUploadError extends Error {
   constructor(
     readonly status: number,
@@ -27,3 +29,5 @@ export class UploadNetworkError extends Error {
     Object.setPrototypeOf(this, UploadNetworkError.prototype);
   }
 }
+
+export { EmptyFileNotAllowedError, isEmptyFilePlanError };

--- a/src/shareExtension/errors.ts
+++ b/src/shareExtension/errors.ts
@@ -1,4 +1,4 @@
-import { EmptyFileNotAllowedError, isEmptyFilePlanError } from '../services/drive/file/utils/emptyFileErrors';
+export { EmptyFileNotAllowedError, isEmptyFilePlanError } from '../services/drive/file/utils/emptyFileErrors';
 
 export class HttpUploadError extends Error {
   constructor(
@@ -29,5 +29,3 @@ export class UploadNetworkError extends Error {
     Object.setPrototypeOf(this, UploadNetworkError.prototype);
   }
 }
-
-export { EmptyFileNotAllowedError, isEmptyFilePlanError };

--- a/src/shareExtension/hooks/useShareUpload.ts
+++ b/src/shareExtension/hooks/useShareUpload.ts
@@ -1,7 +1,7 @@
 import * as RNFS from '@dr.pogodin/react-native-fs';
 import { useCallback, useRef, useState } from 'react';
 import { NativeModules, Platform } from 'react-native';
-import { HttpUploadError, MissingFileUriError, UploadNetworkError } from '../errors';
+import { EmptyFileNotAllowedError, HttpUploadError, MissingFileUriError, UploadNetworkError } from '../errors';
 import {
   ShareUploadCredentials,
   ShareUploadSession,
@@ -35,6 +35,7 @@ const exportPhAsset = (phAssetId: string): Promise<PHAssetExportResult> => PHAss
 
 const HTTP_STATUS = {
   UNAUTHORIZED: 401,
+  PAYMENT_REQUIRED: 402,
   FORBIDDEN: 403,
   CONFLICT: 409,
 } as const;
@@ -49,6 +50,7 @@ interface UseShareUploadResult {
   uploadError: unknown;
   progress: UploadProgress | null;
   thumbnailUri: string | null;
+  uploadedCount: number;
   collisionState: CollisionState;
   uploadFiles: (
     files: SharedFile[],
@@ -67,9 +69,11 @@ interface FailedFile {
 }
 
 const classifyError = (error: unknown): UploadErrorType => {
+  if (error instanceof EmptyFileNotAllowedError) return 'payment_required';
   if (error instanceof HttpUploadError) {
     if (error.status === HTTP_STATUS.UNAUTHORIZED || error.status === HTTP_STATUS.FORBIDDEN) return 'session_expired';
     if (error.status === HTTP_STATUS.CONFLICT) return 'file_already_exists';
+    if (error.status === HTTP_STATUS.PAYMENT_REQUIRED) return 'payment_required';
   }
   if (error instanceof MissingFileUriError) return 'prep_failed';
   if (error instanceof UploadNetworkError) return 'no_internet';
@@ -161,6 +165,7 @@ export const useShareUpload = ({ onFileUploaded }: UseShareUploadOptions = {}): 
   const [uploadError, setUploadError] = useState<unknown>(null);
   const [progress, setProgress] = useState<UploadProgress | null>(null);
   const [thumbnailUri, setThumbnailUri] = useState<string | null>(null);
+  const [uploadedCount, setUploadedCount] = useState(0);
   const thumbnailUriRef = useRef<string | null>(null);
 
   const { collisionState, handleCollisionAction, resetCollisionState, resolveCollisions } = useNameCollision();
@@ -175,6 +180,7 @@ export const useShareUpload = ({ onFileUploaded }: UseShareUploadOptions = {}): 
     setUploadError(null);
     setProgress(null);
     setThumbnailUri(null);
+    setUploadedCount(0);
     resetCollisionState();
   }, [resetCollisionState]);
 
@@ -200,6 +206,8 @@ export const useShareUpload = ({ onFileUploaded }: UseShareUploadOptions = {}): 
         setThumbnailUri(null);
 
         const failedFiles: FailedFile[] = [];
+        let actualUploadedCount = 0;
+        let skippedPaymentRequired = 0;
 
         for (let i = 0; i < files.length; i++) {
           try {
@@ -220,19 +228,35 @@ export const useShareUpload = ({ onFileUploaded }: UseShareUploadOptions = {}): 
                 onFileUploaded,
               },
             );
+            actualUploadedCount++;
             if (isSingleFile) {
               thumbnailUriRef.current = thumbnailLocalUri;
               setThumbnailUri(thumbnailLocalUri);
             }
           } catch (error) {
             const uploadErrorType = classifyError(error);
+            const isPaymentRequiredFeature = uploadErrorType === 'payment_required';
+            const isMultiupload = files.length > 1;
+            if (isPaymentRequiredFeature && isMultiupload) {
+              skippedPaymentRequired++;
+              continue;
+            }
             failedFiles.push({ index: i, errorType: uploadErrorType, uploadError: error });
             if (uploadErrorType === 'session_expired') break;
           }
         }
 
+        setUploadedCount(actualUploadedCount);
+
         if (failedFiles.length === 0) {
-          setStatus('success');
+          if (actualUploadedCount === 0 && skippedPaymentRequired > 0) {
+            // All files were empty — treat as payment_required error
+            setErrorType('payment_required');
+            setUploadError(new EmptyFileNotAllowedError());
+            setStatus('error');
+          } else {
+            setStatus('success');
+          }
         } else {
           const { errorType: firstErrorType, uploadError: firstUploadError } = failedFiles[0];
           setErrorType(firstErrorType);
@@ -255,6 +279,7 @@ export const useShareUpload = ({ onFileUploaded }: UseShareUploadOptions = {}): 
     uploadError,
     progress,
     thumbnailUri,
+    uploadedCount,
     collisionState,
     uploadFiles,
     handleCollisionAction,

--- a/src/shareExtension/screens/DriveScreen.tsx
+++ b/src/shareExtension/screens/DriveScreen.tsx
@@ -33,6 +33,7 @@ interface DriveScreenProps {
   uploadError?: unknown;
   uploadProgress?: UploadProgress | null;
   thumbnailUri?: string | null;
+  uploadedCount?: number;
   collisionState?: CollisionState;
   onClose: () => void;
   onSave: (destinationFolderUuid: string, renamedFileName?: string) => void;
@@ -49,6 +50,7 @@ export const DriveScreen = ({
   uploadError,
   uploadProgress,
   thumbnailUri,
+  uploadedCount,
   collisionState,
   onClose,
   onSave,
@@ -219,6 +221,7 @@ export const DriveScreen = ({
           sharedFiles={sharedFiles}
           uploadedFileName={finalName}
           thumbnailUri={thumbnailUri}
+          uploadedCount={uploadedCount}
           onClose={onClose}
           onViewInFolder={handleViewInFolder}
         />

--- a/src/shareExtension/services/shareUploadService.ts
+++ b/src/shareExtension/services/shareUploadService.ts
@@ -9,7 +9,7 @@ import { Platform } from 'react-native';
 import ReactNativeBlobUtil, { FetchBlobResponse } from 'react-native-blob-util';
 import uuid from 'react-native-uuid';
 import packageJson from '../../../package.json';
-import { HttpUploadError, UploadNetworkError } from '../errors';
+import { EmptyFileNotAllowedError, HttpUploadError, isEmptyFilePlanError, UploadNetworkError } from '../errors';
 import {
   buildSdkEncryptionAdapter,
   computeRipemd160Digest,
@@ -172,7 +172,7 @@ const uploadEncryptedPart = async (
 };
 
 const createFileEntry = async (
-  fileId: string,
+  fileId: string | undefined,
   fileExtension: string,
   fileSize: number,
   fileName: string,
@@ -304,6 +304,21 @@ export interface ShareUploadFileResult {
   thumbnailLocalUri: string | null;
 }
 
+const uploadEmptyFile = async (
+  fileExtension: string,
+  fileName: string,
+  bucket: string,
+  folderUuid: string,
+): Promise<ShareUploadFileResult> => {
+  try {
+    await createFileEntry(undefined, fileExtension, 0, fileName, bucket, folderUuid);
+    return { thumbnailLocalUri: null };
+  } catch (err) {
+    if (isEmptyFilePlanError(err)) throw new EmptyFileNotAllowedError();
+    throw err;
+  }
+};
+
 export const shareUploadFile = async (params: ShareUploadFileParams): Promise<ShareUploadFileResult> => {
   const { filePath, fileName, fileExtension, folderUuid, credentials, shareUploadSession, onFileResolved, onProgress } =
     params;
@@ -312,11 +327,20 @@ export const shareUploadFile = async (params: ShareUploadFileParams): Promise<Sh
   const { localPath, fileSize, tempPath: androidTempCopyPath } = await resolveInputFile(filePath);
   onFileResolved?.(fileSize);
 
-  const session = shareUploadSession ?? createShareUploadSession(credentials);
-  const { network, cryptoLib } = session;
+  const cleanup = async () => {
+    if (androidTempCopyPath) await RNFS.unlink(androidTempCopyPath).catch(() => undefined);
+    // On iOS the OS provides a sandboxed temp copy of the shared file; clean it up after upload.
+    if (Platform.OS === 'ios') await RNFS.unlink(localPath).catch(() => undefined);
+  };
 
-  let thumbnailLocalUri: string | null = null;
   try {
+    if (fileSize === 0) {
+      return await uploadEmptyFile(fileExtension, fileName, bucket, folderUuid);
+    }
+
+    const session = shareUploadSession ?? createShareUploadSession(credentials);
+    const { network, cryptoLib } = session;
+
     const uploadContext: UploadFileContext = {
       network,
       cryptoLib,
@@ -330,13 +354,11 @@ export const shareUploadFile = async (params: ShareUploadFileParams): Promise<Sh
       onProgress,
     };
 
-    let uploadResult: { fileUuid: string };
-    if (fileSize >= MULTIPART_THRESHOLD_BYTES) {
-      uploadResult = await shareUploadMultipartFile(uploadContext);
-    } else {
-      uploadResult = await shareUploadSingleFile(uploadContext);
-    }
+    const uploadResult = await (fileSize >= MULTIPART_THRESHOLD_BYTES
+      ? shareUploadMultipartFile(uploadContext)
+      : shareUploadSingleFile(uploadContext));
 
+    let thumbnailLocalUri: string | null = null;
     try {
       thumbnailLocalUri = await generateAndUploadThumbnail(
         localPath,
@@ -349,11 +371,9 @@ export const shareUploadFile = async (params: ShareUploadFileParams): Promise<Sh
     } catch (error) {
       if (__DEV__) console.log('Thumbnail generation/upload failed, proceeding without it, error: ', error);
     }
-  } finally {
-    if (androidTempCopyPath) await RNFS.unlink(androidTempCopyPath).catch(() => undefined);
-    // On iOS the OS provides a sandboxed temp copy of the shared file; clean it up after upload.
-    if (Platform.OS === 'ios') await RNFS.unlink(localPath).catch(() => undefined);
-  }
 
-  return { thumbnailLocalUri };
+    return { thumbnailLocalUri };
+  } finally {
+    await cleanup();
+  }
 };

--- a/src/shareExtension/types.ts
+++ b/src/shareExtension/types.ts
@@ -31,7 +31,8 @@ export type UploadErrorType =
   | 'no_internet'
   | 'session_expired'
   | 'prep_failed'
-  | 'file_already_exists';
+  | 'file_already_exists'
+  | 'payment_required';
 
 export interface UploadProgress {
   currentFile: number;

--- a/src/shareExtension/utils.ts
+++ b/src/shareExtension/utils.ts
@@ -92,6 +92,8 @@ export const getUploadErrorMessage = (errorType: UploadErrorType | null, rawErro
       return shareExtensionTexts.errorPrep;
     case 'file_already_exists':
       return shareExtensionTexts.errorFileAlreadyExists;
+    case 'payment_required':
+      return shareExtensionTexts.errorPaymentRequired;
     case 'general':
       return extractErrorMessage(rawError) ?? shareExtensionTexts.errorGeneral;
     default:

--- a/src/store/slices/ui/index.ts
+++ b/src/store/slices/ui/index.ts
@@ -25,6 +25,7 @@ export interface UIState {
   isPlansModalOpen: boolean;
   isCancelSubscriptionModalOpen: boolean;
   isSharedLinkOptionsModalOpen: boolean;
+  showEmptyFileNotAllowedModal: boolean;
 }
 
 const initialState: UIState = {
@@ -51,6 +52,7 @@ const initialState: UIState = {
   isPlansModalOpen: false,
   isCancelSubscriptionModalOpen: false,
   isSharedLinkOptionsModalOpen: false,
+  showEmptyFileNotAllowedModal: false,
 };
 
 export const uiSlice = createSlice({
@@ -123,6 +125,9 @@ export const uiSlice = createSlice({
     },
     setIsSharedLinkOptionsModalOpen: (state, action: PayloadAction<boolean>) => {
       state.isSharedLinkOptionsModalOpen = action.payload;
+    },
+    setShowEmptyFileNotAllowedModal: (state, action: PayloadAction<boolean>) => {
+      state.showEmptyFileNotAllowedModal = action.payload;
     },
   },
 });

--- a/src/types/drive/folderUpload.ts
+++ b/src/types/drive/folderUpload.ts
@@ -40,6 +40,7 @@ export interface FolderUploadResult {
   totalFiles: number;
   uploadedFiles: number;
   failedFiles: number;
+  skippedFiles: number;
   totalFolders: number;
   createdFolders: number;
   failedFolders: number;


### PR DESCRIPTION
Added support for uploading empty files, check  plan restrictions and fixed folder upload cancelation
- Introduced error handling for empty file uploads requiring a paid plan.
- Added user notifications for skipped empty files during folder uploads.
- Updated UI to show a modal when empty file uploads are not allowed.
- Enhanced upload logic to handle empty files and provide appropriate feedback.
- Updated translations for new error messages and modal content.
- Modified folder upload results to include skipped files count.
- Propagate abort signal correctly to abort folder uploads.