### PR TITLE
[PB-5877] bugfix/Fix folder upload issues

### DIFF
--- a/assets/lang/strings.ts
+++ b/assets/lang/strings.ts
@@ -206,6 +206,8 @@ const translations = {
         searchInThisFolder: 'Search items in this folder',
         searchInAllFolders: 'Search all my files',
         encrypting: 'Encrypting',
+        scanningFolder: 'Scanning folder...',
+        scanningFolderShort: 'Scanning...',
         decrypting: 'Decrypting',
         downloadingPercent: 'Downloading... {0}%',
         decryptingPercent: 'Decrypting... {0}%',
@@ -673,6 +675,11 @@ const translations = {
           'You have currently used 3GB of storage. To start uploading more files, please upgrade your storage plan.',
         advice: 'Get a higher plan or remove files you will no longer use in order to upload or sync your files again.',
       },
+      NotEnoughDeviceSpaceModal: {
+        title: 'Not enough space on your device',
+        advice:
+          'Internxt needs free space on your device to encrypt and upload your files. Please free up some storage and try again.',
+      },
       EmptyFileNotAllowedModal: {
         title: 'Empty files not supported',
         message:
@@ -1061,6 +1068,8 @@ const translations = {
         searchInThisFolder: 'Buscar en esta carpeta',
         searchInAllFolders: 'Buscar en todos mis archivos',
         encrypting: 'Encriptando',
+        scanningFolder: 'Escaneando carpeta...',
+        scanningFolderShort: 'Escaneando...',
         decrypting: 'Desencriptando',
         downloadingPercent: 'Descargando... {0}%',
         decryptingPercent: 'Desencriptando... {0}%',
@@ -1526,6 +1535,11 @@ const translations = {
           'Actualmente has usado 10GB de almaceniamiento. Para seguir subiendo más archivos, por favor, mejora tu plan de almacenamiento.',
         advice:
           'Mejora tu plan o borra los archivos que no vayas a usar para subir o sincronizar tus archivos de nuevo.',
+      },
+      NotEnoughDeviceSpaceModal: {
+        title: 'No hay suficiente espacio en tu dispositivo',
+        advice:
+          'Internxt necesita espacio libre en tu dispositivo para encriptar y subir tus archivos. Libera algo de almacenamiento e inténtalo de nuevo.',
       },
       EmptyFileNotAllowedModal: {
         title: 'Archivos vacíos no permitidos',

--- a/ios/Internxt.xcodeproj/project.pbxproj
+++ b/ios/Internxt.xcodeproj/project.pbxproj
@@ -10,13 +10,13 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		1818AB341F31CC033FFF750B /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD55E1E535AECF7719BDD772 /* ExpoModulesProvider.swift */; };
 		18D7DE9587FA2B2314575ED6 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4921399A370F5CE6EE7EA0F /* ExpoModulesProvider.swift */; };
-		24C09574C61FF55529DAFF8A /* libPods-InternxtShareExtension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BC2974BAFE19B2AA4BDF29A1 /* libPods-InternxtShareExtension.a */; };
 		2F8E878CDCAC7D5C07B5C670 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 37A2C3A4643426D3F429F041 /* PrivacyInfo.xcprivacy */; };
+		353DD4AD43EF923515032E17 /* libPods-Internxt.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AE464089D2AF26E8CAEEC6CB /* libPods-Internxt.a */; };
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
+		61F2D7A88201F06723D33BDC /* libPods-InternxtShareExtension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BBED6BCCDD72C0D72F796F82 /* libPods-InternxtShareExtension.a */; };
 		7D373856C83A43879BFBE604 /* InternxtShareExtension.appex in Copy Files */ = {isa = PBXBuildFile; fileRef = 7F5486528A7D46DD91A7910F /* InternxtShareExtension.appex */; };
 		8F8148045BC14A539BD1917D /* ShareExtensionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6F72E1B98D469883DAFB30 /* ShareExtensionViewController.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
-		DC811D94D426EAC8A114E590 /* libPods-Internxt.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FA215C540BF95F26A64F2F6 /* libPods-Internxt.a */; };
 		DEBEAEBF2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBEAEBE2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift */; };
 		DEBEAEC02F72E65B00A6E6D5 /* AppGroupPendingShareModule.m in Sources */ = {isa = PBXBuildFile; fileRef = DEBEAEBD2F72E65B00A6E6D5 /* AppGroupPendingShareModule.m */; };
 		F11748422D0307B40044C1D9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11748412D0307B40044C1D9 /* AppDelegate.swift */; };
@@ -63,20 +63,20 @@
 		30C3C55FF8AE435F8A82A9BC /* InternxtShareExtension.entitlements */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; path = InternxtShareExtension.entitlements; sourceTree = "<group>"; };
 		37A2C3A4643426D3F429F041 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = Internxt/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		3A6F72E1B98D469883DAFB30 /* ShareExtensionViewController.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; path = ShareExtensionViewController.swift; sourceTree = "<group>"; };
-		5FA215C540BF95F26A64F2F6 /* libPods-Internxt.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Internxt.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		60332A8E6FC972BA25BDFAC7 /* Pods-InternxtShareExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtShareExtension.release.xcconfig"; path = "Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension.release.xcconfig"; sourceTree = "<group>"; };
-		619167A9846BFB149A4E4B07 /* Pods-Internxt.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.release.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.release.xcconfig"; sourceTree = "<group>"; };
+		63B48B926126B5434D8744F8 /* Pods-InternxtShareExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtShareExtension.debug.xcconfig"; path = "Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		7F5486528A7D46DD91A7910F /* InternxtShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; fileEncoding = 9; includeInIndex = 0; path = InternxtShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		A4921399A370F5CE6EE7EA0F /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-InternxtShareExtension/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = Internxt/SplashScreen.storyboard; sourceTree = "<group>"; };
-		B85DFBD084E638185FB887AE /* Pods-InternxtShareExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtShareExtension.debug.xcconfig"; path = "Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension.debug.xcconfig"; sourceTree = "<group>"; };
+		AE464089D2AF26E8CAEEC6CB /* libPods-Internxt.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Internxt.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
-		BC2974BAFE19B2AA4BDF29A1 /* libPods-InternxtShareExtension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-InternxtShareExtension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		BBED6BCCDD72C0D72F796F82 /* libPods-InternxtShareExtension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-InternxtShareExtension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD55E1E535AECF7719BDD772 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-Internxt/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
+		C00B75BF3D056BA881E694AC /* Pods-Internxt.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.release.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.release.xcconfig"; sourceTree = "<group>"; };
+		C0F415F987B8A59D7CD72A59 /* Pods-Internxt.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.debug.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.debug.xcconfig"; sourceTree = "<group>"; };
 		DAE15E8DB4DF4E048E04B0E0 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DD6CED1DD255C7CBCA0B6717 /* Pods-InternxtShareExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtShareExtension.release.xcconfig"; path = "Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension.release.xcconfig"; sourceTree = "<group>"; };
 		DEBEAEBD2F72E65B00A6E6D5 /* AppGroupPendingShareModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = AppGroupPendingShareModule.m; path = Internxt/AppGroupPendingShareModule.m; sourceTree = "<group>"; };
 		DEBEAEBE2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppGroupPendingShareModule.swift; path = Internxt/AppGroupPendingShareModule.swift; sourceTree = "<group>"; };
-		DEF416740AEC235EDB62E97F /* Pods-Internxt.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.debug.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.debug.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		F11748412D0307B40044C1D9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = Internxt/AppDelegate.swift; sourceTree = "<group>"; };
 		F11748442D0722820044C1D9 /* Internxt-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "Internxt-Bridging-Header.h"; path = "Internxt/Internxt-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -87,7 +87,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DC811D94D426EAC8A114E590 /* libPods-Internxt.a in Frameworks */,
+				353DD4AD43EF923515032E17 /* libPods-Internxt.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -95,7 +95,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				24C09574C61FF55529DAFF8A /* libPods-InternxtShareExtension.a in Frameworks */,
+				61F2D7A88201F06723D33BDC /* libPods-InternxtShareExtension.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -122,8 +122,8 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				5FA215C540BF95F26A64F2F6 /* libPods-Internxt.a */,
-				BC2974BAFE19B2AA4BDF29A1 /* libPods-InternxtShareExtension.a */,
+				AE464089D2AF26E8CAEEC6CB /* libPods-Internxt.a */,
+				BBED6BCCDD72C0D72F796F82 /* libPods-InternxtShareExtension.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -149,10 +149,10 @@
 		808723478BA906DED7CCCEE0 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				DEF416740AEC235EDB62E97F /* Pods-Internxt.debug.xcconfig */,
-				619167A9846BFB149A4E4B07 /* Pods-Internxt.release.xcconfig */,
-				B85DFBD084E638185FB887AE /* Pods-InternxtShareExtension.debug.xcconfig */,
-				60332A8E6FC972BA25BDFAC7 /* Pods-InternxtShareExtension.release.xcconfig */,
+				C0F415F987B8A59D7CD72A59 /* Pods-Internxt.debug.xcconfig */,
+				C00B75BF3D056BA881E694AC /* Pods-Internxt.release.xcconfig */,
+				63B48B926126B5434D8744F8 /* Pods-InternxtShareExtension.debug.xcconfig */,
+				DD6CED1DD255C7CBCA0B6717 /* Pods-InternxtShareExtension.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -222,7 +222,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "Internxt" */;
 			buildPhases = (
-				AA3DED567AE440A188E26BB3 /* [CP] Check Pods Manifest.lock */,
+				9749A9A2F46DB1E7F4196AEC /* [CP] Check Pods Manifest.lock */,
 				C23BF8EF9D9B379F6EADAAE0 /* [Expo] Configure project */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
@@ -230,8 +230,8 @@
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				DDE0311FCC774124B044B69C /* Embed Foundation Extensions */,
 				EF531C08E8F54B18956A8C0E /* Copy Files */,
-				6A9D51C204F887718EC358B4 /* [CP] Embed Pods Frameworks */,
-				70E986EE3D72E31C86FF20C3 /* [CP] Copy Pods Resources */,
+				A8138DEFA393F6FFB394E7B5 /* [CP] Embed Pods Frameworks */,
+				4B3A95EC80E71334D4D0CAD2 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -247,14 +247,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DDB0A9F040BE45D9929C1B2D /* Build configuration list for PBXNativeTarget "InternxtShareExtension" */;
 			buildPhases = (
-				BA2DCD346879282460B0B6CD /* [CP] Check Pods Manifest.lock */,
+				FF344C830A01D2CD57C3053D /* [CP] Check Pods Manifest.lock */,
 				90134DAC718F4FE0B3AB7B91 /* Start Packager */,
 				BEAE0DA94817B237B864F997 /* [Expo] Configure project */,
 				3495BDAE4F75461EBD6FFF8F /* Sources */,
 				3ABC9B4F4B9D448B9797EBD7 /* Frameworks */,
 				2F5766E756C84914803E7082 /* Resources */,
 				AA9E71431FBB401A8272B8C4 /* Bundle React Native code and images */,
-				3EF7B1EFC832DA8463E066E7 /* [CP] Copy Pods Resources */,
+				E0007E640EC3051DD157AAB4 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -343,71 +343,7 @@
 			shellPath = /bin/sh;
 			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n# The project root by default is one level up from the ios directory\nexport PROJECT_ROOT=\"$PROJECT_DIR\"/..\n\nif [[ \"$CONFIGURATION\" = *Debug* ]]; then\n  export SKIP_BUNDLING=1\nfi\nif [[ -z \"$ENTRY_FILE\" ]]; then\n  # Set the entry JS file using the bundler's entry resolution.\n  export ENTRY_FILE=\"$(\"$NODE_BINARY\" -e \"require('expo/scripts/resolveAppEntry')\" \"$PROJECT_ROOT\" ios absolute | tail -n 1)\"\nfi\n\nif [[ -z \"$CLI_PATH\" ]]; then\n  # Use Expo CLI\n  export CLI_PATH=\"$(\"$NODE_BINARY\" --print \"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\")\"\nfi\nif [[ -z \"$BUNDLE_COMMAND\" ]]; then\n  # Default Expo CLI command for bundling\n  export BUNDLE_COMMAND=\"export:embed\"\nfi\n\n# Source .xcode.env.updates if it exists to allow\n# SKIP_BUNDLING to be unset if needed\nif [[ -f \"$PODS_ROOT/../.xcode.env.updates\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.updates\"\nfi\n# Source local changes to allow overrides\n# if needed\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`\n\n";
 		};
-		3EF7B1EFC832DA8463E066E7 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension-resources.sh",
-				"${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/ExpoConstants_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoDevice/ExpoDevice_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoFileSystem/ExpoFileSystem_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoLocalization/ExpoLocalization_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoMediaLibrary/ExpoMediaLibrary_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoSystemUI/ExpoSystemUI_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/RNCAsyncStorage/RNCAsyncStorage_resources.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/RNSVG/RNSVGFilters.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/React-Core_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/React-cxxreact/React-cxxreact_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/ReactNativeFs/RNFS_PrivacyInfo.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/react-native-blob-util/ReactNativeBlobUtilPrivacyInfo.bundle",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoConstants_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoDevice_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoFileSystem_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoLocalization_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoMediaLibrary_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoSystemUI_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNCAsyncStorage_resources.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNSVGFilters.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-Core_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-cxxreact_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNFS_PrivacyInfo.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ReactNativeBlobUtilPrivacyInfo.bundle",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		6A9D51C204F887718EC358B4 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Internxt/Pods-Internxt-frameworks.sh",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/React-Core-prebuilt/React.framework/React",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ReactNativeDependencies/ReactNativeDependencies.framework/ReactNativeDependencies",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermes.framework/hermes",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/React.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ReactNativeDependencies.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Internxt/Pods-Internxt-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		70E986EE3D72E31C86FF20C3 /* [CP] Copy Pods Resources */ = {
+		4B3A95EC80E71334D4D0CAD2 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -467,7 +403,7 @@
 			shellPath = /bin/sh;
 			shellScript = "export RCT_METRO_PORT=\"${RCT_METRO_PORT:=8081}\"\necho \"export RCT_METRO_PORT=${RCT_METRO_PORT}\" > \"${SRCROOT}/../node_modules/react-native/scripts/.packager.env\"\nif [ -z \"${RCT_NO_LAUNCH_PACKAGER+xxx}\" ] ; then\n  if nc -w 5 -z localhost ${RCT_METRO_PORT} ; then\n    if ! curl -s \"http://localhost:${RCT_METRO_PORT}/status\" | grep -q \"packager-status:running\" ; then\n      echo \"Port ${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\"\n      exit 2\n    fi\n  else\n    open \"$SRCROOT/../node_modules/react-native/scripts/launchPackager.command\" || echo \"Can't start packager automatically\"\n  fi\nfi\n";
 		};
-		AA3DED567AE440A188E26BB3 /* [CP] Check Pods Manifest.lock */ = {
+		9749A9A2F46DB1E7F4196AEC /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -489,6 +425,28 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		A8138DEFA393F6FFB394E7B5 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Internxt/Pods-Internxt-frameworks.sh",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/React-Core-prebuilt/React.framework/React",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ReactNativeDependencies/ReactNativeDependencies.framework/ReactNativeDependencies",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermes.framework/hermes",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/React.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ReactNativeDependencies.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Internxt/Pods-Internxt-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		AA9E71431FBB401A8272B8C4 /* Bundle React Native code and images */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -502,28 +460,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -e\n  NODE_BINARY=${NODE_BINARY:-node}\n  \n  # Source environment files\n  if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n    source \"$PODS_ROOT/../.xcode.env\"\n  fi\n  if [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n    source \"$PODS_ROOT/../.xcode.env.local\"\n  fi\n  \n  # Set project root\n  export PROJECT_ROOT=\"$PROJECT_DIR\"/..\n  \n  # Set entry file\n  export ENTRY_FILE=\"$PROJECT_ROOT/index.share.js\"\n  \n  # Set up Expo CLI\n  if [[ -z \"$CLI_PATH\" ]]; then\n    export CLI_PATH=\"$(\"$NODE_BINARY\" --print \"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\")\"\n  fi\n  \n  if [[ -z \"$BUNDLE_COMMAND\" ]]; then\n    export BUNDLE_COMMAND=\"export:embed\"\n  fi\n  \n  REACT_NATIVE_SCRIPTS_PATH=$(\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts'\")\n  WITH_ENVIRONMENT=\"$REACT_NATIVE_SCRIPTS_PATH/xcode/with-environment.sh\"\n  REACT_NATIVE_XCODE=\"$REACT_NATIVE_SCRIPTS_PATH/react-native-xcode.sh\"\n  \n  /bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"";
-		};
-		BA2DCD346879282460B0B6CD /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-InternxtShareExtension-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
 		};
 		BEAE0DA94817B237B864F997 /* [Expo] Configure project */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -573,6 +509,70 @@
 			shellPath = /bin/sh;
 			shellScript = "# This script configures Expo modules and generates the modules provider file.\nbash -l -c \"./Pods/Target\\ Support\\ Files/Pods-Internxt/expo-configure-project.sh\"\n";
 		};
+		E0007E640EC3051DD157AAB4 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/ExpoConstants_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoDevice/ExpoDevice_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoFileSystem/ExpoFileSystem_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoLocalization/ExpoLocalization_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoMediaLibrary/ExpoMediaLibrary_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoSystemUI/ExpoSystemUI_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/RNCAsyncStorage/RNCAsyncStorage_resources.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/RNSVG/RNSVGFilters.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/React-Core_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/React-cxxreact/React-cxxreact_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/ReactNativeFs/RNFS_PrivacyInfo.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/react-native-blob-util/ReactNativeBlobUtilPrivacyInfo.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoConstants_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoDevice_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoFileSystem_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoLocalization_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoMediaLibrary_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoSystemUI_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNCAsyncStorage_resources.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNSVGFilters.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-Core_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-cxxreact_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNFS_PrivacyInfo.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ReactNativeBlobUtilPrivacyInfo.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FF344C830A01D2CD57C3053D /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-InternxtShareExtension-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -609,7 +609,7 @@
 /* Begin XCBuildConfiguration section */
 		00BF7E5F54544AE9B1CDE9D5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B85DFBD084E638185FB887AE /* Pods-InternxtShareExtension.debug.xcconfig */;
+			baseConfigurationReference = 63B48B926126B5434D8744F8 /* Pods-InternxtShareExtension.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = InternxtShareExtension/InternxtShareExtension.entitlements;
@@ -638,7 +638,7 @@
 		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DEF416740AEC235EDB62E97F /* Pods-Internxt.debug.xcconfig */;
+			baseConfigurationReference = C0F415F987B8A59D7CD72A59 /* Pods-Internxt.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -677,7 +677,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 619167A9846BFB149A4E4B07 /* Pods-Internxt.release.xcconfig */;
+			baseConfigurationReference = C00B75BF3D056BA881E694AC /* Pods-Internxt.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -828,7 +828,7 @@
 		};
 		B247FB85ACF44D11B7509F34 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 60332A8E6FC972BA25BDFAC7 /* Pods-InternxtShareExtension.release.xcconfig */;
+			baseConfigurationReference = DD6CED1DD255C7CBCA0B6717 /* Pods-InternxtShareExtension.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = InternxtShareExtension/InternxtShareExtension.entitlements;

--- a/src/components/drive/lists/items/DriveGridModeItem/DriveGridModeItem.tsx
+++ b/src/components/drive/lists/items/DriveGridModeItem/DriveGridModeItem.tsx
@@ -98,6 +98,68 @@ function DriveGridModeItemComp(props: DriveItemProps): JSX.Element {
     );
   };
 
+  const renderUploadOverlay = () => {
+    if (!isUploading) return null;
+
+    if (isFolderScanning) {
+      return (
+        <TouchableOpacity
+          onPress={props.onActionsPress}
+          accessibilityLabel={'Cancel folder upload'}
+          style={tailwind('absolute top-0 bottom-0 w-full flex-row items-center justify-center')}
+        >
+          <View
+            style={[
+              tailwind('rounded px-1 py-0.5 flex-row items-center'),
+              { backgroundColor: getColor('text-primary') },
+            ]}
+          >
+            <AppText style={[tailwind('text-xs'), { color: getColor('text-white') }]}>
+              {strings.screens.drive.scanningFolderShort}
+            </AppText>
+            <XCircleIcon weight="bold" color={getColor('text-white')} size={14} style={tailwind('ml-1')} />
+          </View>
+        </TouchableOpacity>
+      );
+    }
+
+    if (isFolderUploading) {
+      return (
+        <TouchableOpacity
+          onPress={props.onActionsPress}
+          accessibilityLabel={'Cancel folder upload'}
+          style={tailwind('absolute top-0 bottom-0 w-full flex-row items-center justify-center')}
+        >
+          <View
+            style={[
+              tailwind('rounded px-1 py-0.5 flex-row items-center'),
+              { backgroundColor: getColor('text-primary') },
+            ]}
+          >
+            <ArrowCircleUpIcon weight="fill" color={getColor('text-white')} size={14} />
+            <AppText style={[tailwind('ml-1 text-xs'), { color: getColor('text-white') }]}>
+              {props.folderUploadProgress?.totalFiles
+                ? `${props.folderUploadProgress.uploadedFiles}/${props.folderUploadProgress.totalFiles}`
+                : '...'}
+            </AppText>
+            <XCircleIcon weight="bold" color={getColor('text-white')} size={14} style={tailwind('ml-1')} />
+          </View>
+        </TouchableOpacity>
+      );
+    }
+
+    return (
+      <View style={tailwind('absolute top-0 bottom-0 w-full flex-row items-center justify-center')}>
+        <View style={[tailwind('rounded px-1 py-0.5 flex-row'), { backgroundColor: getColor('text-primary') }]}>
+          <ArrowCircleUpIcon weight="fill" color={getColor('text-white')} size={16} />
+          <AppText style={[tailwind('ml-1.5 text-xs'), { color: getColor('text-white') }]}>
+            {((props.progress || 0) * 100).toFixed(0) + '%'}
+          </AppText>
+        </View>
+      </View>
+    );
+  };
+
   return (
     <TouchableHighlight
       disabled={!isFolderUploading && (isUploading || isDownloading)}
@@ -122,58 +184,7 @@ function DriveGridModeItemComp(props: DriveItemProps): JSX.Element {
               )}
             </View>
 
-            {isUploading &&
-              (isFolderScanning ? (
-                <TouchableOpacity
-                  onPress={props.onActionsPress}
-                  accessibilityLabel={'Cancel folder upload'}
-                  style={tailwind('absolute top-0 bottom-0 w-full flex-row items-center justify-center')}
-                >
-                  <View
-                    style={[
-                      tailwind('rounded px-1 py-0.5 flex-row items-center'),
-                      { backgroundColor: getColor('text-primary') },
-                    ]}
-                  >
-                    <AppText style={[tailwind('text-xs'), { color: getColor('text-white') }]}>
-                      {strings.screens.drive.scanningFolderShort}
-                    </AppText>
-                    <XCircleIcon weight="bold" color={getColor('text-white')} size={14} style={tailwind('ml-1')} />
-                  </View>
-                </TouchableOpacity>
-              ) : isFolderUploading ? (
-                <TouchableOpacity
-                  onPress={props.onActionsPress}
-                  accessibilityLabel={'Cancel folder upload'}
-                  style={tailwind('absolute top-0 bottom-0 w-full flex-row items-center justify-center')}
-                >
-                  <View
-                    style={[
-                      tailwind('rounded px-1 py-0.5 flex-row items-center'),
-                      { backgroundColor: getColor('text-primary') },
-                    ]}
-                  >
-                    <ArrowCircleUpIcon weight="fill" color={getColor('text-white')} size={14} />
-                    <AppText style={[tailwind('ml-1 text-xs'), { color: getColor('text-white') }]}>
-                      {props.folderUploadProgress?.totalFiles
-                        ? `${props.folderUploadProgress.uploadedFiles}/${props.folderUploadProgress.totalFiles}`
-                        : '...'}
-                    </AppText>
-                    <XCircleIcon weight="bold" color={getColor('text-white')} size={14} style={tailwind('ml-1')} />
-                  </View>
-                </TouchableOpacity>
-              ) : (
-                <View style={tailwind('absolute top-0 bottom-0 w-full flex-row items-center justify-center')}>
-                  <View
-                    style={[tailwind('rounded px-1 py-0.5 flex-row'), { backgroundColor: getColor('text-primary') }]}
-                  >
-                    <ArrowCircleUpIcon weight="fill" color={getColor('text-white')} size={16} />
-                    <AppText style={[tailwind('ml-1.5 text-xs'), { color: getColor('text-white') }]}>
-                      {((props.progress || 0) * 100).toFixed(0) + '%'}
-                    </AppText>
-                  </View>
-                </View>
-              ))}
+            {renderUploadOverlay()}
           </View>
 
           <View style={[tailwind('flex items-start justify-center items-center mt-2.5 px-2 py-1')]}>

--- a/src/components/drive/lists/items/DriveGridModeItem/DriveGridModeItem.tsx
+++ b/src/components/drive/lists/items/DriveGridModeItem/DriveGridModeItem.tsx
@@ -1,4 +1,5 @@
 import { time } from '@internxt-mobile/services/common/time';
+import strings from '../../../../../../assets/lang/strings';
 import { driveFileService } from '@internxt-mobile/services/drive/file';
 import { items } from '@internxt/lib';
 import { ArrowCircleUpIcon, XCircleIcon } from 'phosphor-react-native';
@@ -29,6 +30,7 @@ function DriveGridModeItemComp(props: DriveItemProps): JSX.Element {
   const isUploading = props.status === DriveItemStatus.Uploading;
   const isDownloading = props.status === DriveItemStatus.Downloading;
   const isFolderUploading = isUploading && isFolder && !!props.folderUploadProgress;
+  const isFolderScanning = isUploading && isFolder && !props.folderUploadProgress;
   const maxThumbnailHeight = 96;
 
   const getThumbnailWidth = () => {
@@ -121,7 +123,25 @@ function DriveGridModeItemComp(props: DriveItemProps): JSX.Element {
             </View>
 
             {isUploading &&
-              (isFolderUploading ? (
+              (isFolderScanning ? (
+                <TouchableOpacity
+                  onPress={props.onActionsPress}
+                  accessibilityLabel={'Cancel folder upload'}
+                  style={tailwind('absolute top-0 bottom-0 w-full flex-row items-center justify-center')}
+                >
+                  <View
+                    style={[
+                      tailwind('rounded px-1 py-0.5 flex-row items-center'),
+                      { backgroundColor: getColor('text-primary') },
+                    ]}
+                  >
+                    <AppText style={[tailwind('text-xs'), { color: getColor('text-white') }]}>
+                      {strings.screens.drive.scanningFolderShort}
+                    </AppText>
+                    <XCircleIcon weight="bold" color={getColor('text-white')} size={14} style={tailwind('ml-1')} />
+                  </View>
+                </TouchableOpacity>
+              ) : isFolderUploading ? (
                 <TouchableOpacity
                   onPress={props.onActionsPress}
                   accessibilityLabel={'Cancel folder upload'}

--- a/src/components/drive/lists/items/DriveListModeItem/DriveListModeItem.tsx
+++ b/src/components/drive/lists/items/DriveListModeItem/DriveListModeItem.tsx
@@ -26,6 +26,7 @@ export function DriveListModeItem(props: DriveItemProps): JSX.Element {
   const isUploading = props.status === DriveItemStatus.Uploading;
   const isDownloading = props.status === DriveItemStatus.Downloading;
   const isFolderUploading = isUploading && isFolder && !!props.folderUploadProgress;
+  const isFolderScanning = isUploading && isFolder && !props.folderUploadProgress;
 
   const getUpdatedAt = () => {
     if (props.data.createdAt) {
@@ -38,6 +39,13 @@ export function DriveListModeItem(props: DriveItemProps): JSX.Element {
   const progress = props.progress;
 
   const renderUploadProgress = () => {
+    if (isFolderScanning) {
+      return (
+        <AppText style={[tailwind('text-xs'), { color: getColor('text-primary') }]}>
+          {strings.screens.drive.scanningFolder}
+        </AppText>
+      );
+    }
     if (isFolderUploading) {
       return (
         <View style={tailwind('flex-row items-center')}>
@@ -76,7 +84,7 @@ export function DriveListModeItem(props: DriveItemProps): JSX.Element {
 
   const renderOptionsButton = () => {
     if (props.hideOptionsButton) return null;
-    if (isFolderUploading) {
+    if (isFolderUploading || isFolderScanning) {
       return (
         <TouchableOpacity
           onPress={props.onActionsPress}

--- a/src/components/modals/AddModal/hooks/useFolderUpload.ts
+++ b/src/components/modals/AddModal/hooks/useFolderUpload.ts
@@ -132,6 +132,18 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
   const { limit } = useAppSelector((state) => state.storage);
   const usage = useAppSelector(storageSelectors.usage);
 
+  const hasShownEmptyFileNoticeRef = useRef(false);
+
+  const handleEmptyFileSkipped = () => {
+    if (!hasShownEmptyFileNoticeRef.current) {
+      hasShownEmptyFileNoticeRef.current = true;
+      notificationsService.show({
+        type: NotificationType.Warning,
+        text1: strings.messages.emptyFileSkippedDuringFolderUpload,
+      });
+    }
+  };
+
   const collisionResolverRef = useRef<((action: NameCollisionAction | null) => void) | null>(null);
   const [collisionState, setCollisionState] = useState<{
     isOpen: boolean;
@@ -163,20 +175,22 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
     collisionResolverRef.current?.(null);
   };
 
+  const resolveCollision = async (pickedName: string, parentUuid: string): Promise<string | null> => {
+    const { existentFolders } = await driveFolderService.checkDuplicatedFolders(parentUuid, [pickedName]);
+    if (existentFolders.length === 0) return pickedName;
+    const existing = existentFolders[0];
+    const action = await waitForCollisionResolution(pickedName, existing.uuid, existing.id);
+    if (action === null) return null;
+    if (action === 'replace') {
+      await driveTrashService.moveToTrash([{ uuid: existing.uuid, id: existing.id, type: 'folder' }]);
+      return pickedName;
+    }
+    return getUniqueFolderName(pickedName, parentUuid);
+  };
+
   const handleUploadFolder = async () => {
     dispatch(uiActions.setShowUploadFileModal(false));
-
-    let hasShownEmptyFileNotice = false;
-
-    const handleEmptyFileSkipped = () => {
-      if (!hasShownEmptyFileNotice) {
-        hasShownEmptyFileNotice = true;
-        notificationsService.show({
-          type: NotificationType.Warning,
-          text1: strings.messages.emptyFileSkippedDuringFolderUpload,
-        });
-      }
-    };
+    hasShownEmptyFileNoticeRef.current = false;
 
     const uploadId = uuid.v4().toString();
     const abortController = new AbortController();
@@ -227,18 +241,10 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
         throw new Error('No focused folder UUID');
       }
 
-      // Name collision check
-      const { existentFolders } = await driveFolderService.checkDuplicatedFolders(focusedFolder.uuid, [picked.name]);
-      if (existentFolders.length > 0) {
-        const existing = existentFolders[0];
-        const action = await waitForCollisionResolution(picked.name, existing.uuid, existing.id);
-        if (action === null) return;
-        if (action === 'replace') {
-          await driveTrashService.moveToTrash([{ uuid: existing.uuid, id: existing.id, type: 'folder' }]);
-        } else {
-          picked.name = await getUniqueFolderName(picked.name, focusedFolder.uuid);
-        }
-      }
+      // 5. Name collision check
+      const resolvedName = await resolveCollision(picked.name, focusedFolder.uuid);
+      if (resolvedName === null) return;
+      picked.name = resolvedName;
 
       // 5. Create the root folder (merge if already exists)
       const rootFolderUuid = await createFolderWithMerge(focusedFolder.uuid, picked.name);

--- a/src/components/modals/AddModal/hooks/useFolderUpload.ts
+++ b/src/components/modals/AddModal/hooks/useFolderUpload.ts
@@ -25,8 +25,9 @@ import fileSystemService from '../../../../services/FileSystemService';
 import notificationsService from '../../../../services/NotificationsService';
 import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
 import { driveActions, driveThunks } from '../../../../store/slices/drive';
+import { storageSelectors } from '../../../../store/slices/storage';
 import { uiActions } from '../../../../store/slices/ui';
-import { NotificationType, ProgressCallback } from '../../../../types';
+import { INFINITE_PLAN, NotificationType, ProgressCallback } from '../../../../types';
 import { FolderTreeNode } from '../../../../types/drive/folderUpload';
 import { NameCollisionAction } from '../../NameCollisionModal';
 
@@ -86,6 +87,8 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
   const dispatch = useAppDispatch();
   const { focusedFolder, loadFolderContent } = useDrive();
   const folderUploads = useAppSelector((state) => state.drive.folderUploads);
+  const { limit } = useAppSelector((state) => state.storage);
+  const usage = useAppSelector(storageSelectors.usage);
 
   const collisionResolverRef = useRef<((action: NameCollisionAction | null) => void) | null>(null);
   const [collisionState, setCollisionState] = useState<{
@@ -133,11 +136,24 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
       }
     };
 
-    const uploadFolderFileIOS = async (fileNode: FolderTreeNode, parentUuid: string, signal: AbortSignal): Promise<void> => {
+    const uploadFolderFileIOS = async (
+      fileNode: FolderTreeNode,
+      parentUuid: string,
+      signal: AbortSignal,
+    ): Promise<void> => {
       const filePath = fileNode.uri.replace('file://', '');
       const { extension, plainName } = getFileExtensionAndPlainName(fileNode.name);
       try {
-        await uploadAndCreateFileEntry(filePath, plainName, extension, parentUuid, noopProgress, undefined, undefined, signal);
+        await uploadAndCreateFileEntry(
+          filePath,
+          plainName,
+          extension,
+          parentUuid,
+          noopProgress,
+          undefined,
+          undefined,
+          signal,
+        );
       } catch (err) {
         if (err instanceof EmptyFileNotAllowedError) {
           handleEmptyFileSkipped();
@@ -159,7 +175,16 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
       try {
         await StorageAccessFramework.copyAsync({ from: fileNode.uri, to: tempUri });
         if (signal.aborted) return;
-        await uploadAndCreateFileEntry(tempPath, plainName, extension, parentUuid, noopProgress, undefined, undefined, signal);
+        await uploadAndCreateFileEntry(
+          tempPath,
+          plainName,
+          extension,
+          parentUuid,
+          noopProgress,
+          undefined,
+          undefined,
+          signal,
+        );
       } catch (err) {
         if (err instanceof EmptyFileNotAllowedError) {
           handleEmptyFileSkipped();
@@ -173,6 +198,7 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
     };
 
     const uploadId = uuid.v4().toString();
+    const abortController = new AbortController();
 
     try {
       // 1. Pick folder
@@ -180,14 +206,38 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
       if (!picked) return;
       logger.info(`[useFolderUpload][${uploadId}] Folder: "${picked.name}" (${picked.uri})`);
 
+      const startedAt = Date.now();
+      dispatch(
+        driveActions.addFolderUpload({
+          uploadId,
+          folderName: picked.name,
+          totalFiles: 0,
+          uploadedFiles: 0,
+          failedFiles: 0,
+          status: 'scanning',
+          startedAt,
+        }),
+      );
+      folderUploadCancellationService.register(uploadId, abortController);
+
       // 2. Traverse
-      const tree = await folderTraversalService.traverseFolder(picked.uri);
+      const tree = await folderTraversalService.traverseFolder(picked.uri, abortController.signal);
       logger.info(`[useFolderUpload][${uploadId}] Tree: ${tree.files.length} files, ${tree.dirs.length} dirs`);
 
-      // 3. Storage quota check
+      // 3. Device space check
+      if (tree.files.length > 0) {
+        const maxFileSize = Math.max(...tree.files.map((f) => f.size));
+        const hasDeviceSpace = await fileSystemService.checkAvailableStorage(maxFileSize).catch(() => true);
+        if (!hasDeviceSpace) {
+          dispatch(uiActions.setShowNotEnoughDeviceSpaceModal(true));
+          return;
+        }
+      }
+
+      // 4. Cloud quota check
       const totalSize = tree.files.reduce((sum, file) => sum + file.size, 0);
-      const hasStorage = await fileSystemService.checkAvailableStorage(totalSize).catch(() => true);
-      if (!hasStorage) {
+      const isUnlimited = limit >= INFINITE_PLAN;
+      if (!isUnlimited && usage + totalSize > limit) {
         dispatch(uiActions.setShowRunOutSpaceModal(true));
         return;
       }
@@ -209,25 +259,17 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
         }
       }
 
-      // 4. Create the root folder (merge if already exists)
+      // 5. Create the root folder (merge if already exists)
       const rootFolderUuid = await createFolderWithMerge(focusedFolder.uuid, picked.name);
       logger.info(`[useFolderUpload][${uploadId}] Root folder "${picked.name}" - ${rootFolderUuid}`);
 
-      // 5. Initialize progress state + AbortController
-      const startedAt = Date.now();
       dispatch(
-        driveActions.addFolderUpload({
+        driveActions.updateFolderUpload({
           uploadId,
-          folderName: picked.name,
           totalFiles: tree.files.length,
-          uploadedFiles: 0,
-          failedFiles: 0,
           status: 'uploading',
-          startedAt,
         }),
       );
-      const abortController = new AbortController();
-      folderUploadCancellationService.register(uploadId, abortController);
 
       // 6. Log upload start
       analytics.track(DriveAnalyticsEvent.FolderUploadStarted, {
@@ -280,6 +322,10 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
       // 9. Display result
       showFolderUploadResult(result, picked.name);
     } catch (err) {
+      if (abortController.signal.aborted) {
+        notificationsService.show({ type: NotificationType.Info, text1: strings.messages.folderUploadCancelled });
+        return;
+      }
       const error = err as Error;
       if (!(err instanceof FolderTooLargeError)) {
         errorService.reportError(error);

--- a/src/components/modals/AddModal/hooks/useFolderUpload.ts
+++ b/src/components/modals/AddModal/hooks/useFolderUpload.ts
@@ -34,6 +34,48 @@ import { NameCollisionAction } from '../../NameCollisionModal';
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noopProgress: ProgressCallback = () => {};
 
+const uploadFolderFileIOS = async (
+  fileNode: FolderTreeNode,
+  parentUuid: string,
+  signal: AbortSignal,
+  uploadAndCreateFileEntry: UploadFileEntryFn,
+  onEmptyFileSkipped: () => void,
+): Promise<void> => {
+  const filePath = fileNode.uri.replace('file://', '');
+  const { extension, plainName } = getFileExtensionAndPlainName(fileNode.name);
+  try {
+    await uploadAndCreateFileEntry(filePath, plainName, extension, parentUuid, noopProgress, undefined, undefined, signal);
+  } catch (err) {
+    if (err instanceof EmptyFileNotAllowedError) onEmptyFileSkipped();
+    throw err;
+  }
+};
+
+const uploadFolderFileAndroid = async (
+  fileNode: FolderTreeNode,
+  parentUuid: string,
+  signal: AbortSignal,
+  uploadId: string,
+  uploadAndCreateFileEntry: UploadFileEntryFn,
+  onEmptyFileSkipped: () => void,
+): Promise<void> => {
+  const { extension, plainName } = getFileExtensionAndPlainName(fileNode.name);
+  const tempPath = fileSystemService.tmpFilePath(`${uploadId}_${fileNode.name}`);
+  const tempUri = fileSystemService.pathToUri(tempPath);
+  try {
+    await StorageAccessFramework.copyAsync({ from: fileNode.uri, to: tempUri });
+    if (signal.aborted) return;
+    await uploadAndCreateFileEntry(tempPath, plainName, extension, parentUuid, noopProgress, undefined, undefined, signal);
+  } catch (err) {
+    if (err instanceof EmptyFileNotAllowedError) onEmptyFileSkipped();
+    throw err;
+  } finally {
+    await fileSystemService.unlinkIfExists(tempPath).catch((e) => {
+      logger.warn('[useFolderUpload] Failed to unlink temp file: ' + (e as Error).message);
+    });
+  }
+};
+
 const showFolderUploadResult = (
   result: { cancelled: boolean; failedFiles: number; uploadedFiles: number; totalFiles: number; skippedFiles: number },
   folderName: string,
@@ -132,67 +174,6 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
         notificationsService.show({
           type: NotificationType.Warning,
           text1: strings.messages.emptyFileSkippedDuringFolderUpload,
-        });
-      }
-    };
-
-    const uploadFolderFileIOS = async (
-      fileNode: FolderTreeNode,
-      parentUuid: string,
-      signal: AbortSignal,
-    ): Promise<void> => {
-      const filePath = fileNode.uri.replace('file://', '');
-      const { extension, plainName } = getFileExtensionAndPlainName(fileNode.name);
-      try {
-        await uploadAndCreateFileEntry(
-          filePath,
-          plainName,
-          extension,
-          parentUuid,
-          noopProgress,
-          undefined,
-          undefined,
-          signal,
-        );
-      } catch (err) {
-        if (err instanceof EmptyFileNotAllowedError) {
-          handleEmptyFileSkipped();
-        }
-        throw err;
-      }
-    };
-
-    const uploadFolderFileAndroid = async (
-      fileNode: FolderTreeNode,
-      parentUuid: string,
-      signal: AbortSignal,
-      uploadId: string,
-    ): Promise<void> => {
-      const { extension, plainName } = getFileExtensionAndPlainName(fileNode.name);
-      // Prefix with uploadId to isolate temp files across concurrent uploads
-      const tempPath = fileSystemService.tmpFilePath(`${uploadId}_${fileNode.name}`);
-      const tempUri = fileSystemService.pathToUri(tempPath);
-      try {
-        await StorageAccessFramework.copyAsync({ from: fileNode.uri, to: tempUri });
-        if (signal.aborted) return;
-        await uploadAndCreateFileEntry(
-          tempPath,
-          plainName,
-          extension,
-          parentUuid,
-          noopProgress,
-          undefined,
-          undefined,
-          signal,
-        );
-      } catch (err) {
-        if (err instanceof EmptyFileNotAllowedError) {
-          handleEmptyFileSkipped();
-        }
-        throw err;
-      } finally {
-        await fileSystemService.unlinkIfExists(tempPath).catch((e) => {
-          logger.warn('[useFolderUpload] Failed to unlink temp file: ' + (e as Error).message);
         });
       }
     };
@@ -298,9 +279,9 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
         },
         uploadFile: async (fileNode, parentUuid, signal) => {
           if (Platform.OS === 'android' && fileNode.uri.startsWith('content://')) {
-            await uploadFolderFileAndroid(fileNode, parentUuid, signal, uploadId);
+            await uploadFolderFileAndroid(fileNode, parentUuid, signal, uploadId, uploadAndCreateFileEntry, handleEmptyFileSkipped);
           } else {
-            await uploadFolderFileIOS(fileNode, parentUuid, signal);
+            await uploadFolderFileIOS(fileNode, parentUuid, signal, uploadAndCreateFileEntry, handleEmptyFileSkipped);
           }
         },
       });

--- a/src/components/modals/NotEnoughDeviceSpaceModal/index.tsx
+++ b/src/components/modals/NotEnoughDeviceSpaceModal/index.tsx
@@ -1,0 +1,77 @@
+import { TouchableHighlight, TouchableWithoutFeedback, View } from 'react-native';
+import Modal from 'react-native-modal';
+
+import AppText from 'src/components/AppText';
+import { useTailwind } from 'tailwind-rn';
+import strings from '../../../../assets/lang/strings';
+import useGetColor from '../../../hooks/useColor';
+import { useAppDispatch, useAppSelector } from '../../../store/hooks';
+import { uiActions } from '../../../store/slices/ui';
+
+const NotEnoughDeviceSpaceModal = (): JSX.Element => {
+  const tailwind = useTailwind();
+  const getColor = useGetColor();
+  const dispatch = useAppDispatch();
+
+  const isVisible = useAppSelector((state) => state.ui.showNotEnoughDeviceSpaceModal);
+
+  const handleClose = () => {
+    dispatch(uiActions.setShowNotEnoughDeviceSpaceModal(false));
+  };
+
+  return (
+    <Modal
+      isVisible={isVisible}
+      onModalHide={handleClose}
+      onBackdropPress={handleClose}
+      onBackButtonPress={handleClose}
+      style={{ margin: 0, justifyContent: 'flex-end' }}
+      animationIn="slideInUp"
+      animationOut="slideOutDown"
+      animationInTiming={250}
+      animationOutTiming={250}
+      backdropTransitionInTiming={250}
+      backdropTransitionOutTiming={0}
+      useNativeDriver
+      useNativeDriverForBackdrop
+      hideModalContentWhileAnimating
+      coverScreen={false}
+    >
+      <View style={tailwind('bg-transparent')}>
+        <TouchableWithoutFeedback onPress={handleClose}>
+          <View style={tailwind('flex-grow')} />
+        </TouchableWithoutFeedback>
+
+        <View>
+          <View style={tailwind('flex-row bg-white px-5 py-3 rounded-t-xl justify-center')}>
+            <View style={tailwind('h-1 w-20 bg-gray-20 rounded-full')} />
+          </View>
+
+          <View style={tailwind('bg-white justify-center px-5 pt-3 pb-8')}>
+            <AppText style={tailwind('text-center text-lg text-gray-100')} medium>
+              {strings.modals.NotEnoughDeviceSpaceModal.title}
+            </AppText>
+
+            <View style={tailwind('flex-grow my-6')}>
+              <AppText style={tailwind('text-sm text-center text-gray-50')}>
+                {strings.modals.NotEnoughDeviceSpaceModal.advice}
+              </AppText>
+            </View>
+
+            <TouchableHighlight
+              underlayColor={getColor('text-gray-10')}
+              style={tailwind('bg-gray-5 rounded-lg py-2 mx-6 items-center justify-center')}
+              onPress={handleClose}
+            >
+              <AppText style={tailwind('text-lg text-gray-80')} medium>
+                {strings.buttons.close}
+              </AppText>
+            </TouchableHighlight>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+export default NotEnoughDeviceSpaceModal;

--- a/src/navigation/TabExplorerNavigator.tsx
+++ b/src/navigation/TabExplorerNavigator.tsx
@@ -16,6 +16,7 @@ import DriveRenameModal from '../components/modals/DriveRenameModal';
 import MoveItemsModal from '../components/modals/MoveItemsModal';
 import RunOutOfStorageModal from '../components/modals/RunOutOfStorageModal';
 import EmptyFileNotAllowedModal from '../components/modals/EmptyFileNotAllowedModal';
+import NotEnoughDeviceSpaceModal from '../components/modals/NotEnoughDeviceSpaceModal';
 import { SharedLinkInfoModal } from '../components/modals/SharedLinkInfoModal';
 import SignOutModal from '../components/modals/SignOutModal';
 import useGetColor from '../hooks/useColor';
@@ -88,6 +89,7 @@ export default function TabExplorerNavigator(props: RootStackScreenProps<'TabExp
       <DriveRenameModal />
       <RunOutOfStorageModal />
       <EmptyFileNotAllowedModal />
+      <NotEnoughDeviceSpaceModal />
       <SignOutModal />
       <SecurityModal isOpen={isSecurityModalOpen} onClose={onSecurityModalClosed} />
     </View>

--- a/src/screens/drive/DriveFolderScreen/DriveFolderScreen.helpers.ts
+++ b/src/screens/drive/DriveFolderScreen/DriveFolderScreen.helpers.ts
@@ -40,15 +40,22 @@ export const buildDeepLinkRoutes = (folderUuid: string, ancestors: FolderAncesto
   return routes;
 };
 
+const FOLDER_UPLOAD_ID_PREFIX = 'folder-upload-';
+
+export const isFolderUploadItem = (item: DriveListItem): boolean => item.id.startsWith(FOLDER_UPLOAD_ID_PREFIX);
+
 export const buildFolderUploadListItem = (state: FolderUploadState): DriveListItem => ({
-  id: `folder-upload-${state.uploadId}`,
+  id: `${FOLDER_UPLOAD_ID_PREFIX}${state.uploadId}`,
   status: DriveItemStatus.Uploading,
   progress: state.totalFiles > 0 ? state.uploadedFiles / state.totalFiles : 0,
-  folderUploadProgress: {
-    uploadedFiles: state.uploadedFiles,
-    totalFiles: state.totalFiles,
-    failedFiles: state.failedFiles,
-  },
+  folderUploadProgress:
+    state.status === 'scanning'
+      ? undefined
+      : {
+          uploadedFiles: state.uploadedFiles,
+          totalFiles: state.totalFiles,
+          failedFiles: state.failedFiles,
+        },
   data: {
     id: -1,
     uuid: state.uploadId,

--- a/src/screens/drive/DriveFolderScreen/DriveFolderScreen.tsx
+++ b/src/screens/drive/DriveFolderScreen/DriveFolderScreen.tsx
@@ -24,7 +24,7 @@ import { DriveListType, SortDirection, SortType } from '../../../types/drive/ui'
 import { DriveScreenProps, DriveStackParamList } from '../../../types/navigation';
 import { DriveFolderEmpty } from './DriveFolderEmpty';
 import { DriveFolderError } from './DriveFolderError';
-import { buildFolderUploadListItem } from './DriveFolderScreen.helpers';
+import { buildFolderUploadListItem, isFolderUploadItem } from './DriveFolderScreen.helpers';
 import { DriveFolderScreenHeader } from './DriveFolderScreenHeader';
 import { useDeepLinkNavigationResolver } from './useDeepLinkNavigationResolver';
 
@@ -218,7 +218,7 @@ export function DriveFolderScreen({ navigation }: DriveScreenProps<'DriveFolder'
         }),
       );
       handleOnFilePress(driveItem);
-    } else if (driveItem.data.uuid) {
+    } else if (driveItem.data.uuid && !isFolderUploadItem(driveItem)) {
       driveCtx.loadFolderContent(driveItem.data.uuid, { focusFolder: true, resetPagination: true }).catch((error) => {
         errorService.reportError(error);
         const err = errorService.castError(error, 'content');
@@ -239,7 +239,7 @@ export function DriveFolderScreen({ navigation }: DriveScreenProps<'DriveFolder'
   };
 
   const handleDriveItemActionsPress = (driveItem: DriveListItem) => {
-    if (driveItem.id.startsWith('folder-upload-')) {
+    if (isFolderUploadItem(driveItem)) {
       const uploadId = driveItem.data.uuid;
       folderUploadCancellationService.cancel(uploadId);
       dispatch(driveActions.removeFolderUpload(uploadId));

--- a/src/services/drive/folder/folderTraversal.service.spec.ts
+++ b/src/services/drive/folder/folderTraversal.service.spec.ts
@@ -59,7 +59,7 @@ describe('folderTraversalService.traverseFolder', () => {
   });
 
   describe('when the URI uses the file:// scheme', () => {
-    it('when the folder is empty, then it returns empty dirs and files arrays', async () => {
+    test('when the folder is empty, then it returns empty dirs and files arrays', async () => {
       mockReadDir.mockResolvedValue([]);
 
       const result = await folderTraversalService.traverseFolder('file:///var/mobile/Photos');
@@ -67,7 +67,7 @@ describe('folderTraversalService.traverseFolder', () => {
       expect(result).toEqual({ dirs: [], files: [] });
     });
 
-    it('when the folder contains only files, then it returns them with correct relativePath and parentPath', async () => {
+    test('when the folder contains only files, then it returns them with correct relativePath and parentPath', async () => {
       mockReadDir.mockResolvedValue([
         mockFile('photo1.jpg', '/var/mobile/Photos/photo1.jpg', 2048),
         mockFile('photo2.jpg', '/var/mobile/Photos/photo2.jpg', 3072),
@@ -96,7 +96,7 @@ describe('folderTraversalService.traverseFolder', () => {
       ]);
     });
 
-    it('when the folder has nested subdirectories, then it traverses all levels in DFS pre-order with correct relativePath and parentPath', async () => {
+    test('when the folder has nested subdirectories, then it traverses all levels in DFS pre-order with correct relativePath and parentPath', async () => {
       const root = '/var/mobile/Root';
 
       mockReadDir.mockImplementation((path: string) => {
@@ -164,7 +164,7 @@ describe('folderTraversalService.traverseFolder', () => {
       ]);
     });
 
-    it('when the folder contains more than 3000 files, then it throws FolderTooLargeError and shows an alert', async () => {
+    test('when the folder contains more than 3000 files, then it throws FolderTooLargeError and shows an alert', async () => {
       const files = Array.from({ length: 3001 }, (_, i) => mockFile(`file${i}.txt`, `/var/mobile/Big/file${i}.txt`));
       mockReadDir.mockResolvedValue(files);
 
@@ -177,7 +177,7 @@ describe('folderTraversalService.traverseFolder', () => {
       );
     });
 
-    it('when the folder contains exactly 3000 files, then it resolves without throwing', async () => {
+    test('when the folder contains exactly 3000 files, then it resolves without throwing', async () => {
       const files = Array.from({ length: 3000 }, (_, i) => mockFile(`file${i}.txt`, `/var/mobile/Big/file${i}.txt`));
       mockReadDir.mockResolvedValue(files);
 
@@ -188,7 +188,7 @@ describe('folderTraversalService.traverseFolder', () => {
       expect(mockAlert).not.toHaveBeenCalled();
     });
 
-    it('when the root path contains percent-encoded characters, then it decodes them before reading', async () => {
+    test('when the root path contains percent-encoded characters, then it decodes them before reading', async () => {
       mockReadDir.mockResolvedValue([mockFile('a.txt', '/var/mobile/My Folder/a.txt', 10)]);
 
       const result = await folderTraversalService.traverseFolder('file:///var/mobile/My%20Folder');
@@ -207,22 +207,34 @@ describe('folderTraversalService.traverseFolder', () => {
     const safNestedUri = (dir: string, name: string) =>
       `${treeUri}/document/primary%3ADownload%2F${encodeURIComponent(dir)}%2F${encodeURIComponent(name)}`;
 
-    const infoFile = (uri: string, size = 1024) => ({ exists: true as const, isDirectory: false, size, uri, modificationTime: 0 });
+    const infoFile = (uri: string, size = 1024) => ({
+      exists: true as const,
+      isDirectory: false,
+      size,
+      uri,
+      modificationTime: 0,
+    });
     const infoDir = (uri: string) => ({ exists: true as const, isDirectory: true, size: 0, uri, modificationTime: 0 });
 
-    it('when the folder is empty, then it returns empty dirs and files arrays', async () => {
-      mockReadDirectoryAsync.mockResolvedValue([]);
+    test('when the folder is empty, then it returns empty dirs and files arrays', async () => {
+      mockReadDirectoryAsync.mockImplementation((uri: string) => {
+        if (uri === treeUri) return Promise.resolve([]);
+        return Promise.reject(new Error('Not a directory'));
+      });
 
       const result = await folderTraversalService.traverseFolder(treeUri);
 
       expect(result).toEqual({ dirs: [], files: [] });
     });
 
-    it('when the folder contains only files, then it returns them with correct relativePath and parentPath', async () => {
+    test('when the folder contains only files, then it returns them with correct relativePath and parentPath', async () => {
       const uri1 = safFileUri('photo1.jpg');
       const uri2 = safFileUri('photo2.jpg');
 
-      mockReadDirectoryAsync.mockResolvedValue([uri1, uri2]);
+      mockReadDirectoryAsync.mockImplementation((uri: string) => {
+        if (uri === treeUri) return Promise.resolve([uri1, uri2]);
+        return Promise.reject(new Error('Not a directory'));
+      });
       mockGetInfoAsync.mockImplementation((uri: string) => {
         if (uri === uri1) return Promise.resolve(infoFile(uri1, 2048));
         if (uri === uri2) return Promise.resolve(infoFile(uri2, 3072));
@@ -237,7 +249,7 @@ describe('folderTraversalService.traverseFolder', () => {
       ]);
     });
 
-    it('when the folder has nested subdirectories, then it traverses all levels in DFS pre-order with correct relativePath and parentPath', async () => {
+    test('when the folder has nested subdirectories, then it traverses all levels in DFS pre-order with correct relativePath and parentPath', async () => {
       const level1Uri = safDirUri('level1');
       const deepTxtUri = safNestedUri('level1', 'deep.txt');
       const rootTxtUri = safFileUri('root.txt');
@@ -245,7 +257,7 @@ describe('folderTraversalService.traverseFolder', () => {
       mockReadDirectoryAsync.mockImplementation((uri: string) => {
         if (uri === treeUri) return Promise.resolve([level1Uri, rootTxtUri]);
         if (uri === level1Uri) return Promise.resolve([deepTxtUri]);
-        return Promise.resolve([]);
+        return Promise.reject(new Error('Not a directory'));
       });
       mockGetInfoAsync.mockImplementation((uri: string) => {
         if (uri === level1Uri) return Promise.resolve(infoDir(level1Uri));
@@ -259,15 +271,25 @@ describe('folderTraversalService.traverseFolder', () => {
         { relativePath: 'level1', parentPath: '', name: 'level1', isDirectory: true, size: 0, uri: level1Uri },
       ]);
       expect(result.files).toEqual([
-        { relativePath: 'level1/deep.txt', parentPath: 'level1', name: 'deep.txt', isDirectory: false, size: 300, uri: deepTxtUri },
+        {
+          relativePath: 'level1/deep.txt',
+          parentPath: 'level1',
+          name: 'deep.txt',
+          isDirectory: false,
+          size: 300,
+          uri: deepTxtUri,
+        },
         { relativePath: 'root.txt', parentPath: '', name: 'root.txt', isDirectory: false, size: 100, uri: rootTxtUri },
       ]);
     });
 
-    it('when the document URI contains percent-encoded characters in the name, then it decodes them correctly', async () => {
+    test('when the document URI contains percent-encoded characters in the name, then it decodes them correctly', async () => {
       const uri = safFileUri('my file.txt');
 
-      mockReadDirectoryAsync.mockResolvedValue([uri]);
+      mockReadDirectoryAsync.mockImplementation((calledUri: string) => {
+        if (calledUri === treeUri) return Promise.resolve([uri]);
+        return Promise.reject(new Error('Not a directory'));
+      });
       mockGetInfoAsync.mockResolvedValue(infoFile(uri, 512));
 
       const result = await folderTraversalService.traverseFolder(treeUri);
@@ -276,9 +298,12 @@ describe('folderTraversalService.traverseFolder', () => {
       expect(result.files[0].relativePath).toBe('my file.txt');
     });
 
-    it('when the folder contains more than 3000 files, then it throws FolderTooLargeError and shows an alert', async () => {
+    test('when the folder contains more than 3000 files, then it throws FolderTooLargeError and shows an alert', async () => {
       const uris = Array.from({ length: 3001 }, (_, i) => safFileUri(`file${i}.txt`));
-      mockReadDirectoryAsync.mockResolvedValue(uris);
+      mockReadDirectoryAsync.mockImplementation((uri: string) => {
+        if (uri === treeUri) return Promise.resolve(uris);
+        return Promise.reject(new Error('Not a directory'));
+      });
       mockGetInfoAsync.mockImplementation((uri: string) => Promise.resolve(infoFile(uri)));
 
       await expect(folderTraversalService.traverseFolder(treeUri)).rejects.toBeInstanceOf(FolderTooLargeError);
@@ -288,9 +313,12 @@ describe('folderTraversalService.traverseFolder', () => {
       );
     });
 
-    it('when the folder contains exactly 3000 files, then it resolves without throwing', async () => {
+    test('when the folder contains exactly 3000 files, then it resolves without throwing', async () => {
       const uris = Array.from({ length: 3000 }, (_, i) => safFileUri(`file${i}.txt`));
-      mockReadDirectoryAsync.mockResolvedValue(uris);
+      mockReadDirectoryAsync.mockImplementation((uri: string) => {
+        if (uri === treeUri) return Promise.resolve(uris);
+        return Promise.reject(new Error('Not a directory'));
+      });
       mockGetInfoAsync.mockImplementation((uri: string) => Promise.resolve(infoFile(uri)));
 
       const result = await folderTraversalService.traverseFolder(treeUri);
@@ -299,10 +327,154 @@ describe('folderTraversalService.traverseFolder', () => {
       expect(result.dirs).toHaveLength(0);
       expect(mockAlert).not.toHaveBeenCalled();
     });
+
+    test('when getInfoAsync rejects (throws), then it falls back gracefully and still processes the item', async () => {
+      const uri = safFileUri('photo.jpg');
+
+      mockReadDirectoryAsync.mockImplementation((calledUri: string) => {
+        if (calledUri === treeUri) return Promise.resolve([uri]);
+        return Promise.reject(new Error('Not a directory'));
+      });
+      mockGetInfoAsync.mockRejectedValue(new Error('Function not implemented'));
+
+      const result = await folderTraversalService.traverseFolder(treeUri);
+
+      expect(result.files).toHaveLength(1);
+      expect(result.files[0].name).toBe('photo.jpg');
+      expect(result.files[0].size).toBe(0);
+    });
+
+    describe('SAF volume prefix stripping', () => {
+      test('when info.name returns a volume-prefixed name (patch inactive), then it strips the prefix', async () => {
+        const uri = safFileUri('IMG_20260417.jpeg');
+
+        mockReadDirectoryAsync.mockImplementation((calledUri: string) => {
+          if (calledUri === treeUri) return Promise.resolve([uri]);
+          return Promise.reject(new Error('Not a directory'));
+        });
+        // Simulates the expo-file-system patch being inactive: info.name carries the SAF prefix
+        mockGetInfoAsync.mockResolvedValue({ ...infoFile(uri, 512), name: 'primary:IMG_20260417.jpeg' });
+
+        const result = await folderTraversalService.traverseFolder(treeUri);
+
+        expect(result.files[0].name).toBe('IMG_20260417.jpeg');
+        expect(result.files[0].relativePath).toBe('IMG_20260417.jpeg');
+      });
+
+      test('when the URI encodes a root-level name without a slash, then it strips the volume prefix from the document segment', async () => {
+        // URI like: .../document/primary%3ADCIM (no slash after the prefix)
+        const uri = `${treeUri}/document/primary%3ADCIM`;
+
+        mockReadDirectoryAsync.mockImplementation((calledUri: string) => {
+          if (calledUri === treeUri) return Promise.resolve([uri]);
+          return Promise.reject(new Error('Not a directory'));
+        });
+        mockGetInfoAsync.mockResolvedValue({ ...infoFile(uri, 100), name: undefined });
+
+        const result = await folderTraversalService.traverseFolder(treeUri);
+
+        expect(result.files[0].name).toBe('DCIM');
+      });
+
+      test('when a folder name legitimately contains a colon not matching the whitelist, then it is preserved', async () => {
+        const uri = safFileUri('notes: draft.txt');
+
+        mockReadDirectoryAsync.mockImplementation((calledUri: string) => {
+          if (calledUri === treeUri) return Promise.resolve([uri]);
+          return Promise.reject(new Error('Not a directory'));
+        });
+        mockGetInfoAsync.mockResolvedValue({ ...infoFile(uri, 200), name: 'notes: draft.txt' });
+
+        const result = await folderTraversalService.traverseFolder(treeUri);
+
+        expect(result.files[0].name).toBe('notes: draft.txt');
+      });
+
+      test('when the URI uses a short SD-card UUID prefix, then it strips the prefix', async () => {
+        // SD card URIs use a short hex UUID like "1A2B-3C4D"
+        const sdUri =
+          'content://com.android.externalstorage.documents/tree/1A2B-3C4D%3APictures/document/1A2B-3C4D%3APictures%2Ffoo.jpg';
+
+        mockReadDirectoryAsync.mockImplementation((calledUri: string) => {
+          if (calledUri === treeUri) return Promise.resolve([sdUri]);
+          return Promise.reject(new Error('Not a directory'));
+        });
+        mockGetInfoAsync.mockResolvedValue({ ...infoFile(sdUri, 300), name: undefined });
+
+        const result = await folderTraversalService.traverseFolder(treeUri);
+
+        expect(result.files[0].name).toBe('foo.jpg');
+      });
+    });
+
+    describe('Cancellation via AbortSignal', () => {
+      test('when the signal is aborted before traversal starts, then it throws an AbortError immediately', async () => {
+        const controller = new AbortController();
+        controller.abort();
+
+        mockReadDirectoryAsync.mockResolvedValue([safFileUri('file.txt')]);
+        mockGetInfoAsync.mockResolvedValue(infoFile(safFileUri('file.txt')));
+
+        await expect(folderTraversalService.traverseFolder(treeUri, controller.signal)).rejects.toMatchObject({
+          name: 'AbortError',
+        });
+      });
+
+      test('when the signal is aborted mid-traversal, then it stops processing remaining items', async () => {
+        const controller = new AbortController();
+        const uri1 = safFileUri('file1.txt');
+        const uri2 = safFileUri('file2.txt');
+
+        mockReadDirectoryAsync.mockImplementation((uri: string) => {
+          if (uri === treeUri) return Promise.resolve([uri1, uri2]);
+          return Promise.reject(new Error('Not a directory'));
+        });
+        mockGetInfoAsync.mockImplementation((uri: string) => {
+          if (uri === uri1) {
+            controller.abort();
+            return Promise.resolve(infoFile(uri1, 100));
+          }
+          return Promise.resolve(infoFile(uri, 200));
+        });
+
+        await expect(folderTraversalService.traverseFolder(treeUri, controller.signal)).rejects.toMatchObject({
+          name: 'AbortError',
+        });
+        // uri2 was never processed because abort was detected at the start of the second iteration
+        expect(mockGetInfoAsync).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('SAF directory detection via readDirectoryAsync', () => {
+      test('when getInfoAsync returns exists:false but readDirectoryAsync succeeds, then the item is treated as a directory', async () => {
+        const subDirUri = safDirUri('SubFolder');
+        const fileUri = safNestedUri('SubFolder', 'file.txt');
+
+        mockReadDirectoryAsync.mockImplementation((uri: string) => {
+          if (uri === treeUri) return Promise.resolve([subDirUri]);
+          if (uri === subDirUri) return Promise.resolve([fileUri]);
+          return Promise.reject(new Error('Not a directory'));
+        });
+        mockGetInfoAsync.mockImplementation((uri: string) => {
+          // Patch inactive: getInfoAsync claims the dir doesn't exist
+          if (uri === subDirUri) return Promise.resolve({ exists: false });
+          if (uri === fileUri) return Promise.resolve(infoFile(fileUri, 512));
+        });
+
+        const result = await folderTraversalService.traverseFolder(treeUri);
+
+        expect(result.dirs).toHaveLength(1);
+        expect(result.dirs[0].name).toBe('SubFolder');
+        expect(result.dirs[0].isDirectory).toBe(true);
+        expect(result.files).toHaveLength(1);
+        expect(result.files[0].name).toBe('file.txt');
+        expect(result.files[0].relativePath).toBe('SubFolder/file.txt');
+      });
+    });
   });
 
   describe('when the URI uses an unsupported scheme', () => {
-    it('when traverseFolder is called, then it throws an unsupported scheme error', async () => {
+    test('when traverseFolder is called, then it throws an unsupported scheme error', async () => {
       await expect(folderTraversalService.traverseFolder('ftp://example.com/folder')).rejects.toThrow(
         'Unsupported URI scheme',
       );

--- a/src/services/drive/folder/folderTraversal.service.ts
+++ b/src/services/drive/folder/folderTraversal.service.ts
@@ -3,6 +3,7 @@ import { getInfoAsync, StorageAccessFramework } from 'expo-file-system/legacy';
 import { Alert } from 'react-native';
 import strings from '../../../../assets/lang/strings';
 import { FolderTree, FolderTreeNode } from '../../../types/drive/folderUpload';
+import { getNameFromSafUri, SAF_VOLUME_PREFIX_RE } from './utils/safUri';
 
 const MAX_FILES = 3000;
 
@@ -16,13 +17,6 @@ export class FolderTooLargeError extends Error {
 type TraverseContext = {
   dirPath: string;
   rootPath: string;
-  result: FolderTree;
-  fileCount: number;
-};
-
-type SAFTraverseContext = {
-  dirUri: string;
-  currentRelativePath: string;
   result: FolderTree;
   fileCount: number;
 };
@@ -63,41 +57,38 @@ const traverseFileUri = async ({ dirPath, rootPath, result, fileCount }: Travers
   return fileCount;
 };
 
-const getNameFromSafUri = (childUri: string): string => {
-  const documentPart = childUri.split('/document/').pop() ?? '';
-  const decoded = decodeURIComponent(documentPart);
-  return decoded.split('/').pop() ?? decoded;
-};
-
-const traverseSafUri = async ({
-  dirUri,
-  currentRelativePath,
-  result,
-  fileCount,
-}: SAFTraverseContext): Promise<number> => {
-  const childUris = await StorageAccessFramework.readDirectoryAsync(dirUri);
-
+/**
+ * Traverses SAF child URIs recursively.
+ *
+ * Each child gets exactly one readDirectoryAsync call:
+ * - Resolves → directory; the returned list is reused directly for recursion.
+ * - Throws   → file.
+ *
+ * Checks signal.aborted before each item so cancellation takes effect within one loop tick.
+ */
+const traverseSafChildren = async (
+  childUris: string[],
+  currentRelativePath: string,
+  result: FolderTree,
+  fileCount: number,
+  signal?: AbortSignal,
+): Promise<number> => {
   for (const childUri of childUris) {
-    const info = await getInfoAsync(childUri);
+    if (signal?.aborted) throw new DOMException('Folder scan cancelled', 'AbortError');
+
+    const info = await getInfoAsync(childUri).catch(() => ({ exists: false as const }));
     const infoName = (info as { name?: string }).name;
-    const name = infoName || getNameFromSafUri(childUri);
-    const isDirectory = info.exists ? info.isDirectory : false;
+    const useInfoName = infoName != null && !SAF_VOLUME_PREFIX_RE.test(infoName);
+    const name = useInfoName ? infoName : getNameFromSafUri(childUri);
+
     const relativePath = currentRelativePath ? `${currentRelativePath}/${name}` : name;
     const parentPath = currentRelativePath;
 
-    const node: FolderTreeNode = {
-      relativePath,
-      parentPath,
-      name,
-      isDirectory,
-      size: isDirectory || !info.exists ? 0 : info.size,
-      uri: childUri,
-    };
-
-    if (isDirectory) {
-      result.dirs.push(node);
-      fileCount = await traverseSafUri({ dirUri: childUri, currentRelativePath: relativePath, result, fileCount });
-    } else {
+    let grandchildUris: string[];
+    try {
+      grandchildUris = await StorageAccessFramework.readDirectoryAsync(childUri);
+    } catch {
+      const size = (info as { size?: number }).size ?? 0;
       fileCount++;
       if (fileCount > MAX_FILES) {
         Alert.alert(
@@ -106,8 +97,12 @@ const traverseSafUri = async ({
         );
         throw new FolderTooLargeError();
       }
-      result.files.push(node);
+      result.files.push({ relativePath, parentPath, name, isDirectory: false, size, uri: childUri });
+      continue;
     }
+
+    result.dirs.push({ relativePath, parentPath, name, isDirectory: true, size: 0, uri: childUri });
+    fileCount = await traverseSafChildren(grandchildUris, relativePath, result, fileCount, signal);
   }
 
   return fileCount;
@@ -122,7 +117,7 @@ const traverseSafUri = async ({
  * @throws {FolderTooLargeError} When the folder contains more than {@link MAX_FILES} files.
  * @throws {Error} When the URI scheme is not supported.
  */
-const traverseFolder = async (uri: string): Promise<FolderTree> => {
+const traverseFolder = async (uri: string, signal?: AbortSignal): Promise<FolderTree> => {
   if (uri.startsWith('file://')) {
     const rootPath = decodeURIComponent(uri.replace('file://', '').replace(/\/$/, ''));
     const result: FolderTree = { dirs: [], files: [] };
@@ -132,7 +127,8 @@ const traverseFolder = async (uri: string): Promise<FolderTree> => {
 
   if (uri.startsWith('content://')) {
     const result: FolderTree = { dirs: [], files: [] };
-    await traverseSafUri({ dirUri: uri, currentRelativePath: '', result, fileCount: 0 });
+    const rootChildUris = await StorageAccessFramework.readDirectoryAsync(uri);
+    await traverseSafChildren(rootChildUris, '', result, 0, signal);
     return result;
   }
 

--- a/src/services/drive/folder/folderTraversal.service.ts
+++ b/src/services/drive/folder/folderTraversal.service.ts
@@ -3,7 +3,7 @@ import { getInfoAsync, StorageAccessFramework } from 'expo-file-system/legacy';
 import { Alert } from 'react-native';
 import strings from '../../../../assets/lang/strings';
 import { FolderTree, FolderTreeNode } from '../../../types/drive/folderUpload';
-import { getNameFromSafUri, SAF_VOLUME_PREFIX_RE } from './utils/safUri';
+import { getNameFromSafUri, hasSafVolumePrefix } from './utils/safUri';
 
 const MAX_FILES = 3000;
 
@@ -78,7 +78,7 @@ const traverseSafChildren = async (
 
     const info = await getInfoAsync(childUri).catch(() => ({ exists: false as const }));
     const infoName = (info as { name?: string }).name;
-    const useInfoName = infoName != null && !SAF_VOLUME_PREFIX_RE.test(infoName);
+    const useInfoName = infoName != null && !hasSafVolumePrefix(infoName);
     const name = useInfoName ? infoName : getNameFromSafUri(childUri);
 
     const relativePath = currentRelativePath ? `${currentRelativePath}/${name}` : name;

--- a/src/services/drive/folder/folderUpload.service.ts
+++ b/src/services/drive/folder/folderUpload.service.ts
@@ -1,6 +1,7 @@
 import { logger } from '@internxt-mobile/services/common';
 import { errorCodes, isErrorWithCode, pickDirectory } from '@react-native-documents/picker';
 import strings from '../../../../assets/lang/strings';
+import { getSafTreeName } from './utils/safUri';
 
 export interface PickedFolder {
   uri: string;
@@ -16,9 +17,7 @@ const pickFolder = async (): Promise<PickedFolder | null> => {
     const result = await pickDirectory({ requestLongTermAccess: false });
     const uri = result.uri;
 
-    const decoded = decodeURIComponent(uri);
-    const segments = decoded.replace(/\/$/, '').split('/');
-    const name = segments[segments.length - 1] || strings.generic.unnamedFolder;
+    const name = getSafTreeName(uri, strings.generic.unnamedFolder);
 
     logger.info(`[folderUpload] Folder picked — uri: ${uri}, name: ${name}`);
 

--- a/src/services/drive/folder/utils/safUri.spec.ts
+++ b/src/services/drive/folder/utils/safUri.spec.ts
@@ -1,9 +1,9 @@
-import { getNameFromSafUri, getSafTreeName, SAF_VOLUME_PREFIX_RE } from './safUri';
+import { getNameFromSafUri, getSafTreeName, hasSafVolumePrefix } from './safUri';
 
 const tree = 'content://com.android.externalstorage.documents/tree/primary%3ADownload';
 const childUri = (encoded: string) => `${tree}/document/${encoded}`;
 
-describe('SAF_VOLUME_PREFIX_RE', () => {
+describe('hasSafVolumePrefix', () => {
   test.each([
     ['primary:DCIM', 'primary'],
     ['secondary:folder', 'secondary'],
@@ -12,8 +12,8 @@ describe('SAF_VOLUME_PREFIX_RE', () => {
     ['raw:/absolute/path', 'raw'],
     ['1A2B-3C4D:Pictures', 'short SD-card UUID'],
     ['550e8400-e29b-41d4-a716-446655440000:folder', 'long UUID'],
-  ])('when the input is "%s" (%s), then it matches', (input) => {
-    expect(SAF_VOLUME_PREFIX_RE.test(input)).toBe(true);
+  ])('when the input is "%s" (%s), then it returns true', (input) => {
+    expect(hasSafVolumePrefix(input)).toBe(true);
   });
 
   test.each([
@@ -21,8 +21,8 @@ describe('SAF_VOLUME_PREFIX_RE', () => {
     ['my-folder', 'no colon'],
     ['IMG_20260417.jpeg', 'plain filename'],
     ['', 'empty string'],
-  ])('when the input is "%s" (%s), then it does not match', (input) => {
-    expect(SAF_VOLUME_PREFIX_RE.test(input)).toBe(false);
+  ])('when the input is "%s" (%s), then it returns false', (input) => {
+    expect(hasSafVolumePrefix(input)).toBe(false);
   });
 });
 

--- a/src/services/drive/folder/utils/safUri.spec.ts
+++ b/src/services/drive/folder/utils/safUri.spec.ts
@@ -1,0 +1,101 @@
+import { getNameFromSafUri, getSafTreeName, SAF_VOLUME_PREFIX_RE } from './safUri';
+
+const tree = 'content://com.android.externalstorage.documents/tree/primary%3ADownload';
+const childUri = (encoded: string) => `${tree}/document/${encoded}`;
+
+describe('SAF_VOLUME_PREFIX_RE', () => {
+  test.each([
+    ['primary:DCIM', 'primary'],
+    ['secondary:folder', 'secondary'],
+    ['home:Documents', 'home'],
+    ['downloads:file.pdf', 'downloads'],
+    ['raw:/absolute/path', 'raw'],
+    ['1A2B-3C4D:Pictures', 'short SD-card UUID'],
+    ['550e8400-e29b-41d4-a716-446655440000:folder', 'long UUID'],
+  ])('when the input is "%s" (%s), then it matches', (input) => {
+    expect(SAF_VOLUME_PREFIX_RE.test(input)).toBe(true);
+  });
+
+  test.each([
+    ['notes: draft.txt', 'colon not at start'],
+    ['my-folder', 'no colon'],
+    ['IMG_20260417.jpeg', 'plain filename'],
+    ['', 'empty string'],
+  ])('when the input is "%s" (%s), then it does not match', (input) => {
+    expect(SAF_VOLUME_PREFIX_RE.test(input)).toBe(false);
+  });
+});
+
+describe('getNameFromSafUri', () => {
+  test('when the URI contains a simple filename, then it returns the filename', () => {
+    const uri = childUri('primary%3ADownload%2Fphoto.jpg');
+    expect(getNameFromSafUri(uri)).toBe('photo.jpg');
+  });
+
+  test('when the URI contains a nested path, then it returns only the last segment', () => {
+    const uri = childUri('primary%3ADownload%2FSubFolder%2Fdeep.txt');
+    expect(getNameFromSafUri(uri)).toBe('deep.txt');
+  });
+
+  test('when the URI points to a folder with no trailing filename, then it returns the folder name', () => {
+    const uri = childUri('primary%3ADownload%2FRecordings');
+    expect(getNameFromSafUri(uri)).toBe('Recordings');
+  });
+
+  test('when the name contains percent-encoded spaces, then it decodes them', () => {
+    const uri = childUri('primary%3ADownload%2FMy%20Files');
+    expect(getNameFromSafUri(uri)).toBe('My Files');
+  });
+
+  test('when the document segment has no slash after the volume prefix, then it strips the prefix', () => {
+    const uri = childUri('primary%3ADCIM');
+    expect(getNameFromSafUri(uri)).toBe('DCIM');
+  });
+
+  test('when the URI uses a short SD-card UUID prefix, then it strips the prefix', () => {
+    const uri =
+      'content://com.android.externalstorage.documents/tree/1A2B-3C4D%3APictures/document/1A2B-3C4D%3APictures%2Ffoo.jpg';
+    expect(getNameFromSafUri(uri)).toBe('foo.jpg');
+  });
+
+  test('when the URI uses a long UUID prefix, then it strips the prefix', () => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    const uri = `content://com.android.externalstorage.documents/tree/${encodeURIComponent(uuid + ':Music')}/document/${encodeURIComponent(uuid + ':Music/song.mp3')}`;
+    expect(getNameFromSafUri(uri)).toBe('song.mp3');
+  });
+
+  test('when the name contains a colon that is not a volume prefix, then it preserves it', () => {
+    const uri = childUri(encodeURIComponent('primary:Download/notes: draft.txt'));
+    expect(getNameFromSafUri(uri)).toBe('notes: draft.txt');
+  });
+});
+
+describe('getSafTreeName', () => {
+  test('when the tree URI encodes a primary volume folder, then it returns the folder name without the prefix', () => {
+    expect(getSafTreeName('content://com.android.externalstorage.documents/tree/primary%3AMusic', 'Unnamed')).toBe(
+      'Music',
+    );
+  });
+
+  test('when the tree URI has a trailing slash, then it strips it before extracting the name', () => {
+    expect(getSafTreeName('content://com.android.externalstorage.documents/tree/primary%3ADownload/', 'Unnamed')).toBe(
+      'Download',
+    );
+  });
+
+  test('when the tree URI uses a short SD-card UUID prefix, then it strips the prefix', () => {
+    expect(getSafTreeName('content://com.android.externalstorage.documents/tree/1A2B-3C4D%3APictures', 'Unnamed')).toBe(
+      'Pictures',
+    );
+  });
+
+  test('when stripping the prefix leaves an empty string, then it returns the fallback', () => {
+    expect(getSafTreeName('content://com.android.externalstorage.documents/tree/primary%3A', 'Unnamed')).toBe(
+      'Unnamed',
+    );
+  });
+
+  test('when the URI segment has no volume prefix, then it returns the name as-is', () => {
+    expect(getSafTreeName('content://com.android.externalstorage.documents/tree/MyFolder', 'Unnamed')).toBe('MyFolder');
+  });
+});

--- a/src/services/drive/folder/utils/safUri.ts
+++ b/src/services/drive/folder/utils/safUri.ts
@@ -1,6 +1,6 @@
-// Matches SAF storage volume prefixes only
+// Matches SAF storage volume prefixes
 export const SAF_VOLUME_PREFIX_RE =
-  /^(primary|secondary|home|downloads|raw|[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}):/;
+  /^(primary|secondary|home|downloads|raw|[0-9a-f]{4}-[0-9a-f]{4}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}):/i;
 
 /**
  * Extracts the display name from a SAF child document URI.

--- a/src/services/drive/folder/utils/safUri.ts
+++ b/src/services/drive/folder/utils/safUri.ts
@@ -1,6 +1,12 @@
-// Matches SAF storage volume prefixes
-export const SAF_VOLUME_PREFIX_RE =
-  /^(primary|secondary|home|downloads|raw|[0-9a-f]{4}-[0-9a-f]{4}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}):/i;
+const SAF_WORD_VOLUME_RE = /^(primary|secondary|home|downloads|raw):/;
+const SAF_SHORT_UUID_RE = /^[0-9a-f]{4}-[0-9a-f]{4}:/i;
+const SAF_FULL_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}:/i;
+
+export const hasSafVolumePrefix = (safUri: string): boolean =>
+  SAF_WORD_VOLUME_RE.test(safUri) || SAF_SHORT_UUID_RE.test(safUri) || SAF_FULL_UUID_RE.test(safUri);
+
+export const stripSafVolumePrefix = (safUri: string): string =>
+  safUri.replace(SAF_WORD_VOLUME_RE, '').replace(SAF_SHORT_UUID_RE, '').replace(SAF_FULL_UUID_RE, '');
 
 /**
  * Extracts the display name from a SAF child document URI.
@@ -8,7 +14,7 @@ export const SAF_VOLUME_PREFIX_RE =
 export const getNameFromSafUri = (childUri: string): string => {
   const documentPart = childUri.split('/document/').pop() ?? '';
   const decoded = decodeURIComponent(documentPart);
-  const withoutVolume = decoded.replace(SAF_VOLUME_PREFIX_RE, '');
+  const withoutVolume = stripSafVolumePrefix(decoded);
   return withoutVolume.split('/').pop() || withoutVolume;
 };
 
@@ -19,5 +25,5 @@ export const getNameFromSafUri = (childUri: string): string => {
 export const getSafTreeName = (treeUri: string, fallback: string): string => {
   const decoded = decodeURIComponent(treeUri);
   const rawName = decoded.replace(/\/$/, '').split('/').pop() ?? '';
-  return rawName.replace(SAF_VOLUME_PREFIX_RE, '') || fallback;
+  return stripSafVolumePrefix(rawName) || fallback;
 };

--- a/src/services/drive/folder/utils/safUri.ts
+++ b/src/services/drive/folder/utils/safUri.ts
@@ -1,0 +1,23 @@
+// Matches SAF storage volume prefixes only
+export const SAF_VOLUME_PREFIX_RE =
+  /^(primary|secondary|home|downloads|raw|[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}):/;
+
+/**
+ * Extracts the display name from a SAF child document URI.
+ */
+export const getNameFromSafUri = (childUri: string): string => {
+  const documentPart = childUri.split('/document/').pop() ?? '';
+  const decoded = decodeURIComponent(documentPart);
+  const withoutVolume = decoded.replace(SAF_VOLUME_PREFIX_RE, '');
+  return withoutVolume.split('/').pop() || withoutVolume;
+};
+
+/**
+ * Extracts the display name from a SAF tree root URI returned by the directory picker.
+ *
+ */
+export const getSafTreeName = (treeUri: string, fallback: string): string => {
+  const decoded = decodeURIComponent(treeUri);
+  const rawName = decoded.replace(/\/$/, '').split('/').pop() ?? '';
+  return rawName.replace(SAF_VOLUME_PREFIX_RE, '') || fallback;
+};

--- a/src/store/slices/ui/index.ts
+++ b/src/store/slices/ui/index.ts
@@ -26,6 +26,7 @@ export interface UIState {
   isCancelSubscriptionModalOpen: boolean;
   isSharedLinkOptionsModalOpen: boolean;
   showEmptyFileNotAllowedModal: boolean;
+  showNotEnoughDeviceSpaceModal: boolean;
 }
 
 const initialState: UIState = {
@@ -53,6 +54,7 @@ const initialState: UIState = {
   isCancelSubscriptionModalOpen: false,
   isSharedLinkOptionsModalOpen: false,
   showEmptyFileNotAllowedModal: false,
+  showNotEnoughDeviceSpaceModal: false,
 };
 
 export const uiSlice = createSlice({
@@ -128,6 +130,9 @@ export const uiSlice = createSlice({
     },
     setShowEmptyFileNotAllowedModal: (state, action: PayloadAction<boolean>) => {
       state.showEmptyFileNotAllowedModal = action.payload;
+    },
+    setShowNotEnoughDeviceSpaceModal: (state, action: PayloadAction<boolean>) => {
+      state.showNotEnoughDeviceSpaceModal = action.payload;
     },
   },
 });

--- a/src/types/drive/folderUpload.ts
+++ b/src/types/drive/folderUpload.ts
@@ -24,7 +24,7 @@ export interface FolderUploadProgress {
   failedFiles: number;
 }
 
-export type FolderUploadStatus = 'uploading' | 'cancelled' | 'completed' | 'error';
+export type FolderUploadStatus = 'scanning' | 'uploading' | 'cancelled' | 'completed' | 'error';
 
 export interface FolderUploadState {
   uploadId: string;


### PR DESCRIPTION
Fixes some issues that QA has reported and instroduces some UX improvements: 
  1. Android: file/folder names showed the SAF volume prefix (e.g. primary:photo.jpg)    
  2. "Upgrade plan" modal appeared incorrectly when uploading folders even with enough cloud storage                                                                                                                  
  3. Android: subfolders were not created as folders (they were lost or treated as files)

Changes applied for fix the issues:
- Introduced a new scanning state for folder uploads in drive list items.
- Implemented NotEnoughDeviceSpaceModal to alert users when device space is insufficient.
- Enhanced folder upload logic to check for device space before proceeding with uploads.
- Added utility functions for handling SAF URIs and extracting names.
- Updated folder upload state to include 'scanning' status.
- Refactored folder traversal service to support cancellation via AbortSignal.
- Added tests for new utility functions and folder traversal behavior.