### PR TITLE
[PB-6085] feature/Added unit tests for photo upload service layer

### DIFF
--- a/__mocks__/expo-sqlite.ts
+++ b/__mocks__/expo-sqlite.ts
@@ -1,0 +1,9 @@
+const mockDb = {
+  execAsync: jest.fn().mockResolvedValue(undefined),
+  runAsync: jest.fn().mockResolvedValue(undefined),
+  getFirstAsync: jest.fn().mockResolvedValue(null),
+  getAllAsync: jest.fn().mockResolvedValue([]),
+};
+
+export const openDatabaseAsync = jest.fn().mockResolvedValue(mockDb);
+export const NativeDatabase = jest.fn();

--- a/__mocks__/network-cache.ts
+++ b/__mocks__/network-cache.ts
@@ -1,0 +1,3 @@
+export default {
+  clearNetworkCache: jest.fn().mockResolvedValue(true),
+};

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -16,6 +16,7 @@ const untranspiledModulePatterns = [
   'react-native-svg',
   'react-native-blob-util',
   '@internxt/rn-crypto',
+  '@internxt/lib',
   '@scure/bip39',
   '@scure/base',
   '@noble/hashes',
@@ -35,6 +36,8 @@ const config: Config.InitialOptions = {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   moduleNameMapper: {
     '@internxt/rn-crypto': '<rootDir>/__mocks__/@internxt/rn-crypto.ts',
+    '.*/modules/network-cache.*': '<rootDir>/__mocks__/network-cache.ts',
+    'expo-sqlite': '<rootDir>/__mocks__/expo-sqlite.ts',
   },
 };
 

--- a/src/services/photos/PhotoBackupFolders.spec.ts
+++ b/src/services/photos/PhotoBackupFolders.spec.ts
@@ -57,6 +57,7 @@ describe('PhotoBackupFolders.getOrCreateFolderForDate', () => {
     const folderNames = mockCreateFolder.mock.calls.map((call) => call[1]);
     const monthCalls = folderNames.filter((name) => name === '06');
     expect(monthCalls).toHaveLength(1);
+    expect(mockCreateFolder).toHaveBeenCalledTimes(6);
   });
 
   test('when called for two dates in different years, then separate year folders are created', async () => {

--- a/src/services/photos/PhotoBackupFolders.spec.ts
+++ b/src/services/photos/PhotoBackupFolders.spec.ts
@@ -1,0 +1,97 @@
+import { createFolderWithMerge } from 'src/services/drive/folder/folderOrchestration.service';
+import { photoBackupFolders } from './PhotoBackupFolders';
+
+jest.mock('src/services/AsyncStorageService', () => ({
+  __esModule: true,
+  default: {
+    getUser: jest.fn().mockResolvedValue({ rootFolderId: 'root-uuid' }),
+  },
+}));
+
+jest.mock('src/services/drive/folder/folderOrchestration.service', () => ({
+  createFolderWithMerge: jest.fn(),
+}));
+
+const mockCreateFolder = createFolderWithMerge as jest.Mock;
+
+const DEVICE_ID = 'device-123';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  photoBackupFolders.clearCache();
+  mockCreateFolder
+    .mockResolvedValueOnce('photos-root-uuid')
+    .mockResolvedValueOnce('device-uuid')
+    .mockResolvedValueOnce('year-uuid')
+    .mockResolvedValueOnce('month-uuid')
+    .mockResolvedValueOnce('day-uuid');
+});
+
+describe('PhotoBackupFolders.getOrCreateFolderForDate', () => {
+  test('when called for a date, then creates the full folder hierarchy and returns the day folder uuid', async () => {
+    const uuid = await photoBackupFolders.getOrCreateFolderForDate(DEVICE_ID, new Date('2024-06-15'));
+    expect(uuid).toBe('day-uuid');
+    expect(mockCreateFolder).toHaveBeenCalledTimes(5);
+  });
+
+  test('when called twice for the same date, then creates folders only once', async () => {
+    await photoBackupFolders.getOrCreateFolderForDate(DEVICE_ID, new Date('2024-06-15'));
+    await photoBackupFolders.getOrCreateFolderForDate(DEVICE_ID, new Date('2024-06-15'));
+
+    expect(mockCreateFolder).toHaveBeenCalledTimes(5);
+  });
+
+  test('when called for two dates in the same month, then the month folder is created only once', async () => {
+    mockCreateFolder
+      .mockReset()
+      .mockResolvedValueOnce('photos-root-uuid')
+      .mockResolvedValueOnce('device-uuid')
+      .mockResolvedValueOnce('year-uuid')
+      .mockResolvedValueOnce('month-uuid')
+      .mockResolvedValueOnce('day-15-uuid')
+      .mockResolvedValueOnce('day-20-uuid');
+
+    await photoBackupFolders.getOrCreateFolderForDate(DEVICE_ID, new Date('2024-06-15'));
+    await photoBackupFolders.getOrCreateFolderForDate(DEVICE_ID, new Date('2024-06-20'));
+
+    const folderNames = mockCreateFolder.mock.calls.map((call) => call[1]);
+    const monthCalls = folderNames.filter((name) => name === '06');
+    expect(monthCalls).toHaveLength(1);
+  });
+
+  test('when called for two dates in different years, then separate year folders are created', async () => {
+    mockCreateFolder
+      .mockReset()
+      .mockResolvedValueOnce('photos-root-uuid')
+      .mockResolvedValueOnce('device-uuid')
+      .mockResolvedValueOnce('year-2023-uuid')
+      .mockResolvedValueOnce('month-uuid')
+      .mockResolvedValueOnce('day-uuid')
+      .mockResolvedValueOnce('year-2024-uuid')
+      .mockResolvedValueOnce('month-uuid-2')
+      .mockResolvedValueOnce('day-uuid-2');
+
+    await photoBackupFolders.getOrCreateFolderForDate(DEVICE_ID, new Date('2023-06-15'));
+    await photoBackupFolders.getOrCreateFolderForDate(DEVICE_ID, new Date('2024-06-15'));
+
+    const folderNames = mockCreateFolder.mock.calls.map((call) => call[1]);
+    expect(folderNames.filter((name) => name === '2023')).toHaveLength(1);
+    expect(folderNames.filter((name) => name === '2024')).toHaveLength(1);
+  });
+
+  test('when the cache is cleared and called again, then folders are created from scratch', async () => {
+    await photoBackupFolders.getOrCreateFolderForDate(DEVICE_ID, new Date('2024-06-15'));
+    const callsAfterFirst = mockCreateFolder.mock.calls.length;
+
+    photoBackupFolders.clearCache();
+    mockCreateFolder
+      .mockResolvedValueOnce('photos-root-uuid')
+      .mockResolvedValueOnce('device-uuid')
+      .mockResolvedValueOnce('year-uuid')
+      .mockResolvedValueOnce('month-uuid')
+      .mockResolvedValueOnce('day-uuid');
+
+    await photoBackupFolders.getOrCreateFolderForDate(DEVICE_ID, new Date('2024-06-15'));
+    expect(mockCreateFolder).toHaveBeenCalledTimes(callsAfterFirst * 2);
+  });
+});

--- a/src/services/photos/PhotoDeduplicator.spec.ts
+++ b/src/services/photos/PhotoDeduplicator.spec.ts
@@ -15,12 +15,13 @@ describe('PhotoDeduplicator', () => {
     jest.clearAllMocks();
   });
 
-  test('when no photos have been synced before, then all photos are queued for sync', async () => {
+  test('when no photos have been synced before, then all photos are queued as new', async () => {
     mockDB.getSyncedEntries.mockResolvedValueOnce(new Map());
 
-    const result = await PhotoDeduplicator.getAssetsToSync([makeAsset('a'), makeAsset('b'), makeAsset('c')]);
+    const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([makeAsset('a'), makeAsset('b'), makeAsset('c')]);
 
-    expect(result.map((a) => a.id)).toEqual(['a', 'b', 'c']);
+    expect(newAssets.map((a) => a.id)).toEqual(['a', 'b', 'c']);
+    expect(editedAssets).toHaveLength(0);
   });
 
   test('when all photos are already synced and unmodified, then nothing is queued', async () => {
@@ -32,29 +33,32 @@ describe('PhotoDeduplicator', () => {
       ]),
     );
 
-    const result = await PhotoDeduplicator.getAssetsToSync([makeAsset('a'), makeAsset('b'), makeAsset('c')]);
+    const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([makeAsset('a'), makeAsset('b'), makeAsset('c')]);
 
-    expect(result).toHaveLength(0);
+    expect(newAssets).toHaveLength(0);
+    expect(editedAssets).toHaveLength(0);
   });
 
-  test('when some photos are already synced, then only the unsynced ones are queued', async () => {
+  test('when some photos are already synced, then only the unsynced ones are queued as new', async () => {
     mockDB.getSyncedEntries.mockResolvedValueOnce(
       new Map([['b', { modificationTime: 1000 }]]),
     );
 
-    const result = await PhotoDeduplicator.getAssetsToSync([makeAsset('a'), makeAsset('b'), makeAsset('c')]);
+    const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([makeAsset('a'), makeAsset('b'), makeAsset('c')]);
 
-    expect(result.map((a) => a.id)).toEqual(['a', 'c']);
+    expect(newAssets.map((a) => a.id)).toEqual(['a', 'c']);
+    expect(editedAssets).toHaveLength(0);
   });
 
-  test('when a previously synced photo has been edited on the device, then it is re-queued for sync', async () => {
+  test('when a previously synced photo has been edited on the device, then it is queued as an edit', async () => {
     mockDB.getSyncedEntries.mockResolvedValueOnce(
       new Map([['a', { modificationTime: 500 }]]),
     );
 
-    const result = await PhotoDeduplicator.getAssetsToSync([makeAsset('a', 1000)]);
+    const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([makeAsset('a', 1000)]);
 
-    expect(result.map((asset) => asset.id)).toEqual(['a']);
+    expect(newAssets).toHaveLength(0);
+    expect(editedAssets.map((a) => a.id)).toEqual(['a']);
   });
 
   test('when a synced photo has no recorded modification time, then it is not re-queued', async () => {
@@ -62,15 +66,17 @@ describe('PhotoDeduplicator', () => {
       new Map([['a', { modificationTime: null }]]),
     );
 
-    const result = await PhotoDeduplicator.getAssetsToSync([makeAsset('a', 1000)]);
+    const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([makeAsset('a', 1000)]);
 
-    expect(result).toHaveLength(0);
+    expect(newAssets).toHaveLength(0);
+    expect(editedAssets).toHaveLength(0);
   });
 
   test('when there are no photos to check, then no database query is made and nothing is queued', async () => {
-    const result = await PhotoDeduplicator.getAssetsToSync([]);
+    const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([]);
 
     expect(mockDB.getSyncedEntries).not.toHaveBeenCalled();
-    expect(result).toHaveLength(0);
+    expect(newAssets).toHaveLength(0);
+    expect(editedAssets).toHaveLength(0);
   });
 });

--- a/src/services/photos/PhotoDeviceId.spec.ts
+++ b/src/services/photos/PhotoDeviceId.spec.ts
@@ -1,0 +1,51 @@
+import secureStorageService from 'src/services/SecureStorageService';
+import { PhotoDeviceId } from './PhotoDeviceId';
+
+jest.mock('react-native-uuid', () => ({ v4: jest.fn(() => 'generated-uuid') }));
+
+jest.mock('src/services/SecureStorageService', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+  },
+}));
+
+const mockGetItem = secureStorageService.getItem as jest.Mock;
+const mockSetItem = secureStorageService.setItem as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('PhotoDeviceId', () => {
+  test('when a device ID is already stored, then it is returned without creating a new one', async () => {
+    mockGetItem.mockResolvedValue('existing-device-id');
+
+    const id = await PhotoDeviceId.getOrCreate();
+
+    expect(id).toBe('existing-device-id');
+    expect(mockSetItem).not.toHaveBeenCalled();
+  });
+
+  test('when no device ID is stored, then a new one is generated and saved', async () => {
+    mockGetItem.mockResolvedValue(null);
+    mockSetItem.mockResolvedValue(undefined);
+
+    const id = await PhotoDeviceId.getOrCreate();
+
+    expect(id).toBe('generated-uuid');
+    expect(mockSetItem).toHaveBeenCalledTimes(1);
+    expect(mockSetItem).toHaveBeenCalledWith(expect.any(String), 'generated-uuid');
+  });
+
+  test('when no device ID is stored, then successive calls generate only one ID per call', async () => {
+    mockGetItem.mockResolvedValue(null);
+    mockSetItem.mockResolvedValue(undefined);
+
+    await PhotoDeviceId.getOrCreate();
+    await PhotoDeviceId.getOrCreate();
+
+    expect(mockSetItem).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/services/photos/PhotoUploadQueue.spec.ts
+++ b/src/services/photos/PhotoUploadQueue.spec.ts
@@ -1,0 +1,107 @@
+import * as MediaLibrary from 'expo-media-library';
+import { AssetUploadJob, PhotoUploadQueue } from './PhotoUploadQueue';
+import { PhotoUploadService } from './PhotoUploadService';
+
+jest.mock('./PhotoUploadService', () => ({
+  PhotoUploadService: {
+    upload: jest.fn(),
+    replace: jest.fn(),
+  },
+}));
+
+const mockUpload = PhotoUploadService.upload as jest.Mock;
+const mockReplace = PhotoUploadService.replace as jest.Mock;
+
+const makeAsset = (id: string): MediaLibrary.Asset =>
+  ({
+    id,
+    filename: `${id}.jpg`,
+    uri: `file:///${id}.jpg`,
+    mediaType: MediaLibrary.MediaType.photo,
+    creationTime: Date.now(),
+    modificationTime: Date.now(),
+    duration: 0,
+    width: 100,
+    height: 100,
+  }) as MediaLibrary.Asset;
+
+const DEVICE_ID = 'device-123';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('PhotoUploadQueue.start', () => {
+  test('when a job succeeds, then onAssetStart and onAssetDone are called with the asset id and remote file id', async () => {
+    const asset = makeAsset('a1');
+    mockUpload.mockResolvedValue('remote-file-id');
+
+    const onAssetStart = jest.fn();
+    const onAssetDone = jest.fn();
+
+    await PhotoUploadQueue.start([{ asset }], DEVICE_ID, { onAssetStart, onAssetDone });
+
+    expect(onAssetStart).toHaveBeenCalledWith('a1');
+    expect(onAssetDone).toHaveBeenCalledWith('a1', 'remote-file-id', asset.modificationTime);
+  });
+
+  test('when a job fails, then onAssetError is called with the asset id and the error', async () => {
+    const asset = makeAsset('a1');
+    const error = new Error('network error');
+    mockUpload.mockRejectedValue(error);
+
+    const onAssetError = jest.fn();
+
+    await PhotoUploadQueue.start([{ asset }], DEVICE_ID, { onAssetError });
+
+    expect(onAssetError).toHaveBeenCalledWith('a1', error);
+  });
+
+  test('when one job fails and another succeeds, then both callbacks are called and the queue completes', async () => {
+    const a1 = makeAsset('a1');
+    const a2 = makeAsset('a2');
+    mockUpload.mockRejectedValueOnce(new Error('fail')).mockResolvedValueOnce('remote-id');
+
+    const onAssetDone = jest.fn();
+    const onAssetError = jest.fn();
+
+    await PhotoUploadQueue.start([{ asset: a1 }, { asset: a2 }], DEVICE_ID, { onAssetDone, onAssetError });
+
+    expect(onAssetError).toHaveBeenCalledWith('a1', expect.any(Error));
+    expect(onAssetDone).toHaveBeenCalledWith('a2', 'remote-id', a2.modificationTime);
+  });
+
+  test('when a job has an existing remote file id, then replace is called instead of upload', async () => {
+    const asset = makeAsset('a1');
+    const job: AssetUploadJob = { asset, existingRemoteFileId: 'existing-remote-id' };
+    mockReplace.mockResolvedValue('existing-remote-id');
+
+    const onAssetDone = jest.fn();
+
+    await PhotoUploadQueue.start([job], DEVICE_ID, { onAssetDone });
+
+    expect(mockReplace).toHaveBeenCalledWith(asset, 'existing-remote-id', DEVICE_ID, expect.any(Function));
+    expect(mockUpload).not.toHaveBeenCalled();
+    expect(onAssetDone).toHaveBeenCalledWith('a1', 'existing-remote-id', asset.modificationTime);
+  });
+
+  test('when the job list is empty, then no callbacks are called and the queue completes', async () => {
+    const onAssetStart = jest.fn();
+    const onAssetDone = jest.fn();
+
+    await expect(PhotoUploadQueue.start([], DEVICE_ID, { onAssetStart, onAssetDone })).resolves.toBeUndefined();
+    expect(onAssetStart).not.toHaveBeenCalled();
+    expect(onAssetDone).not.toHaveBeenCalled();
+  });
+
+  test('when all jobs succeed, then onAssetDone is called once per job', async () => {
+    const jobs = ['a1', 'a2', 'a3'].map((id) => ({ asset: makeAsset(id) }));
+    mockUpload.mockResolvedValue('remote-id');
+
+    const onAssetDone = jest.fn();
+
+    await PhotoUploadQueue.start(jobs, DEVICE_ID, { onAssetDone });
+
+    expect(onAssetDone).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/services/photos/PhotoUploadService.utils.spec.ts
+++ b/src/services/photos/PhotoUploadService.utils.spec.ts
@@ -34,6 +34,10 @@ describe('stripFileScheme', () => {
     expect(stripFileScheme('file:///data/My%20Camera/photo.jpg')).toBe('/data/My Camera/photo.jpg');
   });
 
+  test('when the extension contains a percent-encoded dot, then it decodes it', () => {
+    expect(stripFileScheme('file:///downloads/photo.jpg%2Epng')).toBe('/downloads/photo.jpg.png');
+  });
+
   test('when a plain path without scheme is provided, then it returns it unchanged', () => {
     expect(stripFileScheme('/data/user/0/com.app/photo.jpg')).toBe('/data/user/0/com.app/photo.jpg');
   });

--- a/src/services/photos/PhotoUploadService.utils.spec.ts
+++ b/src/services/photos/PhotoUploadService.utils.spec.ts
@@ -1,0 +1,79 @@
+import {
+  extractExtensionFromContentUri,
+  splitFileNameAndExtension,
+  stripFileScheme,
+  stripFileSchemeAndFragment,
+} from './PhotoUploadService.utils';
+
+describe('stripFileSchemeAndFragment', () => {
+  test('when a file URI has no fragment, then it returns the decoded path', () => {
+    expect(stripFileSchemeAndFragment('file:///var/mobile/Media/DCIM/photo.jpg')).toBe(
+      '/var/mobile/Media/DCIM/photo.jpg',
+    );
+  });
+
+  test('when a video URI has an iOS metadata fragment, then it strips the fragment', () => {
+    expect(stripFileSchemeAndFragment('file:///var/mobile/Media/DCIM/video.mov#t=0.0')).toBe(
+      '/var/mobile/Media/DCIM/video.mov',
+    );
+  });
+
+  test('when the path contains percent-encoded characters, then it decodes them', () => {
+    expect(stripFileSchemeAndFragment('file:///var/mobile/My%20Photos/photo.jpg')).toBe(
+      '/var/mobile/My Photos/photo.jpg',
+    );
+  });
+});
+
+describe('stripFileScheme', () => {
+  test('when a file URI is provided, then it returns the decoded path without the scheme', () => {
+    expect(stripFileScheme('file:///data/user/0/com.app/photo.jpg')).toBe('/data/user/0/com.app/photo.jpg');
+  });
+
+  test('when the path contains percent-encoded characters, then it decodes them', () => {
+    expect(stripFileScheme('file:///data/My%20Camera/photo.jpg')).toBe('/data/My Camera/photo.jpg');
+  });
+
+  test('when a plain path without scheme is provided, then it returns it unchanged', () => {
+    expect(stripFileScheme('/data/user/0/com.app/photo.jpg')).toBe('/data/user/0/com.app/photo.jpg');
+  });
+});
+
+describe('extractExtensionFromContentUri', () => {
+  test('when a standard content URI with an extension is provided, then it returns the extension', () => {
+    expect(extractExtensionFromContentUri('content://media/external/images/media/12345.jpg')).toBe('jpg');
+  });
+
+  test('when the URI has a query string after the extension, then it returns the extension without the query', () => {
+    expect(extractExtensionFromContentUri('content://media/external/images/media/photo.jpg?size=large')).toBe('jpg');
+  });
+
+  test('when the URI has no extension, then it falls back to tmp', () => {
+    expect(extractExtensionFromContentUri('content://media/external/images/media/12345')).toBe('tmp');
+  });
+
+  test('when the URI has no path segments, then it falls back to tmp', () => {
+    expect(extractExtensionFromContentUri('content://')).toBe('tmp');
+  });
+});
+
+describe('splitFileNameAndExtension', () => {
+  test('when a filename with an extension is provided, then it splits correctly', () => {
+    expect(splitFileNameAndExtension('photo.jpg')).toEqual({ plainName: 'photo', fileExtension: 'jpg' });
+  });
+
+  test('when a filename has multiple dots, then it uses the last dot as the separator', () => {
+    expect(splitFileNameAndExtension('my.vacation.photo.jpg')).toEqual({
+      plainName: 'my.vacation.photo',
+      fileExtension: 'jpg',
+    });
+  });
+
+  test('when a filename has no extension, then it returns the full name and an empty extension', () => {
+    expect(splitFileNameAndExtension('photo')).toEqual({ plainName: 'photo', fileExtension: '' });
+  });
+
+  test('when a filename starts with a dot and has no other dots, then it returns the full name and an empty extension', () => {
+    expect(splitFileNameAndExtension('.hidden')).toEqual({ plainName: '', fileExtension: 'hidden' });
+  });
+});


### PR DESCRIPTION
Covers PhotoBackupFolders caching behaviour, PhotoDeduplicator new/edited asset detection, PhotoDeviceId getOrCreate logic, PhotoUploadQueue success/error/replace flows, and PhotoUploadService URI parsing utilities.                                        
                                                                                                                                                                                                               
  ## Summary                                                                                                                         
  - Unit tests for all services introduced in [Photo backup upload services PR](https://github.com/internxt/drive-mobile/pull/436)
  - Tests covering folder caching, deduplication, device ID persistence, upload queue concurrency, and URI parsing edge cases