### PR TITLE
[PB-5928]: Download & decryption in the SAF documents provider

### DIFF
--- a/android/app/src/main/java/com/internxt/cloud/auth/InternxtAuthCredentialsModule.kt
+++ b/android/app/src/main/java/com/internxt/cloud/auth/InternxtAuthCredentialsModule.kt
@@ -27,6 +27,7 @@ class InternxtAuthCredentialsModule(private val ctx: ReactApplicationContext) :
                 bearerToken = map.requireString("bearerToken"),
                 userId = map.requireString("userId"),
                 bridgeUser = map.requireString("bridgeUser"),
+                mnemonic = map.requireString("mnemonic"),
                 rootFolderUuid = map.requireString("rootFolderUuid"),
                 email = map.optString("email"),
                 driveBaseUrl = map.requireString("driveBaseUrl"),

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -37,6 +37,9 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         @Volatile var errorMessage: String? = null
         val rows = mutableListOf<Map<String, Any?>>()
     }
+    private val itemKinds = ConcurrentHashMap<String, ItemKind>()
+
+    private enum class ItemKind { FILE, FOLDER }
 
     override fun onCreate(): Boolean {
         val ctx = context ?: return false

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -5,6 +5,9 @@ import android.database.MatrixCursor
 import android.net.Uri
 import android.os.Bundle
 import android.os.CancellationSignal
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.OperationCanceledException
 import android.os.ParcelFileDescriptor
 import android.provider.DocumentsContract
 import android.provider.DocumentsContract.Document
@@ -16,8 +19,16 @@ import com.internxt.cloud.documents.api.InternxtApiClient
 import com.internxt.cloud.documents.api.InternxtApiException
 import com.internxt.cloud.documents.api.model.TrashItem
 import com.internxt.cloud.documents.auth.InternxtAuthManager
+import com.internxt.cloud.documents.cache.DocumentCache
+import com.internxt.cloud.documents.crypto.FileKeyDeriver
+import com.internxt.cloud.documents.download.EncryptedFileDownloader
+import com.rncrypto.util.CryptoService
+import okhttp3.OkHttpClient
+import java.io.File
 import java.io.FileNotFoundException
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.Executors
 
 class InternxtDocumentsProvider : DocumentsProvider() {
@@ -38,12 +49,22 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         val rows = mutableListOf<Map<String, Any?>>()
     }
     private val itemKinds = ConcurrentHashMap<String, ItemKind>()
+    private lateinit var closeHandler: Handler
+    private val downloadClient: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(2, TimeUnit.MINUTES)
+            .writeTimeout(2, TimeUnit.MINUTES)
+            .callTimeout(0, TimeUnit.MILLISECONDS)
+            .build()
+    }
 
     private enum class ItemKind { FILE, FOLDER }
 
     override fun onCreate(): Boolean {
         val ctx = context ?: return false
         authManager = InternxtAuthManager.create(ctx.applicationContext) ?: return false
+        closeHandler = Handler(HandlerThread("InternxtDocsClose").apply { start() }.looper)
         return true
     }
 
@@ -341,7 +362,79 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         mode: String?,
         signal: CancellationSignal?
     ): ParcelFileDescriptor {
-        throw UnsupportedOperationException("Not implemented yet")
+        val ctx = context ?: throw FileNotFoundException("No context")
+        val id = documentId ?: throw FileNotFoundException("No document id")
+        if (mode != null && mode != "r") {
+            throw UnsupportedOperationException("Only read-only access is supported (mode=$mode)")
+        }
+
+        val cfg = authManager.loadAuthConfig() ?: throw FileNotFoundException("Not authenticated")
+        val api = InternxtApiClient(cfg)
+
+        val file = try {
+            api.getFile(id) ?: throw FileNotFoundException("File not found: $id")
+        } catch (e: InternxtApiException) {
+            throw FileNotFoundException("getFile $id failed: ${e.message}")
+        }
+        val bucket = file.bucket ?: throw FileNotFoundException("File $id has no bucket")
+        val fileId = file.fileId ?: throw FileNotFoundException("File $id has no fileId")
+        val updatedAt = file.updatedAt ?: throw FileNotFoundException("File $id has no updatedAt")
+
+        val cacheFile = DocumentCache.cacheFileFor(ctx, id, updatedAt)
+        if (cacheFile.exists() && cacheFile.length() > 0) {
+            Log.d(TAG, "openDocument cache hit id=$id")
+            return ParcelFileDescriptor.open(cacheFile, ParcelFileDescriptor.MODE_READ_ONLY)
+        }
+
+        val (tempEnc, tempDec) = DocumentCache.tempPaths(ctx, id)
+        try {
+            signal?.throwIfCanceled()
+            val links = api.getDownloadLinks(bucket, fileId)
+            EncryptedFileDownloader.download(downloadClient, links.shards, tempEnc, signal)
+
+            signal?.throwIfCanceled()
+            val key = FileKeyDeriver.deriveFileKey(cfg.mnemonic, bucket, links.index)
+            val iv = FileKeyDeriver.deriveIv(links.index)
+            decryptBlocking(tempEnc, tempDec, FileKeyDeriver.toHex(key), FileKeyDeriver.toHex(iv))
+
+            if (!tempDec.renameTo(cacheFile)) {
+                throw FileNotFoundException("Failed to promote temp file to cache for $id")
+            }
+            tempEnc.delete()
+            DocumentCache.pruneSiblings(ctx, id, cacheFile)
+
+            Log.d(TAG, "openDocument cached id=$id size=${cacheFile.length()}")
+            return ParcelFileDescriptor.open(
+                cacheFile,
+                ParcelFileDescriptor.MODE_READ_ONLY,
+                closeHandler,
+            ) { DocumentCache.deleteTempsFor(ctx, id) }
+        } catch (e: OperationCanceledException) {
+            tempEnc.delete(); tempDec.delete()
+            throw FileNotFoundException("openDocument $id cancelled").apply { initCause(e) }
+        } catch (e: Exception) {
+            tempEnc.delete(); tempDec.delete()
+            Log.w(TAG, "openDocument $id failed: ${e.javaClass.simpleName}: ${e.message}")
+            if (e is FileNotFoundException) throw e
+            throw FileNotFoundException("openDocument $id failed: ${e.message}").apply { initCause(e) }
+        }
+    }
+
+    private fun decryptBlocking(src: File, dst: File, hexKey: String, hexIv: String) {
+        val latch = CountDownLatch(1)
+        val errorRef = arrayOfNulls<Exception>(1)
+        CryptoService.getInstance().decryptFile(
+            src.absolutePath,
+            dst.absolutePath,
+            hexKey,
+            hexIv,
+            /* runInBackground = */ true,
+        ) { err ->
+            errorRef[0] = err
+            latch.countDown()
+        }
+        latch.await()
+        errorRef[0]?.let { throw it }
     }
 
     private fun resolveRootProjection(projection: Array<String>?): Array<String> =

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -379,17 +379,15 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         val fileUuid = decoded.uuid
 
         val future = openExecutor.submit<ParcelFileDescriptor> {
-            openDocumentBlocking(ctx, id, mode, signal, fileUuid)
+            openDocumentBlocking(ctx, id, signal, fileUuid)
         }
         return try {
             future.get()
         } catch (e: java.util.concurrent.ExecutionException) {
             val cause = e.cause
-            when (cause) {
-                is FileNotFoundException -> throw cause
-                is UnsupportedOperationException -> throw cause
-                null -> throw FileNotFoundException("openDocument failed: ${e.message}")
-                else -> throw FileNotFoundException("openDocument failed: ${cause.javaClass.simpleName}: ${cause.message}").apply { initCause(cause) }
+            if (cause is FileNotFoundException) throw cause
+            throw FileNotFoundException("openDocument failed: ${cause?.message ?: e.message}").apply {
+                if (cause != null) initCause(cause)
             }
         }
     }
@@ -397,7 +395,6 @@ class InternxtDocumentsProvider : DocumentsProvider() {
     private fun openDocumentBlocking(
         ctx: android.content.Context,
         id: String,
-        mode: String?,
         signal: CancellationSignal?,
         fileUuid: String,
     ): ParcelFileDescriptor {

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -39,6 +39,10 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         Thread(r, "InternxtDocsProvider-loader").apply { isDaemon = true }
     }
 
+    private val openExecutor = Executors.newCachedThreadPool { r ->
+        Thread(r, "InternxtDocsProvider-open").apply { isDaemon = true }
+    }
+
     private val folderLoads = ConcurrentHashMap<String, FolderLoad>()
 
     private enum class LoadState { LOADING, DONE, ERROR }
@@ -368,21 +372,52 @@ class InternxtDocumentsProvider : DocumentsProvider() {
             throw UnsupportedOperationException("Only read-only access is supported (mode=$mode)")
         }
 
-        val cfg = authManager.loadAuthConfig() ?: throw FileNotFoundException("Not authenticated")
+        val decoded = DocumentId.decode(id)
+        if (decoded?.kind != DocumentId.Kind.FILE) {
+            throw FileNotFoundException("openDocument requires a file id (got=$id)")
+        }
+        val fileUuid = decoded.uuid
+
+        val future = openExecutor.submit<ParcelFileDescriptor> {
+            openDocumentBlocking(ctx, id, mode, signal, fileUuid)
+        }
+        return try {
+            future.get()
+        } catch (e: java.util.concurrent.ExecutionException) {
+            val cause = e.cause
+            when (cause) {
+                is FileNotFoundException -> throw cause
+                is UnsupportedOperationException -> throw cause
+                null -> throw FileNotFoundException("openDocument failed: ${e.message}")
+                else -> throw FileNotFoundException("openDocument failed: ${cause.javaClass.simpleName}: ${cause.message}").apply { initCause(cause) }
+            }
+        }
+    }
+
+    private fun openDocumentBlocking(
+        ctx: android.content.Context,
+        id: String,
+        mode: String?,
+        signal: CancellationSignal?,
+        fileUuid: String,
+    ): ParcelFileDescriptor {
+        val cfg = authManager?.loadAuthConfig() ?: throw FileNotFoundException("Not authenticated")
+        if (cfg.mnemonic.isBlank()) {
+            throw FileNotFoundException("Stored credentials have no mnemonic; sign out and back in")
+        }
         val api = InternxtApiClient(cfg)
 
         val file = try {
-            api.getFile(id) ?: throw FileNotFoundException("File not found: $id")
+            api.getFile(fileUuid) ?: throw FileNotFoundException("File not found: $fileUuid")
         } catch (e: InternxtApiException) {
-            throw FileNotFoundException("getFile $id failed: ${e.message}")
+            throw FileNotFoundException("getFile $fileUuid failed: ${e.message}")
         }
-        val bucket = file.bucket ?: throw FileNotFoundException("File $id has no bucket")
-        val fileId = file.fileId ?: throw FileNotFoundException("File $id has no fileId")
-        val updatedAt = file.updatedAt ?: throw FileNotFoundException("File $id has no updatedAt")
+        val bucket = file.bucket ?: throw FileNotFoundException("File $fileUuid has no bucket")
+        val fileId = file.fileId ?: throw FileNotFoundException("File $fileUuid has no fileId")
+        val updatedAt = file.updatedAt ?: throw FileNotFoundException("File $fileUuid has no updatedAt")
 
         val cacheFile = DocumentCache.cacheFileFor(ctx, id, updatedAt)
         if (cacheFile.exists() && cacheFile.length() > 0) {
-            Log.d(TAG, "openDocument cache hit id=$id")
             return ParcelFileDescriptor.open(cacheFile, ParcelFileDescriptor.MODE_READ_ONLY)
         }
 
@@ -403,7 +438,6 @@ class InternxtDocumentsProvider : DocumentsProvider() {
             tempEnc.delete()
             DocumentCache.pruneSiblings(ctx, id, cacheFile)
 
-            Log.d(TAG, "openDocument cached id=$id size=${cacheFile.length()}")
             return ParcelFileDescriptor.open(
                 cacheFile,
                 ParcelFileDescriptor.MODE_READ_ONLY,
@@ -414,7 +448,6 @@ class InternxtDocumentsProvider : DocumentsProvider() {
             throw FileNotFoundException("openDocument $id cancelled").apply { initCause(e) }
         } catch (e: Exception) {
             tempEnc.delete(); tempDec.delete()
-            Log.w(TAG, "openDocument $id failed: ${e.javaClass.simpleName}: ${e.message}")
             if (e is FileNotFoundException) throw e
             throw FileNotFoundException("openDocument $id failed: ${e.message}").apply { initCause(e) }
         }

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -396,7 +396,12 @@ class InternxtDocumentsProvider : DocumentsProvider() {
             throw FileNotFoundException("Stored credentials have no mnemonic; sign out and back in")
         }
         val api = InternxtApiClient(cfg)
-        val file = requireFileMetadata(api, fileUuid)
+        val file = try {
+            requireFileMetadata(api, fileUuid)
+        } catch (e: FileNotFoundException) {
+            DocumentCache.existingCacheFor(ctx, id)?.let { return openCached(ctx, id, it) }
+            throw e
+        }
 
         val cacheFile = DocumentCache.cacheFileFor(ctx, id, file.updatedAt)
         if (cacheFile.exists() && cacheFile.length() > 0) {

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -21,14 +21,14 @@ import com.internxt.cloud.documents.api.model.TrashItem
 import com.internxt.cloud.documents.auth.InternxtAuthManager
 import com.internxt.cloud.documents.cache.DocumentCache
 import com.internxt.cloud.documents.crypto.FileKeyDeriver
+import com.internxt.cloud.documents.crypto.toHex
 import com.internxt.cloud.documents.download.EncryptedFileDownloader
+import com.internxt.cloud.documents.http.HttpClients
 import com.rncrypto.util.CryptoService
-import okhttp3.OkHttpClient
 import java.io.File
 import java.io.FileNotFoundException
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.Executors
 
 class InternxtDocumentsProvider : DocumentsProvider() {
@@ -54,20 +54,13 @@ class InternxtDocumentsProvider : DocumentsProvider() {
     }
     private val itemKinds = ConcurrentHashMap<String, ItemKind>()
     private lateinit var closeHandler: Handler
-    private val downloadClient: OkHttpClient by lazy {
-        OkHttpClient.Builder()
-            .connectTimeout(30, TimeUnit.SECONDS)
-            .readTimeout(2, TimeUnit.MINUTES)
-            .writeTimeout(2, TimeUnit.MINUTES)
-            .callTimeout(0, TimeUnit.MILLISECONDS)
-            .build()
-    }
 
     private enum class ItemKind { FILE, FOLDER }
 
     override fun onCreate(): Boolean {
         val ctx = context ?: return false
         authManager = InternxtAuthManager.create(ctx.applicationContext) ?: return false
+        // Process-scoped: ContentProvider has no shutdown hook, so the thread lives until the process dies.
         closeHandler = Handler(HandlerThread("InternxtDocsClose").apply { start() }.looper)
         return true
     }
@@ -403,56 +396,82 @@ class InternxtDocumentsProvider : DocumentsProvider() {
             throw FileNotFoundException("Stored credentials have no mnemonic; sign out and back in")
         }
         val api = InternxtApiClient(cfg)
+        val file = requireFileMetadata(api, fileUuid)
 
+        val cacheFile = DocumentCache.cacheFileFor(ctx, id, file.updatedAt)
+        if (cacheFile.exists() && cacheFile.length() > 0) {
+            return openCached(ctx, id, cacheFile)
+        }
+        materializeIntoCache(ctx, id, api, cfg.mnemonic, file, cacheFile, signal)
+        return openCached(ctx, id, cacheFile)
+    }
+
+    private data class FileMetadata(
+        val bucket: String,
+        val fileId: String,
+        val updatedAt: String,
+    )
+
+    private fun requireFileMetadata(api: InternxtApiClient, fileUuid: String): FileMetadata {
         val file = try {
             api.getFile(fileUuid) ?: throw FileNotFoundException("File not found: $fileUuid")
         } catch (e: InternxtApiException) {
             throw FileNotFoundException("getFile $fileUuid failed: ${e.message}")
         }
-        val bucket = file.bucket ?: throw FileNotFoundException("File $fileUuid has no bucket")
-        val fileId = file.fileId ?: throw FileNotFoundException("File $fileUuid has no fileId")
-        val updatedAt = file.updatedAt ?: throw FileNotFoundException("File $fileUuid has no updatedAt")
+        return FileMetadata(
+            bucket = file.bucket ?: throw FileNotFoundException("File $fileUuid has no bucket"),
+            fileId = file.fileId ?: throw FileNotFoundException("File $fileUuid has no fileId"),
+            updatedAt = file.updatedAt ?: throw FileNotFoundException("File $fileUuid has no updatedAt"),
+        )
+    }
 
-        val cacheFile = DocumentCache.cacheFileFor(ctx, id, updatedAt)
-        if (cacheFile.exists() && cacheFile.length() > 0) {
-            return ParcelFileDescriptor.open(cacheFile, ParcelFileDescriptor.MODE_READ_ONLY)
-        }
-
+    private fun materializeIntoCache(
+        ctx: android.content.Context,
+        id: String,
+        api: InternxtApiClient,
+        mnemonic: String,
+        file: FileMetadata,
+        cacheFile: File,
+        signal: CancellationSignal?,
+    ) {
         val (tempEnc, tempDec) = DocumentCache.tempPaths(ctx, id)
         try {
             signal?.throwIfCanceled()
-            val links = api.getDownloadLinks(bucket, fileId)
-            EncryptedFileDownloader.download(downloadClient, links.shards, tempEnc, signal)
+            val links = api.getDownloadLinks(file.bucket, file.fileId)
+            EncryptedFileDownloader.download(HttpClients.download, links.shards, tempEnc, signal)
 
             signal?.throwIfCanceled()
-            val key = FileKeyDeriver.deriveFileKey(cfg.mnemonic, bucket, links.index)
+            val key = FileKeyDeriver.deriveFileKey(mnemonic, file.bucket, links.index)
             val iv = FileKeyDeriver.deriveIv(links.index)
-            decryptBlocking(tempEnc, tempDec, FileKeyDeriver.toHex(key), FileKeyDeriver.toHex(iv))
+            decryptBlocking(tempEnc, tempDec, key.toHex(), iv.toHex())
 
             if (!tempDec.renameTo(cacheFile)) {
                 throw FileNotFoundException("Failed to promote temp file to cache for $id")
             }
             tempEnc.delete()
             DocumentCache.pruneSiblings(ctx, id, cacheFile)
-
-            return ParcelFileDescriptor.open(
-                cacheFile,
-                ParcelFileDescriptor.MODE_READ_ONLY,
-                closeHandler,
-            ) { DocumentCache.deleteTempsFor(ctx, id) }
-        } catch (e: OperationCanceledException) {
-            tempEnc.delete(); tempDec.delete()
-            throw FileNotFoundException("openDocument $id cancelled").apply { initCause(e) }
         } catch (e: Exception) {
-            tempEnc.delete(); tempDec.delete()
-            if (e is FileNotFoundException) throw e
-            throw FileNotFoundException("openDocument $id failed: ${e.message}").apply { initCause(e) }
+            tempEnc.delete()
+            tempDec.delete()
+            throw when (e) {
+                is FileNotFoundException -> e
+                is OperationCanceledException ->
+                    FileNotFoundException("openDocument $id cancelled").apply { initCause(e) }
+                else ->
+                    FileNotFoundException("openDocument $id failed: ${e.message}").apply { initCause(e) }
+            }
         }
     }
 
+    private fun openCached(ctx: android.content.Context, id: String, cacheFile: File): ParcelFileDescriptor =
+        ParcelFileDescriptor.open(
+            cacheFile,
+            ParcelFileDescriptor.MODE_READ_ONLY,
+            closeHandler,
+        ) { DocumentCache.deleteTempsFor(ctx, id) }
+
     private fun decryptBlocking(src: File, dst: File, hexKey: String, hexIv: String) {
-        val latch = CountDownLatch(1)
-        val errorRef = arrayOfNulls<Exception>(1)
+        val done = CompletableFuture<Unit>()
         CryptoService.getInstance().decryptFile(
             src.absolutePath,
             dst.absolutePath,
@@ -460,11 +479,13 @@ class InternxtDocumentsProvider : DocumentsProvider() {
             hexIv,
             /* runInBackground = */ true,
         ) { err ->
-            errorRef[0] = err
-            latch.countDown()
+            if (err != null) done.completeExceptionally(err) else done.complete(Unit)
         }
-        latch.await()
-        errorRef[0]?.let { throw it }
+        try {
+            done.get()
+        } catch (e: java.util.concurrent.ExecutionException) {
+            throw e.cause ?: e
+        }
     }
 
     private fun resolveRootProjection(projection: Array<String>?): Array<String> =

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/AuthConfig.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/AuthConfig.kt
@@ -6,6 +6,7 @@ data class AuthConfig(
     val bearerToken: String,
     val bridgeUser: String,
     val userId: String,
+    val mnemonic: String,
     val clientName: String,
     val clientVersion: String,
     val desktopToken: String? = null

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
@@ -113,9 +113,37 @@ class InternxtApiClient(
     }
 
     fun getDownloadLinks(bucketId: String, fileId: String): DownloadLinks {
-        val url = bridgeUrl("buckets/$bucketId/files/$fileId/mirrors")
-        val body = executeApiRequest(bridgeRequest(url).get().build())
-        return parseDownloadLinks(body)
+        val url = bridgeUrl("buckets/$bucketId/files/$fileId/info")
+        val request = bridgeRequest(url).header("x-api-version", "2").get().build()
+        val body = executeApiRequest(request)
+
+        val index = body.optStringOrNull("index")
+            ?: throw InternxtApiException.ApiError(500, "Bridge /info response missing 'index'")
+        val version = body.optInt("version", 1)
+        if (version != 2) {
+            throw InternxtApiException.ApiError(409, "File version=$version is not supported (V2 only)")
+        }
+
+        val shardsJson = body.optJSONArray("shards") ?: JSONArray()
+        if (shardsJson.length() == 0) {
+            throw InternxtApiException.ApiError(404, "No shards returned for file $fileId")
+        }
+        val shards = shardsJson.map { obj ->
+            Shard(
+                index = obj.optInt("index"),
+                size = obj.optLongFlexible("size"),
+                hash = obj.optString("hash"),
+                url = obj.optString("url")
+            )
+        }
+
+        return DownloadLinks(
+            bucket = bucketId,
+            index = index,
+            size = body.optLongFlexible("size"),
+            version = version,
+            shards = shards
+        )
     }
 
     private fun driveRequest(url: okhttp3.HttpUrl): Request.Builder =
@@ -140,6 +168,16 @@ class InternxtApiClient(
     private fun bridgeUrl(path: String) = "${config.bridgeBaseUrl.trimEnd('/')}/$path".toHttpUrl()
 
     private fun executeApiRequest(request: Request): JSONObject {
+        val bodyStr = executeRaw(request)
+        return if (bodyStr.isBlank()) JSONObject() else JSONObject(bodyStr)
+    }
+
+    private fun executeApiRequestArray(request: Request): JSONArray {
+        val bodyStr = executeRaw(request)
+        return if (bodyStr.isBlank()) JSONArray() else JSONArray(bodyStr)
+    }
+
+    private fun executeRaw(request: Request): String {
         val response: Response = try {
             client.newCall(request).execute()
         } catch (e: IOException) {
@@ -148,7 +186,7 @@ class InternxtApiClient(
         response.use { resp ->
             val bodyStr = resp.body?.string().orEmpty()
             when (resp.code) {
-                in 200..299 -> return if (bodyStr.isBlank()) JSONObject() else JSONObject(bodyStr)
+                in 200..299 -> return bodyStr
                 401 -> throw InternxtApiException.UnauthorizedException()
                 404 -> throw InternxtApiException.NotFoundException()
                 else -> throw InternxtApiException.ApiError(resp.code, bodyStr)
@@ -177,32 +215,19 @@ class InternxtApiClient(
         fileId = obj.optStringOrNull("fileId")
     )
 
-    private fun parseDownloadLinks(obj: JSONObject): DownloadLinks {
-        val shardsJson = obj.optJSONArray("shards") ?: JSONArray()
-        val shards = shardsJson.map {
-            Shard(
-                index = it.optInt("index"),
-                size = it.optLongFlexible("size"),
-                hash = it.optString("hash"),
-                url = it.optString("url")
-            )
-        }
-        return DownloadLinks(
-            bucket = obj.optString("bucket"),
-            index = obj.optString("index"),
-            size = obj.optLongFlexible("size"),
-            version = obj.optInt("version", 1),
-            shards = shards
-        )
-    }
-
     companion object {
         const val DEFAULT_PAGE_SIZE = 50
 
         private val JSON = "application/json; charset=utf-8".toMediaType()
 
-        private fun defaultClient(): OkHttpClient = OkHttpClient.Builder()
-            .callTimeout(30, TimeUnit.SECONDS)
-            .build()
+        private val sharedClient: OkHttpClient by lazy {
+            OkHttpClient.Builder()
+                .connectTimeout(15, TimeUnit.SECONDS)
+                .readTimeout(15, TimeUnit.SECONDS)
+                .callTimeout(30, TimeUnit.SECONDS)
+                .build()
+        }
+
+        private fun defaultClient(): OkHttpClient = sharedClient
     }
 }

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit
 
 class InternxtApiClient(
     private val config: AuthConfig,
-    private val client: OkHttpClient = defaultClient()
+    private val client: OkHttpClient = sharedClient
 ) {
 
     fun listFolderFolders(parentUuid: String, offset: Int = 0, limit: Int = DEFAULT_PAGE_SIZE): List<DriveFolder> =
@@ -168,16 +168,6 @@ class InternxtApiClient(
     private fun bridgeUrl(path: String) = "${config.bridgeBaseUrl.trimEnd('/')}/$path".toHttpUrl()
 
     private fun executeApiRequest(request: Request): JSONObject {
-        val bodyStr = executeRaw(request)
-        return if (bodyStr.isBlank()) JSONObject() else JSONObject(bodyStr)
-    }
-
-    private fun executeApiRequestArray(request: Request): JSONArray {
-        val bodyStr = executeRaw(request)
-        return if (bodyStr.isBlank()) JSONArray() else JSONArray(bodyStr)
-    }
-
-    private fun executeRaw(request: Request): String {
         val response: Response = try {
             client.newCall(request).execute()
         } catch (e: IOException) {
@@ -185,8 +175,8 @@ class InternxtApiClient(
         }
         response.use { resp ->
             val bodyStr = resp.body?.string().orEmpty()
-            when (resp.code) {
-                in 200..299 -> return bodyStr
+            return when (resp.code) {
+                in 200..299 -> if (bodyStr.isBlank()) JSONObject() else JSONObject(bodyStr)
                 401 -> throw InternxtApiException.UnauthorizedException()
                 404 -> throw InternxtApiException.NotFoundException()
                 else -> throw InternxtApiException.ApiError(resp.code, bodyStr)
@@ -220,14 +210,12 @@ class InternxtApiClient(
 
         private val JSON = "application/json; charset=utf-8".toMediaType()
 
-        private val sharedClient: OkHttpClient by lazy {
+        internal val sharedClient: OkHttpClient by lazy {
             OkHttpClient.Builder()
                 .connectTimeout(15, TimeUnit.SECONDS)
                 .readTimeout(15, TimeUnit.SECONDS)
                 .callTimeout(30, TimeUnit.SECONDS)
                 .build()
         }
-
-        private fun defaultClient(): OkHttpClient = sharedClient
     }
 }

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
@@ -6,6 +6,7 @@ import com.internxt.cloud.documents.api.model.DriveFolder
 import com.internxt.cloud.documents.api.model.Shard
 import com.internxt.cloud.documents.api.model.TrashItem
 import com.internxt.cloud.documents.crypto.HashUtil
+import com.internxt.cloud.documents.http.HttpClients
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -16,11 +17,10 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.io.IOException
 import java.util.Base64
-import java.util.concurrent.TimeUnit
 
 class InternxtApiClient(
     private val config: AuthConfig,
-    private val client: OkHttpClient = sharedClient
+    private val client: OkHttpClient = HttpClients.api
 ) {
 
     fun listFolderFolders(parentUuid: String, offset: Int = 0, limit: Int = DEFAULT_PAGE_SIZE): List<DriveFolder> =
@@ -115,34 +115,34 @@ class InternxtApiClient(
     fun getDownloadLinks(bucketId: String, fileId: String): DownloadLinks {
         val url = bridgeUrl("buckets/$bucketId/files/$fileId/info")
         val request = bridgeRequest(url).header("x-api-version", "2").get().build()
-        val body = executeApiRequest(request)
+        return parseDownloadLinks(executeApiRequest(request), bucketId, fileId)
+    }
 
+    private fun parseDownloadLinks(body: JSONObject, bucketId: String, fileId: String): DownloadLinks {
         val index = body.optStringOrNull("index")
-            ?: throw InternxtApiException.ApiError(500, "Bridge /info response missing 'index'")
+            ?: throw InternxtApiException.MalformedResponse("Bridge /info missing 'index'")
         val version = body.optInt("version", 1)
         if (version != 2) {
-            throw InternxtApiException.ApiError(409, "File version=$version is not supported (V2 only)")
+            throw InternxtApiException.MalformedResponse("File version=$version is not supported (V2 only)")
         }
-
         val shardsJson = body.optJSONArray("shards") ?: JSONArray()
         if (shardsJson.length() == 0) {
-            throw InternxtApiException.ApiError(404, "No shards returned for file $fileId")
+            throw InternxtApiException.MalformedResponse("No shards returned for file $fileId")
         }
         val shards = shardsJson.map { obj ->
             Shard(
                 index = obj.optInt("index"),
                 size = obj.optLongFlexible("size"),
                 hash = obj.optString("hash"),
-                url = obj.optString("url")
+                url = obj.optString("url"),
             )
         }
-
         return DownloadLinks(
             bucket = bucketId,
             index = index,
             size = body.optLongFlexible("size"),
             version = version,
-            shards = shards
+            shards = shards,
         )
     }
 
@@ -209,13 +209,5 @@ class InternxtApiClient(
         const val DEFAULT_PAGE_SIZE = 50
 
         private val JSON = "application/json; charset=utf-8".toMediaType()
-
-        internal val sharedClient: OkHttpClient by lazy {
-            OkHttpClient.Builder()
-                .connectTimeout(15, TimeUnit.SECONDS)
-                .readTimeout(15, TimeUnit.SECONDS)
-                .callTimeout(30, TimeUnit.SECONDS)
-                .build()
-        }
     }
 }

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiException.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiException.kt
@@ -7,4 +7,5 @@ sealed class InternxtApiException(message: String, cause: Throwable? = null) : I
     class NotFoundException(message: String = "404 Not Found") : InternxtApiException(message)
     class ApiError(val code: Int, val body: String?) : InternxtApiException("HTTP $code: ${body ?: ""}")
     class NetworkException(cause: Throwable) : InternxtApiException("Network error", cause)
+    class MalformedResponse(message: String) : InternxtApiException("Malformed response: $message")
 }

--- a/android/app/src/main/java/com/internxt/cloud/documents/auth/InternxtAuthManager.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/auth/InternxtAuthManager.kt
@@ -16,6 +16,7 @@ class InternxtAuthManager(private val prefs: SharedPreferences) {
         val bearerToken: String,
         val userId: String,
         val bridgeUser: String,
+        val mnemonic: String,
         val rootFolderUuid: String,
         val email: String?,
         val driveBaseUrl: String,
@@ -40,6 +41,7 @@ class InternxtAuthManager(private val prefs: SharedPreferences) {
             bearerToken = required(KEY_BEARER_TOKEN),
             bridgeUser = required(KEY_BRIDGE_USER),
             userId = required(KEY_USER_ID),
+            mnemonic = required(KEY_MNEMONIC),
             clientName = BuildConfig.INTERNXT_CLIENT_NAME,
             clientVersion = BuildConfig.INTERNXT_CLIENT_VERSION,
             desktopToken = prefs.getString(KEY_DESKTOP_TOKEN, null)?.takeIf { it.isNotBlank() },
@@ -54,6 +56,7 @@ class InternxtAuthManager(private val prefs: SharedPreferences) {
             .putString(KEY_BEARER_TOKEN, creds.bearerToken)
             .putString(KEY_USER_ID, creds.userId)
             .putString(KEY_BRIDGE_USER, creds.bridgeUser)
+            .putString(KEY_MNEMONIC, creds.mnemonic)
             .putString(KEY_ROOT_FOLDER_UUID, creds.rootFolderUuid)
             .putString(KEY_EMAIL, creds.email)
             .putString(KEY_DRIVE_BASE_URL, creds.driveBaseUrl)
@@ -70,6 +73,7 @@ class InternxtAuthManager(private val prefs: SharedPreferences) {
         private const val KEY_BEARER_TOKEN = "bearerToken"
         private const val KEY_USER_ID = "userId"
         private const val KEY_BRIDGE_USER = "bridgeUser"
+        private const val KEY_MNEMONIC = "mnemonic"
         private const val KEY_ROOT_FOLDER_UUID = "rootFolderUuid"
         private const val KEY_EMAIL = "email"
         private const val KEY_DRIVE_BASE_URL = "driveBaseUrl"
@@ -80,6 +84,7 @@ class InternxtAuthManager(private val prefs: SharedPreferences) {
             KEY_BEARER_TOKEN,
             KEY_USER_ID,
             KEY_BRIDGE_USER,
+            KEY_MNEMONIC,
             KEY_ROOT_FOLDER_UUID,
             KEY_DRIVE_BASE_URL,
             KEY_BRIDGE_BASE_URL,

--- a/android/app/src/main/java/com/internxt/cloud/documents/cache/DocumentCache.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/cache/DocumentCache.kt
@@ -11,41 +11,35 @@ object DocumentCache {
     private const val DEC_SUFFIX = ".dec"
     private const val ENC_SUFFIX = ".enc"
 
-    fun cacheFileFor(context: Context, uuid: String, updatedAt: String): File {
-        val dir = File(context.cacheDir, "$ROOT_DIR/$CACHE_DIR").apply { mkdirs() }
-        return File(dir, "${uuid}_${slugFromUpdatedAt(updatedAt)}$DEC_SUFFIX")
-    }
+    fun cacheFileFor(context: Context, uuid: String, updatedAt: String): File =
+        File(cacheDir(context), "${uuid}_${slugFromUpdatedAt(updatedAt)}$DEC_SUFFIX")
 
     fun tempPaths(context: Context, uuid: String): Pair<File, File> {
-        val dir = File(context.cacheDir, "$ROOT_DIR/$TMP_DIR").apply { mkdirs() }
+        val dir = tmpDir(context)
         val token = "${uuid}_${System.nanoTime()}"
         return File(dir, "$token$ENC_SUFFIX") to File(dir, "$token$DEC_SUFFIX")
     }
 
     fun pruneSiblings(context: Context, uuid: String, keep: File) {
-        val dir = File(context.cacheDir, "$ROOT_DIR/$CACHE_DIR")
-        val children = dir.listFiles() ?: return
-        for (file in children) {
-            if (file == keep) continue
-            if (file.name.startsWith("${uuid}_") && file.name.endsWith(DEC_SUFFIX)) {
-                file.delete()
-            }
+        deleteMatching(cacheDir(context)) {
+            it != keep && it.name.startsWith("${uuid}_") && it.name.endsWith(DEC_SUFFIX)
         }
     }
 
     fun deleteTempsFor(context: Context, uuid: String) {
-        val dir = File(context.cacheDir, "$ROOT_DIR/$TMP_DIR")
-        val children = dir.listFiles() ?: return
-        for (file in children) {
-            if (file.name.startsWith("${uuid}_")) file.delete()
-        }
+        deleteMatching(tmpDir(context)) { it.name.startsWith("${uuid}_") }
     }
 
-    fun slugFromUpdatedAt(updatedAt: String): String {
-        val sb = StringBuilder(updatedAt.length)
-        for (c in updatedAt) {
-            if (c.isLetterOrDigit()) sb.append(c)
-        }
-        return if (sb.isEmpty()) "0" else sb.toString()
+    private fun cacheDir(context: Context): File =
+        File(context.cacheDir, "$ROOT_DIR/$CACHE_DIR").apply { mkdirs() }
+
+    private fun tmpDir(context: Context): File =
+        File(context.cacheDir, "$ROOT_DIR/$TMP_DIR").apply { mkdirs() }
+
+    private inline fun deleteMatching(dir: File, predicate: (File) -> Boolean) {
+        dir.listFiles()?.forEach { if (predicate(it)) it.delete() }
     }
+
+    private fun slugFromUpdatedAt(updatedAt: String): String =
+        updatedAt.filter { it.isLetterOrDigit() }.ifEmpty { "0" }
 }

--- a/android/app/src/main/java/com/internxt/cloud/documents/cache/DocumentCache.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/cache/DocumentCache.kt
@@ -14,6 +14,11 @@ object DocumentCache {
     fun cacheFileFor(context: Context, uuid: String, updatedAt: String): File =
         File(cacheDir(context), "${uuid}_${slugFromUpdatedAt(updatedAt)}$DEC_SUFFIX")
 
+    fun existingCacheFor(context: Context, uuid: String): File? =
+        cacheDir(context).listFiles()
+            ?.filter { it.name.startsWith("${uuid}_") && it.name.endsWith(DEC_SUFFIX) && it.length() > 0 }
+            ?.maxByOrNull { it.lastModified() }
+
     fun tempPaths(context: Context, uuid: String): Pair<File, File> {
         val dir = tmpDir(context)
         val token = "${uuid}_${System.nanoTime()}"

--- a/android/app/src/main/java/com/internxt/cloud/documents/cache/DocumentCache.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/cache/DocumentCache.kt
@@ -1,0 +1,51 @@
+package com.internxt.cloud.documents.cache
+
+import android.content.Context
+import java.io.File
+
+object DocumentCache {
+
+    private const val ROOT_DIR = "internxt_documents"
+    private const val CACHE_DIR = "cache"
+    private const val TMP_DIR = "tmp"
+    private const val DEC_SUFFIX = ".dec"
+    private const val ENC_SUFFIX = ".enc"
+
+    fun cacheFileFor(context: Context, uuid: String, updatedAt: String): File {
+        val dir = File(context.cacheDir, "$ROOT_DIR/$CACHE_DIR").apply { mkdirs() }
+        return File(dir, "${uuid}_${slugFromUpdatedAt(updatedAt)}$DEC_SUFFIX")
+    }
+
+    fun tempPaths(context: Context, uuid: String): Pair<File, File> {
+        val dir = File(context.cacheDir, "$ROOT_DIR/$TMP_DIR").apply { mkdirs() }
+        val token = "${uuid}_${System.nanoTime()}"
+        return File(dir, "$token$ENC_SUFFIX") to File(dir, "$token$DEC_SUFFIX")
+    }
+
+    fun pruneSiblings(context: Context, uuid: String, keep: File) {
+        val dir = File(context.cacheDir, "$ROOT_DIR/$CACHE_DIR")
+        val children = dir.listFiles() ?: return
+        for (file in children) {
+            if (file == keep) continue
+            if (file.name.startsWith("${uuid}_") && file.name.endsWith(DEC_SUFFIX)) {
+                file.delete()
+            }
+        }
+    }
+
+    fun deleteTempsFor(context: Context, uuid: String) {
+        val dir = File(context.cacheDir, "$ROOT_DIR/$TMP_DIR")
+        val children = dir.listFiles() ?: return
+        for (file in children) {
+            if (file.name.startsWith("${uuid}_")) file.delete()
+        }
+    }
+
+    fun slugFromUpdatedAt(updatedAt: String): String {
+        val sb = StringBuilder(updatedAt.length)
+        for (c in updatedAt) {
+            if (c.isLetterOrDigit()) sb.append(c)
+        }
+        return if (sb.isEmpty()) "0" else sb.toString()
+    }
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/crypto/FileKeyDeriver.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/crypto/FileKeyDeriver.kt
@@ -1,8 +1,17 @@
 package com.internxt.cloud.documents.crypto
 
+import com.facebook.common.util.Hex
 import com.rncrypto.util.CryptoService
-import java.security.MessageDigest
 
+/**
+ * Derives the AES-CTR key/IV used to decrypt files from Internxt's network shards.
+ * Matches src/network/crypto.ts: generateFileKey.
+ *
+ *   seed      = PBKDF2(mnemonic, "mnemonic", 2048, 64)
+ *   bucketKey = SHA-512( seed || bucketId )
+ *   fileKey   = SHA-512( bucketKey[0..32] || index )[0..32]
+ *   iv        = index[0..16]
+ */
 object FileKeyDeriver {
 
     private const val PBKDF2_SALT = "mnemonic"
@@ -12,47 +21,14 @@ object FileKeyDeriver {
     private const val IV_LENGTH = 16
 
     fun deriveFileKey(mnemonic: String, bucketIdHex: String, indexHex: String): ByteArray {
-        val seed = pbkdf2Seed(mnemonic)
-        val bucketKey = sha512(seed, hexDecode(bucketIdHex))
-        val fileKey = sha512(bucketKey.copyOf(FILE_KEY_LENGTH), hexDecode(indexHex))
+        val crypto = CryptoService.getInstance()
+        val seed = crypto.pbkdf2(mnemonic, PBKDF2_SALT.toByteArray(Charsets.UTF_8), PBKDF2_ROUNDS, SEED_LENGTH)
+        val bucketKey = crypto.sha512(listOf(seed, Hex.decodeHex(bucketIdHex)))
+        val fileKey = crypto.sha512(listOf(bucketKey.copyOf(FILE_KEY_LENGTH), Hex.decodeHex(indexHex)))
         return fileKey.copyOf(FILE_KEY_LENGTH)
     }
 
-    fun deriveIv(indexHex: String): ByteArray = hexDecode(indexHex).copyOf(IV_LENGTH)
+    fun deriveIv(indexHex: String): ByteArray = Hex.decodeHex(indexHex).copyOf(IV_LENGTH)
 
-    fun toHex(bytes: ByteArray): String {
-        val sb = StringBuilder(bytes.size * 2)
-        for (b in bytes) {
-            val v = b.toInt() and 0xff
-            sb.append(HEX[v ushr 4])
-            sb.append(HEX[v and 0x0f])
-        }
-        return sb.toString()
-    }
-
-    private fun pbkdf2Seed(mnemonic: String): ByteArray =
-        CryptoService.getInstance().pbkdf2(mnemonic, PBKDF2_SALT.toByteArray(Charsets.UTF_8), PBKDF2_ROUNDS, SEED_LENGTH)
-
-    private fun sha512(key: ByteArray, data: ByteArray): ByteArray {
-        val md = MessageDigest.getInstance("SHA-512")
-        md.update(key)
-        md.update(data)
-        return md.digest()
-    }
-
-    private fun hexDecode(hex: String): ByteArray {
-        require(hex.length % 2 == 0) { "Hex string must have even length" }
-        val out = ByteArray(hex.length / 2)
-        var i = 0
-        while (i < hex.length) {
-            val hi = Character.digit(hex[i], 16)
-            val lo = Character.digit(hex[i + 1], 16)
-            require(hi >= 0 && lo >= 0) { "Invalid hex character at position $i" }
-            out[i / 2] = ((hi shl 4) or lo).toByte()
-            i += 2
-        }
-        return out
-    }
-
-    private val HEX = "0123456789abcdef".toCharArray()
+    fun toHex(bytes: ByteArray): String = Hex.encodeHex(bytes, /* truncateAtFirstZero = */ false)
 }

--- a/android/app/src/main/java/com/internxt/cloud/documents/crypto/FileKeyDeriver.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/crypto/FileKeyDeriver.kt
@@ -29,6 +29,6 @@ object FileKeyDeriver {
     }
 
     fun deriveIv(indexHex: String): ByteArray = Hex.decodeHex(indexHex).copyOf(IV_LENGTH)
-
-    fun toHex(bytes: ByteArray): String = Hex.encodeHex(bytes, /* truncateAtFirstZero = */ false)
 }
+
+fun ByteArray.toHex(): String = Hex.encodeHex(this, /* truncateAtFirstZero = */ false)

--- a/android/app/src/main/java/com/internxt/cloud/documents/crypto/FileKeyDeriver.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/crypto/FileKeyDeriver.kt
@@ -1,0 +1,58 @@
+package com.internxt.cloud.documents.crypto
+
+import com.rncrypto.util.CryptoService
+import java.security.MessageDigest
+
+object FileKeyDeriver {
+
+    private const val PBKDF2_SALT = "mnemonic"
+    private const val PBKDF2_ROUNDS = 2048
+    private const val SEED_LENGTH = 64
+    private const val FILE_KEY_LENGTH = 32
+    private const val IV_LENGTH = 16
+
+    fun deriveFileKey(mnemonic: String, bucketIdHex: String, indexHex: String): ByteArray {
+        val seed = pbkdf2Seed(mnemonic)
+        val bucketKey = sha512(seed, hexDecode(bucketIdHex))
+        val fileKey = sha512(bucketKey.copyOf(FILE_KEY_LENGTH), hexDecode(indexHex))
+        return fileKey.copyOf(FILE_KEY_LENGTH)
+    }
+
+    fun deriveIv(indexHex: String): ByteArray = hexDecode(indexHex).copyOf(IV_LENGTH)
+
+    fun toHex(bytes: ByteArray): String {
+        val sb = StringBuilder(bytes.size * 2)
+        for (b in bytes) {
+            val v = b.toInt() and 0xff
+            sb.append(HEX[v ushr 4])
+            sb.append(HEX[v and 0x0f])
+        }
+        return sb.toString()
+    }
+
+    private fun pbkdf2Seed(mnemonic: String): ByteArray =
+        CryptoService.getInstance().pbkdf2(mnemonic, PBKDF2_SALT.toByteArray(Charsets.UTF_8), PBKDF2_ROUNDS, SEED_LENGTH)
+
+    private fun sha512(key: ByteArray, data: ByteArray): ByteArray {
+        val md = MessageDigest.getInstance("SHA-512")
+        md.update(key)
+        md.update(data)
+        return md.digest()
+    }
+
+    private fun hexDecode(hex: String): ByteArray {
+        require(hex.length % 2 == 0) { "Hex string must have even length" }
+        val out = ByteArray(hex.length / 2)
+        var i = 0
+        while (i < hex.length) {
+            val hi = Character.digit(hex[i], 16)
+            val lo = Character.digit(hex[i + 1], 16)
+            require(hi >= 0 && lo >= 0) { "Invalid hex character at position $i" }
+            out[i / 2] = ((hi shl 4) or lo).toByte()
+            i += 2
+        }
+        return out
+    }
+
+    private val HEX = "0123456789abcdef".toCharArray()
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/download/EncryptedFileDownloader.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/download/EncryptedFileDownloader.kt
@@ -1,0 +1,67 @@
+package com.internxt.cloud.documents.download
+
+import android.os.CancellationSignal
+import android.os.OperationCanceledException
+import com.internxt.cloud.documents.api.model.Shard
+import okhttp3.Call
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicReference
+
+object EncryptedFileDownloader {
+
+    private const val COPY_BUFFER_SIZE = 16 * 1024
+
+    @Throws(IOException::class, OperationCanceledException::class)
+    fun download(
+        client: OkHttpClient,
+        shards: List<Shard>,
+        target: File,
+        signal: CancellationSignal?
+    ) {
+        require(shards.isNotEmpty()) { "No shards to download" }
+        target.parentFile?.mkdirs()
+        if (target.exists()) target.delete()
+
+        val activeCall = AtomicReference<Call?>(null)
+        signal?.setOnCancelListener { activeCall.get()?.cancel() }
+
+        FileOutputStream(target, /* append = */ true).use { out ->
+            for (shard in shards.sortedBy { it.index }) {
+                signal?.throwIfCanceled()
+
+                val request = Request.Builder().url(shard.url).get().build()
+                val call = client.newCall(request)
+                activeCall.set(call)
+
+                try {
+                    call.execute().use { response ->
+                        if (!response.isSuccessful) {
+                            throw IOException("Shard ${shard.index} HTTP ${response.code}")
+                        }
+                        val body = response.body ?: throw IOException("Shard ${shard.index} empty body")
+                        val buffer = ByteArray(COPY_BUFFER_SIZE)
+                        body.byteStream().use { input ->
+                            while (true) {
+                                val read = input.read(buffer)
+                                if (read == -1) break
+                                out.write(buffer, 0, read)
+                            }
+                        }
+                    }
+                } catch (e: IOException) {
+                    if (signal?.isCanceled == true) {
+                        throw OperationCanceledException("Download cancelled").apply { initCause(e) }
+                    }
+                    throw e
+                } finally {
+                    activeCall.set(null)
+                }
+            }
+            out.flush()
+        }
+    }
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/download/EncryptedFileDownloader.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/download/EncryptedFileDownloader.kt
@@ -23,45 +23,62 @@ object EncryptedFileDownloader {
         signal: CancellationSignal?
     ) {
         require(shards.isNotEmpty()) { "No shards to download" }
-        target.parentFile?.mkdirs()
-        if (target.exists()) target.delete()
+        prepareTarget(target)
 
         val activeCall = AtomicReference<Call?>(null)
         signal?.setOnCancelListener { activeCall.get()?.cancel() }
 
         FileOutputStream(target, /* append = */ true).use { out ->
-            for (shard in shards.sortedBy { it.index }) {
+            shards.sortedBy { it.index }.forEach { shard ->
                 signal?.throwIfCanceled()
-
-                val request = Request.Builder().url(shard.url).get().build()
-                val call = client.newCall(request)
-                activeCall.set(call)
-
-                try {
-                    call.execute().use { response ->
-                        if (!response.isSuccessful) {
-                            throw IOException("Shard ${shard.index} HTTP ${response.code}")
-                        }
-                        val body = response.body ?: throw IOException("Shard ${shard.index} empty body")
-                        val buffer = ByteArray(COPY_BUFFER_SIZE)
-                        body.byteStream().use { input ->
-                            while (true) {
-                                val read = input.read(buffer)
-                                if (read == -1) break
-                                out.write(buffer, 0, read)
-                            }
-                        }
-                    }
-                } catch (e: IOException) {
-                    if (signal?.isCanceled == true) {
-                        throw OperationCanceledException("Download cancelled").apply { initCause(e) }
-                    }
-                    throw e
-                } finally {
-                    activeCall.set(null)
-                }
+                downloadShard(client, shard, out, activeCall, signal)
             }
             out.flush()
+        }
+    }
+
+    private fun prepareTarget(target: File) {
+        target.parentFile?.mkdirs()
+        if (target.exists() && !target.delete()) {
+            throw IOException("Failed to delete existing target file: ${target.absolutePath}")
+        }
+    }
+
+    private fun downloadShard(
+        client: OkHttpClient,
+        shard: Shard,
+        out: FileOutputStream,
+        activeCall: AtomicReference<Call?>,
+        signal: CancellationSignal?
+    ) {
+        val request = Request.Builder().url(shard.url).get().build()
+        val call = client.newCall(request)
+        activeCall.set(call)
+
+        try {
+            call.execute().use { response -> writeShardResponse(shard, response, out) }
+        } catch (e: IOException) {
+            if (signal?.isCanceled == true) {
+                throw OperationCanceledException("Download cancelled").apply { initCause(e) }
+            }
+            throw e
+        } finally {
+            activeCall.set(null)
+        }
+    }
+
+    private fun writeShardResponse(shard: Shard, response: okhttp3.Response, out: FileOutputStream) {
+        if (!response.isSuccessful) {
+            throw IOException("Shard ${shard.index} HTTP ${response.code}")
+        }
+        val body = response.body ?: throw IOException("Shard ${shard.index} empty body")
+        val buffer = ByteArray(COPY_BUFFER_SIZE)
+        body.byteStream().use { input ->
+            var read = input.read(buffer)
+            while (read != -1) {
+                out.write(buffer, 0, read)
+                read = input.read(buffer)
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/internxt/cloud/documents/download/EncryptedFileDownloader.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/download/EncryptedFileDownloader.kt
@@ -58,7 +58,7 @@ object EncryptedFileDownloader {
         try {
             call.execute().use { response -> writeShardResponse(shard, response, out) }
         } catch (e: IOException) {
-            if (signal?.isCanceled == true) {
+            if (signal != null && signal.isCanceled) {
                 throw OperationCanceledException("Download cancelled").apply { initCause(e) }
             }
             throw e

--- a/android/app/src/main/java/com/internxt/cloud/documents/http/HttpClients.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/http/HttpClients.kt
@@ -1,0 +1,24 @@
+package com.internxt.cloud.documents.http
+
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
+
+object HttpClients {
+
+    val api: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(15, TimeUnit.SECONDS)
+            .callTimeout(30, TimeUnit.SECONDS)
+            .build()
+    }
+
+    val download: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(2, TimeUnit.MINUTES)
+            .writeTimeout(2, TimeUnit.MINUTES)
+            .callTimeout(0, TimeUnit.MILLISECONDS)
+            .build()
+    }
+}

--- a/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientTest.kt
@@ -34,6 +34,7 @@ class InternxtApiClientTest {
                 bearerToken = "test-token",
                 bridgeUser = "user@example.com",
                 userId = "1234567890",
+                mnemonic = "test mnemonic phrase",
                 clientName = "drive-mobile",
                 clientVersion = "v1.9.0",
                 desktopToken = "desktop-token-xyz"
@@ -148,15 +149,22 @@ class InternxtApiClientTest {
 
         val links = client.getDownloadLinks(BUCKET_ID, "file-id-1")
 
+        assertEquals(BUCKET_ID, links.bucket)
+        assertEquals("idx", links.index)
+        assertEquals(1024L, links.size)
+        assertEquals(2, links.version)
         assertEquals(1, links.shards.size)
         assertEquals("https://shard/0", links.shards[0].url)
         assertEquals(512L, links.shards[0].size)
 
-        val recorded = server.takeRequest()
+        val infoRequest = server.takeRequest()
+        assertEquals("/buckets/$BUCKET_ID/files/file-id-1/info", infoRequest.path)
+        assertEquals("2", infoRequest.getHeader("x-api-version"))
+
         val expectedPass = "c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646"
         val expectedAuth = "Basic " + java.util.Base64.getEncoder()
             .encodeToString("user@example.com:$expectedPass".toByteArray(Charsets.UTF_8))
-        assertEquals(expectedAuth, recorded.getHeader("Authorization"))
+        assertEquals(expectedAuth, infoRequest.getHeader("Authorization"))
     }
 
     @Test

--- a/android/app/src/test/java/com/internxt/cloud/documents/auth/InternxtAuthManagerTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/auth/InternxtAuthManagerTest.kt
@@ -19,6 +19,7 @@ class InternxtAuthManagerTest {
             bearerToken = "bearer-xyz",
             userId = "user-1",
             bridgeUser = USER_EMAIL,
+            mnemonic = "test mnemonic phrase",
             rootFolderUuid = "root-uuid",
             email = USER_EMAIL,
             driveBaseUrl = "https://drive.test/api",

--- a/android/app/src/test/java/com/internxt/cloud/documents/crypto/FileKeyDeriverTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/crypto/FileKeyDeriverTest.kt
@@ -1,0 +1,31 @@
+package com.internxt.cloud.documents.crypto
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FileKeyDeriverTest {
+
+    @Test
+    fun deriveFileKeyMatchesDriveWebForCanonicalTriple() {
+        val fileKey = FileKeyDeriver.deriveFileKey(MNEMONIC, BUCKET_ID, INDEX_HEX)
+        assertEquals(EXPECTED_FILE_KEY_HEX, fileKey.toHex().lowercase())
+    }
+
+    @Test
+    fun deriveIvMatchesFirst16BytesOfIndex() {
+        val iv = FileKeyDeriver.deriveIv(INDEX_HEX)
+        assertEquals(EXPECTED_IV_HEX, iv.toHex().lowercase())
+    }
+
+    companion object {
+        private const val MNEMONIC =
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+        private const val BUCKET_ID = "a1b2c3d4e5f6a1b2c1d2e3f4a5b6c7d8"
+        private const val INDEX_HEX =
+            "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+
+        private const val EXPECTED_FILE_KEY_HEX =
+            "186473ae7deaa32c1b5b9b1c7708c2c29098f24664ece11abfff56839c630fbb"
+        private const val EXPECTED_IV_HEX = "abcdef1234567890abcdef1234567890"
+    }
+}

--- a/src/services/native/InternxtAuthCredentialsModule.ts
+++ b/src/services/native/InternxtAuthCredentialsModule.ts
@@ -4,6 +4,7 @@ export interface InternxtAuthCredentials {
   bearerToken: string;
   userId: string;
   bridgeUser: string;
+  mnemonic: string;
   rootFolderUuid: string;
   email?: string | null;
   driveBaseUrl: string;

--- a/src/store/slices/auth/index.ts
+++ b/src/store/slices/auth/index.ts
@@ -51,6 +51,7 @@ async function syncNativeCredentials(token: string, user: UserSettings): Promise
       bearerToken: token,
       userId: user.userId,
       bridgeUser: user.bridgeUser,
+      mnemonic: user.mnemonic,
       rootFolderUuid: user.rootFolderUuid,
       email: user.email,
       driveBaseUrl: appService.constants.DRIVE_NEW_API_URL,


### PR DESCRIPTION
## PB-5928 — Download & decryption in the SAF documents provider

  Adds end-to-end read-only file access to `InternxtDocumentsProvider`: `openDocument` now fetches encrypted shards from the bridge, decrypts them
  locally with the user's mnemonic, caches the result, and hands SAF a read-only `ParcelFileDescriptor`. Previously this method threw
  `UnsupportedOperationException`.

  ## Summary

  - **Open path (`InternxtDocumentsProvider.openDocument`)**: runs on a dedicated executor, decoded into `requireFileMetadata → materializeIntoCache
   → openCached`. Handles `CancellationSignal`, falls back to a hot cache on `${uuid}_${updatedAt-slug}`, and cleans up temp files on cancel/error.
  - **`EncryptedFileDownloader`**: streams shards in `index` order into a single output file via OkHttp, wires `CancellationSignal` to cancel the
  active call, and surfaces cancellations as `OperationCanceledException`.
  - **`FileKeyDeriver`**: derives the AES-CTR key/IV from `(mnemonic, bucketId, index)` using `CryptoService` — matches the JS
  `src/network/crypto.ts: generateFileKey` algorithm (PBKDF2 → SHA-512 chain). Decryption itself goes through `CryptoService.decryptFile` (native).
  - **`DocumentCache`**: process-local disk cache under `cacheDir/internxt_documents/{cache,tmp}`. Promotes via `rename()`, prunes stale siblings on
   success, wipes temps on close.
  - **Bridge `/info` endpoint**: `getDownloadLinks` now hits `buckets/{bucket}/files/{file}/info` with `x-api-version: 2`, validating `version == 2`
   and non-empty shards.
  - **Auth**: `AuthConfig` and `InternxtAuthManager` now carry the user's `mnemonic` (passed through `InternxtAuthCredentialsModule` from the RN
  auth slice). Required for key derivation; openDocument fails fast with a clear "sign out and back in" message if missing.
  - **`HttpClients`**: single source of truth for OkHttp configuration — short timeouts for API JSON calls, long/no-timeout for shard streaming.
  - **`InternxtApiException.MalformedResponse`**: new sealed variant for client-side response-shape errors (replaces fake `ApiError(500/409/404)`
  thrown by the parser).