### PR TITLE
[PB-6329]: Enforce max upload file size across upload flows

### DIFF
--- a/assets/lang/strings.ts
+++ b/assets/lang/strings.ts
@@ -3,11 +3,6 @@ import { NotificationType } from '../../src/types';
 import { BiometricAccessType } from '../../src/types/app';
 import { SortType } from '../../src/types/drive/ui';
 
-const fileSizeLimitSuffix = {
-  en: 'the maximum file size allowed by your plan.',
-  es: 'el tamaño máximo permitido por tu plan.',
-};
-
 const translations = {
   en: {
     languages: {
@@ -694,8 +689,8 @@ const translations = {
       },
       FileSizeExceededModal: {
         title: 'File too large',
-        messageWithName: `"{0}" exceeds ${fileSizeLimitSuffix.en}`,
-        messageWithCount: `{0} files exceed ${fileSizeLimitSuffix.en}`,
+        messageWithName: '"{0}" exceeds the maximum file size allowed by your plan.',
+        messageWithCount: '{0} files exceed the maximum file size allowed by your plan.',
       },
       ComingSoonModal: {
         title: 'Coming soon!',
@@ -1558,8 +1553,8 @@ const translations = {
       },
       FileSizeExceededModal: {
         title: 'Archivo demasiado grande',
-        messageWithName: `"{0}" excede ${fileSizeLimitSuffix.es}`,
-        messageWithCount: `{0} archivos exceden ${fileSizeLimitSuffix.es}`,
+        messageWithName: '"{0}" excede el tamaño máximo permitido por tu plan.',
+        messageWithCount: '{0} archivos exceden el tamaño máximo permitido por tu plan.',
       },
       ComingSoonModal: {
         title: '¡Próximamente!',

--- a/assets/lang/strings.ts
+++ b/assets/lang/strings.ts
@@ -355,7 +355,7 @@ const translations = {
         errorNoInternet: 'No internet connection. Please try again.',
         errorSessionExpired: 'Session expired. Please sign in again.',
         errorPrep: 'Could not prepare the file for upload.',
-        errorFileTooLarge: 'The maximum upload size is 300 MB at a time.',
+        errorFileTooLarge: 'File size exceeds the maximum allowed by your plan.',
         errorFileAlreadyExists: 'A file with this name already exists in this folder.',
         errorPaymentRequired: 'Uploading empty files requires a paid plan.',
         uploading: 'Uploading…',
@@ -687,6 +687,10 @@ const translations = {
         message:
           'Uploading empty files is only available for some plans. Please upgrade your plan to use this feature.',
       },
+      FileSizeExceededModal: {
+        title: 'File too large',
+        message: 'File size exceeds the maximum allowed by your plan.',
+      },
       ComingSoonModal: {
         title: 'Coming soon!',
         subtitle: 'Our fantastic devs are working on it, so stay tuned!',
@@ -750,10 +754,6 @@ const translations = {
       linkDeleted: 'Link deleted successfully',
       trashEmpty: 'Trash is empty',
       downloadLimit: 'The download limit in mobile app is 10GB.',
-      uploadFileLimit: '{0} file will not be uploaded.\nMax upload size per file is 5GB',
-      uploadFilesLimit: '{0} files will not be uploaded.\nMax upload size per file is 5GB',
-      uploadFileLimitName: '{0} will not be uploaded.\nMax upload size per file is 5GB',
-      limitPerFile: 'Max upload size per file reached',
       folderUploadCompleted: 'Successfully uploaded {0} files to "{1}"',
       folderUploadPartial: '{0} of {1} files uploaded ({2} failed)',
       folderUploadPartialWithSkipped: '{0} of {1} files uploaded ({2} failed, {3} skipped)',
@@ -1216,7 +1216,7 @@ const translations = {
         errorNoInternet: 'Sin conexión a internet. Inténtalo de nuevo.',
         errorSessionExpired: 'Sesión expirada. Inicia sesión de nuevo.',
         errorPrep: 'No se pudo preparar el archivo para la subida.',
-        errorFileTooLarge: 'El tamaño máximo de subida es de 300 MB a la vez.',
+        errorFileTooLarge: 'El tamaño del archivo excede el máximo permitido por tu plan.',
         errorFileAlreadyExists: 'Ya existe un archivo con este nombre en esta carpeta.',
         errorPaymentRequired: 'La subida de archivos vacíos requiere un plan de pago.',
         uploading: 'Subiendo…',
@@ -1550,6 +1550,10 @@ const translations = {
         message:
           'La subida de archivos vacíos solo está disponible en algunos planes. Actualiza tu plan para usar esta función.',
       },
+      FileSizeExceededModal: {
+        title: 'Archivo demasiado grande',
+        message: 'El tamaño del archivo excede el máximo permitido por tu plan.',
+      },
       ComingSoonModal: {
         title: '¡Próximamente!',
         subtitle: 'Nuestros fantásticos programadores están trabajando en ello, así que mantente al tanto!',
@@ -1616,10 +1620,6 @@ const translations = {
       linkDeleted: 'Link eliminado correctamente',
       trashEmpty: 'Papelera vaciada',
       downloadLimit: 'El límite de descarga en la app movil son 10GB',
-      uploadFileLimit: '{0} archivo no se ha subido.\nEl tamaño máximo por archivo es de 5 GB',
-      uploadFilesLimit: '{0} archivos no se han subido.\nEl tamaño máximo por archivo es de 5 GB',
-      uploadFileLimitName: '{0} no se ha subido.\nEl tamaño máximo es de 5 GB',
-      limitPerFile: 'Tamaño máximo por archivo alcanzado',
       folderUploadCompleted: '{0} archivos subidos correctamente a "{1}"',
       folderUploadPartial: '{0} de {1} archivos subidos ({2} fallaron)',
       folderUploadPartialWithSkipped: '{0} de {1} archivos subidos ({2} fallaron, {3} omitidos)',

--- a/assets/lang/strings.ts
+++ b/assets/lang/strings.ts
@@ -3,6 +3,11 @@ import { NotificationType } from '../../src/types';
 import { BiometricAccessType } from '../../src/types/app';
 import { SortType } from '../../src/types/drive/ui';
 
+const fileSizeLimitSuffix = {
+  en: 'the maximum file size allowed by your plan.',
+  es: 'el tamaño máximo permitido por tu plan.',
+};
+
 const translations = {
   en: {
     languages: {
@@ -689,7 +694,8 @@ const translations = {
       },
       FileSizeExceededModal: {
         title: 'File too large',
-        message: 'File size exceeds the maximum allowed by your plan.',
+        messageWithName: `"{0}" exceeds ${fileSizeLimitSuffix.en}`,
+        messageWithCount: `{0} files exceed ${fileSizeLimitSuffix.en}`,
       },
       ComingSoonModal: {
         title: 'Coming soon!',
@@ -1552,7 +1558,8 @@ const translations = {
       },
       FileSizeExceededModal: {
         title: 'Archivo demasiado grande',
-        message: 'El tamaño del archivo excede el máximo permitido por tu plan.',
+        messageWithName: `"{0}" excede ${fileSizeLimitSuffix.es}`,
+        messageWithCount: `{0} archivos exceden ${fileSizeLimitSuffix.es}`,
       },
       ComingSoonModal: {
         title: '¡Próximamente!',

--- a/src/components/modals/AddModal/hooks/useFolderUpload.ts
+++ b/src/components/modals/AddModal/hooks/useFolderUpload.ts
@@ -6,6 +6,7 @@ import uuid from 'react-native-uuid';
 import { useDrive } from '@internxt-mobile/hooks/drive';
 import { logger } from '@internxt-mobile/services/common';
 import { EmptyFileNotAllowedError } from '@internxt-mobile/services/drive/file/utils/emptyFileErrors';
+import { notifyFilesExcludedBySize } from '@internxt-mobile/services/drive/file/utils/fileSizeErrors';
 import errorService from '@internxt-mobile/services/ErrorService';
 import { DriveFileData } from '@internxt-mobile/types/drive/file';
 import strings from '../../../../../assets/lang/strings';
@@ -163,16 +164,6 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
     }
   };
 
-  function notifyFilesExcludedBySize(excluded: FolderTreeNode[]) {
-    const [firstExcluded, ...remainingExcluded] = excluded;
-    if (firstExcluded === undefined) return;
-    const hasMultipleExcluded = remainingExcluded.length > 0;
-    const message = hasMultipleExcluded
-      ? strings.formatString(strings.modals.FileSizeExceededModal.messageWithCount, excluded.length)
-      : strings.formatString(strings.modals.FileSizeExceededModal.messageWithName, firstExcluded.name);
-    dispatch(uiActions.setFileSizeExceededMessage(message));
-  }
-
   const collisionResolverRef = useRef<((action: NameCollisionAction | null) => void) | null>(null);
   const [collisionState, setCollisionState] = useState<{
     isOpen: boolean;
@@ -273,7 +264,7 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
         ? tree.files.filter((file) => file.size > maxUploadFileSize)
         : [];
       if (oversizedFiles.length > 0) {
-        notifyFilesExcludedBySize(oversizedFiles);
+        notifyFilesExcludedBySize(oversizedFiles, dispatch);
         return;
       }
 

--- a/src/components/modals/AddModal/hooks/useFolderUpload.ts
+++ b/src/components/modals/AddModal/hooks/useFolderUpload.ts
@@ -10,6 +10,7 @@ import {
   FileSizeExceededError,
   notifyFilesExcludedBySize,
 } from '@internxt-mobile/services/drive/file/utils/fileSizeErrors';
+import { filterOversizedFromTree } from '../../../../services/drive/folder/utils/filterOversizedFromTree';
 import errorService from '@internxt-mobile/services/ErrorService';
 import { DriveFileData } from '@internxt-mobile/types/drive/file';
 import strings from '../../../../../assets/lang/strings';
@@ -32,7 +33,7 @@ import { driveActions, driveThunks } from '../../../../store/slices/drive';
 import { storageSelectors, storageThunks } from '../../../../store/slices/storage';
 import { uiActions } from '../../../../store/slices/ui';
 import { INFINITE_PLAN, NotificationType, ProgressCallback } from '../../../../types';
-import { FolderTree, FolderTreeNode } from '../../../../types/drive/folderUpload';
+import { FolderTreeNode } from '../../../../types/drive/folderUpload';
 import { NameCollisionAction } from '../../NameCollisionModal';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -157,8 +158,7 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
   const folderUploads = useAppSelector((state) => state.drive.folderUploads);
   const { limit } = useAppSelector((state) => state.storage);
   const usage = useAppSelector(storageSelectors.usage);
-  const maxUploadFileSize = 0;
-
+  const maxUploadFileSize = useAppSelector(storageSelectors.maxUploadFileSize);
   const hasShownEmptyFileNoticeRef = useRef(false);
   const backendOversizedFilesRef = useRef<{ name: string }[]>([]);
 
@@ -174,15 +174,6 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
 
   const handleOversizedFileSkipped = (fileName: string) => {
     backendOversizedFilesRef.current.push({ name: fileName });
-  };
-
-  const filterOversizedFromTree = (tree: FolderTree): FolderTreeNode[] => {
-    if (maxUploadFileSize <= 0) return [];
-    const oversizedFiles = tree.files.filter((file) => file.size > maxUploadFileSize);
-    if (oversizedFiles.length === 0) return [];
-    notifyFilesExcludedBySize(oversizedFiles, dispatch);
-    tree.files = tree.files.filter((file) => file.size <= maxUploadFileSize);
-    return oversizedFiles;
   };
 
   const uploadFolderFile = async (
@@ -310,7 +301,7 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
       }
 
       // 4.1. Per-file size limit: warn upfront and skip oversized files; valid files still upload.
-      const oversizedFiles = filterOversizedFromTree(tree);
+      const oversizedFiles = filterOversizedFromTree(tree, maxUploadFileSize, dispatch);
       if (oversizedFiles.length > 0 && tree.files.length === 0) return;
 
       if (!focusedFolder?.uuid) {

--- a/src/components/modals/AddModal/hooks/useFolderUpload.ts
+++ b/src/components/modals/AddModal/hooks/useFolderUpload.ts
@@ -6,7 +6,6 @@ import uuid from 'react-native-uuid';
 import { useDrive } from '@internxt-mobile/hooks/drive';
 import { logger } from '@internxt-mobile/services/common';
 import { EmptyFileNotAllowedError } from '@internxt-mobile/services/drive/file/utils/emptyFileErrors';
-import { FileSizeExceededError } from '@internxt-mobile/services/drive/file/utils/fileSizeErrors';
 import errorService from '@internxt-mobile/services/ErrorService';
 import { DriveFileData } from '@internxt-mobile/types/drive/file';
 import strings from '../../../../../assets/lang/strings';
@@ -41,7 +40,6 @@ const uploadFolderFileIOS = async (
   signal: AbortSignal,
   uploadAndCreateFileEntry: UploadFileEntryFn,
   onEmptyFileSkipped: () => void,
-  onFileSizeExceededSkipped: (fileName: string) => void,
 ): Promise<void> => {
   const filePath = fileNode.uri.replace('file://', '');
   const { extension, plainName } = getFileExtensionAndPlainName(fileNode.name);
@@ -58,7 +56,6 @@ const uploadFolderFileIOS = async (
     );
   } catch (err) {
     if (err instanceof EmptyFileNotAllowedError) onEmptyFileSkipped();
-    if (err instanceof FileSizeExceededError) onFileSizeExceededSkipped(fileNode.name);
     throw err;
   }
 };
@@ -70,7 +67,6 @@ const uploadFolderFileAndroid = async (
   uploadId: string,
   uploadAndCreateFileEntry: UploadFileEntryFn,
   onEmptyFileSkipped: () => void,
-  onFileSizeExceededSkipped: (fileName: string) => void,
 ): Promise<void> => {
   const { extension, plainName } = getFileExtensionAndPlainName(fileNode.name);
   const tempPath = fileSystemService.tmpFilePath(`${uploadId}_${fileNode.name}`);
@@ -90,7 +86,6 @@ const uploadFolderFileAndroid = async (
     );
   } catch (err) {
     if (err instanceof EmptyFileNotAllowedError) onEmptyFileSkipped();
-    if (err instanceof FileSizeExceededError) onFileSizeExceededSkipped(fileNode.name);
     throw err;
   } finally {
     await fileSystemService.unlinkIfExists(tempPath).catch((e) => {
@@ -154,9 +149,9 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
   const folderUploads = useAppSelector((state) => state.drive.folderUploads);
   const { limit } = useAppSelector((state) => state.storage);
   const usage = useAppSelector(storageSelectors.usage);
+  const maxUploadFileSize = useAppSelector(storageSelectors.maxUploadFileSize);
 
   const hasShownEmptyFileNoticeRef = useRef(false);
-  const skippedOversizedNamesRef = useRef<string[]>([]);
 
   const handleEmptyFileSkipped = () => {
     if (!hasShownEmptyFileNoticeRef.current) {
@@ -168,16 +163,15 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
     }
   };
 
-  const handleFileSizeExceededSkipped = (fileName: string) => {
-    skippedOversizedNamesRef.current.push(fileName);
-    const skipped = skippedOversizedNamesRef.current;
-    const [firstSkippedName, ...remainingSkipped] = skipped;
-    const hasMultipleSkipped = remainingSkipped.length > 0;
-    const message = hasMultipleSkipped
-      ? strings.formatString(strings.modals.FileSizeExceededModal.messageWithCount, skipped.length)
-      : strings.formatString(strings.modals.FileSizeExceededModal.messageWithName, firstSkippedName);
+  function notifyFilesExcludedBySize(excluded: FolderTreeNode[]) {
+    const [firstExcluded, ...remainingExcluded] = excluded;
+    if (firstExcluded === undefined) return;
+    const hasMultipleExcluded = remainingExcluded.length > 0;
+    const message = hasMultipleExcluded
+      ? strings.formatString(strings.modals.FileSizeExceededModal.messageWithCount, excluded.length)
+      : strings.formatString(strings.modals.FileSizeExceededModal.messageWithName, firstExcluded.name);
     dispatch(uiActions.setFileSizeExceededMessage(message));
-  };
+  }
 
   const collisionResolverRef = useRef<((action: NameCollisionAction | null) => void) | null>(null);
   const [collisionState, setCollisionState] = useState<{
@@ -226,7 +220,6 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
   const handleUploadFolder = async () => {
     dispatch(uiActions.setShowUploadFileModal(false));
     hasShownEmptyFileNoticeRef.current = false;
-    skippedOversizedNamesRef.current = [];
     await dispatch(storageThunks.ensureMaxUploadFileSizeFresh()).unwrap();
 
     const uploadId = uuid.v4().toString();
@@ -271,6 +264,16 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
       const isUnlimited = limit >= INFINITE_PLAN;
       if (!isUnlimited && usage + totalSize > limit) {
         dispatch(uiActions.setShowRunOutSpaceModal(true));
+        return;
+      }
+
+      // 4.1. Per-file size limit: block the entire upload if any file exceeds the plan's limit.
+      const hasUploadSizeLimit = maxUploadFileSize > 0;
+      const oversizedFiles = hasUploadSizeLimit
+        ? tree.files.filter((file) => file.size > maxUploadFileSize)
+        : [];
+      if (oversizedFiles.length > 0) {
+        notifyFilesExcludedBySize(oversizedFiles);
         return;
       }
 
@@ -329,7 +332,6 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
               uploadId,
               uploadAndCreateFileEntry,
               handleEmptyFileSkipped,
-              handleFileSizeExceededSkipped,
             );
           } else {
             await uploadFolderFileIOS(
@@ -338,7 +340,6 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
               signal,
               uploadAndCreateFileEntry,
               handleEmptyFileSkipped,
-              handleFileSizeExceededSkipped,
             );
           }
         },

--- a/src/components/modals/AddModal/hooks/useFolderUpload.ts
+++ b/src/components/modals/AddModal/hooks/useFolderUpload.ts
@@ -6,7 +6,10 @@ import uuid from 'react-native-uuid';
 import { useDrive } from '@internxt-mobile/hooks/drive';
 import { logger } from '@internxt-mobile/services/common';
 import { EmptyFileNotAllowedError } from '@internxt-mobile/services/drive/file/utils/emptyFileErrors';
-import { notifyFilesExcludedBySize } from '@internxt-mobile/services/drive/file/utils/fileSizeErrors';
+import {
+  FileSizeExceededError,
+  notifyFilesExcludedBySize,
+} from '@internxt-mobile/services/drive/file/utils/fileSizeErrors';
 import errorService from '@internxt-mobile/services/ErrorService';
 import { DriveFileData } from '@internxt-mobile/types/drive/file';
 import strings from '../../../../../assets/lang/strings';
@@ -41,6 +44,7 @@ const uploadFolderFileIOS = async (
   signal: AbortSignal,
   uploadAndCreateFileEntry: UploadFileEntryFn,
   onEmptyFileSkipped: () => void,
+  onOversizedFileSkipped: (fileName: string) => void,
 ): Promise<void> => {
   const filePath = fileNode.uri.replace('file://', '');
   const { extension, plainName } = getFileExtensionAndPlainName(fileNode.name);
@@ -57,6 +61,7 @@ const uploadFolderFileIOS = async (
     );
   } catch (err) {
     if (err instanceof EmptyFileNotAllowedError) onEmptyFileSkipped();
+    else if (err instanceof FileSizeExceededError) onOversizedFileSkipped(fileNode.name);
     throw err;
   }
 };
@@ -68,6 +73,7 @@ const uploadFolderFileAndroid = async (
   uploadId: string,
   uploadAndCreateFileEntry: UploadFileEntryFn,
   onEmptyFileSkipped: () => void,
+  onOversizedFileSkipped: (fileName: string) => void,
 ): Promise<void> => {
   const { extension, plainName } = getFileExtensionAndPlainName(fileNode.name);
   const tempPath = fileSystemService.tmpFilePath(`${uploadId}_${fileNode.name}`);
@@ -87,6 +93,7 @@ const uploadFolderFileAndroid = async (
     );
   } catch (err) {
     if (err instanceof EmptyFileNotAllowedError) onEmptyFileSkipped();
+    else if (err instanceof FileSizeExceededError) onOversizedFileSkipped(fileNode.name);
     throw err;
   } finally {
     await fileSystemService.unlinkIfExists(tempPath).catch((e) => {
@@ -153,6 +160,7 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
   const maxUploadFileSize = useAppSelector(storageSelectors.maxUploadFileSize);
 
   const hasShownEmptyFileNoticeRef = useRef(false);
+  const backendOversizedFilesRef = useRef<{ name: string }[]>([]);
 
   const handleEmptyFileSkipped = () => {
     if (!hasShownEmptyFileNoticeRef.current) {
@@ -162,6 +170,10 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
         text1: strings.messages.emptyFileSkippedDuringFolderUpload,
       });
     }
+  };
+
+  const handleOversizedFileSkipped = (fileName: string) => {
+    backendOversizedFilesRef.current.push({ name: fileName });
   };
 
   const collisionResolverRef = useRef<((action: NameCollisionAction | null) => void) | null>(null);
@@ -211,6 +223,7 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
   const handleUploadFolder = async () => {
     dispatch(uiActions.setShowUploadFileModal(false));
     hasShownEmptyFileNoticeRef.current = false;
+    backendOversizedFilesRef.current = [];
     await dispatch(storageThunks.ensureMaxUploadFileSizeFresh()).unwrap();
 
     const uploadId = uuid.v4().toString();
@@ -260,9 +273,7 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
 
       // 4.1. Per-file size limit: warn upfront and skip oversized files; valid files still upload.
       const hasUploadSizeLimit = maxUploadFileSize > 0;
-      const oversizedFiles = hasUploadSizeLimit
-        ? tree.files.filter((file) => file.size > maxUploadFileSize)
-        : [];
+      const oversizedFiles = hasUploadSizeLimit ? tree.files.filter((file) => file.size > maxUploadFileSize) : [];
       if (oversizedFiles.length > 0) {
         notifyFilesExcludedBySize(oversizedFiles, dispatch);
         tree.files = tree.files.filter((file) => file.size <= maxUploadFileSize);
@@ -324,6 +335,7 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
               uploadId,
               uploadAndCreateFileEntry,
               handleEmptyFileSkipped,
+              handleOversizedFileSkipped,
             );
           } else {
             await uploadFolderFileIOS(
@@ -332,6 +344,7 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
               signal,
               uploadAndCreateFileEntry,
               handleEmptyFileSkipped,
+              handleOversizedFileSkipped,
             );
           }
         },
@@ -351,7 +364,15 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
         successRate: result.totalFiles > 0 ? result.uploadedFiles / result.totalFiles : 1,
       });
 
-      // 9. Display result — include files skipped by the upfront size check in the totals.
+      // 9. If the backend rejected any files for exceeding the size limit (e.g. the
+      // upfront check used a stale limit), surface the same modal used by the pre-filter,
+      const backendOversizedFiles = backendOversizedFilesRef.current;
+      if (backendOversizedFiles.length > 0) {
+        const allOversizedFiles = [...oversizedFiles, ...backendOversizedFiles];
+        notifyFilesExcludedBySize(allOversizedFiles, dispatch);
+      }
+
+      // 10. Display result — include files skipped by the upfront size check in the totals.
       const preSkippedCount = oversizedFiles.length;
       showFolderUploadResult(
         {

--- a/src/components/modals/AddModal/hooks/useFolderUpload.ts
+++ b/src/components/modals/AddModal/hooks/useFolderUpload.ts
@@ -32,7 +32,7 @@ import { driveActions, driveThunks } from '../../../../store/slices/drive';
 import { storageSelectors, storageThunks } from '../../../../store/slices/storage';
 import { uiActions } from '../../../../store/slices/ui';
 import { INFINITE_PLAN, NotificationType, ProgressCallback } from '../../../../types';
-import { FolderTreeNode } from '../../../../types/drive/folderUpload';
+import { FolderTree, FolderTreeNode } from '../../../../types/drive/folderUpload';
 import { NameCollisionAction } from '../../NameCollisionModal';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -157,7 +157,7 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
   const folderUploads = useAppSelector((state) => state.drive.folderUploads);
   const { limit } = useAppSelector((state) => state.storage);
   const usage = useAppSelector(storageSelectors.usage);
-  const maxUploadFileSize = useAppSelector(storageSelectors.maxUploadFileSize);
+  const maxUploadFileSize = 0;
 
   const hasShownEmptyFileNoticeRef = useRef(false);
   const backendOversizedFilesRef = useRef<{ name: string }[]>([]);
@@ -174,6 +174,44 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
 
   const handleOversizedFileSkipped = (fileName: string) => {
     backendOversizedFilesRef.current.push({ name: fileName });
+  };
+
+  const filterOversizedFromTree = (tree: FolderTree): FolderTreeNode[] => {
+    if (maxUploadFileSize <= 0) return [];
+    const oversizedFiles = tree.files.filter((file) => file.size > maxUploadFileSize);
+    if (oversizedFiles.length === 0) return [];
+    notifyFilesExcludedBySize(oversizedFiles, dispatch);
+    tree.files = tree.files.filter((file) => file.size <= maxUploadFileSize);
+    return oversizedFiles;
+  };
+
+  const uploadFolderFile = async (
+    fileNode: FolderTreeNode,
+    parentUuid: string,
+    signal: AbortSignal,
+    uploadId: string,
+  ): Promise<void> => {
+    const isAndroidContent = Platform.OS === 'android' && fileNode.uri.startsWith('content://');
+    if (isAndroidContent) {
+      await uploadFolderFileAndroid(
+        fileNode,
+        parentUuid,
+        signal,
+        uploadId,
+        uploadAndCreateFileEntry,
+        handleEmptyFileSkipped,
+        handleOversizedFileSkipped,
+      );
+      return;
+    }
+    await uploadFolderFileIOS(
+      fileNode,
+      parentUuid,
+      signal,
+      uploadAndCreateFileEntry,
+      handleEmptyFileSkipped,
+      handleOversizedFileSkipped,
+    );
   };
 
   const collisionResolverRef = useRef<((action: NameCollisionAction | null) => void) | null>(null);
@@ -272,13 +310,8 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
       }
 
       // 4.1. Per-file size limit: warn upfront and skip oversized files; valid files still upload.
-      const hasUploadSizeLimit = maxUploadFileSize > 0;
-      const oversizedFiles = hasUploadSizeLimit ? tree.files.filter((file) => file.size > maxUploadFileSize) : [];
-      if (oversizedFiles.length > 0) {
-        notifyFilesExcludedBySize(oversizedFiles, dispatch);
-        tree.files = tree.files.filter((file) => file.size <= maxUploadFileSize);
-        if (tree.files.length === 0) return;
-      }
+      const oversizedFiles = filterOversizedFromTree(tree);
+      if (oversizedFiles.length > 0 && tree.files.length === 0) return;
 
       if (!focusedFolder?.uuid) {
         throw new Error('No focused folder UUID');
@@ -326,28 +359,7 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
             dispatch(driveActions.updateFolderUpload({ uploadId, uploadedFiles: uploaded, failedFiles: failed }));
           }
         },
-        uploadFile: async (fileNode, parentUuid, signal) => {
-          if (Platform.OS === 'android' && fileNode.uri.startsWith('content://')) {
-            await uploadFolderFileAndroid(
-              fileNode,
-              parentUuid,
-              signal,
-              uploadId,
-              uploadAndCreateFileEntry,
-              handleEmptyFileSkipped,
-              handleOversizedFileSkipped,
-            );
-          } else {
-            await uploadFolderFileIOS(
-              fileNode,
-              parentUuid,
-              signal,
-              uploadAndCreateFileEntry,
-              handleEmptyFileSkipped,
-              handleOversizedFileSkipped,
-            );
-          }
-        },
+        uploadFile: (fileNode, parentUuid, signal) => uploadFolderFile(fileNode, parentUuid, signal, uploadId),
       });
 
       logger.info(

--- a/src/components/modals/AddModal/hooks/useFolderUpload.ts
+++ b/src/components/modals/AddModal/hooks/useFolderUpload.ts
@@ -258,14 +258,15 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
         return;
       }
 
-      // 4.1. Per-file size limit: block the entire upload if any file exceeds the plan's limit.
+      // 4.1. Per-file size limit: warn upfront and skip oversized files; valid files still upload.
       const hasUploadSizeLimit = maxUploadFileSize > 0;
       const oversizedFiles = hasUploadSizeLimit
         ? tree.files.filter((file) => file.size > maxUploadFileSize)
         : [];
       if (oversizedFiles.length > 0) {
         notifyFilesExcludedBySize(oversizedFiles, dispatch);
-        return;
+        tree.files = tree.files.filter((file) => file.size <= maxUploadFileSize);
+        if (tree.files.length === 0) return;
       }
 
       if (!focusedFolder?.uuid) {
@@ -350,8 +351,16 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
         successRate: result.totalFiles > 0 ? result.uploadedFiles / result.totalFiles : 1,
       });
 
-      // 9. Display result
-      showFolderUploadResult(result, picked.name);
+      // 9. Display result — include files skipped by the upfront size check in the totals.
+      const preSkippedCount = oversizedFiles.length;
+      showFolderUploadResult(
+        {
+          ...result,
+          totalFiles: result.totalFiles + preSkippedCount,
+          skippedFiles: result.skippedFiles + preSkippedCount,
+        },
+        picked.name,
+      );
     } catch (err) {
       if (abortController.signal.aborted) {
         notificationsService.show({ type: NotificationType.Info, text1: strings.messages.folderUploadCancelled });

--- a/src/components/modals/AddModal/hooks/useFolderUpload.ts
+++ b/src/components/modals/AddModal/hooks/useFolderUpload.ts
@@ -6,6 +6,7 @@ import uuid from 'react-native-uuid';
 import { useDrive } from '@internxt-mobile/hooks/drive';
 import { logger } from '@internxt-mobile/services/common';
 import { EmptyFileNotAllowedError } from '@internxt-mobile/services/drive/file/utils/emptyFileErrors';
+import { FileSizeExceededError } from '@internxt-mobile/services/drive/file/utils/fileSizeErrors';
 import errorService from '@internxt-mobile/services/ErrorService';
 import { DriveFileData } from '@internxt-mobile/types/drive/file';
 import strings from '../../../../../assets/lang/strings';
@@ -25,7 +26,7 @@ import fileSystemService from '../../../../services/FileSystemService';
 import notificationsService from '../../../../services/NotificationsService';
 import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
 import { driveActions, driveThunks } from '../../../../store/slices/drive';
-import { storageSelectors } from '../../../../store/slices/storage';
+import { storageSelectors, storageThunks } from '../../../../store/slices/storage';
 import { uiActions } from '../../../../store/slices/ui';
 import { INFINITE_PLAN, NotificationType, ProgressCallback } from '../../../../types';
 import { FolderTreeNode } from '../../../../types/drive/folderUpload';
@@ -40,6 +41,7 @@ const uploadFolderFileIOS = async (
   signal: AbortSignal,
   uploadAndCreateFileEntry: UploadFileEntryFn,
   onEmptyFileSkipped: () => void,
+  onFileSizeExceededSkipped: () => void,
 ): Promise<void> => {
   const filePath = fileNode.uri.replace('file://', '');
   const { extension, plainName } = getFileExtensionAndPlainName(fileNode.name);
@@ -47,6 +49,7 @@ const uploadFolderFileIOS = async (
     await uploadAndCreateFileEntry(filePath, plainName, extension, parentUuid, noopProgress, undefined, undefined, signal);
   } catch (err) {
     if (err instanceof EmptyFileNotAllowedError) onEmptyFileSkipped();
+    if (err instanceof FileSizeExceededError) onFileSizeExceededSkipped();
     throw err;
   }
 };
@@ -58,6 +61,7 @@ const uploadFolderFileAndroid = async (
   uploadId: string,
   uploadAndCreateFileEntry: UploadFileEntryFn,
   onEmptyFileSkipped: () => void,
+  onFileSizeExceededSkipped: () => void,
 ): Promise<void> => {
   const { extension, plainName } = getFileExtensionAndPlainName(fileNode.name);
   const tempPath = fileSystemService.tmpFilePath(`${uploadId}_${fileNode.name}`);
@@ -68,6 +72,7 @@ const uploadFolderFileAndroid = async (
     await uploadAndCreateFileEntry(tempPath, plainName, extension, parentUuid, noopProgress, undefined, undefined, signal);
   } catch (err) {
     if (err instanceof EmptyFileNotAllowedError) onEmptyFileSkipped();
+    if (err instanceof FileSizeExceededError) onFileSizeExceededSkipped();
     throw err;
   } finally {
     await fileSystemService.unlinkIfExists(tempPath).catch((e) => {
@@ -133,6 +138,7 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
   const usage = useAppSelector(storageSelectors.usage);
 
   const hasShownEmptyFileNoticeRef = useRef(false);
+  const hasShownFileSizeExceededNoticeRef = useRef(false);
 
   const handleEmptyFileSkipped = () => {
     if (!hasShownEmptyFileNoticeRef.current) {
@@ -141,6 +147,13 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
         type: NotificationType.Warning,
         text1: strings.messages.emptyFileSkippedDuringFolderUpload,
       });
+    }
+  };
+
+  const handleFileSizeExceededSkipped = () => {
+    if (!hasShownFileSizeExceededNoticeRef.current) {
+      hasShownFileSizeExceededNoticeRef.current = true;
+      dispatch(uiActions.setFileSizeExceededMessage(strings.modals.FileSizeExceededModal.message));
     }
   };
 
@@ -191,6 +204,8 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
   const handleUploadFolder = async () => {
     dispatch(uiActions.setShowUploadFileModal(false));
     hasShownEmptyFileNoticeRef.current = false;
+    hasShownFileSizeExceededNoticeRef.current = false;
+    await dispatch(storageThunks.ensureMaxUploadFileSizeFresh()).unwrap();
 
     const uploadId = uuid.v4().toString();
     const abortController = new AbortController();
@@ -285,9 +300,24 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
         },
         uploadFile: async (fileNode, parentUuid, signal) => {
           if (Platform.OS === 'android' && fileNode.uri.startsWith('content://')) {
-            await uploadFolderFileAndroid(fileNode, parentUuid, signal, uploadId, uploadAndCreateFileEntry, handleEmptyFileSkipped);
+            await uploadFolderFileAndroid(
+              fileNode,
+              parentUuid,
+              signal,
+              uploadId,
+              uploadAndCreateFileEntry,
+              handleEmptyFileSkipped,
+              handleFileSizeExceededSkipped,
+            );
           } else {
-            await uploadFolderFileIOS(fileNode, parentUuid, signal, uploadAndCreateFileEntry, handleEmptyFileSkipped);
+            await uploadFolderFileIOS(
+              fileNode,
+              parentUuid,
+              signal,
+              uploadAndCreateFileEntry,
+              handleEmptyFileSkipped,
+              handleFileSizeExceededSkipped,
+            );
           }
         },
       });

--- a/src/components/modals/AddModal/hooks/useFolderUpload.ts
+++ b/src/components/modals/AddModal/hooks/useFolderUpload.ts
@@ -41,15 +41,24 @@ const uploadFolderFileIOS = async (
   signal: AbortSignal,
   uploadAndCreateFileEntry: UploadFileEntryFn,
   onEmptyFileSkipped: () => void,
-  onFileSizeExceededSkipped: () => void,
+  onFileSizeExceededSkipped: (fileName: string) => void,
 ): Promise<void> => {
   const filePath = fileNode.uri.replace('file://', '');
   const { extension, plainName } = getFileExtensionAndPlainName(fileNode.name);
   try {
-    await uploadAndCreateFileEntry(filePath, plainName, extension, parentUuid, noopProgress, undefined, undefined, signal);
+    await uploadAndCreateFileEntry(
+      filePath,
+      plainName,
+      extension,
+      parentUuid,
+      noopProgress,
+      undefined,
+      undefined,
+      signal,
+    );
   } catch (err) {
     if (err instanceof EmptyFileNotAllowedError) onEmptyFileSkipped();
-    if (err instanceof FileSizeExceededError) onFileSizeExceededSkipped();
+    if (err instanceof FileSizeExceededError) onFileSizeExceededSkipped(fileNode.name);
     throw err;
   }
 };
@@ -61,7 +70,7 @@ const uploadFolderFileAndroid = async (
   uploadId: string,
   uploadAndCreateFileEntry: UploadFileEntryFn,
   onEmptyFileSkipped: () => void,
-  onFileSizeExceededSkipped: () => void,
+  onFileSizeExceededSkipped: (fileName: string) => void,
 ): Promise<void> => {
   const { extension, plainName } = getFileExtensionAndPlainName(fileNode.name);
   const tempPath = fileSystemService.tmpFilePath(`${uploadId}_${fileNode.name}`);
@@ -69,10 +78,19 @@ const uploadFolderFileAndroid = async (
   try {
     await StorageAccessFramework.copyAsync({ from: fileNode.uri, to: tempUri });
     if (signal.aborted) return;
-    await uploadAndCreateFileEntry(tempPath, plainName, extension, parentUuid, noopProgress, undefined, undefined, signal);
+    await uploadAndCreateFileEntry(
+      tempPath,
+      plainName,
+      extension,
+      parentUuid,
+      noopProgress,
+      undefined,
+      undefined,
+      signal,
+    );
   } catch (err) {
     if (err instanceof EmptyFileNotAllowedError) onEmptyFileSkipped();
-    if (err instanceof FileSizeExceededError) onFileSizeExceededSkipped();
+    if (err instanceof FileSizeExceededError) onFileSizeExceededSkipped(fileNode.name);
     throw err;
   } finally {
     await fileSystemService.unlinkIfExists(tempPath).catch((e) => {
@@ -138,7 +156,7 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
   const usage = useAppSelector(storageSelectors.usage);
 
   const hasShownEmptyFileNoticeRef = useRef(false);
-  const hasShownFileSizeExceededNoticeRef = useRef(false);
+  const skippedOversizedNamesRef = useRef<string[]>([]);
 
   const handleEmptyFileSkipped = () => {
     if (!hasShownEmptyFileNoticeRef.current) {
@@ -150,11 +168,15 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
     }
   };
 
-  const handleFileSizeExceededSkipped = () => {
-    if (!hasShownFileSizeExceededNoticeRef.current) {
-      hasShownFileSizeExceededNoticeRef.current = true;
-      dispatch(uiActions.setFileSizeExceededMessage(strings.modals.FileSizeExceededModal.message));
-    }
+  const handleFileSizeExceededSkipped = (fileName: string) => {
+    skippedOversizedNamesRef.current.push(fileName);
+    const skipped = skippedOversizedNamesRef.current;
+    const [firstSkippedName, ...remainingSkipped] = skipped;
+    const hasMultipleSkipped = remainingSkipped.length > 0;
+    const message = hasMultipleSkipped
+      ? strings.formatString(strings.modals.FileSizeExceededModal.messageWithCount, skipped.length)
+      : strings.formatString(strings.modals.FileSizeExceededModal.messageWithName, firstSkippedName);
+    dispatch(uiActions.setFileSizeExceededMessage(message));
   };
 
   const collisionResolverRef = useRef<((action: NameCollisionAction | null) => void) | null>(null);
@@ -204,7 +226,7 @@ export const useFolderUpload = ({ uploadAndCreateFileEntry }: { uploadAndCreateF
   const handleUploadFolder = async () => {
     dispatch(uiActions.setShowUploadFileModal(false));
     hasShownEmptyFileNoticeRef.current = false;
-    hasShownFileSizeExceededNoticeRef.current = false;
+    skippedOversizedNamesRef.current = [];
     await dispatch(storageThunks.ensureMaxUploadFileSizeFresh()).unwrap();
 
     const uploadId = uuid.v4().toString();

--- a/src/components/modals/AddModal/index.tsx
+++ b/src/components/modals/AddModal/index.tsx
@@ -21,7 +21,10 @@ import { Alert, PermissionsAndroid, Platform, TouchableHighlight, View } from 'r
 import { useDrive } from '@internxt-mobile/hooks/drive';
 import { imageService, logger } from '@internxt-mobile/services/common';
 import { uploadService } from '@internxt-mobile/services/common/network/upload/upload.service';
-import { EmptyFileNotAllowedError, isEmptyFilePlanError } from '@internxt-mobile/services/drive/file/utils/emptyFileErrors';
+import {
+  EmptyFileNotAllowedError,
+  isEmptyFilePlanError,
+} from '@internxt-mobile/services/drive/file/utils/emptyFileErrors';
 import {
   FileSizeExceededError,
   isFileSizeExceededError,
@@ -165,9 +168,13 @@ function AddModal(): JSX.Element {
     return createdFileEntry;
   }
 
-  const checkFileSizeLimitToUpload = (fileSize: number) => {
+  const checkFileSizeLimitToUpload = (fileSize: number, fileName: string) => {
     if (maxUploadFileSize > 0 && fileSize > maxUploadFileSize) {
-      dispatch(uiActions.setFileSizeExceededMessage(strings.modals.FileSizeExceededModal.message));
+      dispatch(
+        uiActions.setFileSizeExceededMessage(
+          strings.formatString(strings.modals.FileSizeExceededModal.messageWithName, fileName),
+        ),
+      );
       throw new FileSizeExceededError();
     }
     return true;
@@ -195,7 +202,7 @@ function AddModal(): JSX.Element {
     const fileStat = await fileSystemService.stat(filePath);
     // Fix for Android, native document picker not returns the correct fileSize when file is big
     // and cannnot get the stat before we got the file in temporary path
-    checkFileSizeLimitToUpload(fileStat.size);
+    checkFileSizeLimitToUpload(fileStat.size, fileName);
 
     const fileSize = fileStat.size;
 
@@ -418,8 +425,14 @@ function AddModal(): JSX.Element {
 
     await dispatch(storageThunks.ensureMaxUploadFileSizeFresh()).unwrap();
     const { filesToUpload, filesExcluded } = validateAndFilterFiles(documents, maxUploadFileSize);
-    if (filesExcluded.length > 0) {
-      dispatch(uiActions.setFileSizeExceededMessage(strings.modals.FileSizeExceededModal.message));
+    const [firstExcluded, ...remainingExcluded] = filesExcluded;
+    const hasExcluded = firstExcluded !== undefined;
+    const hasMultipleExcluded = remainingExcluded.length > 0;
+    if (hasExcluded) {
+      const message = hasMultipleExcluded
+        ? strings.formatString(strings.modals.FileSizeExceededModal.messageWithCount, filesExcluded.length)
+        : strings.formatString(strings.modals.FileSizeExceededModal.messageWithName, firstExcluded.name);
+      dispatch(uiActions.setFileSizeExceededMessage(message));
     }
 
     if (filesToUpload.length === 0) {

--- a/src/components/modals/AddModal/index.tsx
+++ b/src/components/modals/AddModal/index.tsx
@@ -28,6 +28,7 @@ import {
 import {
   FileSizeExceededError,
   isFileSizeExceededError,
+  notifyFilesExcludedBySize,
 } from '@internxt-mobile/services/drive/file/utils/fileSizeErrors';
 import drive from '@internxt-mobile/services/drive';
 import {
@@ -418,16 +419,6 @@ function AddModal(): JSX.Element {
     return uploadDocuments(documents);
   }
 
-  const notifyFilesExcludedBySize = (excluded: DocumentPickerFile[]) => {
-    const [firstExcluded, ...remainingExcluded] = excluded;
-    if (firstExcluded === undefined) return;
-    const hasMultipleExcluded = remainingExcluded.length > 0;
-    const message = hasMultipleExcluded
-      ? strings.formatString(strings.modals.FileSizeExceededModal.messageWithCount, excluded.length)
-      : strings.formatString(strings.modals.FileSizeExceededModal.messageWithName, firstExcluded.name);
-    dispatch(uiActions.setFileSizeExceededMessage(message));
-  };
-
   const uploadDocuments = async (documents: DocumentPickerFile[]) => {
     if (!focusedFolder) {
       throw new Error('No current folder found');
@@ -435,7 +426,7 @@ function AddModal(): JSX.Element {
 
     await dispatch(storageThunks.ensureMaxUploadFileSizeFresh()).unwrap();
     const { filesToUpload, filesExcluded } = validateAndFilterFiles(documents, maxUploadFileSize);
-    notifyFilesExcludedBySize(filesExcluded);
+    notifyFilesExcludedBySize(filesExcluded, dispatch);
 
     if (filesToUpload.length === 0) {
       dispatch(uiActions.setShowUploadFileModal(false));

--- a/src/components/modals/AddModal/index.tsx
+++ b/src/components/modals/AddModal/index.tsx
@@ -418,22 +418,24 @@ function AddModal(): JSX.Element {
     return uploadDocuments(documents);
   }
 
-  async function uploadDocuments(documents: DocumentPickerFile[]) {
+  const notifyFilesExcludedBySize = (excluded: DocumentPickerFile[]) => {
+    const [firstExcluded, ...remainingExcluded] = excluded;
+    if (firstExcluded === undefined) return;
+    const hasMultipleExcluded = remainingExcluded.length > 0;
+    const message = hasMultipleExcluded
+      ? strings.formatString(strings.modals.FileSizeExceededModal.messageWithCount, excluded.length)
+      : strings.formatString(strings.modals.FileSizeExceededModal.messageWithName, firstExcluded.name);
+    dispatch(uiActions.setFileSizeExceededMessage(message));
+  };
+
+  const uploadDocuments = async (documents: DocumentPickerFile[]) => {
     if (!focusedFolder) {
       throw new Error('No current folder found');
     }
 
     await dispatch(storageThunks.ensureMaxUploadFileSizeFresh()).unwrap();
     const { filesToUpload, filesExcluded } = validateAndFilterFiles(documents, maxUploadFileSize);
-    const [firstExcluded, ...remainingExcluded] = filesExcluded;
-    const hasExcluded = firstExcluded !== undefined;
-    const hasMultipleExcluded = remainingExcluded.length > 0;
-    if (hasExcluded) {
-      const message = hasMultipleExcluded
-        ? strings.formatString(strings.modals.FileSizeExceededModal.messageWithCount, filesExcluded.length)
-        : strings.formatString(strings.modals.FileSizeExceededModal.messageWithName, firstExcluded.name);
-      dispatch(uiActions.setFileSizeExceededMessage(message));
-    }
+    notifyFilesExcludedBySize(filesExcluded);
 
     if (filesToUpload.length === 0) {
       dispatch(uiActions.setShowUploadFileModal(false));
@@ -476,7 +478,7 @@ function AddModal(): JSX.Element {
       cleanupStuckUploads(processedFileIds, formattedFiles);
       dispatch(driveActions.clearBatchFiles(batchFileIds));
     });
-  }
+  };
 
   /**
    * Upload multiple files

--- a/src/components/modals/AddModal/index.tsx
+++ b/src/components/modals/AddModal/index.tsx
@@ -169,13 +169,8 @@ function AddModal(): JSX.Element {
     return createdFileEntry;
   }
 
-  const checkFileSizeLimitToUpload = (fileSize: number, fileName: string) => {
+  const checkFileSizeLimitToUpload = (fileSize: number) => {
     if (maxUploadFileSize > 0 && fileSize > maxUploadFileSize) {
-      dispatch(
-        uiActions.setFileSizeExceededMessage(
-          strings.formatString(strings.modals.FileSizeExceededModal.messageWithName, fileName),
-        ),
-      );
       throw new FileSizeExceededError();
     }
     return true;
@@ -203,7 +198,7 @@ function AddModal(): JSX.Element {
     const fileStat = await fileSystemService.stat(filePath);
     // Fix for Android, native document picker not returns the correct fileSize when file is big
     // and cannnot get the stat before we got the file in temporary path
-    checkFileSizeLimitToUpload(fileStat.size, fileName);
+    checkFileSizeLimitToUpload(fileStat.size);
 
     const fileSize = fileStat.size;
 
@@ -355,6 +350,14 @@ function AddModal(): JSX.Element {
       logger.info('File upload process finished');
       dispatch(driveActions.uploadingFileEnd(uploadingFile.id));
     } catch (error) {
+      if (error instanceof FileSizeExceededError) {
+        dispatch(
+          uiActions.setFileSizeExceededMessage(
+            strings.formatString(strings.modals.FileSizeExceededModal.messageWithName, uploadingFile.name),
+          ),
+        );
+        throw error;
+      }
       logger.error('File upload process failed: ', JSON.stringify(error));
       errorService.reportError(error);
       throw error;

--- a/src/components/modals/AddModal/index.tsx
+++ b/src/components/modals/AddModal/index.tsx
@@ -22,6 +22,10 @@ import { useDrive } from '@internxt-mobile/hooks/drive';
 import { imageService, logger } from '@internxt-mobile/services/common';
 import { uploadService } from '@internxt-mobile/services/common/network/upload/upload.service';
 import { EmptyFileNotAllowedError, isEmptyFilePlanError } from '@internxt-mobile/services/drive/file/utils/emptyFileErrors';
+import {
+  FileSizeExceededError,
+  isFileSizeExceededError,
+} from '@internxt-mobile/services/drive/file/utils/fileSizeErrors';
 import drive from '@internxt-mobile/services/drive';
 import {
   generateFileName,
@@ -40,7 +44,7 @@ import {
 } from 'phosphor-react-native';
 import uuid from 'react-native-uuid';
 import { SLEEP_BECAUSE_MAYBE_BACKEND_IS_NOT_RETURNING_FRESHLY_MODIFIED_OR_CREATED_ITEMS_YET } from 'src/helpers/services';
-import { storageSelectors } from 'src/store/slices/storage';
+import { storageSelectors, storageThunks } from 'src/store/slices/storage';
 import { useTailwind } from 'tailwind-rn';
 import strings from '../../../../assets/lang/strings';
 import { isValidFilename } from '../../../helpers';
@@ -54,7 +58,6 @@ import {
   handleDuplicateFiles,
   initializeUploads,
   prepareUploadFiles,
-  showFileSizeAlert,
   uploadSingleFile,
   validateAndFilterFiles,
 } from '../../../services/drive/file/utils/uploadFileUtils';
@@ -67,7 +70,7 @@ import { NotificationType, ProgressCallback } from '../../../types';
 import { DriveEventKey } from '../../../types/drive/events';
 import { useFolderUpload } from './hooks/useFolderUpload';
 
-import { DocumentPickerFile, UPLOAD_FILE_SIZE_LIMIT, UploadingFile } from '../../../types/drive/operations';
+import { DocumentPickerFile, UploadingFile } from '../../../types/drive/operations';
 import AppText from '../../AppText';
 import BottomModal from '../BottomModal';
 import CreateFolderModal from '../CreateFolderModal';
@@ -86,6 +89,7 @@ function AddModal(): JSX.Element {
 
   const { limit } = useAppSelector((state) => state.storage);
   const usage = useAppSelector(storageSelectors.usage);
+  const maxUploadFileSize = useAppSelector(storageSelectors.maxUploadFileSize);
   const user = useAppSelector((state) => state.auth.user);
   const { handleUploadFolder, nameCollisionModal } = useFolderUpload({ uploadAndCreateFileEntry });
 
@@ -161,13 +165,10 @@ function AddModal(): JSX.Element {
     return createdFileEntry;
   }
 
-  const checkFileSizeLimitToUpload = (fileSize: number, fileName: string) => {
-    if (fileSize >= UPLOAD_FILE_SIZE_LIMIT) {
-      const messageKey = strings.messages.uploadFileLimitName;
-
-      const alertText = strings.formatString(messageKey, fileName).toString();
-      Alert.alert(strings.messages.limitPerFile, alertText);
-      throw new Error(`File ${fileName} exceeds upload size limit`);
+  const checkFileSizeLimitToUpload = (fileSize: number) => {
+    if (maxUploadFileSize > 0 && fileSize > maxUploadFileSize) {
+      dispatch(uiActions.setFileSizeExceededMessage(strings.modals.FileSizeExceededModal.message));
+      throw new FileSizeExceededError();
     }
     return true;
   };
@@ -194,7 +195,7 @@ function AddModal(): JSX.Element {
     const fileStat = await fileSystemService.stat(filePath);
     // Fix for Android, native document picker not returns the correct fileSize when file is big
     // and cannnot get the stat before we got the file in temporary path
-    checkFileSizeLimitToUpload(fileStat.size, fileName);
+    checkFileSizeLimitToUpload(fileStat.size);
 
     const fileSize = fileStat.size;
 
@@ -220,6 +221,7 @@ function AddModal(): JSX.Element {
         return { ...entry, thumbnails: [] } as DriveFileData;
       } catch (err) {
         if (isEmptyFilePlanError(err)) throw new EmptyFileNotAllowedError();
+        if (isFileSizeExceededError(err)) throw new FileSizeExceededError();
         throw err;
       }
     }
@@ -259,7 +261,13 @@ function AddModal(): JSX.Element {
     };
 
     let uploadedThumbnail: Thumbnail | null = null;
-    const generatedDriveItem = await uploadService.createFileEntry(fileEntryByUuid);
+    let generatedDriveItem: DriveFileData;
+    try {
+      generatedDriveItem = await uploadService.createFileEntry(fileEntryByUuid);
+    } catch (err) {
+      if (isFileSizeExceededError(err)) throw new FileSizeExceededError();
+      throw err;
+    }
 
     // If thumbnail generation fails, don't block the upload, we can
     // try thumbnail generation later
@@ -408,8 +416,11 @@ function AddModal(): JSX.Element {
       throw new Error('No current folder found');
     }
 
-    const { filesToUpload, filesExcluded } = validateAndFilterFiles(documents);
-    showFileSizeAlert(filesExcluded);
+    await dispatch(storageThunks.ensureMaxUploadFileSizeFresh()).unwrap();
+    const { filesToUpload, filesExcluded } = validateAndFilterFiles(documents, maxUploadFileSize);
+    if (filesExcluded.length > 0) {
+      dispatch(uiActions.setFileSizeExceededMessage(strings.modals.FileSizeExceededModal.message));
+    }
 
     if (filesToUpload.length === 0) {
       dispatch(uiActions.setShowUploadFileModal(false));
@@ -733,6 +744,7 @@ function AddModal(): JSX.Element {
       if (!focusedFolder) {
         throw new Error('No current folder found');
       }
+      await dispatch(storageThunks.ensureMaxUploadFileSizeFresh()).unwrap();
       try {
         const result = await launchCameraAsync({
           mediaTypes: MediaTypeOptions.All,
@@ -793,6 +805,7 @@ function AddModal(): JSX.Element {
           }
         }
       } catch (error) {
+        if (error instanceof FileSizeExceededError) return;
         logger.error('Error on handleTakePhotoAndUpload function:', JSON.stringify(error));
         const castedError = errorService.castError(error, 'upload');
         notificationsService.show({

--- a/src/components/modals/FileSizeExceededModal/index.tsx
+++ b/src/components/modals/FileSizeExceededModal/index.tsx
@@ -33,7 +33,7 @@ function FileSizeExceededModal(): JSX.Element {
             },
           ]}
         >
-          {message ?? strings.modals.FileSizeExceededModal.message}
+          {message}
         </AppText>
         <AppButton title={strings.buttons.close} type="accept" onPress={handleClose} />
       </View>

--- a/src/components/modals/FileSizeExceededModal/index.tsx
+++ b/src/components/modals/FileSizeExceededModal/index.tsx
@@ -1,0 +1,44 @@
+import strings from 'assets/lang/strings';
+import { View } from 'react-native';
+import AppButton from 'src/components/AppButton';
+import AppText from 'src/components/AppText';
+import useGetColor from 'src/hooks/useColor';
+import { useAppDispatch, useAppSelector } from 'src/store/hooks';
+import { uiActions } from 'src/store/slices/ui';
+import { useTailwind } from 'tailwind-rn';
+import CenterModal from '../CenterModal';
+
+function FileSizeExceededModal(): JSX.Element {
+  const tailwind = useTailwind();
+  const getColor = useGetColor();
+  const dispatch = useAppDispatch();
+  const message = useAppSelector((state) => state.ui.fileSizeExceededMessage);
+
+  const handleClose = () => {
+    dispatch(uiActions.setFileSizeExceededMessage(null));
+  };
+
+  return (
+    <CenterModal isOpen={message !== null} onClosed={handleClose} style={{ overflow: 'hidden' }}>
+      <View style={[tailwind('px-4 py-4'), { backgroundColor: getColor('bg-surface') }]}>
+        <AppText medium style={[tailwind('text-xl mb-2'), { color: getColor('text-gray-100') }]}>
+          {strings.modals.FileSizeExceededModal.title}
+        </AppText>
+        <AppText
+          style={[
+            tailwind('mb-6'),
+            {
+              color: getColor('text-gray-60'),
+              lineHeight: (tailwind('text-base').fontSize as number) * 1.4,
+            },
+          ]}
+        >
+          {message ?? strings.modals.FileSizeExceededModal.message}
+        </AppText>
+        <AppButton title={strings.buttons.close} type="accept" onPress={handleClose} />
+      </View>
+    </CenterModal>
+  );
+}
+
+export default FileSizeExceededModal;

--- a/src/navigation/TabExplorerNavigator.tsx
+++ b/src/navigation/TabExplorerNavigator.tsx
@@ -16,6 +16,7 @@ import DriveRenameModal from '../components/modals/DriveRenameModal';
 import MoveItemsModal from '../components/modals/MoveItemsModal';
 import RunOutOfStorageModal from '../components/modals/RunOutOfStorageModal';
 import EmptyFileNotAllowedModal from '../components/modals/EmptyFileNotAllowedModal';
+import FileSizeExceededModal from '../components/modals/FileSizeExceededModal';
 import NotEnoughDeviceSpaceModal from '../components/modals/NotEnoughDeviceSpaceModal';
 import { SharedLinkInfoModal } from '../components/modals/SharedLinkInfoModal';
 import SignOutModal from '../components/modals/SignOutModal';
@@ -89,6 +90,7 @@ export default function TabExplorerNavigator(props: RootStackScreenProps<'TabExp
       <DriveRenameModal />
       <RunOutOfStorageModal />
       <EmptyFileNotAllowedModal />
+      <FileSizeExceededModal />
       <NotEnoughDeviceSpaceModal />
       <SignOutModal />
       <SecurityModal isOpen={isSecurityModalOpen} onClose={onSecurityModalClosed} />

--- a/src/services/StorageService.ts
+++ b/src/services/StorageService.ts
@@ -20,6 +20,15 @@ class StorageService {
     return limit.maxSpaceBytes;
   }
 
+  public async loadMaxUploadFileSize(): Promise<number> {
+    try {
+      const res = (await this.sdk.storageV2.getFileVersionLimits()) as { maxUploadFileSize?: number };
+      return res.maxUploadFileSize ?? 0;
+    } catch {
+      return 0;
+    }
+  }
+
   public async searchItems(search: string, offset: number): Promise<SearchResultData> {
     const [searchData] = await this.sdk.storageV2.getGlobalSearchItems(search, undefined, offset);
     return searchData;

--- a/src/services/drive/file/utils/fileSizeErrors.spec.ts
+++ b/src/services/drive/file/utils/fileSizeErrors.spec.ts
@@ -1,0 +1,34 @@
+import { FileSizeExceededError, isFileSizeExceededError } from './fileSizeErrors';
+
+describe('FileSizeExceededError', () => {
+  test('when constructed, then it has the expected name and message', () => {
+    const err = new FileSizeExceededError();
+    expect(err).toBeInstanceOf(FileSizeExceededError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('FileSizeExceededError');
+    expect(err.message).toBe('File size exceeds the maximum allowed by your plan');
+  });
+});
+
+describe('isFileSizeExceededError', () => {
+  test('when error has response.data.error = FILE_UPLOAD_SIZE_EXCEEDED, then it returns true', () => {
+    expect(isFileSizeExceededError({ response: { data: { error: 'FILE_UPLOAD_SIZE_EXCEEDED' } } })).toBe(true);
+  });
+
+  test('when error has bare data.error = FILE_UPLOAD_SIZE_EXCEEDED, then it returns true', () => {
+    expect(isFileSizeExceededError({ data: { error: 'FILE_UPLOAD_SIZE_EXCEEDED' } })).toBe(true);
+  });
+
+  test('when error has a different error code, then it returns false', () => {
+    expect(isFileSizeExceededError({ response: { data: { error: 'SOMETHING_ELSE' } } })).toBe(false);
+  });
+
+  test('when error is null or undefined, then it returns false', () => {
+    expect(isFileSizeExceededError(null)).toBe(false);
+    expect(isFileSizeExceededError(undefined)).toBe(false);
+  });
+
+  test('when error has no response/data field, then it returns false', () => {
+    expect(isFileSizeExceededError(new Error('boom'))).toBe(false);
+  });
+});

--- a/src/services/drive/file/utils/fileSizeErrors.ts
+++ b/src/services/drive/file/utils/fileSizeErrors.ts
@@ -1,0 +1,12 @@
+export class FileSizeExceededError extends Error {
+  constructor() {
+    super('File size exceeds the maximum allowed by your plan');
+    this.name = 'FileSizeExceededError';
+    Object.setPrototypeOf(this, FileSizeExceededError.prototype);
+  }
+}
+
+export const isFileSizeExceededError = (error: unknown): boolean => {
+  const e = error as { response?: { data?: { error?: string } }; data?: { error?: string } };
+  return e?.response?.data?.error === 'FILE_UPLOAD_SIZE_EXCEEDED' || e?.data?.error === 'FILE_UPLOAD_SIZE_EXCEEDED';
+};

--- a/src/services/drive/file/utils/fileSizeErrors.ts
+++ b/src/services/drive/file/utils/fileSizeErrors.ts
@@ -1,3 +1,7 @@
+import type { Dispatch } from 'redux';
+import strings from '../../../../../assets/lang/strings';
+import { uiActions } from '../../../../store/slices/ui';
+
 export class FileSizeExceededError extends Error {
   constructor() {
     super('File size exceeds the maximum allowed by your plan');
@@ -9,4 +13,14 @@ export class FileSizeExceededError extends Error {
 export const isFileSizeExceededError = (error: unknown): boolean => {
   const e = error as { response?: { data?: { error?: string } }; data?: { error?: string } };
   return e?.response?.data?.error === 'FILE_UPLOAD_SIZE_EXCEEDED' || e?.data?.error === 'FILE_UPLOAD_SIZE_EXCEEDED';
+};
+
+export const notifyFilesExcludedBySize = (excluded: { name: string }[], dispatch: Dispatch) => {
+  const [firstExcluded, ...remainingExcluded] = excluded;
+  if (firstExcluded === undefined) return;
+  const hasMultipleExcluded = remainingExcluded.length > 0;
+  const message = hasMultipleExcluded
+    ? strings.formatString(strings.modals.FileSizeExceededModal.messageWithCount, excluded.length)
+    : strings.formatString(strings.modals.FileSizeExceededModal.messageWithName, firstExcluded.name);
+  dispatch(uiActions.setFileSizeExceededMessage(message));
 };

--- a/src/services/drive/file/utils/uploadFileUtils.ts
+++ b/src/services/drive/file/utils/uploadFileUtils.ts
@@ -1,14 +1,8 @@
 import { Alert } from 'react-native';
 import uuid from 'react-native-uuid';
 import strings from '../../../../../assets/lang/strings';
-import { isValidFilename } from '../../../../helpers';
 import { driveActions } from '../../../../store/slices/drive';
-import {
-  DocumentPickerFile,
-  FileToUpload,
-  UPLOAD_FILE_SIZE_LIMIT,
-  UploadingFile,
-} from '../../../../types/drive/operations';
+import { DocumentPickerFile, FileToUpload, UploadingFile } from '../../../../types/drive/operations';
 import { checkDuplicatedFiles, File } from './checkDuplicatedFiles';
 import { prepareFilesToUpload } from './prepareFilesToUpload';
 
@@ -25,48 +19,10 @@ import analyticsService, { DriveAnalyticsEvent } from '../../../AnalyticsService
 import { logger } from '../../../common';
 import { uploadService } from '../../../common/network/upload/upload.service';
 import { EmptyFileNotAllowedError, isEmptyFilePlanError } from './emptyFileErrors';
+import { FileSizeExceededError, isFileSizeExceededError } from './fileSizeErrors';
 import { BucketNotFoundError } from './upload.errors';
 
-/**
- * Validate file names and filter out files exceeding the upload size limit.
- *
- * @param {DocumentPickerFile[]} documents - Array of selected documents.
- * @returns {{ filesToUpload: DocumentPickerFile[], filesExcluded: DocumentPickerFile[] }}
- */
-export function validateAndFilterFiles(documents: DocumentPickerFile[]) {
-  const filesToUpload: DocumentPickerFile[] = [];
-  const filesExcluded: DocumentPickerFile[] = [];
-
-  const invalidFiles = documents.filter((file) => !isValidFilename(file.name));
-
-  if (invalidFiles.length > 0) {
-    const invalidFileNames = invalidFiles.map((f) => f.name).join(', ');
-    throw new Error(`Invalid file names: ${invalidFileNames}`);
-  }
-
-  for (const file of documents) {
-    if (file.size <= UPLOAD_FILE_SIZE_LIMIT) {
-      filesToUpload.push(file);
-    } else {
-      filesExcluded.push(file);
-    }
-  }
-
-  return { filesToUpload, filesExcluded };
-}
-
-/**
- * Show an alert when some files exceed the upload size limit.
- *
- * @param {DocumentPickerFile[]} filesExcluded - Files that were excluded due to size.
- */
-export function showFileSizeAlert(filesExcluded: DocumentPickerFile[]) {
-  if (filesExcluded.length === 0) return;
-
-  const messageKey = filesExcluded.length === 1 ? strings.messages.uploadFileLimit : strings.messages.uploadFilesLimit;
-  const alertText = strings.formatString(messageKey, filesExcluded.length).toString();
-  Alert.alert(strings.messages.limitPerFile, alertText);
-}
+export { validateAndFilterFiles } from './validateAndFilterFiles';
 
 /**
  * Handle duplicate files by checking for existing files in the target folder and optionally prompting the user.
@@ -238,6 +194,7 @@ export async function createEmptyFileEntry(bucketId: string, file: UploadingFile
     return await uploadService.createFileEntry(fileEntry);
   } catch (err) {
     if (isEmptyFilePlanError(err)) throw new EmptyFileNotAllowedError();
+    if (isFileSizeExceededError(err)) throw new FileSizeExceededError();
     throw err;
   }
 }
@@ -274,6 +231,11 @@ export async function uploadSingleFile(
   } catch (e) {
     if (e instanceof EmptyFileNotAllowedError) {
       dispatch(uiActions.setShowEmptyFileNotAllowedModal(true));
+      dispatch(driveActions.uploadFileFinished());
+      return;
+    }
+    if (e instanceof FileSizeExceededError) {
+      dispatch(uiActions.setFileSizeExceededMessage(strings.modals.FileSizeExceededModal.message));
       dispatch(driveActions.uploadFileFinished());
       return;
     }

--- a/src/services/drive/file/utils/uploadFileUtils.ts
+++ b/src/services/drive/file/utils/uploadFileUtils.ts
@@ -235,7 +235,11 @@ export async function uploadSingleFile(
       return;
     }
     if (e instanceof FileSizeExceededError) {
-      dispatch(uiActions.setFileSizeExceededMessage(strings.modals.FileSizeExceededModal.message));
+      dispatch(
+        uiActions.setFileSizeExceededMessage(
+          strings.formatString(strings.modals.FileSizeExceededModal.messageWithName, file.name),
+        ),
+      );
       dispatch(driveActions.uploadFileFinished());
       return;
     }
@@ -254,4 +258,3 @@ export async function uploadSingleFile(
     dispatch(driveActions.uploadFileFinished());
   }
 }
-

--- a/src/services/drive/file/utils/validateAndFilterFiles.spec.ts
+++ b/src/services/drive/file/utils/validateAndFilterFiles.spec.ts
@@ -1,0 +1,53 @@
+import { DocumentPickerFile } from '../../../../types/drive/operations';
+import { validateAndFilterFiles } from './validateAndFilterFiles';
+
+const makeFile = (name: string, size: number): DocumentPickerFile => ({
+  uri: `file:///tmp/${name}`,
+  name,
+  size,
+  type: 'application/octet-stream',
+});
+
+describe('validateAndFilterFiles', () => {
+  test('when maxUploadFileSize is 0, then no file is filtered regardless of size', () => {
+    const documents = [makeFile('small.pdf', 10), makeFile('huge.bin', 50 * 1024 * 1024 * 1024)];
+
+    const result = validateAndFilterFiles(documents, 0);
+
+    expect(result.filesToUpload).toHaveLength(2);
+    expect(result.filesExcluded).toHaveLength(0);
+  });
+
+  test('when files are within the limit, then all are accepted', () => {
+    const documents = [makeFile('a.pdf', 1024), makeFile('b.pdf', 2048)];
+
+    const result = validateAndFilterFiles(documents, 4096);
+
+    expect(result.filesToUpload).toHaveLength(2);
+    expect(result.filesExcluded).toHaveLength(0);
+  });
+
+  test('when a file equals the limit, then it is accepted (inclusive boundary)', () => {
+    const documents = [makeFile('exact.pdf', 1000)];
+
+    const result = validateAndFilterFiles(documents, 1000);
+
+    expect(result.filesToUpload).toEqual(documents);
+    expect(result.filesExcluded).toHaveLength(0);
+  });
+
+  test('when a file exceeds the limit, then it is excluded', () => {
+    const documents = [makeFile('ok.pdf', 500), makeFile('too-big.pdf', 5000)];
+
+    const result = validateAndFilterFiles(documents, 1000);
+
+    expect(result.filesToUpload).toEqual([documents[0]]);
+    expect(result.filesExcluded).toEqual([documents[1]]);
+  });
+
+  test('when a filename is invalid, then it throws', () => {
+    const documents = [makeFile('..', 100)];
+
+    expect(() => validateAndFilterFiles(documents, 1000)).toThrow(/Invalid file names/);
+  });
+});

--- a/src/services/drive/file/utils/validateAndFilterFiles.ts
+++ b/src/services/drive/file/utils/validateAndFilterFiles.ts
@@ -1,0 +1,26 @@
+import { isValidFilename } from '../../../../helpers';
+import { DocumentPickerFile } from '../../../../types/drive/operations';
+
+/**
+ * Validate file names and filter out files exceeding the plan's max upload size.
+ * `maxUploadFileSize === 0` means unlimited/unknown — no filtering.
+ */
+export function validateAndFilterFiles(documents: DocumentPickerFile[], maxUploadFileSize: number) {
+  const invalidFiles = documents.filter((file) => !isValidFilename(file.name));
+  if (invalidFiles.length > 0) {
+    const invalidFileNames = invalidFiles.map((f) => f.name).join(', ');
+    throw new Error(`Invalid file names: ${invalidFileNames}`);
+  }
+
+  const filesToUpload: DocumentPickerFile[] = [];
+  const filesExcluded: DocumentPickerFile[] = [];
+  for (const file of documents) {
+    if (maxUploadFileSize === 0 || file.size <= maxUploadFileSize) {
+      filesToUpload.push(file);
+    } else {
+      filesExcluded.push(file);
+    }
+  }
+
+  return { filesToUpload, filesExcluded };
+}

--- a/src/services/drive/folder/folderOrchestration.service.ts
+++ b/src/services/drive/folder/folderOrchestration.service.ts
@@ -1,5 +1,6 @@
 import { logger } from '@internxt-mobile/services/common';
 import { EmptyFileNotAllowedError } from '@internxt-mobile/services/drive/file/utils/emptyFileErrors';
+import { FileSizeExceededError } from '@internxt-mobile/services/drive/file/utils/fileSizeErrors';
 import pLimit from 'p-limit';
 import { AbortError } from '../../../network/errors';
 import { FolderTree, FolderTreeNode, FolderUploadResult, UploadFileCallback } from '../../../types/drive/folderUpload';
@@ -177,6 +178,9 @@ export const uploadFolderContents = async ({
           } else if (err instanceof EmptyFileNotAllowedError) {
             skippedFiles++;
             logger.info(TAG, `skipped empty file: "${file.relativePath}" (plan restriction)`);
+          } else if (err instanceof FileSizeExceededError) {
+            skippedFiles++;
+            logger.info(TAG, `skipped oversized file: "${file.relativePath}" (plan restriction)`);
           } else {
             failedFiles++;
             logger.error(TAG, `failed creation: "${file.relativePath}": ${error.message}`);

--- a/src/services/drive/folder/utils/filterOversizedFromTree.spec.ts
+++ b/src/services/drive/folder/utils/filterOversizedFromTree.spec.ts
@@ -1,0 +1,90 @@
+import { FolderTree, FolderTreeNode } from '../../../../types/drive/folderUpload';
+import { filterOversizedFromTree } from './filterOversizedFromTree';
+
+const mockNotify = jest.fn();
+jest.mock('../../file/utils/fileSizeErrors', () => ({
+  notifyFilesExcludedBySize: (...args: unknown[]) => mockNotify(...args),
+}));
+
+const makeFile = (name: string, size: number): FolderTreeNode => ({
+  name,
+  size,
+  uri: `file:///tmp/${name}`,
+  relativePath: name,
+  parentPath: '',
+  isDirectory: false,
+});
+
+const makeTree = (files: FolderTreeNode[]): FolderTree => ({ files, dirs: [] });
+
+describe('filterOversizedFromTree', () => {
+  beforeEach(() => {
+    mockNotify.mockReset();
+  });
+
+  test('when maxUploadFileSize is 0 (unlimited/unknown), then it skips filtering and does not notify', () => {
+    const tree = makeTree([makeFile('a.pdf', 10), makeFile('huge.bin', 50 * 1024 * 1024 * 1024)]);
+    const dispatch = jest.fn();
+
+    const result = filterOversizedFromTree(tree, 0, dispatch);
+
+    expect(result).toEqual([]);
+    expect(tree.files).toHaveLength(2);
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  test('when a file equals the limit, then it is kept (inclusive boundary)', () => {
+    const exact = makeFile('exact.bin', 1000);
+    const tree = makeTree([exact]);
+    const dispatch = jest.fn();
+
+    const result = filterOversizedFromTree(tree, 1000, dispatch);
+
+    expect(result).toEqual([]);
+    expect(tree.files).toEqual([exact]);
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  test('when some files exceed the limit, then it returns and removes only those, keeping the rest', () => {
+    const small = makeFile('small.pdf', 100);
+    const big = makeFile('big.pdf', 5000);
+    const tree = makeTree([small, big]);
+    const dispatch = jest.fn();
+
+    const result = filterOversizedFromTree(tree, 1000, dispatch);
+
+    expect(result).toEqual([big]);
+    expect(tree.files).toEqual([small]);
+    expect(mockNotify).toHaveBeenCalledWith([big], dispatch);
+  });
+
+  test('when every file exceeds the limit, then it returns all of them and empties tree.files', () => {
+    const big1 = makeFile('big1.pdf', 5000);
+    const big2 = makeFile('big2.pdf', 6000);
+    const tree = makeTree([big1, big2]);
+    const dispatch = jest.fn();
+
+    const result = filterOversizedFromTree(tree, 1000, dispatch);
+
+    expect(result).toEqual([big1, big2]);
+    expect(tree.files).toEqual([]);
+    expect(mockNotify).toHaveBeenCalledWith([big1, big2], dispatch);
+  });
+
+  test('when filtering runs, then tree.dirs is left unchanged', () => {
+    const dir: FolderTreeNode = {
+      name: 'sub',
+      size: 0,
+      uri: 'file:///tmp/sub',
+      relativePath: 'sub',
+      parentPath: '',
+      isDirectory: true,
+    };
+    const tree: FolderTree = { files: [makeFile('big.pdf', 5000)], dirs: [dir] };
+    const dispatch = jest.fn();
+
+    filterOversizedFromTree(tree, 1000, dispatch);
+
+    expect(tree.dirs).toEqual([dir]);
+  });
+});

--- a/src/services/drive/folder/utils/filterOversizedFromTree.ts
+++ b/src/services/drive/folder/utils/filterOversizedFromTree.ts
@@ -1,0 +1,20 @@
+import type { Dispatch } from 'redux';
+import { notifyFilesExcludedBySize } from '../../file/utils/fileSizeErrors';
+import { FolderTree, FolderTreeNode } from '../../../../types/drive/folderUpload';
+
+/**
+ * Removes files exceeding `maxUploadFileSize` from `tree.files` in place and
+ * notifies the user. `maxUploadFileSize <= 0` means unlimited/unknown — skip.
+ */
+export const filterOversizedFromTree = (
+  tree: FolderTree,
+  maxUploadFileSize: number,
+  dispatch: Dispatch,
+): FolderTreeNode[] => {
+  if (maxUploadFileSize <= 0) return [];
+  const oversizedFiles = tree.files.filter((file) => file.size > maxUploadFileSize);
+  if (oversizedFiles.length === 0) return [];
+  notifyFilesExcludedBySize(oversizedFiles, dispatch);
+  tree.files = tree.files.filter((file) => file.size <= maxUploadFileSize);
+  return oversizedFiles;
+};

--- a/src/shareExtension/errors.ts
+++ b/src/shareExtension/errors.ts
@@ -1,4 +1,5 @@
 export { EmptyFileNotAllowedError, isEmptyFilePlanError } from '../services/drive/file/utils/emptyFileErrors';
+export { FileSizeExceededError, isFileSizeExceededError } from '../services/drive/file/utils/fileSizeErrors';
 
 export class HttpUploadError extends Error {
   constructor(

--- a/src/shareExtension/hooks/useShareUpload.ts
+++ b/src/shareExtension/hooks/useShareUpload.ts
@@ -1,13 +1,20 @@
 import * as RNFS from '@dr.pogodin/react-native-fs';
 import { useCallback, useRef, useState } from 'react';
 import { NativeModules, Platform } from 'react-native';
-import { EmptyFileNotAllowedError, HttpUploadError, MissingFileUriError, UploadNetworkError } from '../errors';
+import {
+  EmptyFileNotAllowedError,
+  FileSizeExceededError,
+  HttpUploadError,
+  MissingFileUriError,
+  UploadNetworkError,
+} from '../errors';
 import {
   ShareUploadCredentials,
   ShareUploadSession,
   createShareUploadSession,
   shareUploadFile,
 } from '../services/shareUploadService';
+import ShareSdkManager from '../services/ShareSdkManager';
 import {
   CollisionState,
   NameCollisionAction,
@@ -69,6 +76,7 @@ interface FailedFile {
 }
 
 const classifyError = (error: unknown): UploadErrorType => {
+  if (error instanceof FileSizeExceededError) return 'file_too_large';
   if (error instanceof EmptyFileNotAllowedError) return 'payment_required';
   if (error instanceof HttpUploadError) {
     if (error.status === HTTP_STATUS.UNAUTHORIZED || error.status === HTTP_STATUS.FORBIDDEN) return 'session_expired';
@@ -78,6 +86,15 @@ const classifyError = (error: unknown): UploadErrorType => {
   if (error instanceof MissingFileUriError) return 'prep_failed';
   if (error instanceof UploadNetworkError) return 'no_internet';
   return 'general';
+};
+
+const fetchMaxUploadFileSize = async (): Promise<number> => {
+  try {
+    const res = (await ShareSdkManager.storageV2.getFileVersionLimits()) as { maxUploadFileSize?: number };
+    return res.maxUploadFileSize ?? 0;
+  } catch {
+    return 0;
+  }
 };
 
 const buildProgressState =
@@ -96,6 +113,7 @@ interface ProcessFileParams {
   folderUuid: string;
   credentials: ShareUploadCredentials;
   shareUploadSession: ShareUploadSession;
+  maxUploadFileSize: number;
 }
 
 interface ProcessFileCallbacks {
@@ -123,6 +141,7 @@ const uploadFile = async (
     folderUuid,
     credentials,
     shareUploadSession,
+    maxUploadFileSize,
   }: ProcessFileParams,
   { onProgress, onFileUploaded }: ProcessFileCallbacks,
 ): Promise<string | null> => {
@@ -146,6 +165,7 @@ const uploadFile = async (
     folderUuid,
     credentials,
     shareUploadSession,
+    maxUploadFileSize,
     onFileResolved: (resolvedFileSize) => onProgress({ currentFileSize: resolvedFileSize, bytesUploaded: 0 }),
     onProgress: (bytesUploaded) => onProgress({ bytesUploaded }),
   });
@@ -195,6 +215,7 @@ export const useShareUpload = ({ onFileUploaded }: UseShareUploadOptions = {}): 
       try {
         const isSingleFile = files.length === 1;
         const shareUploadSession = createShareUploadSession(credentials);
+        const maxUploadFileSize = await fetchMaxUploadFileSize();
 
         const renameMap = await resolveCollisions(files, folderUuid, isSingleFile, renamedFileName);
         if (renameMap === null) {
@@ -222,6 +243,7 @@ export const useShareUpload = ({ onFileUploaded }: UseShareUploadOptions = {}): 
                 folderUuid,
                 credentials,
                 shareUploadSession,
+                maxUploadFileSize,
               },
               {
                 onProgress: (fields: Partial<UploadProgress>) => setProgress(buildProgressState(fields)),

--- a/src/shareExtension/services/shareUploadService.ts
+++ b/src/shareExtension/services/shareUploadService.ts
@@ -9,7 +9,14 @@ import { Platform } from 'react-native';
 import ReactNativeBlobUtil, { FetchBlobResponse } from 'react-native-blob-util';
 import uuid from 'react-native-uuid';
 import packageJson from '../../../package.json';
-import { EmptyFileNotAllowedError, HttpUploadError, isEmptyFilePlanError, UploadNetworkError } from '../errors';
+import {
+  EmptyFileNotAllowedError,
+  FileSizeExceededError,
+  HttpUploadError,
+  isEmptyFilePlanError,
+  isFileSizeExceededError,
+  UploadNetworkError,
+} from '../errors';
 import {
   buildSdkEncryptionAdapter,
   computeRipemd160Digest,
@@ -39,6 +46,7 @@ export interface ShareUploadFileParams {
   folderUuid: string;
   credentials: ShareUploadCredentials;
   shareUploadSession?: ShareUploadSession;
+  maxUploadFileSize?: number;
   onFileResolved?: (fileSize: number) => void;
   onProgress?: (bytesUploaded: number) => void;
 }
@@ -180,17 +188,22 @@ const createFileEntry = async (
   folderUuid: string,
 ) => {
   const now = new Date().toISOString();
-  return ShareSdkManager.storageV2.createFileEntryByUuid({
-    fileId,
-    type: fileExtension,
-    size: fileSize,
-    plainName: fileName,
-    bucket,
-    folderUuid,
-    encryptVersion: EncryptionVersion.Aes03,
-    modificationTime: now,
-    creationTime: now,
-  });
+  try {
+    return await ShareSdkManager.storageV2.createFileEntryByUuid({
+      fileId,
+      type: fileExtension,
+      size: fileSize,
+      plainName: fileName,
+      bucket,
+      folderUuid,
+      encryptVersion: EncryptionVersion.Aes03,
+      modificationTime: now,
+      creationTime: now,
+    });
+  } catch (err) {
+    if (isFileSizeExceededError(err)) throw new FileSizeExceededError();
+    throw err;
+  }
 };
 
 interface UploadFileContext {
@@ -320,8 +333,17 @@ const uploadEmptyFile = async (
 };
 
 export const shareUploadFile = async (params: ShareUploadFileParams): Promise<ShareUploadFileResult> => {
-  const { filePath, fileName, fileExtension, folderUuid, credentials, shareUploadSession, onFileResolved, onProgress } =
-    params;
+  const {
+    filePath,
+    fileName,
+    fileExtension,
+    folderUuid,
+    credentials,
+    shareUploadSession,
+    maxUploadFileSize,
+    onFileResolved,
+    onProgress,
+  } = params;
   const { mnemonic, bucket } = credentials;
 
   const { localPath, fileSize, tempPath: androidTempCopyPath } = await resolveInputFile(filePath);
@@ -334,6 +356,10 @@ export const shareUploadFile = async (params: ShareUploadFileParams): Promise<Sh
   };
 
   try {
+    if (maxUploadFileSize && maxUploadFileSize > 0 && fileSize > maxUploadFileSize) {
+      throw new FileSizeExceededError();
+    }
+
     if (fileSize === 0) {
       return await uploadEmptyFile(fileExtension, fileName, bucket, folderUuid);
     }

--- a/src/shareExtension/services/shareUploadService.ts
+++ b/src/shareExtension/services/shareUploadService.ts
@@ -356,7 +356,8 @@ export const shareUploadFile = async (params: ShareUploadFileParams): Promise<Sh
   };
 
   try {
-    if (maxUploadFileSize && maxUploadFileSize > 0 && fileSize > maxUploadFileSize) {
+    const isFileSizeExceeded = !!maxUploadFileSize && maxUploadFileSize > 0 && fileSize > maxUploadFileSize;
+    if (isFileSizeExceeded) {
       throw new FileSizeExceededError();
     }
 

--- a/src/shareExtension/types.ts
+++ b/src/shareExtension/types.ts
@@ -32,6 +32,7 @@ export type UploadErrorType =
   | 'session_expired'
   | 'prep_failed'
   | 'file_already_exists'
+  | 'file_too_large'
   | 'payment_required';
 
 export interface UploadProgress {

--- a/src/shareExtension/utils.spec.ts
+++ b/src/shareExtension/utils.spec.ts
@@ -1,4 +1,13 @@
-import { formatBytes, getFileExtension, getFileNameWithoutExtension, getMimeTypeFromUri, toDisplayUri } from './utils';
+import strings from '../../assets/lang/strings';
+import { FileSizeExceededError } from './errors';
+import {
+  formatBytes,
+  getFileExtension,
+  getFileNameWithoutExtension,
+  getMimeTypeFromUri,
+  getUploadErrorMessage,
+  toDisplayUri,
+} from './utils';
 
 describe('toDisplayUri', () => {
   test('when given a raw filesystem path, then it prepends file://', () => {
@@ -17,12 +26,8 @@ describe('toDisplayUri', () => {
     expect(toDisplayUri('content://media/external/images/media/42')).toBe('content://media/external/images/media/42');
   });
 
-  test('when given an https:// URI, then it returns it unchanged', () => {
+  test('when given a URI starting with http, then it returns it unchanged', () => {
     expect(toDisplayUri('https://example.com/image.jpg')).toBe('https://example.com/image.jpg');
-  });
-
-  test('when given an http:// URI, then it returns it unchanged', () => {
-    expect(toDisplayUri('http://example.com/image.jpg')).toBe('http://example.com/image.jpg');
   });
 });
 
@@ -81,7 +86,19 @@ describe('getMimeTypeFromUri', () => {
 });
 
 describe('formatBytes', () => {
-  test('when given a byte count, then it returns a non-empty human-readable string', () => {
-    expect(formatBytes(1024)).toBeTruthy();
+  test('when given 1024 bytes, then it returns "1 kB"', () => {
+    expect(formatBytes(1024)).toBe('1 kB');
+  });
+});
+
+describe('getUploadErrorMessage', () => {
+  test('when errorType is "file_too_large", then it returns the localized text and ignores the raw error', () => {
+    const raw = new FileSizeExceededError();
+    expect(getUploadErrorMessage('file_too_large')).toBe(strings.screens.ShareExtension.errorFileTooLarge);
+    expect(getUploadErrorMessage('file_too_large', raw)).toBe(strings.screens.ShareExtension.errorFileTooLarge);
+  });
+
+  test('when errorType is null, then it falls back to the generic error string', () => {
+    expect(getUploadErrorMessage(null)).toBe(strings.screens.ShareExtension.errorGeneral);
   });
 });

--- a/src/shareExtension/utils.ts
+++ b/src/shareExtension/utils.ts
@@ -100,6 +100,8 @@ export const getUploadErrorMessage = (errorType: UploadErrorType | null, rawErro
       return shareExtensionTexts.errorFileAlreadyExists;
     case 'payment_required':
       return shareExtensionTexts.errorPaymentRequired;
+    case 'file_too_large':
+      return shareExtensionTexts.errorFileTooLarge;
     case 'general':
       return extractErrorMessage(rawError) ?? shareExtensionTexts.errorGeneral;
     default:

--- a/src/store/slices/storage/index.ts
+++ b/src/store/slices/storage/index.ts
@@ -8,12 +8,18 @@ import { driveThunks } from '../drive';
 export interface StorageState {
   limit: number;
   totalUsage: number;
+  maxUploadFileSize: number;
+  maxUploadFileSizeFetchedAt: number;
 }
 
 const initialState: StorageState = {
   limit: 0,
   totalUsage: 0,
+  maxUploadFileSize: 0,
+  maxUploadFileSizeFetchedAt: 0,
 };
+
+const MAX_UPLOAD_FILE_SIZE_TTL_MS = 60_000;
 
 const initializeThunk = createAsyncThunk<void, void, { state: RootState }>(
   'storage/initialize',
@@ -23,6 +29,7 @@ const initializeThunk = createAsyncThunk<void, void, { state: RootState }>(
     if (user) {
       dispatch(loadLimitThunk());
       dispatch(loadStorageUsageThunk());
+      dispatch(loadMaxUploadFileSizeThunk());
     }
   },
 );
@@ -30,6 +37,22 @@ const initializeThunk = createAsyncThunk<void, void, { state: RootState }>(
 const loadLimitThunk = createAsyncThunk<number, void, { state: RootState }>('storage/loadLimit', async () => {
   return storageService.loadLimit();
 });
+
+const loadMaxUploadFileSizeThunk = createAsyncThunk<number, void, { state: RootState }>(
+  'storage/loadMaxUploadFileSize',
+  async () => {
+    return storageService.loadMaxUploadFileSize();
+  },
+);
+
+const ensureMaxUploadFileSizeFresh = createAsyncThunk<void, void, { state: RootState }>(
+  'storage/ensureMaxUploadFileSizeFresh',
+  async (_, { dispatch, getState }) => {
+    const { maxUploadFileSizeFetchedAt } = getState().storage;
+    if (Date.now() - maxUploadFileSizeFetchedAt < MAX_UPLOAD_FILE_SIZE_TTL_MS) return;
+    await dispatch(loadMaxUploadFileSizeThunk()).unwrap();
+  },
+);
 
 const loadStorageUsageThunk = createAsyncThunk<void, void, { state: RootState }>(
   'storage/loadUsage',
@@ -73,6 +96,10 @@ export const storageSlice = createSlice({
     builder.addCase(loadLimitThunk.fulfilled, (state, action) => {
       state.limit = action.payload;
     });
+    builder.addCase(loadMaxUploadFileSizeThunk.fulfilled, (state, action) => {
+      state.maxUploadFileSize = action.payload;
+      state.maxUploadFileSizeFetchedAt = Date.now();
+    });
   },
 });
 
@@ -82,6 +109,7 @@ export const storageSelectors = {
     return state.storage.limit - state.drive.usage;
   },
   usagePercent: (state: RootState) => Math.round((state.drive.usage / state.storage.limit) * 100),
+  maxUploadFileSize: (state: RootState) => state.storage.maxUploadFileSize,
 };
 
 export const storageActions = storageSlice.actions;
@@ -90,6 +118,8 @@ export const storageThunks = {
   initializeThunk,
   loadLimitThunk,
   loadStorageUsageThunk,
+  loadMaxUploadFileSizeThunk,
+  ensureMaxUploadFileSizeFresh,
 };
 
 export default storageSlice.reducer;

--- a/src/store/slices/storage/storage.maxUploadFileSize.spec.ts
+++ b/src/store/slices/storage/storage.maxUploadFileSize.spec.ts
@@ -1,0 +1,97 @@
+import { configureStore } from '@reduxjs/toolkit';
+
+const mockLoadMaxUploadFileSize = jest.fn();
+jest.mock('src/services/StorageService', () => ({
+  __esModule: true,
+  default: {
+    loadMaxUploadFileSize: () => mockLoadMaxUploadFileSize(),
+    loadLimit: jest.fn(),
+  },
+}));
+
+jest.mock('../drive', () => ({
+  driveThunks: { loadUsageThunk: () => ({ type: 'drive/loadUsage/mocked' }) },
+}));
+
+jest.mock('@internxt-mobile/services/AnalyticsService', () => ({
+  __esModule: true,
+  default: { identify: jest.fn(), track: jest.fn() },
+  AnalyticsEventKey: { Usage: 'usage' },
+}));
+
+import storageReducer, { storageThunks } from './index';
+
+const makeStore = (preloaded?: Parameters<typeof storageReducer>[0]) => {
+  const store = configureStore({
+    reducer: { storage: storageReducer },
+    preloadedState: preloaded ? { storage: preloaded } : undefined,
+  });
+  return store as unknown as {
+    dispatch: (action: unknown) => Promise<unknown>;
+    getState: () => { storage: ReturnType<typeof storageReducer> };
+  };
+};
+
+describe('loadMaxUploadFileSizeThunk', () => {
+  beforeEach(() => {
+    mockLoadMaxUploadFileSize.mockReset();
+  });
+
+  test('when fulfilled, then it stores the value and a recent fetchedAt timestamp', async () => {
+    mockLoadMaxUploadFileSize.mockResolvedValue(2048);
+    const store = makeStore();
+    const before = Date.now();
+
+    await store.dispatch(storageThunks.loadMaxUploadFileSizeThunk());
+
+    const state = store.getState().storage;
+    expect(state.maxUploadFileSize).toBe(2048);
+    expect(state.maxUploadFileSizeFetchedAt).toBeGreaterThanOrEqual(before);
+  });
+});
+
+describe('ensureMaxUploadFileSizeFresh', () => {
+  beforeEach(() => {
+    mockLoadMaxUploadFileSize.mockReset();
+  });
+
+  test('when last fetch is within the TTL, then it does not refetch', async () => {
+    mockLoadMaxUploadFileSize.mockResolvedValue(999);
+    const store = makeStore({
+      limit: 0,
+      totalUsage: 0,
+      maxUploadFileSize: 100,
+      maxUploadFileSizeFetchedAt: Date.now() - 10_000,
+    });
+
+    await store.dispatch(storageThunks.ensureMaxUploadFileSizeFresh());
+
+    expect(mockLoadMaxUploadFileSize).not.toHaveBeenCalled();
+    expect(store.getState().storage.maxUploadFileSize).toBe(100);
+  });
+
+  test('when last fetch is older than the TTL, then it refetches', async () => {
+    mockLoadMaxUploadFileSize.mockResolvedValue(5000);
+    const store = makeStore({
+      limit: 0,
+      totalUsage: 0,
+      maxUploadFileSize: 100,
+      maxUploadFileSizeFetchedAt: Date.now() - 120_000,
+    });
+
+    await store.dispatch(storageThunks.ensureMaxUploadFileSizeFresh());
+
+    expect(mockLoadMaxUploadFileSize).toHaveBeenCalledTimes(1);
+    expect(store.getState().storage.maxUploadFileSize).toBe(5000);
+  });
+
+  test('when never fetched (fetchedAt = 0), then it fetches', async () => {
+    mockLoadMaxUploadFileSize.mockResolvedValue(1);
+    const store = makeStore();
+
+    await store.dispatch(storageThunks.ensureMaxUploadFileSizeFresh());
+
+    expect(mockLoadMaxUploadFileSize).toHaveBeenCalledTimes(1);
+    expect(store.getState().storage.maxUploadFileSize).toBe(1);
+  });
+});

--- a/src/store/slices/ui/index.ts
+++ b/src/store/slices/ui/index.ts
@@ -26,6 +26,7 @@ export interface UIState {
   isCancelSubscriptionModalOpen: boolean;
   isSharedLinkOptionsModalOpen: boolean;
   showEmptyFileNotAllowedModal: boolean;
+  fileSizeExceededMessage: string | null;
   showNotEnoughDeviceSpaceModal: boolean;
 }
 
@@ -54,6 +55,7 @@ const initialState: UIState = {
   isCancelSubscriptionModalOpen: false,
   isSharedLinkOptionsModalOpen: false,
   showEmptyFileNotAllowedModal: false,
+  fileSizeExceededMessage: null,
   showNotEnoughDeviceSpaceModal: false,
 };
 
@@ -130,6 +132,9 @@ export const uiSlice = createSlice({
     },
     setShowEmptyFileNotAllowedModal: (state, action: PayloadAction<boolean>) => {
       state.showEmptyFileNotAllowedModal = action.payload;
+    },
+    setFileSizeExceededMessage: (state, action: PayloadAction<string | null>) => {
+      state.fileSizeExceededMessage = action.payload;
     },
     setShowNotEnoughDeviceSpaceModal: (state, action: PayloadAction<boolean>) => {
       state.showNotEnoughDeviceSpaceModal = action.payload;

--- a/src/types/drive/operations.ts
+++ b/src/types/drive/operations.ts
@@ -75,6 +75,4 @@ export interface DownloadingFile {
 /**
  * CONSTANTS
  */
-const GB = 1024 * 1024 * 1024;
-export const UPLOAD_FILE_SIZE_LIMIT = 5 * GB;
 export const DRIVE_DB_NAME = 'drive.db';


### PR DESCRIPTION
Adds size validation before upload in single-file, folder, and share extension flows so oversized files are skipped client-side instead of failing mid-upload. Adds a FileSizeExceededModal that surfaces either the skipped file name or the total count, and a storageThunks.ensureMaxUploadFileSizeFresh thunk so the limit reflects the user's current plan before each upload starts.