### PR TITLE
[_] bugfix/Fix photo preview and Android video player issues

### DIFF
--- a/src/components/photos/VideoViewer/VideoViewer.tsx
+++ b/src/components/photos/VideoViewer/VideoViewer.tsx
@@ -40,6 +40,11 @@ export const VideoViewer: React.FC<VideoViewerProps> = ({ source, onPlay, onPaus
   const videoPlayer = useRef<VideoRef>(null);
 
   useEffect(() => {
+    setLoadError(undefined);
+    setPlaying(false);
+  }, [source]);
+
+  useEffect(() => {
     if (playing) {
       onPlay?.();
     } else {

--- a/src/components/photos/VideoViewer/VideoViewer.tsx
+++ b/src/components/photos/VideoViewer/VideoViewer.tsx
@@ -1,7 +1,7 @@
 import fileSystemService from '@internxt-mobile/services/FileSystemService';
 import * as NavigationBar from 'expo-navigation-bar';
 import * as ScreenOrientation from 'expo-screen-orientation';
-import { Play } from 'phosphor-react-native';
+import { PlayIcon } from 'phosphor-react-native';
 import React, { useEffect, useRef, useState } from 'react';
 import { Image, Platform, TouchableOpacity, View } from 'react-native';
 import Video, { VideoRef } from 'react-native-video';
@@ -12,6 +12,7 @@ interface VideoViewerProps {
   thumbnail?: string;
   onPlay?: () => void;
   onPause?: () => void;
+  onEnd?: () => void;
   onVideoLoadError?: () => void;
 }
 
@@ -33,24 +34,25 @@ const unlockOrientation = async () => {
   }
 };
 
-export const VideoViewer: React.FC<VideoViewerProps> = ({ source, onPlay, onPause, thumbnail, onVideoLoadError }) => {
+export const VideoViewer: React.FC<VideoViewerProps> = ({
+  source,
+  onPlay,
+  onPause,
+  onEnd,
+  thumbnail,
+  onVideoLoadError,
+}) => {
   const tailwind = useTailwind();
   const [playing, setPlaying] = useState(false);
+  const [hasStarted, setHasStarted] = useState(false);
   const [loadError, setLoadError] = useState<unknown>();
   const videoPlayer = useRef<VideoRef>(null);
 
   useEffect(() => {
     setLoadError(undefined);
     setPlaying(false);
+    setHasStarted(false);
   }, [source]);
-
-  useEffect(() => {
-    if (playing) {
-      onPlay?.();
-    } else {
-      onPause?.();
-    }
-  }, [playing]);
 
   useEffect(() => {
     return () => {
@@ -71,7 +73,9 @@ export const VideoViewer: React.FC<VideoViewerProps> = ({ source, onPlay, onPaus
       await NavigationBar.setVisibilityAsync('hidden');
       await NavigationBar.setBehaviorAsync('overlay-swipe');
     }
+    setHasStarted(true);
     setPlaying(true);
+    onPlay?.();
   };
 
   const handleFullscreenPresent = () => {
@@ -80,7 +84,9 @@ export const VideoViewer: React.FC<VideoViewerProps> = ({ source, onPlay, onPaus
 
   const handleFullscreenWillDismiss = () => {
     if (isIOS) {
+      onEnd?.();
       setPlaying(false);
+      setHasStarted(false);
       lockToPortrait();
     } else {
       ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP);
@@ -99,14 +105,17 @@ export const VideoViewer: React.FC<VideoViewerProps> = ({ source, onPlay, onPaus
   };
 
   const handleEnd = () => {
+    onEnd?.();
     setPlaying(false);
+    setHasStarted(false);
+    videoPlayer.current?.seek(0);
     videoPlayer.current?.dismissFullscreenPlayer();
     lockToPortrait();
   };
 
   // On iOS the native fullscreen player covers everything, so the thumbnail can stay.
-  // On Android the video plays inline, so the thumbnail must hide to reveal the Video component.
-  const showThumbnail = isIOS || !playing;
+  // On Android hide the thumbnail once started so the paused frame stays visible.
+  const showThumbnail = isIOS || !hasStarted;
 
   return (
     <View style={tailwind('h-full')}>
@@ -121,7 +130,7 @@ export const VideoViewer: React.FC<VideoViewerProps> = ({ source, onPlay, onPaus
                 { backgroundColor: 'rgba(0,0,0,0.5)' },
               ]}
             >
-              <Play size={40} weight="fill" color="#fff" />
+              <PlayIcon size={40} weight="fill" color="#fff" />
             </TouchableOpacity>
           </View>
         )}
@@ -140,10 +149,20 @@ export const VideoViewer: React.FC<VideoViewerProps> = ({ source, onPlay, onPaus
             resizeMode="contain"
             repeat={false}
             ignoreSilentSwitch="ignore"
-            controls={isAndroid && playing}
+            controls={isAndroid && hasStarted}
             style={isAndroid ? { width: '100%', height: '100%' } : undefined}
             onError={handleError}
             onEnd={handleEnd}
+            onPlaybackStateChanged={(e) => {
+              if (isAndroid && hasStarted && !e.isSeeking) {
+                setPlaying(e.isPlaying);
+                if (e.isPlaying) {
+                  onPlay?.();
+                } else {
+                  onPause?.();
+                }
+              }
+            }}
             onFullscreenPlayerWillPresent={handleFullscreenPresent}
             onFullscreenPlayerWillDismiss={handleFullscreenWillDismiss}
             onFullscreenPlayerDidDismiss={handleFullscreenDidDismiss}

--- a/src/screens/PhotoPreviewScreen/components/PreviewCarousel.tsx
+++ b/src/screens/PhotoPreviewScreen/components/PreviewCarousel.tsx
@@ -7,6 +7,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTailwind } from 'tailwind-rn';
 import AppText from '../../../components/AppText';
 import useGetColor from '../../../hooks/useColor';
+import { logger } from '../../../services/common';
 import { useCloudThumbnail } from '../../PhotosScreen/hooks/useCloudThumbnail';
 import { TimelinePhotoItem } from '../../PhotosScreen/types';
 
@@ -133,6 +134,15 @@ export const PreviewCarousel = ({
     transform: [{ translateY: withTiming(visible ? 0 : 20, { duration: 150, easing: Easing.out(Easing.quad) }) }],
   }));
 
+  const getItemLayout = useCallback(
+    (_: ArrayLike<TimelinePhotoItem> | null | undefined, index: number) => ({
+      length: THUMB_W_INACTIVE + THUMB_GAP,
+      offset: (THUMB_W_INACTIVE + THUMB_GAP) * index,
+      index,
+    }),
+    [],
+  );
+
   const renderItem: ListRenderItem<TimelinePhotoItem> = useCallback(
     ({ item, index }) => (
       <View style={{ marginRight: index < items.length - 1 ? THUMB_GAP : 0 }}>
@@ -162,10 +172,13 @@ export const PreviewCarousel = ({
             horizontal
             showsHorizontalScrollIndicator={false}
             contentContainerStyle={{ paddingHorizontal: 12 }}
+            getItemLayout={getItemLayout}
             windowSize={5}
             initialNumToRender={30}
             maxToRenderPerBatch={20}
-            onScrollToIndexFailed={() => undefined}
+            onScrollToIndexFailed={(info) => {
+              logger.error('Scroll to index failed:', info);
+            }}
           />
         </View>
 

--- a/src/screens/PhotoPreviewScreen/components/PreviewPage.tsx
+++ b/src/screens/PhotoPreviewScreen/components/PreviewPage.tsx
@@ -17,6 +17,8 @@ interface PageContentProps {
   onReset: () => void;
   onVideoPlay: () => void;
   onVideoPause: () => void;
+  onVideoEnd: () => void;
+  videoResetKey?: number;
 }
 
 const PageContent = ({
@@ -28,12 +30,21 @@ const PageContent = ({
   onReset,
   onVideoPlay,
   onVideoPause,
+  onVideoEnd,
+  videoResetKey,
 }: PageContentProps): JSX.Element => {
   const tailwind = useTailwind();
   if (item.mediaType === 'video') {
     if (uri) {
       return (
-        <VideoViewer source={uri} thumbnail={thumbnailUri ?? undefined} onPlay={onVideoPlay} onPause={onVideoPause} />
+        <VideoViewer
+          key={videoResetKey}
+          source={uri}
+          thumbnail={thumbnailUri ?? undefined}
+          onPlay={onVideoPlay}
+          onPause={onVideoPause}
+          onEnd={onVideoEnd}
+        />
       );
     }
     return (
@@ -65,14 +76,28 @@ interface PreviewPageProps {
   onTap: () => void;
   onZoomChange: (zoomed: boolean) => void;
   onSwipeDown: () => void;
+  onVideoPlay?: () => void;
+  onVideoPause?: () => void;
+  onVideoEnd?: () => void;
+  videoResetKey?: number;
+  hasVideoStarted?: boolean;
 }
 
-export const PreviewPage = ({ item, onTap, onZoomChange, onSwipeDown }: PreviewPageProps): JSX.Element => {
+export const PreviewPage = ({
+  item,
+  onTap,
+  onZoomChange,
+  onSwipeDown,
+  onVideoPlay,
+  onVideoPause,
+  onVideoEnd,
+  videoResetKey,
+  hasVideoStarted,
+}: PreviewPageProps): JSX.Element => {
   const tailwind = useTailwind();
   const { width: screenWidth } = useWindowDimensions();
   const { uri, thumbnailUri } = usePreviewSource(item);
   const [zoomed, setZoomed] = useState(false);
-  const [videoPlaying, setVideoPlaying] = useState(false);
   const translateY = useSharedValue(0);
 
   const handleZoom = useCallback(() => {
@@ -86,15 +111,19 @@ export const PreviewPage = ({ item, onTap, onZoomChange, onSwipeDown }: PreviewP
   }, [onZoomChange]);
 
   const playVideo = useCallback(() => {
-    setVideoPlaying(true);
-  }, []);
+    onVideoPlay?.();
+  }, [onVideoPlay]);
 
   const pauseVideo = useCallback(() => {
-    setVideoPlaying(false);
-  }, []);
+    onVideoPause?.();
+  }, [onVideoPause]);
+
+  const endVideo = useCallback(() => {
+    onVideoEnd?.();
+  }, [onVideoEnd]);
 
   const swipeDownGesture = Gesture.Pan()
-    .enabled(!zoomed && !videoPlaying)
+    .enabled(!zoomed && !hasVideoStarted)
     .activeOffsetY(10)
     .failOffsetX([-15, 15])
     .onUpdate((e) => {
@@ -126,6 +155,8 @@ export const PreviewPage = ({ item, onTap, onZoomChange, onSwipeDown }: PreviewP
           onReset={handleReset}
           onVideoPlay={playVideo}
           onVideoPause={pauseVideo}
+          onVideoEnd={endVideo}
+          videoResetKey={videoResetKey}
         />
       </Animated.View>
     </GestureDetector>

--- a/src/screens/PhotoPreviewScreen/components/PreviewPage.tsx
+++ b/src/screens/PhotoPreviewScreen/components/PreviewPage.tsx
@@ -52,7 +52,10 @@ const PageContent = ({
 
   return (
     <View style={tailwind('flex-1 justify-center items-center')}>
-      <ActivityIndicator color="white" size="large" />
+      {thumbnailUri ? (
+        <Image source={{ uri: thumbnailUri }} style={tailwind('w-full h-full')} resizeMode="contain" />
+      ) : null}
+      {uri === undefined ? <ActivityIndicator style={tailwind('absolute')} color="white" size="large" /> : null}
     </View>
   );
 };

--- a/src/screens/PhotoPreviewScreen/components/PreviewPager.tsx
+++ b/src/screens/PhotoPreviewScreen/components/PreviewPager.tsx
@@ -11,6 +11,11 @@ interface PreviewPagerProps {
   onTap: () => void;
   onZoomChange: (zoomed: boolean) => void;
   onSwipeDown: () => void;
+  onVideoPlay?: () => void;
+  onVideoPause?: () => void;
+  onVideoEnd?: () => void;
+  videoResetKey?: number;
+  hasVideoStarted?: boolean;
 }
 
 export const PreviewPager = ({
@@ -21,6 +26,11 @@ export const PreviewPager = ({
   onTap,
   onZoomChange,
   onSwipeDown,
+  onVideoPlay,
+  onVideoPause,
+  onVideoEnd,
+  videoResetKey,
+  hasVideoStarted,
 }: PreviewPagerProps): JSX.Element => {
   const { width: screenWidth } = useWindowDimensions();
   const listRef = useRef<FlatList<TimelinePhotoItem>>(null);
@@ -34,8 +44,20 @@ export const PreviewPager = ({
   }, [activeIndex, items.length]);
 
   const renderItem: ListRenderItem<TimelinePhotoItem> = useCallback(
-    ({ item }) => <PreviewPage item={item} onTap={onTap} onZoomChange={onZoomChange} onSwipeDown={onSwipeDown} />,
-    [onTap, onZoomChange, onSwipeDown],
+    ({ item }) => (
+      <PreviewPage
+        item={item}
+        onTap={onTap}
+        onZoomChange={onZoomChange}
+        onSwipeDown={onSwipeDown}
+        onVideoPlay={onVideoPlay}
+        onVideoPause={onVideoPause}
+        onVideoEnd={onVideoEnd}
+        videoResetKey={videoResetKey}
+        hasVideoStarted={hasVideoStarted}
+      />
+    ),
+    [onTap, onZoomChange, onSwipeDown, onVideoPlay, onVideoPause, onVideoEnd, videoResetKey, hasVideoStarted],
   );
 
   const getItemLayout = useCallback(

--- a/src/screens/PhotoPreviewScreen/hooks/usePreviewSource.ts
+++ b/src/screens/PhotoPreviewScreen/hooks/usePreviewSource.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { logger } from 'src/services/common';
 import { PhotoAssetFetchService } from '../../../services/photos/PhotoAssetFetchService';
 import { TimelinePhotoItem } from '../../PhotosScreen/types';
 
@@ -9,7 +10,7 @@ export interface UsePreviewSourceResult {
 
 export const usePreviewSource = (item: TimelinePhotoItem): UsePreviewSourceResult => {
   const thumbnailUri = item.type === 'cloud-only' ? item.thumbnailPath : (item.uri ?? null);
-  const [uri, setUri] = useState<string | null | undefined>(thumbnailUri ?? undefined);
+  const [uri, setUri] = useState<string | null | undefined>(undefined);
   const abortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
@@ -17,18 +18,20 @@ export const usePreviewSource = (item: TimelinePhotoItem): UsePreviewSourceResul
     const controller = new AbortController();
     abortRef.current = controller;
 
-    setUri(thumbnailUri ?? undefined);
+    setUri(undefined);
+    logger.info(`[usePreviewSource] fetching asset — id: ${item.id}, type: ${item.type}, mediaType: ${item.mediaType}`);
 
     PhotoAssetFetchService.fetchUri(item, controller.signal).then((fullUri) => {
       if (!controller.signal.aborted) {
-        setUri(fullUri ?? thumbnailUri ?? null);
+        logger.info(`[usePreviewSource] asset ready — id: ${item.id}, uri: ${fullUri ?? 'null'}`);
+        setUri(fullUri ?? null);
       }
     });
 
     return () => {
       controller.abort();
     };
-  }, [item.id, thumbnailUri]);
+  }, [item.id]);
 
   return { uri, thumbnailUri };
 };

--- a/src/screens/PhotoPreviewScreen/index.tsx
+++ b/src/screens/PhotoPreviewScreen/index.tsx
@@ -24,6 +24,10 @@ export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
   const [isUiVisible, setIsUiVisible] = useState(true);
   const [zoomActive, setZoomActive] = useState(false);
   const [metadataOpen, setMetadataOpen] = useState(false);
+  const [hasVideoStarted, setHasVideoStarted] = useState(false);
+  const [videoResetKey, setVideoResetKey] = useState(0);
+
+  const resetVideoPlayer = useCallback(() => setVideoResetKey((key) => key + 1), []);
 
   const handleTap = useCallback(() => {
     setIsUiVisible((visible) => !visible);
@@ -39,6 +43,38 @@ export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
   const handleSwipeDown = useCallback(() => {
     navigation.goBack();
   }, [navigation]);
+
+  const exitVideoMode = useCallback(() => {
+    setHasVideoStarted(false);
+    resetVideoPlayer();
+    setIsUiVisible(true);
+  }, [resetVideoPlayer]);
+
+  const closePreviewScreen = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+
+  const handleClose = useCallback(() => {
+    if (hasVideoStarted) {
+      exitVideoMode();
+    } else {
+      closePreviewScreen();
+    }
+  }, [hasVideoStarted, exitVideoMode, closePreviewScreen]);
+
+  const handleVideoPlay = useCallback(() => {
+    setHasVideoStarted(true);
+    setIsUiVisible(false);
+  }, []);
+
+  const handleVideoPause = useCallback(() => {
+    setIsUiVisible(true);
+  }, []);
+
+  const handleVideoEnd = useCallback(() => {
+    setHasVideoStarted(false);
+    setIsUiVisible(true);
+  }, []);
 
   const handleExport = useCallback(async () => {
     const item = items[currentIndex];
@@ -59,7 +95,7 @@ export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
     }
   }, [items, currentIndex]);
 
-  const showCarousel = isUiVisible && !zoomActive;
+  const showCarousel = isUiVisible && !zoomActive && !hasVideoStarted;
   const currentItem = items[currentIndex];
 
   return (
@@ -73,11 +109,16 @@ export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
         onTap={handleTap}
         onZoomChange={handleZoomChange}
         onSwipeDown={handleSwipeDown}
+        onVideoPlay={handleVideoPlay}
+        onVideoPause={handleVideoPause}
+        onVideoEnd={handleVideoEnd}
+        videoResetKey={videoResetKey}
+        hasVideoStarted={hasVideoStarted}
       />
       <PreviewHeader
         visible={isUiVisible}
         item={currentItem}
-        onClose={handleSwipeDown}
+        onClose={handleClose}
         onMore={() => setMetadataOpen(true)}
       />
       {showCarousel && (

--- a/src/services/photos/PhotoAssetFetchService.ts
+++ b/src/services/photos/PhotoAssetFetchService.ts
@@ -30,7 +30,7 @@ const downloadCloudAsset = async (item: CloudPhotoItem, signal: AbortSignal): Pr
   const cachePath = cachePathFor(item.id, ext);
 
   const alreadyCached = await fileSystemService.exists(cachePath);
-  if (alreadyCached) return cachePath;
+  if (alreadyCached) return fileSystemService.pathToUri(cachePath);
 
   const asset = await photosLocalDB.getCloudAssetById(item.id);
   if (!asset?.fileId) {
@@ -61,7 +61,7 @@ const downloadCloudAsset = async (item: CloudPhotoItem, signal: AbortSignal): Pr
       return null;
     }
 
-    return cachePath;
+    return fileSystemService.pathToUri(cachePath);
   } catch (error) {
     if (!signal.aborted) {
       logger.error(`[PhotoAssetFetchService] Download failed for ${item.id}: ${error}`);


### PR DESCRIPTION
Fixed three issues in the photo preview screen: black frames when opening cloud assets on Android, incorrect video player HUD behavior (controls appearing before the user taps play), and broken carousel thumbnail scroll when jumping between items.

  ## Changes Summary

  - **`PhotoAssetFetchService.ts`**: applies `pathToUri` to cached paths before returning them so Android resolves local files correctly instead of showing a black screen
  - **`usePreviewSource.ts`**: always initialises URI as `undefined` (instead of the thumbnail) so the loading state is consistent
  - **`PreviewPage.tsx`**: shows the thumbnail as background while the full asset loads instead of a bare spinner
  - **`PreviewPager.tsx`**: forwards the new video callbacks (`onVideoPlay`, `onVideoPause`, `onVideoEnd`), `videoResetKey`, and `hasVideoStarted` down to each `PreviewPage`
  - **`PhotoPreviewScreen/index.tsx`**:  
     - manages `hasVideoStarted` and `videoResetKey` state
     - close button exits video mode (resets player, shows UI) when a video is active instead of navigating back
     - hides the thumbnail carousel strip during video playback.
  - **`VideoViewer.tsx`**:  
     - introduces `hasStarted` state to show Android native controls
     - manage play/pause callbacks via `onPlaybackStateChanged` on Android for correct HUD behavior
     - seeks back to 0 and resets state on `onEnd`
  - **`PreviewCarousel.tsx`**:  adds `getItemLayout` so `scrollToIndex` calculates item offsets correctly
