### PR TITLE
PB-6400] feature/Implement Export, Save and Copy actions

### DIFF
--- a/assets/lang/strings.ts
+++ b/assets/lang/strings.ts
@@ -243,6 +243,11 @@ const translations = {
             removeFromFavorites: 'Remove from favorites',
             moveToTrash: 'Move to trash',
           },
+          actionProgress: {
+            preparing: 'Preparing…',
+            saving: 'Saving to gallery…',
+            copying: 'Copying…',
+          },
         },
       },
       forgot_password: {
@@ -1196,6 +1201,11 @@ const translations = {
             addToFavorites: 'Añadir a favoritos',
             removeFromFavorites: 'Quitar de favoritos',
             moveToTrash: 'Mover a la papelera',
+          },
+          actionProgress: {
+            preparing: 'Preparando…',
+            saving: 'Guardando en galería…',
+            copying: 'Copiando…',
           },
         },
       },

--- a/src/screens/PhotoPreviewScreen/components/PreviewCarousel.tsx
+++ b/src/screens/PhotoPreviewScreen/components/PreviewCarousel.tsx
@@ -184,7 +184,7 @@ export const PreviewCarousel = ({
 
         <View style={[tailwind('flex-row'), { paddingBottom: insets.bottom + 8 }]}>
           <ActionButton icon={<ExportIcon size={26} color="white" />} label="Export" onPress={onExport} />
-          <ActionButton icon={<StarIcon size={26} color="white" />} label="Favorite" onPress={() => undefined} />
+          {/* <ActionButton icon={<StarIcon size={26} color="white" />} label="Favorite" onPress={() => undefined} /> */}
           <ActionButton icon={<DotsThreeOutlineIcon size={26} color="white" />} label="More" onPress={onMore} />
           <ActionButton icon={<TrashIcon size={26} color="white" />} label="Delete" onPress={() => undefined} />
         </View>

--- a/src/screens/PhotosScreen/components/ActionProgressModal.tsx
+++ b/src/screens/PhotosScreen/components/ActionProgressModal.tsx
@@ -1,0 +1,48 @@
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
+import AppText from 'src/components/AppText';
+import useGetColor from 'src/hooks/useColor';
+import { useTailwind } from 'tailwind-rn';
+
+interface ActionProgressModalProps {
+  visible: boolean;
+  label: string;
+}
+
+const ActionProgressModal = ({ visible, label }: ActionProgressModalProps): JSX.Element | null => {
+  const tailwind = useTailwind();
+  const getColor = useGetColor();
+
+  if (!visible) return null;
+
+  return (
+    <View style={styles.backdrop}>
+      <View style={[styles.card, { backgroundColor: getColor('bg-surface') }]}>
+        <ActivityIndicator size="large" color={getColor('text-primary')} />
+        <AppText style={[tailwind('mt-4 text-base text-center'), { color: getColor('text-gray-80') }]}>{label}</AppText>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.35)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 999,
+  },
+  card: {
+    borderRadius: 16,
+    paddingHorizontal: 32,
+    paddingVertical: 28,
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.15,
+    shadowRadius: 12,
+    elevation: 8,
+  },
+});
+
+export default ActionProgressModal;

--- a/src/screens/PhotosScreen/components/MoreActionsBottomSheet.tsx
+++ b/src/screens/PhotosScreen/components/MoreActionsBottomSheet.tsx
@@ -49,12 +49,7 @@ const ActionRow = ({ icon, label, onPress, isDestructive, isLast }: ActionRowPro
       style={[tailwind('flex-row items-center px-4'), styles.row]}
       hitSlop={{ top: 2, bottom: 2 }}
     >
-      <View
-        style={[
-          styles.rowInner,
-          !isLast && { borderBottomColor: SEPARATOR_COLOR, borderBottomWidth: 1 },
-        ]}
-      >
+      <View style={[styles.rowInner, !isLast && { borderBottomColor: SEPARATOR_COLOR, borderBottomWidth: 1 }]}>
         <View style={styles.iconContainer}>{icon}</View>
         <AppText
           medium
@@ -114,6 +109,7 @@ const MoreActionsBottomSheet = ({
   const areAllSelectedItemsBacked = selectedItems.every(isItemBacked);
   const isOneItemSelected = selectedItems.length === 1;
   const hasBackedOrCloud = selectedItems.some(isItemBacked);
+  const isSinglePhoto = isOneItemSelected && selectedItems[0]?.mediaType === 'photo';
 
   const iconColor = getColor('text-gray-80');
   const actionStrings = strings.screens.photos.selection.more;
@@ -127,12 +123,13 @@ const MoreActionsBottomSheet = ({
           icon: <ExportIcon size={22} color={iconColor} />,
           onPress: onExport,
         },
-        areAllSelectedItemsBacked && {
-          key: 'copy',
-          label: actionStrings.copy,
-          icon: <CopyIcon size={22} color={iconColor} />,
-          onPress: onCopy,
-        },
+        areAllSelectedItemsBacked &&
+          isSinglePhoto && {
+            key: 'copy',
+            label: actionStrings.copy,
+            icon: <CopyIcon size={22} color={iconColor} />,
+            onPress: onCopy,
+          },
         areAllSelectedItemsBacked &&
           isOneItemSelected && {
             key: 'duplicate',
@@ -170,6 +167,7 @@ const MoreActionsBottomSheet = ({
     [
       areAllSelectedItemsBacked,
       isOneItemSelected,
+      isSinglePhoto,
       hasBackedOrCloud,
       iconColor,
       actionStrings,

--- a/src/screens/PhotosScreen/hooks/usePhotoActions.ts
+++ b/src/screens/PhotosScreen/hooks/usePhotoActions.ts
@@ -1,0 +1,104 @@
+import strings from 'assets/lang/strings';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { logger } from 'src/services/common';
+import { photoActionsService } from 'src/services/photos/PhotoActionsService';
+import { PhotoSelection } from './usePhotoSelection';
+
+export interface UsePhotoActionsReturn {
+  actionLabel: string | null;
+  isMoreActionsSheetOpen: boolean;
+  handleExport: () => Promise<void>;
+  handleSave: () => Promise<void>;
+  handleCopy: () => Promise<void>;
+  handleMore: () => void;
+  handleMoreClose: () => void;
+  todoAction: (name: string) => () => void;
+}
+
+export const usePhotoActions = (selection: PhotoSelection): UsePhotoActionsReturn => {
+  const [actionLabel, setActionLabel] = useState<string | null>(null);
+  const [isMoreActionsSheetOpen, setIsMoreActionsSheetOpen] = useState(false);
+  const actionAbortRef = useRef<AbortController | null>(null);
+
+  useEffect(
+    () => () => {
+      actionAbortRef.current?.abort();
+    },
+    [],
+  );
+
+  const startAction = useCallback((label: string): AbortController => {
+    actionAbortRef.current?.abort();
+    const controller = new AbortController();
+    actionAbortRef.current = controller;
+    setActionLabel(label);
+    return controller;
+  }, []);
+
+  const finishAction = useCallback(() => {
+    setActionLabel(null);
+    selection.exitSelectMode();
+    setIsMoreActionsSheetOpen(false);
+  }, [selection]);
+
+  const handleExport = useCallback(async () => {
+    const { signal } = startAction(strings.screens.photos.selection.actionProgress.preparing);
+    try {
+      await photoActionsService.exportItems(selection.selectedItems, signal);
+    } catch (error) {
+      logger.error(`[usePhotoActions] Export error: ${error}`);
+    } finally {
+      finishAction();
+    }
+  }, [startAction, finishAction, selection.selectedItems]);
+
+  const handleSave = useCallback(async () => {
+    const { signal } = startAction(strings.screens.photos.selection.actionProgress.saving);
+    try {
+      for (const item of selection.selectedItems) {
+        await photoActionsService.saveToDevice(item, signal);
+        if (signal.aborted) break;
+      }
+    } catch (error) {
+      logger.error(`[usePhotoActions] Save error: ${error}`);
+    } finally {
+      finishAction();
+    }
+  }, [startAction, finishAction, selection.selectedItems]);
+
+  const handleCopy = useCallback(async () => {
+    const item = selection.selectedItems[0];
+    if (!item) return;
+    const { signal } = startAction(strings.screens.photos.selection.actionProgress.copying);
+    try {
+      await photoActionsService.copyToClipboard(item, signal);
+    } catch (error) {
+      logger.error(`[usePhotoActions] Copy error: ${error}`);
+    } finally {
+      finishAction();
+    }
+  }, [startAction, finishAction, selection.selectedItems]);
+
+  const todoAction = useCallback(
+    (name: string) => () => {
+      logger.info(`[usePhotoActions] action not yet implemented: ${name}`);
+      selection.exitSelectMode();
+      setIsMoreActionsSheetOpen(false);
+    },
+    [selection],
+  );
+
+  const handleMore = useCallback(() => setIsMoreActionsSheetOpen(true), []);
+  const handleMoreClose = useCallback(() => setIsMoreActionsSheetOpen(false), []);
+
+  return {
+    actionLabel,
+    isMoreActionsSheetOpen,
+    handleExport,
+    handleSave,
+    handleCopy,
+    handleMore,
+    handleMoreClose,
+    todoAction,
+  };
+};

--- a/src/screens/PhotosScreen/index.tsx
+++ b/src/screens/PhotosScreen/index.tsx
@@ -8,6 +8,7 @@ import { uiActions } from 'src/store/slices/ui';
 import { TabExplorerScreenNavigationProp } from 'src/types/navigation';
 import { useTailwind } from 'tailwind-rn';
 import { photoPermissionService } from '../../services/photos/photoPermissionService';
+import ActionProgressModal from './components/ActionProgressModal';
 import BackupDisabledBanner from './components/BackupDisabledBanner';
 import MoreActionsBottomSheet from './components/MoreActionsBottomSheet';
 import PhotosHeader from './components/PhotosHeader';
@@ -16,6 +17,7 @@ import PhotosTimeline from './components/PhotosTimeline';
 import SelectionHeader from './components/SelectionHeader';
 import SelectionToolbar from './components/SelectionToolbar';
 import EnableBackupBottomSheet from './EnableBackupBottomSheet';
+import { usePhotoActions } from './hooks/usePhotoActions';
 import { usePhotoSelection } from './hooks/usePhotoSelection';
 import { usePhotosTimeline } from './hooks/usePhotosTimeline';
 import { PhotosAccessState, TimelinePhotoItem } from './types';
@@ -26,7 +28,6 @@ const PhotosScreen = (): JSX.Element => {
   const navigation = useNavigation<TabExplorerScreenNavigationProp<'Photos'>>();
   const { enabled, permissionStatus } = useAppSelector((state) => state.photos);
   const [isEnableBackupSheetOpen, setIsEnableBackupSheetOpen] = useState(false);
-  const [isMoreActionsSheetOpen, setIsMoreActionsSheetOpen] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const { timelineDateGroups, isLoading, loadNextPage, reloadLocal } = usePhotosTimeline();
 
@@ -36,6 +37,7 @@ const PhotosScreen = (): JSX.Element => {
   );
 
   const selection = usePhotoSelection(allItems);
+  const actions = usePhotoActions(selection);
 
   const handlePhotoPress = useCallback(
     (id: string) => {
@@ -57,24 +59,13 @@ const PhotosScreen = (): JSX.Element => {
     [selection],
   );
 
-  const handleSelectPress = useCallback(() => selection.enterSelectMode(), [selection]);
-
-  const todoAction = useCallback(
-    (name: string) => () => {
-      console.log(`action:${name}`, [...selection.selectedIds]);
-      selection.exitSelectMode();
-      setIsMoreActionsSheetOpen(false);
-    },
-    [selection],
-  );
-
-  const handleMore = useCallback(() => setIsMoreActionsSheetOpen(true), []);
-  const handleMoreClose = useCallback(() => setIsMoreActionsSheetOpen(false), []);
-
-  const accessState: PhotosAccessState = useMemo<PhotosAccessState>(
+  const accessState = useMemo<PhotosAccessState>(
     () => (enabled ? { type: 'available' } : { type: 'backup-off' }),
     [enabled],
   );
+
+  const handleSelectPress = useCallback(() => selection.enterSelectMode(), [selection]);
+
   const handleEnableBackup = useCallback(() => setIsEnableBackupSheetOpen(true), []);
   const listHeader =
     accessState.type === 'backup-off' ? <BackupDisabledBanner onEnablePress={handleEnableBackup} /> : undefined;
@@ -87,8 +78,6 @@ const PhotosScreen = (): JSX.Element => {
       setRefreshing(false);
     }
   }, [dispatch, reloadLocal]);
-
-  const handleUpgradePress = useCallback(() => undefined, []);
 
   useEffect(() => {
     dispatch(uiActions.setIsTabBarHidden(selection.selectMode));
@@ -141,30 +130,32 @@ const PhotosScreen = (): JSX.Element => {
           isSelectMode={selection.selectMode}
           selectedIds={selection.selectedIds}
         />
-        {accessState.type === 'photos-locked' && <PhotosLockedOverlay onUpgradePress={handleUpgradePress} />}
+        {accessState.type === 'photos-locked' && <PhotosLockedOverlay onUpgradePress={() => undefined} />}
       </View>
 
       <SelectionToolbar
         visible={selection.selectMode && selection.selectedIds.size > 0}
         selectedItems={selection.selectedItems}
-        onExport={todoAction('export')}
-        onFavorite={todoAction('favorite')}
-        onMore={handleMore}
-        onDelete={todoAction('delete')}
-        onInfo={todoAction('info')}
+        onExport={actions.handleExport}
+        onFavorite={actions.todoAction('favorite')}
+        onMore={actions.handleMore}
+        onDelete={actions.todoAction('delete')}
+        onInfo={actions.todoAction('info')}
       />
 
       <MoreActionsBottomSheet
-        isOpen={isMoreActionsSheetOpen}
+        isOpen={actions.isMoreActionsSheetOpen}
         selectedItems={selection.selectedItems}
-        onClose={handleMoreClose}
-        onExport={todoAction('export')}
-        onCopy={todoAction('copy')}
-        onDuplicate={todoAction('duplicate')}
-        onSave={todoAction('save')}
-        onFavorite={todoAction('favorite')}
-        onTrash={todoAction('trash')}
+        onClose={actions.handleMoreClose}
+        onExport={actions.handleExport}
+        onCopy={actions.handleCopy}
+        onDuplicate={actions.todoAction('duplicate')}
+        onSave={actions.handleSave}
+        onFavorite={actions.todoAction('favorite')}
+        onTrash={actions.todoAction('trash')}
       />
+
+      <ActionProgressModal visible={actions.actionLabel !== null} label={actions.actionLabel ?? ''} />
 
       <EnableBackupBottomSheet isOpen={isEnableBackupSheetOpen} onClose={() => setIsEnableBackupSheetOpen(false)} />
     </AppScreen>

--- a/src/services/photos/PhotoActionsService.spec.ts
+++ b/src/services/photos/PhotoActionsService.spec.ts
@@ -1,0 +1,168 @@
+import * as RNFS from '@dr.pogodin/react-native-fs';
+import * as Clipboard from 'expo-clipboard';
+import * as MediaLibrary from 'expo-media-library';
+import { PhotoItem } from 'src/screens/PhotosScreen/types';
+import fileSystemService from 'src/services/FileSystemService';
+import { photoActionsService } from './PhotoActionsService';
+import { PhotoAssetFetchService } from './PhotoAssetFetchService';
+
+jest.mock('./PhotoAssetFetchService', () => ({
+  PhotoAssetFetchService: {
+    resolveExportUri: jest.fn(),
+    fetchUri: jest.fn(),
+  },
+}));
+
+jest.mock('src/services/FileSystemService', () => ({
+  __esModule: true,
+  default: { shareFile: jest.fn(), getCacheDir: jest.fn(() => '/cache') },
+}));
+
+jest.mock('expo-media-library', () => ({
+  requestPermissionsAsync: jest.fn(),
+  saveToLibraryAsync: jest.fn(),
+}));
+
+jest.mock('@dr.pogodin/react-native-fs', () => ({
+  readFile: jest.fn(),
+}));
+
+jest.mock('expo-clipboard', () => ({
+  setImageAsync: jest.fn(),
+}));
+
+jest.mock('src/services/common', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const mockResolveExportUri = PhotoAssetFetchService.resolveExportUri as jest.Mock;
+const mockFetchUri = PhotoAssetFetchService.fetchUri as jest.Mock;
+const mockShareFile = fileSystemService.shareFile as jest.Mock;
+const mockRequestPermissions = MediaLibrary.requestPermissionsAsync as jest.Mock;
+const mockSaveToLibrary = MediaLibrary.saveToLibraryAsync as jest.Mock;
+const mockReadFile = RNFS.readFile as jest.Mock;
+const mockSetImage = Clipboard.setImageAsync as jest.Mock;
+
+const makeLocalItem = (id = 'asset-1'): PhotoItem => ({
+  id,
+  type: 'local',
+  uri: `ph://${id}`,
+  mediaType: 'photo',
+  createdAt: Date.now(),
+  backupState: 'backed',
+});
+
+const makeSignal = () => new AbortController().signal;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('exportItems', () => {
+  test('when resolveExportUri returns null, then shareFile is not called', async () => {
+    mockResolveExportUri.mockResolvedValue(null);
+
+    await photoActionsService.exportItems([makeLocalItem()], makeSignal());
+
+    expect(mockShareFile).not.toHaveBeenCalled();
+  });
+
+  test('when resolveExportUri returns a URI, then shareFile is called with the file URI', async () => {
+    mockResolveExportUri.mockResolvedValue({ uri: '/cache/photo_share/asset-1.jpg' });
+
+    await photoActionsService.exportItems([makeLocalItem()], makeSignal());
+
+    expect(mockShareFile).toHaveBeenCalledWith({ title: '', fileUri: 'file:///cache/photo_share/asset-1.jpg' });
+  });
+
+  test('when resolveExportUri returns a cleanup callback, then cleanup is called even if shareFile throws', async () => {
+    const cleanup = jest.fn();
+    mockResolveExportUri.mockResolvedValue({ uri: '/cache/photo_share/asset-1.jpg', cleanup });
+    mockShareFile.mockRejectedValue(new Error('share failed'));
+
+    await photoActionsService.exportItems([makeLocalItem()], makeSignal());
+
+    expect(cleanup).toHaveBeenCalled();
+  });
+
+  test('when signal is already aborted, then resolveExportUri is not called', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await photoActionsService.exportItems([makeLocalItem()], controller.signal);
+
+    expect(mockResolveExportUri).not.toHaveBeenCalled();
+  });
+
+  test('when processing multiple items, then each item is exported in sequence', async () => {
+    const items = [makeLocalItem('a'), makeLocalItem('b')];
+    mockResolveExportUri.mockResolvedValueOnce({ uri: '/cache/a.jpg' }).mockResolvedValueOnce({ uri: '/cache/b.jpg' });
+
+    await photoActionsService.exportItems(items, makeSignal());
+
+    expect(mockShareFile).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('saveToDevice', () => {
+  test('when media library permission is denied, then saveToLibraryAsync is not called', async () => {
+    mockRequestPermissions.mockResolvedValue({ status: 'denied' });
+
+    await photoActionsService.saveToDevice(makeLocalItem(), makeSignal());
+
+    expect(mockSaveToLibrary).not.toHaveBeenCalled();
+  });
+
+  test('when fetchUri returns null, then saveToLibraryAsync is not called', async () => {
+    mockRequestPermissions.mockResolvedValue({ status: 'granted' });
+    mockFetchUri.mockResolvedValue(null);
+
+    await photoActionsService.saveToDevice(makeLocalItem(), makeSignal());
+
+    expect(mockSaveToLibrary).not.toHaveBeenCalled();
+  });
+
+  test('when permission is granted and URI is resolved, then saveToLibraryAsync is called with the file URI', async () => {
+    mockRequestPermissions.mockResolvedValue({ status: 'granted' });
+    mockFetchUri.mockResolvedValue('file:///cache/photo.jpg');
+
+    await photoActionsService.saveToDevice(makeLocalItem(), makeSignal());
+
+    expect(mockSaveToLibrary).toHaveBeenCalledWith('file:///cache/photo.jpg');
+  });
+
+  test('when saveToLibraryAsync throws, then the error is re-thrown', async () => {
+    mockRequestPermissions.mockResolvedValue({ status: 'granted' });
+    mockFetchUri.mockResolvedValue('file:///cache/photo.jpg');
+    mockSaveToLibrary.mockRejectedValue(new Error('disk full'));
+
+    await expect(photoActionsService.saveToDevice(makeLocalItem(), makeSignal())).rejects.toThrow('disk full');
+  });
+});
+
+describe('copyToClipboard', () => {
+  test('when fetchUri returns null, then setImageAsync is not called', async () => {
+    mockFetchUri.mockResolvedValue(null);
+
+    await photoActionsService.copyToClipboard(makeLocalItem(), makeSignal());
+
+    expect(mockSetImage).not.toHaveBeenCalled();
+  });
+
+  test('when fetchUri returns a file URI, then readFile is called with the stripped path', async () => {
+    mockFetchUri.mockResolvedValue('file:///cache/photo.jpg');
+    mockReadFile.mockResolvedValue('base64data');
+
+    await photoActionsService.copyToClipboard(makeLocalItem(), makeSignal());
+
+    expect(mockReadFile).toHaveBeenCalledWith('/cache/photo.jpg', 'base64');
+    expect(mockSetImage).toHaveBeenCalledWith('base64data');
+  });
+
+  test('when readFile throws, then the error is re-thrown', async () => {
+    mockFetchUri.mockResolvedValue('file:///cache/photo.jpg');
+    mockReadFile.mockRejectedValue(new Error('read error'));
+
+    await expect(photoActionsService.copyToClipboard(makeLocalItem(), makeSignal())).rejects.toThrow('read error');
+  });
+});

--- a/src/services/photos/PhotoActionsService.ts
+++ b/src/services/photos/PhotoActionsService.ts
@@ -1,0 +1,81 @@
+import * as RNFS from '@dr.pogodin/react-native-fs';
+import * as Clipboard from 'expo-clipboard';
+import * as MediaLibrary from 'expo-media-library';
+import { TimelinePhotoItem } from 'src/screens/PhotosScreen/types';
+import { logger } from 'src/services/common';
+import { stripFileUri, toFileUri } from 'src/services/common/uri/uriHelpers';
+import fileSystemService from 'src/services/FileSystemService';
+import { PhotoAssetFetchService } from './PhotoAssetFetchService';
+
+class PhotoActionsService {
+  async exportItems(items: TimelinePhotoItem[], signal: AbortSignal): Promise<void> {
+    for (const item of items) {
+      if (signal.aborted) {
+        return;
+      }
+
+      let result;
+      try {
+        result = await PhotoAssetFetchService.resolveExportUri(item, signal);
+        if (!result) {
+          logger.warn(`[PhotoActionsService] export — no URI resolved for ${item.id}, skipping`);
+          continue;
+        }
+        if (signal.aborted) {
+          return;
+        }
+
+        await fileSystemService.shareFile({ title: '', fileUri: toFileUri(result.uri) });
+      } catch (error) {
+        logger.error(`[PhotoActionsService] export failed for ${item.id}: ${error}`);
+      } finally {
+        result?.cleanup?.();
+      }
+    }
+  }
+
+  async saveToDevice(item: TimelinePhotoItem, signal: AbortSignal): Promise<void> {
+    const { status } = await MediaLibrary.requestPermissionsAsync(true);
+    if (status !== 'granted') {
+      logger.warn(`[PhotoActionsService] saveToDevice — permission not granted (status: ${status})`);
+      return;
+    }
+
+    const uri = await PhotoAssetFetchService.fetchUri(item, signal);
+    if (!uri) {
+      logger.warn(`[PhotoActionsService] saveToDevice — no URI resolved for ${item.id}`);
+      return;
+    }
+    if (signal.aborted) {
+      return;
+    }
+
+    try {
+      const fileUri = toFileUri(uri);
+      await MediaLibrary.saveToLibraryAsync(fileUri);
+    } catch (error) {
+      logger.error(`[PhotoActionsService] saveToDevice failed for ${item.id}: ${error}`);
+      throw error;
+    }
+  }
+
+  async copyToClipboard(item: TimelinePhotoItem, signal: AbortSignal): Promise<void> {
+    const uri = await PhotoAssetFetchService.fetchUri(item, signal);
+    if (!uri) {
+      logger.warn(`[PhotoActionsService] copyToClipboard — no URI resolved for ${item.id}`);
+      return;
+    }
+    if (signal.aborted) return;
+
+    try {
+      const fileUri = stripFileUri(uri);
+      const base64 = await RNFS.readFile(fileUri, 'base64');
+      await Clipboard.setImageAsync(base64);
+    } catch (error) {
+      logger.error(`[PhotoActionsService] copyToClipboard failed for ${item.id}: ${error}`);
+      throw error;
+    }
+  }
+}
+
+export const photoActionsService = new PhotoActionsService();

--- a/src/services/photos/PhotoAssetFetchService.spec.ts
+++ b/src/services/photos/PhotoAssetFetchService.spec.ts
@@ -1,0 +1,197 @@
+import asyncStorageService from '@internxt-mobile/services/AsyncStorageService';
+import { driveFileService } from '@internxt-mobile/services/drive/file';
+import * as ExpoFileSystemLegacy from 'expo-file-system/legacy';
+import { Platform } from 'react-native';
+import { CloudPhotoItem, PhotoItem } from 'src/screens/PhotosScreen/types';
+import fileSystemService from 'src/services/FileSystemService';
+import { PhotoAssetFetchService } from './PhotoAssetFetchService';
+import { photoMediaLibraryService } from './PhotoMediaLibraryService';
+import { photosLocalDB } from './database/photosLocalDB';
+
+jest.mock('./PhotoMediaLibraryService', () => ({
+  photoMediaLibraryService: { getAssetInfo: jest.fn() },
+}));
+
+jest.mock('./database/photosLocalDB', () => ({
+  photosLocalDB: { getCloudAssetById: jest.fn() },
+}));
+
+jest.mock('src/services/FileSystemService', () => ({
+  __esModule: true,
+  default: {
+    getCacheDir: jest.fn(() => '/cache'),
+    exists: jest.fn(),
+    ensureDir: jest.fn(),
+    pathToUri: jest.fn((p: string) => `file://${p}`),
+    unlinkIfExists: jest.fn(),
+  },
+}));
+
+jest.mock('@internxt-mobile/services/AsyncStorageService', () => ({
+  __esModule: true,
+  default: { getUser: jest.fn() },
+}));
+
+jest.mock('@internxt-mobile/services/drive/file', () => ({
+  driveFileService: { downloadFile: jest.fn() },
+}));
+
+jest.mock('expo-file-system/legacy', () => ({
+  copyAsync: jest.fn(),
+}));
+
+jest.mock('@internxt-mobile/services/common', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const mockGetAssetInfo = photoMediaLibraryService.getAssetInfo as jest.Mock;
+const mockExists = fileSystemService.exists as jest.Mock;
+const mockCopyAsync = ExpoFileSystemLegacy.copyAsync as jest.Mock;
+const mockGetCloudAssetById = photosLocalDB.getCloudAssetById as jest.Mock;
+const mockGetUser = asyncStorageService.getUser as jest.Mock;
+const mockDownloadFile = driveFileService.downloadFile as jest.Mock;
+
+const makeLocalItem = (overrides: Partial<PhotoItem> = {}): PhotoItem => ({
+  id: 'ABCD-1234/L0/001',
+  type: 'local',
+  uri: 'ph://ABCD-1234/L0/001',
+  mediaType: 'photo',
+  createdAt: Date.now(),
+  backupState: 'backed',
+  ...overrides,
+});
+
+const makeCloudItem = (overrides: Partial<CloudPhotoItem> = {}): CloudPhotoItem => ({
+  id: 'cloud-uuid-1',
+  type: 'cloud-only',
+  mediaType: 'photo',
+  fileName: 'photo.jpg',
+  thumbnailPath: null,
+  thumbnailBucketId: null,
+  thumbnailBucketFile: null,
+  thumbnailType: null,
+  deviceId: 'device-1',
+  createdAt: Date.now(),
+  ...overrides,
+});
+
+const makeSignal = () => new AbortController().signal;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockExists.mockResolvedValue(false);
+  mockCopyAsync.mockResolvedValue(undefined);
+  mockGetAssetInfo.mockResolvedValue({ localUri: 'file:///cache/photo.jpg', filename: 'IMG_1234.JPG' });
+  mockGetUser.mockResolvedValue({ bucket: 'bucket-id', mnemonic: 'mnemonic' });
+  mockDownloadFile.mockResolvedValue(undefined);
+});
+
+describe('fetchUri — local item', () => {
+  test('when getAssetInfo returns a localUri, then that URI is returned', async () => {
+    mockGetAssetInfo.mockResolvedValue({ localUri: 'file:///dcim/photo.jpg', filename: 'photo.jpg' });
+
+    const result = await PhotoAssetFetchService.fetchUri(makeLocalItem(), makeSignal());
+
+    expect(result).toBe('file:///dcim/photo.jpg');
+  });
+
+  test('when getAssetInfo returns no localUri, then item.uri is returned as fallback', async () => {
+    mockGetAssetInfo.mockResolvedValue({ localUri: undefined, filename: 'photo.jpg' });
+
+    const result = await PhotoAssetFetchService.fetchUri(makeLocalItem({ uri: 'ph://ABCD-1234/L0/001' }), makeSignal());
+
+    expect(result).toBe('ph://ABCD-1234/L0/001');
+  });
+
+  test('when getAssetInfo throws, then item.uri is returned as fallback', async () => {
+    mockGetAssetInfo.mockRejectedValue(new Error('asset not found'));
+
+    const result = await PhotoAssetFetchService.fetchUri(makeLocalItem({ uri: 'ph://ABCD-1234/L0/001' }), makeSignal());
+
+    expect(result).toBe('ph://ABCD-1234/L0/001');
+  });
+});
+
+describe('fetchUri — cloud item', () => {
+  test('when asset is already cached, then downloadFile is not called and the cached URI is returned', async () => {
+    mockExists.mockResolvedValue(true);
+    (fileSystemService.pathToUri as jest.Mock).mockReturnValue('file:///cache/photo_preview/cloud-uuid-1.jpg');
+
+    const result = await PhotoAssetFetchService.fetchUri(makeCloudItem(), makeSignal());
+
+    expect(mockDownloadFile).not.toHaveBeenCalled();
+    expect(result).toBe('file:///cache/photo_preview/cloud-uuid-1.jpg');
+  });
+
+  test('when asset is not cached and has no fileId in the database, then null is returned without downloading', async () => {
+    mockGetCloudAssetById.mockResolvedValue(null);
+
+    const result = await PhotoAssetFetchService.fetchUri(makeCloudItem(), makeSignal());
+
+    expect(mockDownloadFile).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  test('when asset is not cached and has a fileId, then downloadFile is called and the cache path is returned', async () => {
+    mockGetCloudAssetById.mockResolvedValue({ fileId: 'file-id-123', fileSize: 500_000 });
+    (fileSystemService.pathToUri as jest.Mock).mockReturnValue('file:///cache/photo_preview/cloud-uuid-1.jpg');
+
+    const result = await PhotoAssetFetchService.fetchUri(makeCloudItem(), makeSignal());
+
+    expect(mockDownloadFile).toHaveBeenCalledWith(
+      expect.anything(),
+      'bucket-id',
+      'file-id-123',
+      expect.objectContaining({ downloadPath: '/cache/photo_preview/cloud-uuid-1.jpg' }),
+      500_000,
+    );
+    expect(result).toBe('file:///cache/photo_preview/cloud-uuid-1.jpg');
+  });
+});
+
+describe('resolveExportUri', () => {
+  test('when item is local and platform is iOS, then the asset is copied to sandbox and a cleanup is returned', async () => {
+    Object.defineProperty(Platform, 'OS', { get: () => 'ios', configurable: true });
+    mockGetAssetInfo.mockResolvedValue({ localUri: 'file:///dcim/photo.jpg', filename: 'IMG_1234.JPG' });
+
+    const result = await PhotoAssetFetchService.resolveExportUri(makeLocalItem(), makeSignal());
+
+    expect(mockCopyAsync).toHaveBeenCalledWith({
+      from: 'ph://ABCD-1234/L0/001',
+      to: 'file:///cache/photo_share/ABCD-1234_L0_001.JPG',
+    });
+    expect(result?.uri).toBe('/cache/photo_share/ABCD-1234_L0_001.JPG');
+    expect(result?.cleanup).toBeInstanceOf(Function);
+  });
+
+  test('when item is local and platform is Android, then fetchUri is used without sandbox copy', async () => {
+    Object.defineProperty(Platform, 'OS', { get: () => 'android', configurable: true });
+    mockGetAssetInfo.mockResolvedValue({ localUri: 'file:///sdcard/photo.jpg', filename: 'photo.jpg' });
+
+    const result = await PhotoAssetFetchService.resolveExportUri(makeLocalItem(), makeSignal());
+
+    expect(mockCopyAsync).not.toHaveBeenCalled();
+    expect(result?.uri).toBe('file:///sdcard/photo.jpg');
+    expect(result?.cleanup).toBeUndefined();
+  });
+
+  test('when item is cloud-only, then fetchUri is used regardless of platform', async () => {
+    Object.defineProperty(Platform, 'OS', { get: () => 'ios', configurable: true });
+    (photosLocalDB.getCloudAssetById as jest.Mock).mockResolvedValue(null);
+
+    const result = await PhotoAssetFetchService.resolveExportUri(makeCloudItem(), makeSignal());
+
+    expect(mockCopyAsync).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  test('when iOS sandbox copy cleanup is called, then unlinkIfExists is called on the sandbox path', async () => {
+    Object.defineProperty(Platform, 'OS', { get: () => 'ios', configurable: true });
+    (fileSystemService.unlinkIfExists as jest.Mock).mockResolvedValue(undefined);
+
+    const result = await PhotoAssetFetchService.resolveExportUri(makeLocalItem(), makeSignal());
+    result?.cleanup?.();
+
+    expect(fileSystemService.unlinkIfExists).toHaveBeenCalledWith('/cache/photo_share/ABCD-1234_L0_001.JPG');
+  });
+});

--- a/src/services/photos/PhotoAssetFetchService.ts
+++ b/src/services/photos/PhotoAssetFetchService.ts
@@ -1,12 +1,18 @@
 import asyncStorageService from '@internxt-mobile/services/AsyncStorageService';
 import { logger } from '@internxt-mobile/services/common';
+import { toFileUri } from '@internxt-mobile/services/common/uri/uriHelpers';
 import { driveFileService } from '@internxt-mobile/services/drive/file';
 import fileSystemService from '@internxt-mobile/services/FileSystemService';
+import { copyAsync } from 'expo-file-system/legacy';
+import { Platform } from 'react-native';
 import { CloudPhotoItem, PhotoItem } from 'src/screens/PhotosScreen/types';
 import { photosLocalDB } from './database/photosLocalDB';
 import { photoMediaLibraryService } from './PhotoMediaLibraryService';
+import { splitFileNameAndExtension } from './PhotoUploadService.utils';
 
 const getCacheDir = () => fileSystemService.getCacheDir() + '/photo_preview/';
+const getShareTempDir = () => fileSystemService.getCacheDir() + '/photo_share/';
+const assetIdToFileName = (id: string, ext: string) => `${id.replace(/\//g, '_')}.${ext}`;
 
 const cachePathFor = (remoteFileId: string, ext: string) => `${getCacheDir()}${remoteFileId}.${ext}`;
 
@@ -71,11 +77,41 @@ const downloadCloudAsset = async (item: CloudPhotoItem, signal: AbortSignal): Pr
   }
 };
 
+const copyPhAssetToSandbox = async (item: PhotoItem): Promise<string> => {
+  const info = await photoMediaLibraryService.getAssetInfo(item.id);
+  const { fileExtension: ext } = splitFileNameAndExtension(info.filename);
+
+  const cacheDir = getShareTempDir();
+  await fileSystemService.ensureDir(cacheDir);
+  const destPath = `${cacheDir}${assetIdToFileName(item.id, ext)}`;
+  if (!item.uri) {
+    throw new Error(`copyPhAssetToSandbox: asset ${item.id} has no URI`);
+  }
+
+  await copyAsync({ from: item.uri, to: toFileUri(destPath) });
+  return destPath;
+};
+
+export type ExportUri = { uri: string; cleanup?: () => void };
+
 export const PhotoAssetFetchService = {
   fetchUri: async (item: PhotoItem | CloudPhotoItem, signal: AbortSignal): Promise<string | null> => {
     if (item.type === 'local') {
       return resolveLocalUri(item);
     }
     return downloadCloudAsset(item, signal);
+  },
+
+  resolveExportUri: async (item: PhotoItem | CloudPhotoItem, signal: AbortSignal): Promise<ExportUri | null> => {
+    if (item.type === 'local' && Platform.OS === 'ios') {
+      const sandboxPath = await copyPhAssetToSandbox(item);
+      return {
+        uri: sandboxPath,
+        cleanup: () => fileSystemService.unlinkIfExists(sandboxPath).catch(() => undefined),
+      };
+    }
+
+    const uri = await PhotoAssetFetchService.fetchUri(item, signal);
+    return uri ? { uri } : null;
   },
 };


### PR DESCRIPTION
Implemented export, save and copy actions.
  - **Export**: opens the native share sheet for selected items.
  - **Save**: downloads cloud assets if needed and saves to the device gallery via `expo-media-library`.
  - **Copy**: copies the image bytes to the system clipboard via `expo-clipboard`. Restricted to single photo selection.

  ## Summary
  - `PhotoActionsService` centralizes the three actions. `PhotoAssetFetchService` gains `resolveExportUri` which encapsulates the platform specific URI resolution and temporary file cleanup.
  - `usePhotoActions`: encapsulates all state and coordination logic for selection actions.
  - `ActionProgressModal: a fullscreen overlay that blocks interaction while an action is in progress
  - `Favorite` action hidden in `PhotoPreviewScreen` and actions sheet. 