### PR TITLE
[PB-6401] feature/Delete photos action

### DIFF
--- a/assets/lang/strings.ts
+++ b/assets/lang/strings.ts
@@ -253,9 +253,11 @@ const translations = {
             uploadingToCloud: 'Uploading to cloud…',
           },
           deleteModal: {
-            title: 'Delete item(s)',
-            message:
-              'These photos will be deleted from Internxt Drive on all your devices. They will remain in Trash for a limited time.',
+            title: (count: number) => (count === 1 ? 'Delete item' : 'Delete items'),
+            message: (count: number) =>
+              count === 1
+                ? 'This photo will be deleted from Internxt Drive on all your devices. It will remain in Trash for a limited time.'
+                : 'These photos will be deleted from Internxt Drive on all your devices. They will remain in Trash for a limited time.',
             confirm: 'Delete',
           },
         },
@@ -1224,9 +1226,11 @@ const translations = {
             uploadingToCloud: 'Subiendo a la nube…',
           },
           deleteModal: {
-            title: 'Eliminar elemento(s)',
-            message:
-              'Estas fotos se eliminarán de Internxt Drive en todos tus dispositivos. Permanecerán en la papelera durante un tiempo limitado.',
+            title: (count: number) => (count === 1 ? 'Eliminar elemento' : 'Eliminar elementos'),
+            message: (count: number) =>
+              count === 1
+                ? 'Esta foto se eliminará de Internxt Drive en todos tus dispositivos. Permanecerá en la papelera durante un tiempo limitado.'
+                : 'Estas fotos se eliminarán de Internxt Drive en todos tus dispositivos. Permanecerán en la papelera durante un tiempo limitado.',
             confirm: 'Eliminar',
           },
         },

--- a/assets/lang/strings.ts
+++ b/assets/lang/strings.ts
@@ -243,11 +243,20 @@ const translations = {
             addToFavorites: 'Add to favorites',
             removeFromFavorites: 'Remove from favorites',
             moveToTrash: 'Move to trash',
+            uploadToCloud: 'Upload to cloud',
           },
           actionProgress: {
             preparing: 'Preparing…',
             saving: 'Saving to gallery…',
             copying: 'Copying…',
+            movingToTrash: 'Moving to trash…',
+            uploadingToCloud: 'Uploading to cloud…',
+          },
+          deleteModal: {
+            title: 'Delete item(s)',
+            message:
+              'These photos will be deleted from Internxt Drive on all your devices. They will remain in Trash for a limited time.',
+            confirm: 'Delete',
           },
         },
         refreshLocalError: 'Gallery could not be loaded',
@@ -1205,11 +1214,20 @@ const translations = {
             addToFavorites: 'Añadir a favoritos',
             removeFromFavorites: 'Quitar de favoritos',
             moveToTrash: 'Mover a la papelera',
+            uploadToCloud: 'Subir a la nube',
           },
           actionProgress: {
             preparing: 'Preparando…',
             saving: 'Guardando en galería…',
             copying: 'Copiando…',
+            movingToTrash: 'Moviendo a la papelera…',
+            uploadingToCloud: 'Subiendo a la nube…',
+          },
+          deleteModal: {
+            title: 'Eliminar elemento(s)',
+            message:
+              'Estas fotos se eliminarán de Internxt Drive en todos tus dispositivos. Permanecerán en la papelera durante un tiempo limitado.',
+            confirm: 'Eliminar',
           },
         },
         refreshLocalError: 'No se pudo cargar la galería',

--- a/src/components/modals/ConfirmModal/ConfirmModal.tsx
+++ b/src/components/modals/ConfirmModal/ConfirmModal.tsx
@@ -26,7 +26,7 @@ export const ConfirmModal: React.FC<ConfirmModalProps> = (props) => {
   return (
     <Portal>
       <CenterModal isOpen={props.isOpen} onClosed={props.onClose}>
-        <View style={[tailwind('px-4 py-4'), { backgroundColor: getColor('bg-surface') }]}>
+        <View style={tailwind('px-4 py-4 rounded-xl overflow-hidden')}>
           <AppText medium style={[tailwind('text-xl'), { color: getColor('text-gray-100') }]}>
             {props.title}
           </AppText>

--- a/src/screens/HomeScreen/useDiscoverPhotosSheet.spec.tsx
+++ b/src/screens/HomeScreen/useDiscoverPhotosSheet.spec.tsx
@@ -35,7 +35,6 @@ const makeWrapper = (photosState?: Partial<PhotosState>) => {
         totalScannedAssets: 0,
         totalAssetsUploaded: 0,
         currentUploadProgress: 0,
-        lastSyncTimestamp: null,
         uploadingAssetIds: [],
         deviceId: null,
         sessionTotalAssets: 0,

--- a/src/screens/PhotoPreviewScreen/components/PreviewCarousel.tsx
+++ b/src/screens/PhotoPreviewScreen/components/PreviewCarousel.tsx
@@ -105,6 +105,7 @@ interface PreviewCarouselProps {
   visible: boolean;
   onExport: () => void;
   onMore: () => void;
+  onDelete: () => void;
 }
 
 export const PreviewCarousel = ({
@@ -114,6 +115,7 @@ export const PreviewCarousel = ({
   visible,
   onExport,
   onMore,
+  onDelete,
 }: PreviewCarouselProps): JSX.Element => {
   const tailwind = useTailwind();
   const insets = useSafeAreaInsets();
@@ -186,7 +188,7 @@ export const PreviewCarousel = ({
           <ActionButton icon={<ExportIcon size={26} color="white" />} label="Export" onPress={onExport} />
           {/* <ActionButton icon={<StarIcon size={26} color="white" />} label="Favorite" onPress={() => undefined} /> */}
           <ActionButton icon={<DotsThreeOutlineIcon size={26} color="white" />} label="More" onPress={onMore} />
-          <ActionButton icon={<TrashIcon size={26} color="white" />} label="Delete" onPress={() => undefined} />
+          <ActionButton icon={<TrashIcon size={26} color="white" />} label="Delete" onPress={onDelete} />
         </View>
       </LinearGradient>
     </Animated.View>

--- a/src/screens/PhotoPreviewScreen/index.tsx
+++ b/src/screens/PhotoPreviewScreen/index.tsx
@@ -1,9 +1,12 @@
 import { useNavigation } from '@react-navigation/native';
+import strings from 'assets/lang/strings';
 import { useCallback, useState } from 'react';
 import { StatusBar, View } from 'react-native';
+import { ConfirmModal } from 'src/components/modals/ConfirmModal/ConfirmModal';
 import { logger } from 'src/services/common';
 import { toFileUri } from 'src/services/common/uri/uriHelpers';
 import fileSystemService from 'src/services/FileSystemService';
+import { photoActionsService } from 'src/services/photos/PhotoActionsService';
 import { PhotoAssetFetchService } from 'src/services/photos/PhotoAssetFetchService';
 import { RootStackScreenProps } from 'src/types/navigation';
 import { useTailwind } from 'tailwind-rn';
@@ -16,12 +19,13 @@ import { usePreviewItems } from './hooks/usePreviewItems';
 type Props = RootStackScreenProps<'PhotoPreview'>;
 
 export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
-  const { initialId, items: routeItems } = route.params;
+  const { initialId, items: routeItems, onTrashed } = route.params;
   const { items, currentIndex, setCurrentIndex } = usePreviewItems(initialId, routeItems);
   const tailwind = useTailwind();
   const navigation = useNavigation();
 
   const [isUiVisible, setIsUiVisible] = useState(true);
+  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
   const [zoomActive, setZoomActive] = useState(false);
   const [metadataOpen, setMetadataOpen] = useState(false);
   const [hasVideoStarted, setHasVideoStarted] = useState(false);
@@ -76,6 +80,24 @@ export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
     setIsUiVisible(true);
   }, []);
 
+  const handleDeletePress = useCallback(() => setIsDeleteConfirmOpen(true), []);
+
+  const handleDeleteConfirm = useCallback(async () => {
+    setIsDeleteConfirmOpen(false);
+    const currentItem = items[currentIndex];
+    if (!currentItem) {
+      return;
+    }
+    const controller = new AbortController();
+    try {
+      await photoActionsService.trash([currentItem], controller.signal);
+      await onTrashed?.();
+      navigation.goBack();
+    } catch (error) {
+      logger.error(`[PhotoPreview] Delete failed: ${error}`);
+    }
+  }, [items, currentIndex, onTrashed, navigation]);
+
   const handleExport = useCallback(async () => {
     const item = items[currentIndex];
     if (!item) {
@@ -129,9 +151,20 @@ export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
           visible={isUiVisible}
           onExport={handleExport}
           onMore={() => setMetadataOpen(true)}
+          onDelete={handleDeletePress}
         />
       )}
       {metadataOpen && currentItem && <MetadataPanel item={currentItem} onClose={() => setMetadataOpen(false)} />}
+      <ConfirmModal
+        isOpen={isDeleteConfirmOpen}
+        onClose={() => setIsDeleteConfirmOpen(false)}
+        title={strings.screens.photos.selection.deleteModal.title}
+        message={strings.screens.photos.selection.deleteModal.message}
+        confirmLabel={strings.screens.photos.selection.deleteModal.confirm}
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => setIsDeleteConfirmOpen(false)}
+        type="confirm-danger"
+      />
     </View>
   );
 };

--- a/src/screens/PhotoPreviewScreen/index.tsx
+++ b/src/screens/PhotoPreviewScreen/index.tsx
@@ -158,8 +158,8 @@ export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
       <ConfirmModal
         isOpen={isDeleteConfirmOpen}
         onClose={() => setIsDeleteConfirmOpen(false)}
-        title={strings.screens.photos.selection.deleteModal.title}
-        message={strings.screens.photos.selection.deleteModal.message}
+        title={strings.screens.photos.selection.deleteModal.title(1)}
+        message={strings.screens.photos.selection.deleteModal.message(1)}
         confirmLabel={strings.screens.photos.selection.deleteModal.confirm}
         onConfirm={handleDeleteConfirm}
         onCancel={() => setIsDeleteConfirmOpen(false)}

--- a/src/screens/PhotosScreen/components/MoreActionsBottomSheet.tsx
+++ b/src/screens/PhotosScreen/components/MoreActionsBottomSheet.tsx
@@ -1,5 +1,6 @@
 import {
   CaretLeftIcon,
+  CloudArrowUpIcon,
   CopyIcon,
   DownloadSimpleIcon,
   ExportIcon,
@@ -14,7 +15,7 @@ import useGetColor from 'src/hooks/useColor';
 import { useTailwind } from 'tailwind-rn';
 import strings from '../../../../assets/lang/strings';
 import { TimelinePhotoItem } from '../types';
-import { isItemBacked } from '../utils/photoUtils';
+import { isItemBacked, isLocalItemNotBacked } from '../utils/photoUtils';
 
 interface MoreActionsBottomSheetProps {
   isOpen: boolean;
@@ -26,6 +27,7 @@ interface MoreActionsBottomSheetProps {
   onSave: () => void;
   onFavorite: () => void;
   onTrash: () => void;
+  onRestore: () => void;
 }
 
 interface ActionRowProps {
@@ -75,6 +77,7 @@ const MoreActionsBottomSheet = ({
   onSave,
   onFavorite,
   onTrash,
+  onRestore,
 }: MoreActionsBottomSheetProps): JSX.Element => {
   const tailwind = useTailwind();
   const getColor = useGetColor();
@@ -107,6 +110,7 @@ const MoreActionsBottomSheet = ({
   }, [isOpen]);
 
   const areAllSelectedItemsBacked = selectedItems.every(isItemBacked);
+  const areAllSelectedNotBacked = selectedItems.every(isLocalItemNotBacked);
   const isOneItemSelected = selectedItems.length === 1;
   const hasBackedOrCloud = selectedItems.some(isItemBacked);
   const isSinglePhoto = isOneItemSelected && selectedItems[0]?.mediaType === 'photo';
@@ -137,6 +141,12 @@ const MoreActionsBottomSheet = ({
             icon: <PlusSquareIcon size={22} color={iconColor} />,
             onPress: onDuplicate,
           },
+        areAllSelectedNotBacked && {
+          key: 'restore',
+          label: actionStrings.uploadToCloud,
+          icon: <CloudArrowUpIcon size={22} color={iconColor} />,
+          onPress: onRestore,
+        },
         hasBackedOrCloud && {
           key: 'save',
           label: actionStrings.save,
@@ -166,6 +176,7 @@ const MoreActionsBottomSheet = ({
       }[],
     [
       areAllSelectedItemsBacked,
+      areAllSelectedNotBacked,
       isOneItemSelected,
       isSinglePhoto,
       hasBackedOrCloud,
@@ -177,6 +188,7 @@ const MoreActionsBottomSheet = ({
       onSave,
       onFavorite,
       onTrash,
+      onRestore,
     ],
   );
 

--- a/src/screens/PhotosScreen/hooks/useCloudAssets.spec.ts
+++ b/src/screens/PhotosScreen/hooks/useCloudAssets.spec.ts
@@ -20,8 +20,7 @@ jest.mock('src/store/hooks', () => ({
 const mockPhotosLocalDB = photosLocalDB as jest.Mocked<typeof photosLocalDB>;
 const mockUseAppSelector = useAppSelector as jest.Mock;
 
-const makeStoreState = (overrides: { lastSyncTimestamp?: number | null; cloudFetchRevision?: number } = {}) => ({
-  lastSyncTimestamp: overrides.lastSyncTimestamp ?? null,
+const makeStoreState = (overrides: { cloudFetchRevision?: number } = {}) => ({
   cloudFetchRevision: overrides.cloudFetchRevision ?? 0,
 });
 
@@ -60,8 +59,7 @@ describe('useCloudAssets', () => {
 
     const { result } = renderHook(() => useCloudAssets());
 
-    // Flush the immediate lastSyncTimestamp effect only — do not run timers
-    // so the debounce from cloudFetchRevision has not yet fired
+    // Flush mount effect only — do not run timers so the debounce from cloudFetchRevision has not yet fired
     await act(flushAsync);
 
     expect(result.current.cloudItems).toHaveLength(1);
@@ -107,7 +105,7 @@ describe('useCloudAssets', () => {
     expect(result.current.cloudItems[0].id).toBe('r2');
   });
 
-  test('when last sync timestamp updates, then cloud items reload from the database immediately', async () => {
+  test('when reloadCloud is called, then cloud items reload from the database immediately', async () => {
     mockPhotosLocalDB.getAllCloudAssets
       .mockResolvedValueOnce([]) // mount
       .mockResolvedValueOnce([
@@ -126,19 +124,13 @@ describe('useCloudAssets', () => {
         },
       ]);
 
-    const { result, rerender } = renderHook(() => useCloudAssets());
+    const { result } = renderHook(() => useCloudAssets());
 
     await act(flushAsync);
     expect(result.current.cloudItems).toHaveLength(0);
 
-    mockUseAppSelector.mockImplementation((selector: (s: { photos: ReturnType<typeof makeStoreState> }) => unknown) =>
-      selector({ photos: makeStoreState({ lastSyncTimestamp: Date.now() }) }),
-    );
-
-    // lastSyncTimestamp effect is immediate — no timer needed
     await act(async () => {
-      rerender({});
-      await flushAsync();
+      await result.current.reloadCloud();
     });
 
     expect(result.current.cloudItems).toHaveLength(1);

--- a/src/screens/PhotosScreen/hooks/useCloudAssets.ts
+++ b/src/screens/PhotosScreen/hooks/useCloudAssets.ts
@@ -6,11 +6,12 @@ import { cloudEntryToPhotoItem } from '../utils/photoTimelineGroups';
 
 export interface CloudAssetsResult {
   cloudItems: CloudPhotoItem[];
+  reloadCloud: () => Promise<void>;
 }
 
 export const useCloudAssets = (): CloudAssetsResult => {
   const [cloudItems, setCloudItems] = useState<CloudPhotoItem[]>([]);
-  const { lastSyncTimestamp, cloudFetchRevision } = useAppSelector((state) => state.photos);
+  const { cloudFetchRevision } = useAppSelector((state) => state.photos);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const reloadCloudFromDB = useCallback(async () => {
@@ -23,10 +24,10 @@ export const useCloudAssets = (): CloudAssetsResult => {
     setCloudItems(deduplicated.map(cloudEntryToPhotoItem));
   }, []);
 
-  // Immediate reload when the backup cycle completes
+  // Initial load on mount
   useEffect(() => {
     reloadCloudFromDB();
-  }, [reloadCloudFromDB, lastSyncTimestamp]);
+  }, [reloadCloudFromDB]);
 
   // Debounced reload during cloud history sync — parallel workers can fire many
   // rapid increments; coalescing them prevents FlashList from reconciling 2000+
@@ -38,5 +39,5 @@ export const useCloudAssets = (): CloudAssetsResult => {
     };
   }, [reloadCloudFromDB, cloudFetchRevision]);
 
-  return { cloudItems };
+  return { cloudItems, reloadCloud: reloadCloudFromDB };
 };

--- a/src/screens/PhotosScreen/hooks/usePhotoActions.ts
+++ b/src/screens/PhotosScreen/hooks/usePhotoActions.ts
@@ -2,22 +2,40 @@ import strings from 'assets/lang/strings';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { logger } from 'src/services/common';
 import { photoActionsService } from 'src/services/photos/PhotoActionsService';
+import { useAppDispatch } from 'src/store/hooks';
+import { runUploadThunk } from 'src/store/slices/photos';
 import { PhotoSelection } from './usePhotoSelection';
 
 export interface UsePhotoActionsReturn {
   actionLabel: string | null;
   isMoreActionsSheetOpen: boolean;
+  isDeleteConfirmOpen: boolean;
   handleExport: () => Promise<void>;
   handleSave: () => Promise<void>;
   handleCopy: () => Promise<void>;
+  handleDelete: () => void;
+  handleTrash: () => void;
+  handleDeleteClose: () => void;
+  handleTrashConfirm: () => Promise<void>;
+  handleRestore: () => Promise<void>;
   handleMore: () => void;
   handleMoreClose: () => void;
   todoAction: (name: string) => () => void;
 }
 
-export const usePhotoActions = (selection: PhotoSelection): UsePhotoActionsReturn => {
+interface UsePhotoActionsOpts {
+  reloadLocal: () => Promise<void>;
+  reloadCloud: () => Promise<void>;
+}
+
+export const usePhotoActions = (
+  selection: PhotoSelection,
+  { reloadLocal, reloadCloud }: UsePhotoActionsOpts,
+): UsePhotoActionsReturn => {
+  const dispatch = useAppDispatch();
   const [actionLabel, setActionLabel] = useState<string | null>(null);
   const [isMoreActionsSheetOpen, setIsMoreActionsSheetOpen] = useState(false);
+  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
   const actionAbortRef = useRef<AbortController | null>(null);
 
   useEffect(
@@ -79,6 +97,46 @@ export const usePhotoActions = (selection: PhotoSelection): UsePhotoActionsRetur
     }
   }, [startAction, finishAction, selection.selectedItems]);
 
+  const handleDelete = useCallback(() => {
+    setIsMoreActionsSheetOpen(false);
+    setIsDeleteConfirmOpen(true);
+  }, []);
+
+  const handleTrash = useCallback(() => {
+    setIsMoreActionsSheetOpen(false);
+    setIsDeleteConfirmOpen(true);
+  }, []);
+
+  const handleDeleteClose = useCallback(() => setIsDeleteConfirmOpen(false), []);
+
+  const handleTrashConfirm = useCallback(async () => {
+    setIsDeleteConfirmOpen(false);
+    const { signal } = startAction(strings.screens.photos.selection.actionProgress.movingToTrash);
+    try {
+      await photoActionsService.trash(selection.selectedItems, signal);
+      await reloadLocal();
+      await reloadCloud();
+    } catch (error) {
+      logger.error(`[usePhotoActions] Trash error: ${error}`);
+    } finally {
+      finishAction();
+    }
+  }, [startAction, finishAction, selection.selectedItems, reloadLocal, reloadCloud]);
+
+  const handleRestore = useCallback(async () => {
+    const { signal } = startAction(strings.screens.photos.selection.actionProgress.uploadingToCloud);
+    try {
+      await photoActionsService.restoreToCloud(selection.selectedItems, signal);
+      await dispatch(runUploadThunk({ bypassEnabled: true })).unwrap();
+      await reloadLocal();
+      await reloadCloud();
+    } catch (error) {
+      logger.error(`[usePhotoActions] Restore error: ${error}`);
+    } finally {
+      finishAction();
+    }
+  }, [startAction, finishAction, selection.selectedItems, dispatch, reloadLocal, reloadCloud]);
+
   const todoAction = useCallback(
     (name: string) => () => {
       logger.info(`[usePhotoActions] action not yet implemented: ${name}`);
@@ -94,9 +152,15 @@ export const usePhotoActions = (selection: PhotoSelection): UsePhotoActionsRetur
   return {
     actionLabel,
     isMoreActionsSheetOpen,
+    isDeleteConfirmOpen,
     handleExport,
     handleSave,
     handleCopy,
+    handleDelete,
+    handleTrash,
+    handleDeleteClose,
+    handleTrashConfirm,
+    handleRestore,
     handleMore,
     handleMoreClose,
     todoAction,

--- a/src/screens/PhotosScreen/hooks/usePhotosTimeline.ts
+++ b/src/screens/PhotosScreen/hooks/usePhotosTimeline.ts
@@ -10,11 +10,12 @@ export interface PhotosTimelineResult {
   isLoading: boolean;
   loadNextPage: () => void;
   reloadLocal: () => Promise<void>;
+  reloadCloud: () => Promise<void>;
 }
 
 export const usePhotosTimeline = (): PhotosTimelineResult => {
   const { assets, isLoading, syncedIds, uploadingIdSet, loadNextPage, reload: reloadLocal } = useLocalAssets();
-  const { cloudItems } = useCloudAssets();
+  const { cloudItems, reloadCloud } = useCloudAssets();
 
   const { syncStatus, sessionTotalAssets, sessionUploadedAssets, isFetchingCloudHistory } = useAppSelector(
     (state) => state.photos,
@@ -36,5 +37,5 @@ export const usePhotosTimeline = (): PhotosTimelineResult => {
     })) as TimelineDateGroup[];
   }, [mergedGroups, syncStatus, sessionTotalAssets, sessionUploadedAssets, isFetchingCloudHistory]);
 
-  return { timelineDateGroups, isLoading, loadNextPage, reloadLocal };
+  return { timelineDateGroups, isLoading, loadNextPage, reloadLocal, reloadCloud };
 };

--- a/src/screens/PhotosScreen/index.tsx
+++ b/src/screens/PhotosScreen/index.tsx
@@ -187,8 +187,8 @@ const PhotosScreen = (): JSX.Element => {
       <ConfirmModal
         isOpen={actions.isDeleteConfirmOpen}
         onClose={actions.handleDeleteClose}
-        title={strings.screens.photos.selection.deleteModal.title}
-        message={strings.screens.photos.selection.deleteModal.message}
+        title={strings.screens.photos.selection.deleteModal.title(selection.selectedIds.size)}
+        message={strings.screens.photos.selection.deleteModal.message(selection.selectedIds.size)}
         confirmLabel={strings.screens.photos.selection.deleteModal.confirm}
         onConfirm={actions.handleTrashConfirm}
         onCancel={actions.handleDeleteClose}

--- a/src/screens/PhotosScreen/index.tsx
+++ b/src/screens/PhotosScreen/index.tsx
@@ -1,13 +1,14 @@
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import strings from 'assets/lang/strings';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { View } from 'react-native';
 import AppScreen from 'src/components/AppScreen';
+import { ConfirmModal } from 'src/components/modals/ConfirmModal/ConfirmModal';
 import { useAppDispatch, useAppSelector } from 'src/store/hooks';
 import { forceRefreshThunk, photosActions, runBackupCycleThunk } from 'src/store/slices/photos';
 import { uiActions } from 'src/store/slices/ui';
 import { TabExplorerScreenNavigationProp } from 'src/types/navigation';
 import { useTailwind } from 'tailwind-rn';
-import strings from '../../../assets/lang/strings';
 import notificationsService from '../../services/NotificationsService';
 import { photoPermissionService } from '../../services/photos/photoPermissionService';
 import { NotificationType } from '../../types';
@@ -32,7 +33,7 @@ const PhotosScreen = (): JSX.Element => {
   const { enabled, permissionStatus } = useAppSelector((state) => state.photos);
   const [isEnableBackupSheetOpen, setIsEnableBackupSheetOpen] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
-  const { timelineDateGroups, isLoading, loadNextPage, reloadLocal } = usePhotosTimeline();
+  const { timelineDateGroups, isLoading, loadNextPage, reloadLocal, reloadCloud } = usePhotosTimeline();
 
   const allItems = useMemo<TimelinePhotoItem[]>(
     () => timelineDateGroups.flatMap((dateGroup) => dateGroup.group.photos),
@@ -40,7 +41,11 @@ const PhotosScreen = (): JSX.Element => {
   );
 
   const selection = usePhotoSelection(allItems);
-  const actions = usePhotoActions(selection);
+  const actions = usePhotoActions(selection, { reloadLocal, reloadCloud });
+
+  const handleTrashedFromPreview = useCallback(async () => {
+    await Promise.all([reloadLocal(), reloadCloud()]);
+  }, [reloadLocal, reloadCloud]);
 
   const handlePhotoPress = useCallback(
     (id: string) => {
@@ -48,9 +53,9 @@ const PhotosScreen = (): JSX.Element => {
         selection.toggleSelect(id);
         return;
       }
-      navigation.navigate('PhotoPreview', { initialId: id, items: allItems });
+      navigation.navigate('PhotoPreview', { initialId: id, items: allItems, onTrashed: handleTrashedFromPreview });
     },
-    [selection, navigation, allItems],
+    [selection, navigation, allItems, handleTrashedFromPreview],
   );
 
   const handlePhotoLongPress = useCallback(
@@ -160,7 +165,7 @@ const PhotosScreen = (): JSX.Element => {
         onExport={actions.handleExport}
         onFavorite={actions.todoAction('favorite')}
         onMore={actions.handleMore}
-        onDelete={actions.todoAction('delete')}
+        onDelete={actions.handleDelete}
         onInfo={actions.todoAction('info')}
       />
 
@@ -173,10 +178,22 @@ const PhotosScreen = (): JSX.Element => {
         onDuplicate={actions.todoAction('duplicate')}
         onSave={actions.handleSave}
         onFavorite={actions.todoAction('favorite')}
-        onTrash={actions.todoAction('trash')}
+        onTrash={actions.handleTrash}
+        onRestore={actions.handleRestore}
       />
 
       <ActionProgressModal visible={actions.actionLabel !== null} label={actions.actionLabel ?? ''} />
+
+      <ConfirmModal
+        isOpen={actions.isDeleteConfirmOpen}
+        onClose={actions.handleDeleteClose}
+        title={strings.screens.photos.selection.deleteModal.title}
+        message={strings.screens.photos.selection.deleteModal.message}
+        confirmLabel={strings.screens.photos.selection.deleteModal.confirm}
+        onConfirm={actions.handleTrashConfirm}
+        onCancel={actions.handleDeleteClose}
+        type="confirm-danger"
+      />
 
       <EnableBackupBottomSheet isOpen={isEnableBackupSheetOpen} onClose={() => setIsEnableBackupSheetOpen(false)} />
     </AppScreen>

--- a/src/screens/PhotosScreen/utils/photoUtils.ts
+++ b/src/screens/PhotosScreen/utils/photoUtils.ts
@@ -2,3 +2,6 @@ import { TimelinePhotoItem } from '../types';
 
 export const isItemBacked = (item: TimelinePhotoItem): boolean =>
   item.type === 'cloud-only' || (item.type === 'local' && item.backupState === 'backed');
+
+export const isLocalItemNotBacked = (item: TimelinePhotoItem): boolean =>
+  item.type === 'local' && item.backupState === 'not-backed';

--- a/src/services/photos/PhotoActionsService.spec.ts
+++ b/src/services/photos/PhotoActionsService.spec.ts
@@ -1,10 +1,12 @@
 import * as RNFS from '@dr.pogodin/react-native-fs';
 import * as Clipboard from 'expo-clipboard';
 import * as MediaLibrary from 'expo-media-library';
-import { PhotoItem } from 'src/screens/PhotosScreen/types';
+import { CloudPhotoItem, PhotoItem } from 'src/screens/PhotosScreen/types';
 import fileSystemService from 'src/services/FileSystemService';
+import { driveTrashService } from 'src/services/drive/trash/driveTrash.service';
 import { photoActionsService } from './PhotoActionsService';
 import { PhotoAssetFetchService } from './PhotoAssetFetchService';
+import { photosLocalDB } from './database/photosLocalDB';
 
 jest.mock('./PhotoAssetFetchService', () => ({
   PhotoAssetFetchService: {
@@ -35,6 +37,19 @@ jest.mock('src/services/common', () => ({
   logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
 }));
 
+jest.mock('./database/photosLocalDB', () => ({
+  photosLocalDB: {
+    getStatus: jest.fn(),
+    deleteCloudAsset: jest.fn(),
+    markAssetDeleted: jest.fn(),
+    markPending: jest.fn(),
+  },
+}));
+
+jest.mock('src/services/drive/trash/driveTrash.service', () => ({
+  driveTrashService: { moveToTrash: jest.fn() },
+}));
+
 const mockResolveExportUri = PhotoAssetFetchService.resolveExportUri as jest.Mock;
 const mockFetchUri = PhotoAssetFetchService.fetchUri as jest.Mock;
 const mockShareFile = fileSystemService.shareFile as jest.Mock;
@@ -42,8 +57,11 @@ const mockRequestPermissions = MediaLibrary.requestPermissionsAsync as jest.Mock
 const mockSaveToLibrary = MediaLibrary.saveToLibraryAsync as jest.Mock;
 const mockReadFile = RNFS.readFile as jest.Mock;
 const mockSetImage = Clipboard.setImageAsync as jest.Mock;
+const mockDB = photosLocalDB as jest.Mocked<typeof photosLocalDB>;
 
-const makeLocalItem = (id = 'asset-1'): PhotoItem => ({
+const mockMoveToTrash = driveTrashService.moveToTrash as jest.Mock;
+
+const makeLocalBacked = (id = 'asset-1'): PhotoItem => ({
   id,
   type: 'local',
   uri: `ph://${id}`,
@@ -52,10 +70,39 @@ const makeLocalItem = (id = 'asset-1'): PhotoItem => ({
   backupState: 'backed',
 });
 
+const makeLocalNotBacked = (id = 'asset-nb'): PhotoItem => ({
+  id,
+  type: 'local',
+  uri: `ph://${id}`,
+  mediaType: 'photo',
+  createdAt: Date.now(),
+  backupState: 'not-backed',
+});
+
+const makeCloudOnly = (id = 'remote-1'): CloudPhotoItem => ({
+  id,
+  type: 'cloud-only',
+  mediaType: 'photo',
+  createdAt: Date.now(),
+  fileName: 'photo.jpg',
+  thumbnailPath: null,
+  thumbnailBucketId: null,
+  thumbnailBucketFile: null,
+  thumbnailType: null,
+  deviceId: 'device-1',
+});
+
+const makeLocalItem = makeLocalBacked;
+
 const makeSignal = () => new AbortController().signal;
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockDB.getStatus.mockResolvedValue(null);
+  mockDB.deleteCloudAsset.mockResolvedValue(undefined);
+  mockDB.markAssetDeleted.mockResolvedValue(undefined);
+  mockDB.markPending.mockResolvedValue(undefined);
+  mockMoveToTrash.mockResolvedValue(undefined);
 });
 
 describe('exportItems', () => {
@@ -164,5 +211,92 @@ describe('copyToClipboard', () => {
     mockReadFile.mockRejectedValue(new Error('read error'));
 
     await expect(photoActionsService.copyToClipboard(makeLocalItem(), makeSignal())).rejects.toThrow('read error');
+  });
+});
+
+describe('trash', () => {
+  test('when a cloud-only item is trashed, then it is sent to Drive trash and its cloud asset is deleted', async () => {
+    const item = makeCloudOnly('remote-1');
+
+    await photoActionsService.trash([item], makeSignal());
+
+    expect(mockMoveToTrash).toHaveBeenCalledWith([{ id: 'remote-1', type: 'file', uuid: 'remote-1' }]);
+    expect(mockDB.deleteCloudAsset).toHaveBeenCalledWith('remote-1');
+    expect(mockDB.markAssetDeleted).not.toHaveBeenCalled();
+  });
+
+  test('when a local backed item with a remote file id is trashed, then its remote id is sent to Drive trash and the asset is tombstoned', async () => {
+    mockDB.getStatus.mockResolvedValueOnce({ remoteFileId: 'remote-abc' } as never);
+    const item = makeLocalBacked('local-1');
+
+    await photoActionsService.trash([item], makeSignal());
+
+    expect(mockMoveToTrash).toHaveBeenCalledWith([{ id: 'remote-abc', type: 'file', uuid: 'remote-abc' }]);
+    expect(mockDB.markAssetDeleted).toHaveBeenCalledWith('local-1');
+    expect(mockDB.deleteCloudAsset).toHaveBeenCalledWith('remote-abc');
+  });
+
+  test('when a local backed item has no remote file id in the database, then it is skipped entirely', async () => {
+    mockDB.getStatus.mockResolvedValueOnce({ remoteFileId: null } as never);
+    const item = makeLocalBacked('local-orphan');
+
+    await photoActionsService.trash([item], makeSignal());
+
+    expect(mockMoveToTrash).not.toHaveBeenCalled();
+    expect(mockDB.markAssetDeleted).not.toHaveBeenCalled();
+    expect(mockDB.deleteCloudAsset).not.toHaveBeenCalled();
+  });
+
+  test('when a local not-backed item is in the list, then it is skipped', async () => {
+    const item = makeLocalNotBacked('local-nb');
+
+    await photoActionsService.trash([item], makeSignal());
+
+    expect(mockMoveToTrash).not.toHaveBeenCalled();
+    expect(mockDB.markAssetDeleted).not.toHaveBeenCalled();
+  });
+
+  test('when the list is empty, then Drive trash is not called', async () => {
+    await photoActionsService.trash([], makeSignal());
+
+    expect(mockMoveToTrash).not.toHaveBeenCalled();
+  });
+
+  test('when the signal is aborted before processing starts, then nothing is sent to trash', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await photoActionsService.trash([makeCloudOnly()], controller.signal);
+
+    expect(mockMoveToTrash).not.toHaveBeenCalled();
+  });
+});
+
+describe('restoreToCloud', () => {
+  test('when a local item is restored, then it is marked pending', async () => {
+    const item = makeLocalNotBacked('local-1');
+
+    await photoActionsService.restoreToCloud([item], makeSignal());
+
+    expect(mockDB.markPending).toHaveBeenCalledWith('local-1');
+  });
+
+  test('when a cloud-only item is in the list, then it is ignored', async () => {
+    const cloud = makeCloudOnly('remote-1');
+    const local = makeLocalNotBacked('local-1');
+
+    await photoActionsService.restoreToCloud([cloud, local], makeSignal());
+
+    expect(mockDB.markPending).toHaveBeenCalledTimes(1);
+    expect(mockDB.markPending).toHaveBeenCalledWith('local-1');
+  });
+
+  test('when the signal is aborted before processing starts, then nothing is marked pending', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await photoActionsService.restoreToCloud([makeLocalNotBacked()], controller.signal);
+
+    expect(mockDB.markPending).not.toHaveBeenCalled();
   });
 });

--- a/src/services/photos/PhotoActionsService.ts
+++ b/src/services/photos/PhotoActionsService.ts
@@ -4,8 +4,12 @@ import * as MediaLibrary from 'expo-media-library';
 import { TimelinePhotoItem } from 'src/screens/PhotosScreen/types';
 import { logger } from 'src/services/common';
 import { stripFileUri, toFileUri } from 'src/services/common/uri/uriHelpers';
+import { driveTrashService } from 'src/services/drive/trash/driveTrash.service';
 import fileSystemService from 'src/services/FileSystemService';
+import { photosLocalDB } from './database/photosLocalDB';
 import { PhotoAssetFetchService } from './PhotoAssetFetchService';
+
+type CleanupItem = { type: 'cloud'; assetId: string } | { type: 'local-backed'; assetId: string; remoteFileId: string };
 
 class PhotoActionsService {
   async exportItems(items: TimelinePhotoItem[], signal: AbortSignal): Promise<void> {
@@ -57,6 +61,76 @@ class PhotoActionsService {
       logger.error(`[PhotoActionsService] saveToDevice failed for ${item.id}: ${error}`);
       throw error;
     }
+  }
+
+  private async classifyItems(
+    items: TimelinePhotoItem[],
+    signal: AbortSignal,
+  ): Promise<{
+    trashPayload: { id: string; type: 'file'; uuid: string }[];
+    cleanupItems: CleanupItem[];
+  }> {
+    const trashPayload: { id: string; type: 'file'; uuid: string }[] = [];
+    const cleanupItems: CleanupItem[] = [];
+
+    for (const item of items) {
+      if (signal.aborted) {
+        return { trashPayload, cleanupItems };
+      }
+
+      if (item.type === 'cloud-only') {
+        trashPayload.push({ id: item.id, type: 'file', uuid: item.id });
+        cleanupItems.push({ type: 'cloud', assetId: item.id });
+      } else if (item.type === 'local' && item.backupState === 'backed') {
+        const itemDbEntry = await photosLocalDB.getStatus(item.id);
+
+        if (itemDbEntry?.remoteFileId) {
+          const { remoteFileId } = itemDbEntry;
+          trashPayload.push({ id: remoteFileId, type: 'file', uuid: remoteFileId });
+          cleanupItems.push({ type: 'local-backed', assetId: item.id, remoteFileId });
+        } else {
+          logger.info(`[PhotoActionsService] trash — local-backed ${item.id} has no remoteFileId, skipping`);
+        }
+      } else {
+        logger.info(
+          `[PhotoActionsService] trash — skipping ${item.id} (type=${item.type}, backupState=${item.type === 'local' ? item.backupState : 'n/a'})`,
+        );
+      }
+    }
+
+    return { trashPayload, cleanupItems };
+  }
+
+  private async removeItemsFromDB(cleanupItems: CleanupItem[]): Promise<void> {
+    for (const target of cleanupItems) {
+      if (target.type === 'cloud') {
+        await photosLocalDB.deleteCloudAsset(target.assetId);
+      } else {
+        await photosLocalDB.markAssetDeleted(target.assetId);
+        await photosLocalDB.deleteCloudAsset(target.remoteFileId);
+      }
+    }
+  }
+
+  async restoreToCloud(items: TimelinePhotoItem[], signal: AbortSignal): Promise<void> {
+    for (const item of items) {
+      if (signal.aborted) return;
+      if (item.type !== 'local') continue;
+      await photosLocalDB.markPending(item.id);
+    }
+  }
+
+  async trash(items: TimelinePhotoItem[], signal: AbortSignal): Promise<void> {
+    const { trashPayload, cleanupItems } = await this.classifyItems(items, signal);
+
+    logger.info(`[PhotoActionsService] trash — sending ${trashPayload.length}/${items.length} items to Drive trash`);
+    if (trashPayload.length > 0) {
+      await driveTrashService.moveToTrash(trashPayload);
+      logger.info('[PhotoActionsService] trash — moveToTrash done');
+    }
+
+    await this.removeItemsFromDB(cleanupItems);
+    logger.info('[PhotoActionsService] trash — DB cleanup done');
   }
 
   async copyToClipboard(item: TimelinePhotoItem, signal: AbortSignal): Promise<void> {

--- a/src/services/photos/PhotoDeduplicator.spec.ts
+++ b/src/services/photos/PhotoDeduplicator.spec.ts
@@ -2,23 +2,27 @@ import { PhotoDeduplicator } from './PhotoDeduplicator';
 import { photosLocalDB } from './database/photosLocalDB';
 
 jest.mock('./database/photosLocalDB', () => ({
-  photosLocalDB: { getSyncedEntries: jest.fn() },
+  photosLocalDB: { getSyncedEntries: jest.fn(), getDeletedAssetIds: jest.fn() },
 }));
 
 const mockDB = photosLocalDB as jest.Mocked<typeof photosLocalDB>;
 
-const makeAsset = (id: string, modificationTime = 1000) =>
-  ({ id, modificationTime }) as never;
+const makeAsset = (id: string, modificationTime = 1000) => ({ id, modificationTime }) as never;
 
 describe('PhotoDeduplicator', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockDB.getDeletedAssetIds.mockResolvedValue(new Set());
   });
 
   test('when no photos have been synced before, then all photos are queued as new', async () => {
     mockDB.getSyncedEntries.mockResolvedValueOnce(new Map());
 
-    const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([makeAsset('a'), makeAsset('b'), makeAsset('c')]);
+    const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([
+      makeAsset('a'),
+      makeAsset('b'),
+      makeAsset('c'),
+    ]);
 
     expect(newAssets.map((a) => a.id)).toEqual(['a', 'b', 'c']);
     expect(editedAssets).toHaveLength(0);
@@ -33,27 +37,31 @@ describe('PhotoDeduplicator', () => {
       ]),
     );
 
-    const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([makeAsset('a'), makeAsset('b'), makeAsset('c')]);
+    const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([
+      makeAsset('a'),
+      makeAsset('b'),
+      makeAsset('c'),
+    ]);
 
     expect(newAssets).toHaveLength(0);
     expect(editedAssets).toHaveLength(0);
   });
 
   test('when some photos are already synced, then only the unsynced ones are queued as new', async () => {
-    mockDB.getSyncedEntries.mockResolvedValueOnce(
-      new Map([['b', { modificationTime: 1000 }]]),
-    );
+    mockDB.getSyncedEntries.mockResolvedValueOnce(new Map([['b', { modificationTime: 1000 }]]));
 
-    const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([makeAsset('a'), makeAsset('b'), makeAsset('c')]);
+    const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([
+      makeAsset('a'),
+      makeAsset('b'),
+      makeAsset('c'),
+    ]);
 
     expect(newAssets.map((a) => a.id)).toEqual(['a', 'c']);
     expect(editedAssets).toHaveLength(0);
   });
 
   test('when a previously synced photo has been edited on the device, then it is queued as an edit', async () => {
-    mockDB.getSyncedEntries.mockResolvedValueOnce(
-      new Map([['a', { modificationTime: 500 }]]),
-    );
+    mockDB.getSyncedEntries.mockResolvedValueOnce(new Map([['a', { modificationTime: 500 }]]));
 
     const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([makeAsset('a', 1000)]);
 
@@ -62,9 +70,7 @@ describe('PhotoDeduplicator', () => {
   });
 
   test('when a synced photo has no recorded modification time, then it is not re-queued', async () => {
-    mockDB.getSyncedEntries.mockResolvedValueOnce(
-      new Map([['a', { modificationTime: null }]]),
-    );
+    mockDB.getSyncedEntries.mockResolvedValueOnce(new Map([['a', { modificationTime: null }]]));
 
     const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([makeAsset('a', 1000)]);
 
@@ -76,6 +82,26 @@ describe('PhotoDeduplicator', () => {
     const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([]);
 
     expect(mockDB.getSyncedEntries).not.toHaveBeenCalled();
+    expect(newAssets).toHaveLength(0);
+    expect(editedAssets).toHaveLength(0);
+  });
+
+  test('when a photo was explicitly deleted from cloud, then it is excluded from new assets', async () => {
+    mockDB.getSyncedEntries.mockResolvedValueOnce(new Map());
+    mockDB.getDeletedAssetIds.mockResolvedValueOnce(new Set(['a']));
+
+    const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([makeAsset('a'), makeAsset('b')]);
+
+    expect(newAssets.map((asset) => asset.id)).toEqual(['b']);
+    expect(editedAssets).toHaveLength(0);
+  });
+
+  test('when a previously synced photo was explicitly deleted from cloud, then it is excluded from edited assets', async () => {
+    mockDB.getSyncedEntries.mockResolvedValueOnce(new Map([['a', { modificationTime: 500 }]]));
+    mockDB.getDeletedAssetIds.mockResolvedValueOnce(new Set(['a']));
+
+    const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([makeAsset('a', 1000)]);
+
     expect(newAssets).toHaveLength(0);
     expect(editedAssets).toHaveLength(0);
   });

--- a/src/services/photos/PhotoDeduplicator.ts
+++ b/src/services/photos/PhotoDeduplicator.ts
@@ -20,11 +20,19 @@ export const PhotoDeduplicator = {
       return { newAssets: [], editedAssets: [] };
     }
 
-    const syncedEntries = await photosLocalDB.getSyncedEntries(assets.map((asset) => asset.id));
+    const [syncedEntries, deletedIds] = await Promise.all([
+      photosLocalDB.getSyncedEntries(assets.map((asset) => asset.id)),
+      photosLocalDB.getDeletedAssetIds(),
+    ]);
+
     const newAssets: MediaLibrary.Asset[] = [];
     const editedAssets: MediaLibrary.Asset[] = [];
 
     for (const asset of assets) {
+      const skipBecauseDeleted = deletedIds.has(asset.id);
+      if (skipBecauseDeleted) {
+        continue;
+      }
       const syncedInfo = syncedEntries.get(asset.id);
       if (!syncedInfo) {
         newAssets.push(asset);

--- a/src/services/photos/database/photosLocalDB.ts
+++ b/src/services/photos/database/photosLocalDB.ts
@@ -50,13 +50,14 @@ interface CloudAssetRow {
   encrypt_version: string | null;
 }
 
-export type AssetSyncStatus = 'pending' | 'pending_edit' | 'synced' | 'error';
+export type AssetSyncStatus = 'pending' | 'pending_edit' | 'synced' | 'error' | 'deleted';
 
 export interface AssetSyncEntry {
   assetId: string;
   status: AssetSyncStatus;
   remoteFileId: string | null;
   syncedAt: number | null;
+  deletedAt: number | null;
   errorMessage: string | null;
   attemptCount: number;
   createdAt: number;
@@ -76,6 +77,7 @@ interface AssetSyncRow {
   status: AssetSyncStatus;
   remote_file_id: string | null;
   synced_at: number | null;
+  deleted_at: number | null;
   error_message: string | null;
   attempt_count: number;
   created_at: number;
@@ -135,6 +137,7 @@ const rowToAssetSyncEntry = (row: AssetSyncRow): AssetSyncEntry => ({
   status: row.status,
   remoteFileId: row.remote_file_id,
   syncedAt: row.synced_at,
+  deletedAt: row.deleted_at,
   errorMessage: row.error_message,
   attemptCount: row.attempt_count,
   createdAt: row.created_at,
@@ -251,6 +254,22 @@ class PhotosLocalDB {
       status: asset.status,
       remoteFileId: asset.remote_file_id,
     }));
+  }
+
+  async markAssetDeleted(assetId: string): Promise<void> {
+    await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.markDeleted, [assetId]);
+  }
+
+  async getDeletedAssetIds(): Promise<Set<string>> {
+    const rows = await sqliteService.getAllAsync<{ asset_id: string }>(
+      DB_NAME,
+      assetSyncTable.statements.getDeletedIds,
+    );
+    return new Set(rows.map((row) => row.asset_id));
+  }
+
+  async deleteAssetSync(assetId: string): Promise<void> {
+    await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.deleteById, [assetId]);
   }
 
   async reset(): Promise<void> {

--- a/src/services/photos/database/tables/asset_sync.ts
+++ b/src/services/photos/database/tables/asset_sync.ts
@@ -4,13 +4,14 @@ const statements = {
   createTable: `
     CREATE TABLE IF NOT EXISTS ${TABLE_NAME} (
       asset_id          TEXT    PRIMARY KEY NOT NULL,
-      status            TEXT    NOT NULL CHECK (status IN ('pending', 'pending_edit', 'synced', 'error')),
+      status            TEXT    NOT NULL CHECK (status IN ('pending', 'pending_edit', 'synced', 'error', 'deleted')),
       remote_file_id    TEXT,
       error_message     TEXT,
       attempt_count     INTEGER NOT NULL DEFAULT 0,
       created_at        INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
       last_attempt_at   INTEGER,
       synced_at         INTEGER,
+      deleted_at        INTEGER,
       modification_time INTEGER,
       file_name         TEXT,
       file_size         INTEGER,
@@ -86,7 +87,16 @@ const statements = {
   `,
   getSyncedInList: (placeholders: string) =>
     `SELECT asset_id, modification_time FROM ${TABLE_NAME} WHERE asset_id IN (${placeholders}) AND status = 'synced';`,
-  getPendingAssets: `SELECT asset_id, status, remote_file_id FROM ${TABLE_NAME} WHERE status != 'synced';`,
+  getPendingAssets: `SELECT asset_id, status, remote_file_id FROM ${TABLE_NAME} WHERE status NOT IN ('synced', 'deleted');`,
+  markDeleted: `
+    INSERT INTO ${TABLE_NAME} (asset_id, status, deleted_at)
+    VALUES (?, 'deleted', (unixepoch() * 1000))
+    ON CONFLICT(asset_id) DO UPDATE SET
+      status     = 'deleted',
+      deleted_at = (unixepoch() * 1000);
+  `,
+  getDeletedIds: `SELECT asset_id FROM ${TABLE_NAME} WHERE status = 'deleted';`,
+  deleteById: `DELETE FROM ${TABLE_NAME} WHERE asset_id = ?;`,
   reset: `DELETE FROM ${TABLE_NAME};`,
   getSyncedRemoteFileIds: `SELECT remote_file_id FROM ${TABLE_NAME} WHERE status = 'synced' AND remote_file_id IS NOT NULL;`,
 };

--- a/src/store/slices/photos/index.spec.ts
+++ b/src/store/slices/photos/index.spec.ts
@@ -139,7 +139,6 @@ describe('photos slice', () => {
       totalScannedAssets: 0,
       totalAssetsUploaded: 0,
       currentUploadProgress: 0,
-      lastSyncTimestamp: null,
       uploadingAssetIds: [],
       deviceId: null,
       sessionTotalAssets: 0,
@@ -561,15 +560,6 @@ describe('photos slice', () => {
       expect(mockUploadQueue.start).not.toHaveBeenCalled();
     });
 
-    test('when the thunk completes, then lastSyncTimestamp is updated', async () => {
-      const store = makeStore();
-      store.dispatch(photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted' }));
-      const before = store.getState().photos.lastSyncTimestamp;
-
-      await store.dispatch(forceRefreshThunk());
-
-      expect(store.getState().photos.lastSyncTimestamp).toBeGreaterThan(before ?? 0);
-    });
   });
 
   describe('runBackupCycleThunk', () => {

--- a/src/store/slices/photos/index.ts
+++ b/src/store/slices/photos/index.ts
@@ -28,7 +28,6 @@ export interface PhotosState {
   totalScannedAssets: number;
   totalAssetsUploaded: number;
   currentUploadProgress: number;
-  lastSyncTimestamp: number | null;
   uploadingAssetIds: string[];
   deviceId: string | null;
   sessionTotalAssets: number;
@@ -46,7 +45,6 @@ const initialState: PhotosState = {
   totalScannedAssets: 0,
   totalAssetsUploaded: 0,
   currentUploadProgress: 0,
-  lastSyncTimestamp: null,
   uploadingAssetIds: [],
   deviceId: null,
   sessionTotalAssets: 0,
@@ -182,11 +180,14 @@ export const runDiscoveryThunk = createAsyncThunk<void, void, { state: RootState
   },
 );
 
-export const runUploadThunk = createAsyncThunk<void, void, { state: RootState }>(
+export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean } | void, { state: RootState }>(
   'photos/runUpload',
-  async (_, { getState, dispatch }) => {
+  async (args, { getState, dispatch }) => {
+    const bypassEnabled = args?.bypassEnabled ?? false;
     const { enabled, permissionStatus, deviceId } = getState().photos;
-    if (!enabled || !isPermissionActive(permissionStatus) || !deviceId) return;
+    if ((!enabled && !bypassEnabled) || !isPermissionActive(permissionStatus) || !deviceId) {
+      return;
+    }
 
     const localDBPendingAssets = await photosLocalDB.getPendingAssets();
     if (localDBPendingAssets.length === 0) {
@@ -290,7 +291,6 @@ export const forceRefreshThunk = createAsyncThunk<void, void, { state: RootState
       logger.info('[ForceRefresh] Discovery complete — no pending assets');
     }
     logger.info('[ForceRefresh] Done');
-    dispatch(photosSlice.actions.setLastSyncTimestamp(Date.now()));
   },
 );
 
@@ -319,8 +319,6 @@ export const runBackupCycleThunk = createAsyncThunk<void, void, { state: RootSta
     if (getState().photos.pendingBackupAssets > 0) {
       await dispatch(runUploadThunk());
     }
-
-    dispatch(photosSlice.actions.setLastSyncTimestamp(Date.now()));
   },
 );
 
@@ -375,9 +373,6 @@ export const photosSlice = createSlice({
     },
     incrementTotalAssetsUploaded: (state) => {
       state.totalAssetsUploaded += 1;
-    },
-    setLastSyncTimestamp: (state, action: PayloadAction<number>) => {
-      state.lastSyncTimestamp = action.payload;
     },
     setSessionUploadTotalAssets: (state, action: PayloadAction<number>) => {
       state.sessionTotalAssets = action.payload;

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -28,7 +28,7 @@ export type RootStackParamList = {
   TabExplorer: NavigatorScreenParams<TabExplorerStackParamList>;
   Trash: undefined;
   DrivePreview: undefined;
-  PhotoPreview: { initialId: string; items: TimelinePhotoItem[] };
+  PhotoPreview: { initialId: string; items: TimelinePhotoItem[]; onTrashed?: () => Promise<void> | void };
   Settings: undefined;
   AndroidShare: { files: SharedFile[] } | undefined;
   LargeShareUpload: { metadata: PendingShareMetadata };


### PR DESCRIPTION
### Delete action with tombstone
When a backed-up local photo is trashed, instead of deleting its `asset_sync` row, we now write a `status = 'deleted'` tombstone. `PhotoDeduplicator.getAssetsToSync` fetches these IDs upfront and skips them, so the photo is never re-queued for upload after being explicitly deleted from the cloud.

  ### Restore to cloud
New "Upload to cloud" action in the more sheet, visible when all selected items are `local && not-backed`. It clears the tombstone (marks the asset pending) and triggers upload.

## Summary
 - `asset_sync.ts`: added `'deleted'` to status CHECK constraint, `deleted_at` column, `markDeleted` upsert, `getDeletedIds` query; `getPendingAssets` now excludes `'deleted'` rows
 - `photosLocalDB.ts`: `AssetSyncStatus` includes `'deleted'`; `deletedAt` field on entry/row types
 - `PhotoDeduplicator.ts`: fetches deleted IDs in parallel with synced entries and skips tombstoned assets in the deduplication loop
 - `PhotoActionsService.ts`: `local-backed` branch calls `markAssetDeleted` instead of `deleteAssetSync`; new `restoreToCloud` function
 - `photos/index.ts`: `runUploadThunk` accepts optional `{ bypassEnabled?: boolean }` for force uploads
 - `usePhotoActions.ts`: added `handleRestore` and dispatches `runUploadThunk({ bypassEnabled: true })` after restore and calls `reloadCloud` after both trash and restore
 - `photoUtils.ts`: new `isLocalItemNotBacked` to display reupload action
 - `MoreActionsBottomSheet.tsx`: added `onRestore` prop and "Upload to cloud" action, visible only when all selected items are `local && not-backed`
 - `PhotoPreviewScreen/index.tsx`: added delete modal