### PR TITLE
[PB-6088] feature/Backup status report

### DIFF
--- a/assets/lang/strings.ts
+++ b/assets/lang/strings.ts
@@ -179,6 +179,7 @@ const translations = {
         groupHeader: {
           items: 'items',
           backingUp: 'Backing up',
+          backupPausing: 'Pausing backup',
           backupPaused: 'Backup paused',
           storageFull: 'Storage is full',
           backupCompleted: 'Backup completed',
@@ -1152,6 +1153,7 @@ const translations = {
         groupHeader: {
           items: 'elementos',
           backingUp: 'Guardando copia',
+          backupPausing: 'Pausando backup',
           backupPaused: 'Backup pausado',
           storageFull: 'Almacenamiento lleno',
           backupCompleted: 'Backup completado',

--- a/src/screens/HomeScreen/useDiscoverPhotosSheet.spec.tsx
+++ b/src/screens/HomeScreen/useDiscoverPhotosSheet.spec.tsx
@@ -31,6 +31,7 @@ const makeWrapper = (photosState?: Partial<PhotosState>) => {
         networkCondition: 'wifi-only',
         permissionStatus: 'undetermined',
         syncStatus: 'idle',
+        isPaused: false,
         pendingBackupAssets: 0,
         totalScannedAssets: 0,
         totalAssetsUploaded: 0,

--- a/src/screens/PhotosScreen/components/GroupHeader/GroupHeaderStatus.tsx
+++ b/src/screens/PhotosScreen/components/GroupHeader/GroupHeaderStatus.tsx
@@ -6,10 +6,12 @@ import {
   PlayCircleIcon,
   WarningCircleIcon,
 } from 'phosphor-react-native';
-import { ActivityIndicator } from 'react-native';
+import { ActivityIndicator, TouchableOpacity } from 'react-native';
 import AppText from 'src/components/AppText';
 import { useTailwind } from 'tailwind-rn';
 import strings from '../../../../../assets/lang/strings';
+
+const ICON_HIT_SLOP = { top: 12, bottom: 12, left: 12, right: 12 };
 
 interface ColorProps {
   color: string;
@@ -59,9 +61,16 @@ interface UploadingProps {
   primaryColor: string;
   labelColor: string;
   statusColor: string;
+  onPausePress?: () => void;
 }
 
-export const GroupHeaderUploading = ({ count, primaryColor, labelColor, statusColor }: UploadingProps): JSX.Element => {
+export const GroupHeaderUploading = ({
+  count,
+  primaryColor,
+  labelColor,
+  statusColor,
+  onPausePress,
+}: UploadingProps): JSX.Element => {
   const tailwind = useTailwind();
   return (
     <>
@@ -74,7 +83,21 @@ export const GroupHeaderUploading = ({ count, primaryColor, labelColor, statusCo
           {count.toLocaleString()} {strings.screens.photos.groupHeader.items}
         </AppText>
       )}
-      <PauseCircleIcon size={24} color={primaryColor} weight="fill" />
+      <TouchableOpacity onPress={onPausePress} hitSlop={ICON_HIT_SLOP}>
+        <PauseCircleIcon size={24} color={primaryColor} weight="fill" />
+      </TouchableOpacity>
+    </>
+  );
+};
+
+export const GroupHeaderPausing = ({ color }: ColorProps): JSX.Element => {
+  const tailwind = useTailwind();
+  return (
+    <>
+      <ActivityIndicator size="small" color={color} />
+      <AppText medium style={[tailwind('text-base'), { color, lineHeight: 24 }]}>
+        {strings.screens.photos.groupHeader.backupPausing}
+      </AppText>
     </>
   );
 };
@@ -84,9 +107,16 @@ interface PausedProps {
   primaryColor: string;
   labelColor: string;
   statusColor: string;
+  onResumePress?: () => void;
 }
 
-export const GroupHeaderPaused = ({ count, primaryColor, labelColor, statusColor }: PausedProps): JSX.Element => {
+export const GroupHeaderPaused = ({
+  count,
+  primaryColor,
+  labelColor,
+  statusColor,
+  onResumePress,
+}: PausedProps): JSX.Element => {
   const tailwind = useTailwind();
   return (
     <>
@@ -96,7 +126,9 @@ export const GroupHeaderPaused = ({ count, primaryColor, labelColor, statusColor
       <AppText style={[tailwind('text-sm'), { color: statusColor, lineHeight: 24 }]}>
         {count.toLocaleString()} {strings.screens.photos.groupHeader.items}
       </AppText>
-      <PlayCircleIcon size={24} color={primaryColor} weight="fill" />
+      <TouchableOpacity onPress={onResumePress} hitSlop={ICON_HIT_SLOP}>
+        <PlayCircleIcon size={24} color={primaryColor} weight="fill" />
+      </TouchableOpacity>
     </>
   );
 };

--- a/src/screens/PhotosScreen/components/GroupHeader/PhotosGroupHeader.tsx
+++ b/src/screens/PhotosScreen/components/GroupHeader/PhotosGroupHeader.tsx
@@ -10,6 +10,7 @@ import {
   GroupHeaderFetching,
   GroupHeaderPaused,
   GroupHeaderPausedStorageFull,
+  GroupHeaderPausing,
   GroupHeaderScanning,
   GroupHeaderUploading,
 } from './GroupHeaderStatus';
@@ -19,6 +20,7 @@ export type GroupSyncStatus =
   | { type: 'scanning' }
   | { type: 'fetching' }
   | { type: 'uploading'; count?: number; backupProgress?: number }
+  | { type: 'pausing' }
   | { type: 'paused'; count: number }
   | { type: 'paused-storage-full' }
   | { type: 'completed' }
@@ -29,6 +31,8 @@ interface PhotosGroupHeaderProps {
   syncStatus: GroupSyncStatus;
   isSticky?: boolean;
   stickyOpacity?: Animated.AnimatedInterpolation<number>;
+  onPausePress?: () => void;
+  onResumePress?: () => void;
 }
 
 const GRADIENT_LOCATIONS: [number, number, number] = [0, 0.35, 1];
@@ -48,7 +52,14 @@ const BackupProgressBar = ({
 );
 
 const PhotosGroupHeader = memo(
-  ({ label, syncStatus, isSticky, stickyOpacity }: PhotosGroupHeaderProps): JSX.Element => {
+  ({
+    label,
+    syncStatus,
+    isSticky,
+    stickyOpacity,
+    onPausePress,
+    onResumePress,
+  }: PhotosGroupHeaderProps): JSX.Element => {
     const tailwind = useTailwind();
     const getColor = useGetColor();
 
@@ -97,14 +108,17 @@ const PhotosGroupHeader = memo(
                 primaryColor={primaryColor}
                 labelColor={labelColor}
                 statusColor={statusColor}
+                onPausePress={onPausePress}
               />
             )}
+            {syncStatus.type === 'pausing' && <GroupHeaderPausing color={labelColor} />}
             {syncStatus.type === 'paused' && (
               <GroupHeaderPaused
                 count={syncStatus.count}
                 primaryColor={primaryColor}
                 labelColor={labelColor}
                 statusColor={statusColor}
+                onResumePress={onResumePress}
               />
             )}
             {syncStatus.type === 'paused-storage-full' && <GroupHeaderPausedStorageFull dangerColor={dangerColor} />}

--- a/src/screens/PhotosScreen/components/PhotosTimeline.tsx
+++ b/src/screens/PhotosScreen/components/PhotosTimeline.tsx
@@ -43,6 +43,8 @@ interface PhotosTimelineProps {
   onEndReached?: () => void;
   refreshing?: boolean;
   onRefresh?: () => void;
+  onPausePress?: () => void;
+  onResumePress?: () => void;
 }
 
 const getItemType = (item: FlatItem) => item.type;
@@ -66,6 +68,8 @@ const PhotosTimeline = ({
   onEndReached,
   refreshing,
   onRefresh,
+  onPausePress,
+  onResumePress,
 }: PhotosTimelineProps) => {
   const tailwind = useTailwind();
   const { items, headerIndices } = useMemo(() => {
@@ -73,11 +77,17 @@ const PhotosTimeline = ({
     return buildTimelineItems(effectiveGroups);
   }, [assetsGroupsByDate, isLoading]);
 
-  const extraData = useMemo(() => ({ isSelectMode, selectedIds }), [isSelectMode, selectedIds]);
+  const extraData = useMemo(
+    () => ({ isSelectMode, selectedIds, onPausePress, onResumePress }),
+    [isSelectMode, selectedIds, onPausePress, onResumePress],
+  );
 
   const scrollY = useRef(new Animated.Value(0)).current;
+  // UIKit refuses to deliver touches to views with alpha < 0.01 (the internal threshold).
+  // Using 0.02 as the floor keeps the sticky header visually invisible at scrollY=0 while
+  // staying above the threshold, so pause/resume buttons are always touchable.
   const stickyOpacity = useMemo(
-    () => scrollY.interpolate({ inputRange: [0, 24], outputRange: [0, 1], extrapolate: 'clamp' }),
+    () => scrollY.interpolate({ inputRange: [0, 24], outputRange: [0.02, 1], extrapolate: 'clamp' }),
     [scrollY],
   );
 
@@ -92,6 +102,8 @@ const PhotosTimeline = ({
             syncStatus={showSyncStatus ? item.syncStatus : { type: 'count', count: item.count }}
             isSticky={isSticky}
             stickyOpacity={isSticky ? stickyOpacity : undefined}
+            onPausePress={onPausePress}
+            onResumePress={onResumePress}
           />
         );
       }
@@ -107,7 +119,7 @@ const PhotosTimeline = ({
         </View>
       );
     },
-    [isSelectMode, selectedIds, onPhotoPress, onPhotoLongPress, stickyOpacity],
+    [isSelectMode, selectedIds, onPhotoPress, onPhotoLongPress, stickyOpacity, onPausePress, onResumePress],
   );
 
   const isEmpty = !isLoading && assetsGroupsByDate.length === 0;

--- a/src/screens/PhotosScreen/hooks/usePhotosTimeline.ts
+++ b/src/screens/PhotosScreen/hooks/usePhotosTimeline.ts
@@ -17,9 +17,14 @@ export const usePhotosTimeline = (): PhotosTimelineResult => {
   const { assets, isLoading, syncedIds, uploadingIdSet, loadNextPage, reload: reloadLocal } = useLocalAssets();
   const { cloudItems, reloadCloud } = useCloudAssets();
 
-  const { syncStatus, sessionTotalAssets, sessionUploadedAssets, isFetchingCloudHistory } = useAppSelector(
-    (state) => state.photos,
-  );
+  const {
+    syncStatus,
+    sessionTotalAssets,
+    sessionUploadedAssets,
+    isFetchingCloudHistory,
+    isPaused,
+    pendingBackupAssets,
+  } = useAppSelector((state) => state.photos);
 
   const localGroups = useMemo(
     () => groupAssetsByDate(assets, syncedIds, uploadingIdSet),
@@ -29,13 +34,30 @@ export const usePhotosTimeline = (): PhotosTimelineResult => {
   const mergedGroups = useMemo(() => mergeCloudIntoGroups(localGroups, cloudItems), [localGroups, cloudItems]);
 
   const timelineDateGroups = useMemo(() => {
-    const remainingCount = Math.max(0, sessionTotalAssets - sessionUploadedAssets);
+    const sessionRemaining = Math.max(0, sessionTotalAssets - sessionUploadedAssets);
+    const pausedFromColdStart = isPaused && sessionTotalAssets === 0 && sessionUploadedAssets === 0;
+    const remainingCount = pausedFromColdStart ? pendingBackupAssets : sessionRemaining;
     const backupProgress = sessionTotalAssets > 0 ? sessionUploadedAssets / sessionTotalAssets : undefined;
     return mergedGroups.map((group) => ({
       group,
-      syncStatus: getGroupSyncStatus(group, syncStatus, remainingCount, backupProgress, isFetchingCloudHistory),
+      syncStatus: getGroupSyncStatus({
+        group,
+        syncStatus,
+        remainingCount,
+        backupProgress,
+        isFetchingCloudHistory,
+        isPaused,
+      }),
     })) as TimelineDateGroup[];
-  }, [mergedGroups, syncStatus, sessionTotalAssets, sessionUploadedAssets, isFetchingCloudHistory]);
+  }, [
+    mergedGroups,
+    syncStatus,
+    sessionTotalAssets,
+    sessionUploadedAssets,
+    isFetchingCloudHistory,
+    isPaused,
+    pendingBackupAssets,
+  ]);
 
   return { timelineDateGroups, isLoading, loadNextPage, reloadLocal, reloadCloud };
 };

--- a/src/screens/PhotosScreen/index.tsx
+++ b/src/screens/PhotosScreen/index.tsx
@@ -5,7 +5,7 @@ import { View } from 'react-native';
 import AppScreen from 'src/components/AppScreen';
 import { ConfirmModal } from 'src/components/modals/ConfirmModal/ConfirmModal';
 import { useAppDispatch, useAppSelector } from 'src/store/hooks';
-import { forceRefreshThunk, photosActions, runBackupCycleThunk } from 'src/store/slices/photos';
+import { forceRefreshThunk, pauseBackupThunk, photosActions, resumeBackupThunk, runBackupCycleThunk } from 'src/store/slices/photos';
 import { uiActions } from 'src/store/slices/ui';
 import { TabExplorerScreenNavigationProp } from 'src/types/navigation';
 import { useTailwind } from 'tailwind-rn';
@@ -77,6 +77,9 @@ const PhotosScreen = (): JSX.Element => {
   const handleEnableBackup = useCallback(() => setIsEnableBackupSheetOpen(true), []);
   const listHeader =
     accessState.type === 'backup-off' ? <BackupDisabledBanner onEnablePress={handleEnableBackup} /> : undefined;
+
+  const handlePausePress = useCallback(() => { dispatch(pauseBackupThunk()); }, [dispatch]);
+  const handleResumePress = useCallback(() => { dispatch(resumeBackupThunk()); }, [dispatch]);
 
   const handleRefresh = useCallback(async () => {
     setRefreshing(true);
@@ -155,6 +158,8 @@ const PhotosScreen = (): JSX.Element => {
           onPhotoLongPress={handlePhotoLongPress}
           isSelectMode={selection.selectMode}
           selectedIds={selection.selectedIds}
+          onPausePress={handlePausePress}
+          onResumePress={handleResumePress}
         />
         {accessState.type === 'photos-locked' && <PhotosLockedOverlay onUpgradePress={() => undefined} />}
       </View>

--- a/src/screens/PhotosScreen/utils/photoTimelineGroups.spec.ts
+++ b/src/screens/PhotosScreen/utils/photoTimelineGroups.spec.ts
@@ -173,11 +173,29 @@ describe('getGroupSyncStatus', () => {
   const group = makeDateGroup({ photos: [makePhotoItem(), makePhotoItem()] });
 
   test('when sync status is scanning, then returns a scanning status', () => {
-    expect(getGroupSyncStatus(group, 'scanning', 0, undefined, false)).toEqual({ type: 'scanning' });
+    expect(
+      getGroupSyncStatus({
+        group,
+        syncStatus: 'scanning',
+        remainingCount: 0,
+        backupProgress: undefined,
+        isFetchingCloudHistory: false,
+        isPaused: false,
+      }),
+    ).toEqual({ type: 'scanning' });
   });
 
   test('when sync status is uploading, then returns uploading with remaining count and progress', () => {
-    expect(getGroupSyncStatus(group, 'uploading', 3, 0.5, false)).toEqual({
+    expect(
+      getGroupSyncStatus({
+        group,
+        syncStatus: 'uploading',
+        remainingCount: 3,
+        backupProgress: 0.5,
+        isFetchingCloudHistory: false,
+        isPaused: false,
+      }),
+    ).toEqual({
       type: 'uploading',
       count: 3,
       backupProgress: 0.5,
@@ -185,15 +203,120 @@ describe('getGroupSyncStatus', () => {
   });
 
   test('when isFetchingCloudHistory is true and sync status is idle, then returns a fetching status', () => {
-    expect(getGroupSyncStatus(group, 'idle', 0, undefined, true)).toEqual({ type: 'fetching' });
+    expect(
+      getGroupSyncStatus({
+        group,
+        syncStatus: 'idle',
+        remainingCount: 0,
+        backupProgress: undefined,
+        isFetchingCloudHistory: true,
+        isPaused: false,
+      }),
+    ).toEqual({ type: 'fetching' });
   });
 
   test('when sync status is idle, then returns a count equal to the number of photos in the group', () => {
-    expect(getGroupSyncStatus(group, 'idle', 0, undefined, false)).toEqual({ type: 'count', count: 2 });
+    expect(
+      getGroupSyncStatus({
+        group,
+        syncStatus: 'idle',
+        remainingCount: 0,
+        backupProgress: undefined,
+        isFetchingCloudHistory: false,
+        isPaused: false,
+      }),
+    ).toEqual({ type: 'count', count: 2 });
   });
 
-  test('when sync status is synced, then returns a count equal to the number of photos in the group', () => {
-    expect(getGroupSyncStatus(group, 'synced', 0, undefined, false)).toEqual({ type: 'count', count: 2 });
+  test('when sync status is synced and cloud history is not fetching, then returns completed status', () => {
+    expect(
+      getGroupSyncStatus({
+        group,
+        syncStatus: 'synced',
+        remainingCount: 0,
+        backupProgress: undefined,
+        isFetchingCloudHistory: false,
+        isPaused: false,
+      }),
+    ).toEqual({ type: 'completed' });
+  });
+
+  test('when sync status is synced and cloud history is fetching, then returns fetching status', () => {
+    expect(
+      getGroupSyncStatus({
+        group,
+        syncStatus: 'synced',
+        remainingCount: 0,
+        backupProgress: undefined,
+        isFetchingCloudHistory: true,
+        isPaused: false,
+      }),
+    ).toEqual({ type: 'fetching' });
+  });
+
+  test('when sync status is paused, then returns paused status with remaining count', () => {
+    expect(
+      getGroupSyncStatus({
+        group,
+        syncStatus: 'paused',
+        remainingCount: 5,
+        backupProgress: undefined,
+        isFetchingCloudHistory: false,
+        isPaused: false,
+      }),
+    ).toEqual({ type: 'paused', count: 5 });
+  });
+
+  test('when the backup is paused and sync status is idle, then returns paused regardless of sync status', () => {
+    expect(
+      getGroupSyncStatus({
+        group,
+        syncStatus: 'idle',
+        remainingCount: 5,
+        backupProgress: undefined,
+        isFetchingCloudHistory: false,
+        isPaused: true,
+      }),
+    ).toEqual({ type: 'paused', count: 5 });
+  });
+
+  test('when the backup is paused and sync status is scanning, then returns paused regardless of sync status', () => {
+    expect(
+      getGroupSyncStatus({
+        group,
+        syncStatus: 'scanning',
+        remainingCount: 5,
+        backupProgress: undefined,
+        isFetchingCloudHistory: false,
+        isPaused: true,
+      }),
+    ).toEqual({ type: 'paused', count: 5 });
+  });
+
+  test('when the backup is paused and sync status is pausing, then returns pausing', () => {
+    expect(
+      getGroupSyncStatus({
+        group,
+        syncStatus: 'pausing',
+        remainingCount: 5,
+        backupProgress: undefined,
+        isFetchingCloudHistory: false,
+        isPaused: true,
+      }),
+    ).toEqual({ type: 'pausing' });
+  });
+
+  test('when the backup is paused and cloud history is fetching, then paused takes priority over fetching', () => {
+    expect(
+      getGroupSyncStatus({
+        group,
+        syncStatus: 'idle',
+        remainingCount: 5,
+        backupProgress: undefined,
+        isFetchingCloudHistory: true,
+        isPaused: true,
+      }),
+    ).toEqual({ type: 'paused', count: 5 });
   });
 });
 

--- a/src/screens/PhotosScreen/utils/photoTimelineGroups.ts
+++ b/src/screens/PhotosScreen/utils/photoTimelineGroups.ts
@@ -81,20 +81,43 @@ export const groupAssetsByDate = (
   }));
 };
 
-export const getGroupSyncStatus = (
-  group: PhotoDateGroup,
-  syncStatus: PhotoSyncStatus,
-  remainingCount: number,
-  backupProgress: number | undefined,
-  isFetchingCloudHistory: boolean,
-): GroupSyncStatus => {
+export const getGroupSyncStatus = ({
+  group,
+  syncStatus,
+  remainingCount,
+  backupProgress,
+  isFetchingCloudHistory,
+  isPaused,
+}: {
+  group: PhotoDateGroup;
+  syncStatus: PhotoSyncStatus;
+  remainingCount: number;
+  backupProgress: number | undefined;
+  isFetchingCloudHistory: boolean;
+  isPaused: boolean;
+}): GroupSyncStatus => {
+  if (isPaused) {
+    return syncStatus === 'pausing' ? { type: 'pausing' } : { type: 'paused', count: remainingCount };
+  }
+
   switch (syncStatus) {
     case 'scanning':
       return { type: 'scanning' };
     case 'uploading':
       return { type: 'uploading', count: remainingCount, backupProgress };
+    case 'pausing':
+      return { type: 'pausing' };
+    case 'synced':
+      if (isFetchingCloudHistory) {
+        return { type: 'fetching' };
+      }
+      return { type: 'completed' };
+    case 'paused':
+      return { type: 'paused', count: remainingCount };
     default:
-      if (isFetchingCloudHistory) return { type: 'fetching' };
+      if (isFetchingCloudHistory) {
+        return { type: 'fetching' };
+      }
       return { type: 'count', count: group.photos.length };
   }
 };
@@ -132,7 +155,9 @@ export const mergeCloudIntoGroups = (localGroups: PhotoDateGroup[], cloudItems: 
   const result: PhotoDateGroup[] = localGroups.map((group) => {
     processedKeys.add(group.id);
     const extra = cloudByKey.get(group.id);
-    if (!extra) return group; // no cloud additions — preserve reference so FlashList skips these cells
+    if (!extra) {
+      return group; // no cloud additions — preserve reference so FlashList skips these cells
+    }
     return { ...group, photos: [...group.photos, ...extra] };
   });
 

--- a/src/services/photos/PhotoUploadQueue.spec.ts
+++ b/src/services/photos/PhotoUploadQueue.spec.ts
@@ -80,7 +80,13 @@ describe('PhotoUploadQueue.start', () => {
 
     await PhotoUploadQueue.start([job], DEVICE_ID, { onAssetDone });
 
-    expect(mockReplace).toHaveBeenCalledWith(asset, 'existing-remote-id', DEVICE_ID, expect.any(Function));
+    expect(mockReplace).toHaveBeenCalledWith(
+      asset,
+      'existing-remote-id',
+      DEVICE_ID,
+      expect.any(Function),
+      expect.any(AbortSignal),
+    );
     expect(mockUpload).not.toHaveBeenCalled();
     expect(onAssetDone).toHaveBeenCalledWith('a1', 'existing-remote-id', asset.modificationTime);
   });
@@ -103,5 +109,46 @@ describe('PhotoUploadQueue.start', () => {
     await PhotoUploadQueue.start(jobs, DEVICE_ID, { onAssetDone });
 
     expect(onAssetDone).toHaveBeenCalledTimes(3);
+  });
+
+  test('when upload is called, then the abort signal is passed to the upload service', async () => {
+    const asset = makeAsset('a1');
+    mockUpload.mockResolvedValue('remote-id');
+
+    await PhotoUploadQueue.start([{ asset }], DEVICE_ID, {});
+
+    expect(mockUpload).toHaveBeenCalledWith(asset, DEVICE_ID, expect.any(Function), expect.any(AbortSignal));
+  });
+});
+
+describe('PhotoUploadQueue.abortAll', () => {
+  test('when abort all is called mid run, then subsequent jobs are skipped via the abort signal', async () => {
+    const asset = makeAsset('a1');
+    mockUpload.mockImplementationOnce(async () => {
+      PhotoUploadQueue.abortAll();
+      return 'remote-id';
+    });
+
+    const onAssetStart = jest.fn();
+    const secondAsset = makeAsset('a2');
+    mockUpload.mockResolvedValueOnce('remote-id-2');
+
+    await PhotoUploadQueue.start([{ asset }, { asset: secondAsset }], DEVICE_ID, { onAssetStart });
+
+    // First job ran, second was skipped because signal was aborted after first job
+    expect(onAssetStart).toHaveBeenCalledWith('a1');
+    expect(onAssetStart).not.toHaveBeenCalledWith('a2');
+  });
+
+  test('when start is called again after abort, then a fresh abort signal is created', async () => {
+    const asset = makeAsset('a1');
+    mockUpload.mockResolvedValue('remote-id');
+
+    PhotoUploadQueue.abortAll();
+    await PhotoUploadQueue.start([{ asset }], DEVICE_ID, {});
+
+    const passedSignal = (mockUpload.mock.calls[0] as [unknown, unknown, unknown, AbortSignal])[3];
+    expect(passedSignal).toBeDefined();
+    expect(passedSignal.aborted).toBe(false);
   });
 });

--- a/src/services/photos/PhotoUploadQueue.spec.ts
+++ b/src/services/photos/PhotoUploadQueue.spec.ts
@@ -122,6 +122,22 @@ describe('PhotoUploadQueue.start', () => {
 });
 
 describe('PhotoUploadQueue.abortAll', () => {
+  test('when the upload service rejects with an abort error, then onAssetError receives the original abort error and not a wrapped error', async () => {
+    const asset = makeAsset('a1');
+    const abortError = new Error('AbortError');
+    abortError.name = 'AbortError';
+    mockUpload.mockImplementationOnce(async () => {
+      PhotoUploadQueue.abortAll();
+      throw abortError;
+    });
+
+    const onAssetError = jest.fn();
+    await PhotoUploadQueue.start([{ asset }], DEVICE_ID, { onAssetError });
+
+    expect(onAssetError).toHaveBeenCalledWith('a1', abortError);
+    expect((onAssetError.mock.calls[0][1] as Error).name).toBe('AbortError');
+  });
+
   test('when abort all is called mid run, then subsequent jobs are skipped via the abort signal', async () => {
     const asset = makeAsset('a1');
     mockUpload.mockImplementationOnce(async () => {

--- a/src/services/photos/PhotoUploadQueue.ts
+++ b/src/services/photos/PhotoUploadQueue.ts
@@ -16,29 +16,56 @@ interface UploadQueueCallbacks {
   onAssetError?: (assetId: string, error: Error) => Promise<void> | void;
 }
 
+let currentController: AbortController | null = null;
+
+// TODO: MAKE IT CLASS
 export const PhotoUploadQueue = {
   async start(jobs: AssetUploadJob[], deviceId: string, callbacks: UploadQueueCallbacks): Promise<void> {
-    const limit = pLimit(UPLOAD_CONCURRENCY);
+    currentController = new AbortController();
+    const { signal } = currentController;
 
-    await Promise.all(
-      jobs.map((job) =>
-        limit(async () => {
-          const { asset, existingRemoteFileId } = job;
-          callbacks.onAssetStart?.(asset.id);
-          try {
-            const remoteFileId = existingRemoteFileId
-              ? await PhotoUploadService.replace(asset, existingRemoteFileId, deviceId, (ratio) =>
-                  callbacks.onAssetProgress?.(asset.id, ratio),
-                )
-              : await PhotoUploadService.upload(asset, deviceId, (ratio) =>
-                  callbacks.onAssetProgress?.(asset.id, ratio),
-                );
-            await callbacks.onAssetDone?.(asset.id, remoteFileId, asset.modificationTime);
-          } catch (uploadError) {
-            await callbacks.onAssetError?.(asset.id, uploadError as Error);
-          }
-        }),
-      ),
-    );
+    try {
+      const limit = pLimit(UPLOAD_CONCURRENCY);
+
+      await Promise.all(
+        jobs.map((job) =>
+          limit(async () => {
+            if (signal.aborted) {
+              return;
+            }
+            const { asset, existingRemoteFileId } = job;
+            callbacks.onAssetStart?.(asset.id);
+
+            try {
+              const remoteFileId = existingRemoteFileId
+                ? await PhotoUploadService.replace(
+                    asset,
+                    existingRemoteFileId,
+                    deviceId,
+                    (ratio) => callbacks.onAssetProgress?.(asset.id, ratio),
+                    signal,
+                  )
+                : await PhotoUploadService.upload(
+                    asset,
+                    deviceId,
+                    (ratio) => callbacks.onAssetProgress?.(asset.id, ratio),
+                    signal,
+                  );
+              await callbacks.onAssetDone?.(asset.id, remoteFileId, asset.modificationTime);
+            } catch (uploadError) {
+              await callbacks.onAssetError?.(asset.id, uploadError as Error);
+            }
+          }),
+        ),
+      );
+    } finally {
+      if (currentController?.signal === signal) {
+        currentController = null;
+      }
+    }
+  },
+
+  abortAll(): void {
+    currentController?.abort();
   },
 };

--- a/src/services/photos/PhotoUploadService.spec.ts
+++ b/src/services/photos/PhotoUploadService.spec.ts
@@ -2,6 +2,7 @@ import * as RNFS from '@dr.pogodin/react-native-fs';
 import { EncryptionVersion } from '@internxt/sdk/dist/drive/storage/types';
 import AppError from '@internxt/sdk/dist/shared/types/errors';
 import * as MediaLibrary from 'expo-media-library';
+import { AbortError } from 'src/network/errors';
 import { uploadFile } from 'src/network/upload';
 import asyncStorageService from 'src/services/AsyncStorageService';
 import { isThumbnailSupported } from 'src/services/common/media/thumbnail.constants';
@@ -158,10 +159,18 @@ describe('PhotoUploadService.upload', () => {
     expect(mockCreateFileEntry).not.toHaveBeenCalled();
   });
 
-  test('when the main file upload fails, then the error is propagated to the caller', async () => {
+  test('when the network layer throws an abort error, then the abort error propagates with its name intact and is not wrapped', async () => {
+    mockUploadFile.mockReset().mockRejectedValueOnce(new AbortError());
+
+    await expect(PhotoUploadService.upload(makeAsset(), DEVICE_ID)).rejects.toMatchObject({
+      name: AbortError.errorName,
+    });
+  });
+
+  test('when the network layer throws a generic error, then it is wrapped with bucket upload context', async () => {
     mockUploadFile.mockReset().mockRejectedValueOnce(new Error('network timeout'));
 
-    await expect(PhotoUploadService.upload(makeAsset(), DEVICE_ID)).rejects.toThrow('network timeout');
+    await expect(PhotoUploadService.upload(makeAsset(), DEVICE_ID)).rejects.toThrow('Bucket upload failed');
     expect(mockCreateFileEntry).not.toHaveBeenCalled();
   });
 

--- a/src/services/photos/PhotoUploadService.ts
+++ b/src/services/photos/PhotoUploadService.ts
@@ -71,6 +71,7 @@ const uploadAssetToBucket = async (
   asset: MediaLibrary.Asset,
   deviceId: string,
   onProgress?: (ratio: number) => void,
+  signal?: AbortSignal,
 ): Promise<FileUploadResult> => {
   const { localPath: localFilePath, tempPath } = await resolveLocalPath(asset);
 
@@ -101,7 +102,7 @@ const uploadAssetToBucket = async (
       encryptionKey,
       constants.BRIDGE_URL,
       { user: bridgeUser, pass: bridgePass },
-      { notifyProgress: onProgress },
+      { notifyProgress: onProgress, signal },
     );
   } catch (uploadError) {
     await cleanupTempFile(tempPath);
@@ -167,17 +168,22 @@ const uploadThumbnailForAsset = async (
       encryptVersion: EncryptionVersion.Aes03,
     });
   } catch {
-    // Thumbnail is best-effort — never block the main upload result
+    logger.error(`Failed to upload thumbnail for file ${fileUuid}, with thumbnail path ${thumbnailPath}`);
   } finally {
     await cleanupTempFile(thumbnailPath);
   }
 };
 
 export const PhotoUploadService = {
-  async upload(asset: MediaLibrary.Asset, deviceId: string, onProgress?: (ratio: number) => void): Promise<string> {
+  async upload(
+    asset: MediaLibrary.Asset,
+    deviceId: string,
+    onProgress?: (ratio: number) => void,
+    signal?: AbortSignal,
+  ): Promise<string> {
     let fileUploadResult: FileUploadResult;
     try {
-      fileUploadResult = await uploadAssetToBucket(asset, deviceId, onProgress);
+      fileUploadResult = await uploadAssetToBucket(asset, deviceId, onProgress, signal);
     } catch (err) {
       if (err instanceof FileAlreadyExistsError) {
         return err.existingUuid;
@@ -225,6 +231,7 @@ export const PhotoUploadService = {
     existingRemoteFileId: string,
     deviceId: string,
     onProgress?: (ratio: number) => void,
+    signal?: AbortSignal,
   ): Promise<string> {
     const {
       fileId,
@@ -238,7 +245,7 @@ export const PhotoUploadService = {
       folderUuid,
       modificationIso,
       creationIso,
-    } = await uploadAssetToBucket(asset, deviceId, onProgress);
+    } = await uploadAssetToBucket(asset, deviceId, onProgress, signal);
 
     try {
       try {

--- a/src/services/photos/PhotoUploadService.ts
+++ b/src/services/photos/PhotoUploadService.ts
@@ -106,6 +106,9 @@ const uploadAssetToBucket = async (
     );
   } catch (uploadError) {
     await cleanupTempFile(tempPath);
+    if (uploadError instanceof Error && uploadError.name !== 'Error') {
+      throw uploadError;
+    }
     const message = uploadError instanceof Error ? uploadError.message : String(uploadError);
     throw new Error(`Bucket upload failed for ${fileName}: ${message}`);
   }

--- a/src/store/slices/photos/index.spec.ts
+++ b/src/store/slices/photos/index.spec.ts
@@ -1,5 +1,6 @@
 import { photoPermissionService } from '@internxt-mobile/services/photos/photoPermissionService';
 import { configureStore } from '@reduxjs/toolkit';
+import { AbortError } from 'src/network/errors';
 import asyncStorageService from 'src/services/AsyncStorageService';
 import { PhotoAssetScanner } from 'src/services/photos/PhotoAssetScanner';
 import { photoCloudBrowser } from 'src/services/photos/PhotoCloudBrowser';
@@ -15,11 +16,14 @@ import photosReducer, {
   forceRefreshThunk,
   hydratePhotosStateThunk,
   initDeviceIdThunk,
+  pauseBackupThunk,
   photosSlice,
   PhotosState,
+  resumeBackupThunk,
   runBackupCycleThunk,
   runDiscoveryThunk,
   runFullCloudHistorySyncThunk,
+  runUploadThunk,
   setNetworkConditionThunk,
 } from './index';
 
@@ -51,7 +55,7 @@ jest.mock('src/services/photos/PhotoAssetScanner', () => ({
 }));
 
 jest.mock('src/services/photos/PhotoUploadQueue', () => ({
-  PhotoUploadQueue: { start: jest.fn().mockResolvedValue(undefined) },
+  PhotoUploadQueue: { start: jest.fn().mockResolvedValue(undefined), abortAll: jest.fn() },
 }));
 
 jest.mock('src/services/photos/PhotoDeduplicator', () => ({
@@ -135,6 +139,7 @@ describe('photos slice', () => {
       networkCondition: 'wifi-and-data',
       permissionStatus: 'granted',
       syncStatus: 'idle',
+      isPaused: false,
       pendingBackupAssets: 0,
       totalScannedAssets: 0,
       totalAssetsUploaded: 0,
@@ -154,6 +159,24 @@ describe('photos slice', () => {
     expect(store.getState().photos.enabled).toBe(true);
     expect(store.getState().photos.networkCondition).toBe('wifi-and-data');
     expect(store.getState().photos.permissionStatus).toBe('granted');
+  });
+
+  test('when the app restarts and volatile state was previously persisted, then volatile state is not restored', async () => {
+    mockAsyncStorage.getItem.mockResolvedValueOnce(
+      JSON.stringify({
+        enabled: true,
+        isFetchingCloudHistory: true,
+        syncStatus: 'uploading',
+        uploadingAssetIds: ['a1'],
+      }),
+    );
+
+    const store = makeStore();
+    await store.dispatch(hydratePhotosStateThunk());
+
+    expect(store.getState().photos.isFetchingCloudHistory).toBe(false);
+    expect(store.getState().photos.syncStatus).toBe('idle');
+    expect(store.getState().photos.uploadingAssetIds).toEqual([]);
   });
 
   test('when the app starts and only some settings were saved, then missing fields use their defaults', async () => {
@@ -355,6 +378,7 @@ describe('photos slice', () => {
     mockScanner.scanAll.mockResolvedValueOnce(assets as never);
     mockDeduplicator.getAssetsToSync.mockResolvedValueOnce({ newAssets: assets.slice(3), editedAssets: [] } as never);
     mockPhotosLocalDB.init.mockResolvedValueOnce(undefined);
+    mockPhotosLocalDB.getPendingAssets.mockResolvedValueOnce(assets.slice(3) as never);
     await store.dispatch(runDiscoveryThunk());
 
     expect(store.getState().photos.pendingBackupAssets).toBe(7);
@@ -397,7 +421,7 @@ describe('photos slice', () => {
     expect(store.getState().photos.enabled).toBe(false);
   });
 
-  test('when a backup cycle starts and all conditions are met, then photos are scanned, the pending count is updated and the cycle completes', async () => {
+  test('when a backup cycle starts and all conditions are met, then photos are scanned and upload runs', async () => {
     const store = makeStore();
     store.dispatch(photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted' }));
     mockPermissionService.getStatus.mockResolvedValueOnce('granted');
@@ -406,6 +430,10 @@ describe('photos slice', () => {
     mockScanner.scanAll.mockResolvedValueOnce(assets as never);
     mockDeduplicator.getAssetsToSync.mockResolvedValueOnce({ newAssets: assets, editedAssets: [] } as never);
     mockPhotosLocalDB.init.mockResolvedValueOnce(undefined);
+    // First call: inside runDiscoveryThunk, to count total pending assets
+    mockPhotosLocalDB.getPendingAssets.mockResolvedValueOnce(assets as never);
+    // Second call: inside runUploadThunk — returning empty triggers the early-return synced path
+    mockPhotosLocalDB.getPendingAssets.mockResolvedValueOnce([]);
 
     await store.dispatch(runBackupCycleThunk());
     await Promise.resolve();
@@ -539,7 +567,11 @@ describe('photos slice', () => {
         newAssets: [{ id: 'a1' }],
         editedAssets: [],
       } as never);
+      // First call: inside runDiscoveryThunk, sets pendingBackupAssets
       mockPhotosLocalDB.getPendingAssets.mockResolvedValueOnce([{ assetId: 'a1', status: 'pending' }] as never);
+      // Second call: inside runUploadThunk, provides assets for the upload jobs
+      mockPhotosLocalDB.getPendingAssets.mockResolvedValueOnce([{ assetId: 'a1', status: 'pending' }] as never);
+      mockScanner.getAssetsByIds.mockResolvedValueOnce([{ id: 'a1' }] as never);
 
       const store = makeStore();
       store.dispatch(
@@ -559,7 +591,6 @@ describe('photos slice', () => {
 
       expect(mockUploadQueue.start).not.toHaveBeenCalled();
     });
-
   });
 
   describe('runBackupCycleThunk', () => {
@@ -574,6 +605,129 @@ describe('photos slice', () => {
 
       expect(mockCloudBrowser.syncAllHistory).toHaveBeenCalled();
       expect(mockScanner.scanAll).toHaveBeenCalled();
+    });
+
+    test('when the backup cycle runs while paused, then discovery runs but the upload is skipped and sync status is paused', async () => {
+      mockPhotoDeviceId.getOrCreate.mockResolvedValue('device-id');
+      mockDeduplicator.getAssetsToSync.mockResolvedValueOnce({ newAssets: [{ id: 'a1' } as never], editedAssets: [] });
+
+      const store = makeStore();
+      store.dispatch(
+        photosSlice.actions.setState({
+          enabled: true,
+          permissionStatus: 'granted',
+          deviceId: 'device-1',
+          isPaused: true,
+        }),
+      );
+      mockPermissionService.getStatus.mockResolvedValue('granted');
+
+      await store.dispatch(runBackupCycleThunk());
+
+      expect(mockScanner.scanAll).toHaveBeenCalled();
+      expect(mockUploadQueue.start).not.toHaveBeenCalled();
+      expect(store.getState().photos.syncStatus).toBe('paused');
+    });
+  });
+
+  describe('pauseBackupThunk', () => {
+    test('when the user pauses the backup, then is paused flag persists and sync status becomes pausing', async () => {
+      const store = makeStore();
+      store.dispatch(
+        photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted', syncStatus: 'uploading' }),
+      );
+
+      await store.dispatch(pauseBackupThunk());
+
+      expect(store.getState().photos.isPaused).toBe(true);
+      expect(store.getState().photos.syncStatus).toBe('pausing');
+
+      const persisted = getPersistedState();
+      expect(persisted.isPaused).toBe(true);
+    });
+
+    test('when the user pauses the backup, then volatile state such as sync status is not included in the persisted payload', async () => {
+      const store = makeStore();
+      store.dispatch(photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted' }));
+
+      await store.dispatch(pauseBackupThunk());
+
+      const persisted = getPersistedState();
+      expect(persisted).not.toHaveProperty('syncStatus');
+      expect(persisted).not.toHaveProperty('isFetchingCloudHistory');
+      expect(persisted).not.toHaveProperty('uploadingAssetIds');
+      expect(persisted).not.toHaveProperty('currentUploadProgress');
+    });
+
+    test('when the user pauses the backup, then in flight uploads are aborted via the upload queue', async () => {
+      jest.spyOn(mockUploadQueue, 'abortAll');
+      const store = makeStore();
+      store.dispatch(photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted' }));
+
+      await store.dispatch(pauseBackupThunk());
+
+      expect(mockUploadQueue.abortAll).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('resumeBackupThunk', () => {
+    test('when the user resumes the backup, then is paused flag clears and the backup cycle is dispatched', async () => {
+      mockPhotoDeviceId.getOrCreate.mockResolvedValue('device-id');
+      mockPermissionService.getStatus.mockResolvedValue('granted');
+
+      const store = makeStore();
+      store.dispatch(
+        photosSlice.actions.setState({
+          enabled: true,
+          permissionStatus: 'granted',
+          isPaused: true,
+          syncStatus: 'paused',
+        }),
+      );
+
+      await store.dispatch(resumeBackupThunk());
+
+      expect(store.getState().photos.isPaused).toBe(false);
+
+      const persisted = getPersistedState();
+      expect(persisted.isPaused).toBe(false);
+    });
+  });
+
+  describe('runUploadThunk', () => {
+    test('when the upload loop finishes while paused, then sync status remains paused', async () => {
+      mockPhotosLocalDB.getPendingAssets.mockResolvedValueOnce([{ assetId: 'a1', status: 'pending' }] as never);
+      mockUploadQueue.start.mockImplementationOnce(async (_jobs, _deviceId, callbacks) => {
+        // Simulate pause being set mid-upload
+        store.dispatch(photosSlice.actions.setIsPaused(true));
+        await callbacks.onAssetDone?.('a1', 'remote-1', Date.now());
+      });
+
+      const store = makeStore();
+      store.dispatch(
+        photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted', deviceId: 'device-1' }),
+      );
+
+      await store.dispatch(runUploadThunk());
+
+      expect(store.getState().photos.syncStatus).toBe('paused');
+    });
+
+    test('when an asset fails with abort error, then it is not marked as errored in the local database', async () => {
+      const abortError = new AbortError();
+      mockPhotosLocalDB.getPendingAssets.mockResolvedValueOnce([{ assetId: 'a1', status: 'pending' }] as never);
+      mockUploadQueue.start.mockImplementationOnce(async (_jobs, _deviceId, callbacks) => {
+        await callbacks.onAssetError?.('a1', abortError);
+      });
+
+      const store = makeStore();
+      store.dispatch(
+        photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted', deviceId: 'device-1' }),
+      );
+
+      await store.dispatch(runUploadThunk());
+
+      expect(mockPhotosLocalDB.markError).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/store/slices/photos/index.ts
+++ b/src/store/slices/photos/index.ts
@@ -1,4 +1,5 @@
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { AbortError } from 'src/network/errors';
 import asyncStorageService from 'src/services/AsyncStorageService';
 import errorService from 'src/services/ErrorService';
 import { PhotoAssetScanner } from 'src/services/photos/PhotoAssetScanner';
@@ -17,13 +18,14 @@ import { logger } from '../../../services/common';
 import { RootState } from '../../index';
 
 export type PhotoNetworkCondition = 'wifi-only' | 'wifi-and-data';
-export type PhotoSyncStatus = 'idle' | 'scanning' | 'uploading' | 'synced' | 'paused' | 'error';
+export type PhotoSyncStatus = 'idle' | 'scanning' | 'uploading' | 'pausing' | 'synced' | 'paused' | 'error';
 
 export interface PhotosState {
   enabled: boolean;
   networkCondition: PhotoNetworkCondition;
   permissionStatus: PhotoPermissionStatus;
   syncStatus: PhotoSyncStatus;
+  isPaused: boolean;
   pendingBackupAssets: number;
   totalScannedAssets: number;
   totalAssetsUploaded: number;
@@ -41,6 +43,7 @@ const initialState: PhotosState = {
   networkCondition: 'wifi-only',
   permissionStatus: 'undetermined',
   syncStatus: 'idle',
+  isPaused: false,
   pendingBackupAssets: 0,
   totalScannedAssets: 0,
   totalAssetsUploaded: 0,
@@ -54,7 +57,20 @@ const initialState: PhotosState = {
 };
 
 const persistPhotosSettings = async (state: PhotosState): Promise<void> => {
-  await asyncStorageService.saveItem(AsyncStorageKey.PhotosSettings, JSON.stringify(state));
+  const { enabled, networkCondition, permissionStatus, isPaused, deviceId, totalAssetsUploaded, pendingBackupAssets } =
+    state;
+  await asyncStorageService.saveItem(
+    AsyncStorageKey.PhotosSettings,
+    JSON.stringify({
+      enabled,
+      networkCondition,
+      permissionStatus,
+      isPaused,
+      deviceId,
+      totalAssetsUploaded,
+      pendingBackupAssets,
+    }),
+  );
 };
 
 export const hydratePhotosStateThunk = createAsyncThunk<void, void, { state: RootState }>(
@@ -65,7 +81,28 @@ export const hydratePhotosStateThunk = createAsyncThunk<void, void, { state: Roo
     if (persistedState) {
       try {
         const parsed = JSON.parse(persistedState) as Partial<PhotosState>;
-        dispatch(photosSlice.actions.setState(parsed));
+        const {
+          enabled,
+          networkCondition,
+          permissionStatus,
+          isPaused,
+          deviceId,
+          totalAssetsUploaded,
+          pendingBackupAssets,
+        } = parsed;
+        const stable = {
+          enabled,
+          networkCondition,
+          permissionStatus,
+          isPaused,
+          deviceId,
+          totalAssetsUploaded,
+          pendingBackupAssets,
+        };
+        const defined = Object.fromEntries(
+          Object.entries(stable).filter(([, v]) => v !== undefined),
+        ) as Partial<PhotosState>;
+        dispatch(photosSlice.actions.setState(defined));
       } catch (error) {
         logger.error('Failed to parse photos settings from storage', { error });
       }
@@ -162,10 +199,10 @@ export const runDiscoveryThunk = createAsyncThunk<void, void, { state: RootState
           }),
         ),
       ]);
-      const pendingCount = newAssets.length + editedAssets.length;
+      const allPendingAssets = await photosLocalDB.getPendingAssets();
       dispatch(
         photosSlice.actions.setDiscoveryResult({
-          pendingBackupAssets: pendingCount,
+          pendingBackupAssets: allPendingAssets.length,
           totalScannedAssets: scannedAssets.length,
         }),
       );
@@ -184,8 +221,8 @@ export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean }
   'photos/runUpload',
   async (args, { getState, dispatch }) => {
     const bypassEnabled = args?.bypassEnabled ?? false;
-    const { enabled, permissionStatus, deviceId } = getState().photos;
-    if ((!enabled && !bypassEnabled) || !isPermissionActive(permissionStatus) || !deviceId) {
+    const { enabled, permissionStatus, deviceId, isPaused } = getState().photos;
+    if ((!enabled && !bypassEnabled) || !isPermissionActive(permissionStatus) || !deviceId || isPaused) {
       return;
     }
 
@@ -232,14 +269,30 @@ export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean }
         dispatch(photosSlice.actions.incrementSessionUploadedAssets());
       },
       onAssetError: async (assetId, error) => {
+        if (error.name === AbortError.errorName) {
+          logger.info(`[Upload] Asset ${assetId} aborted by user (pause)`);
+          dispatch(photosSlice.actions.removeUploadingAssetId(assetId));
+          return;
+        }
         logger.error(`[Upload] Asset ${assetId} failed: ${error?.message ?? String(error)}`);
         await photosLocalDB.markError(assetId, error.message);
         dispatch(photosSlice.actions.removeUploadingAssetId(assetId));
       },
     });
 
-    dispatch(photosSlice.actions.setSyncStatus('synced'));
+    const finalIsPaused = getState().photos.isPaused;
+    dispatch(photosSlice.actions.setSyncStatus(finalIsPaused ? 'paused' : 'synced'));
     dispatch(photosSlice.actions.setCurrentUploadProgress(0));
+
+    if (!finalIsPaused) {
+      const remaining = await photosLocalDB.getPendingAssets();
+      if (remaining.length > 0) {
+        // Assets remain pending (e.g. queue was aborted mid-run and user resumed while draining).
+        // runBackupCycleThunk was skipped by the 'pausing' guard — restart it now.
+        logger.info(`[Upload] ${remaining.length} pending assets remain after queue — restarting cycle`);
+        dispatch(runBackupCycleThunk());
+      }
+    }
   },
 );
 
@@ -298,7 +351,7 @@ export const runBackupCycleThunk = createAsyncThunk<void, void, { state: RootSta
   'photos/runBackupCycle',
   async (_, { getState, dispatch }) => {
     const { syncStatus } = getState().photos;
-    if (syncStatus === 'scanning' || syncStatus === 'uploading') {
+    if (syncStatus === 'scanning' || syncStatus === 'uploading' || syncStatus === 'pausing') {
       return;
     }
 
@@ -316,9 +369,41 @@ export const runBackupCycleThunk = createAsyncThunk<void, void, { state: RootSta
 
     await dispatch(runDiscoveryThunk());
 
-    if (getState().photos.pendingBackupAssets > 0) {
+    const { isPaused, pendingBackupAssets } = getState().photos;
+
+    if (isPaused) {
+      // Discovery sets syncStatus to 'idle'; restore 'paused' so the UI shows the play button.
+      dispatch(photosSlice.actions.setSyncStatus('paused'));
+      // Persist the updated pendingBackupAssets so the count survives the next app restart.
+      await persistPhotosSettings(getState().photos);
+      return;
+    }
+
+    if (pendingBackupAssets > 0) {
       await dispatch(runUploadThunk());
     }
+  },
+);
+
+export const pauseBackupThunk = createAsyncThunk<void, void, { state: RootState }>(
+  'photos/pauseBackup',
+  async (_, { getState, dispatch }) => {
+    const state = getState().photos;
+    dispatch(photosSlice.actions.setIsPaused(true));
+    dispatch(photosSlice.actions.setSyncStatus('pausing'));
+    await persistPhotosSettings({ ...state, isPaused: true });
+    PhotoUploadQueue.abortAll();
+  },
+);
+
+export const resumeBackupThunk = createAsyncThunk<void, void, { state: RootState }>(
+  'photos/resumeBackup',
+  async (_, { getState, dispatch }) => {
+    const state = getState().photos;
+    dispatch(photosSlice.actions.setIsPaused(false));
+    dispatch(photosSlice.actions.setSyncStatus('idle'));
+    await persistPhotosSettings({ ...state, isPaused: false });
+    dispatch(runBackupCycleThunk());
   },
 );
 
@@ -352,6 +437,9 @@ export const photosSlice = createSlice({
     },
     setSyncStatus: (state, action: PayloadAction<PhotoSyncStatus>) => {
       state.syncStatus = action.payload;
+    },
+    setIsPaused: (state, action: PayloadAction<boolean>) => {
+      state.isPaused = action.payload;
     },
     setDeviceId: (state, action: PayloadAction<string>) => {
       state.deviceId = action.payload;


### PR DESCRIPTION
Provide realtime visibility of the photo backup status and allows users to pause and resume the upload manually.

  ## Summary
  - **`getGroupSyncStatus`**: added `'synced'` → `completed` and `'paused'` cases
  - **`GroupHeaderStatus` / `PhotosGroupHeader` / `PhotosTimeline`**: `onPausePress` / `onResumePress` handlers propagated from `PhotosScreen` down to the header. Sticky header uses `outputRange: [0.02, 1]` to stay above UIKit's internal touch threshold (`alpha < 0.01`) that blocked taps when the sticky was transparent.

  - **`PhotoUploadQueue`** — singleton `AbortController`; `abortAll()` cancels the active fetch. Signal propagates to `uploadFile()` via `PhotoUploadService`. `AbortError` in `onAssetError` leaves the asset as `pending` (not `error`) so it is retried onresume.

  - **`pauseBackupThunk` / `resumeBackupThunk`**: `isPaused: boolean` persisted in `AsyncStorage` as the durable source of truth. `resumeBackupThunk` resets `syncStatus` to `'idle'` before starting the cycle to avoid the "Backup paused: 0 items" flash.

  - **`persistPhotosSettings`**: only stable fields are persisted.

  - **`runDiscoveryThunk`**: uses `getPendingAssets()` for `pendingBackupAssets` instead of counting only newly discovered assets, preventing the "0 items" flash when entering Photos while paused.

  - **`runBackupCycleThunk`**: persists `pendingBackupAssets` and restores `syncStatus: 'paused'` after discovery when `isPaused`, so the count is correct on the next restart.