### PR TITLE
[PB-6281]: add encrypted file upload flow with multipart support

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -199,6 +199,7 @@ dependencies {
 
     implementation("com.squareup.okhttp3:okhttp:5.3.2")
     implementation("androidx.security:security-crypto:1.1.0")
+    implementation("org.bouncycastle:bcprov-jdk15to18:1.78.1")
 
     testImplementation("junit:junit:4.13.2")
     testImplementation("com.squareup.okhttp3:mockwebserver:5.3.2")

--- a/android/app/src/main/java/com/internxt/cloud/documents/DocumentId.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/DocumentId.kt
@@ -8,9 +8,15 @@ object DocumentId {
 
     private const val FOLDER_PREFIX = "f:"
     private const val FILE_PREFIX = "d:"
+    const val UPLOAD_PREFIX = "u:"
 
     fun encodeFolder(uuid: String): String = FOLDER_PREFIX + uuid
     fun encodeFile(uuid: String): String = FILE_PREFIX + uuid
+    fun encodeUpload(token: String): String = UPLOAD_PREFIX + token
+
+    fun isUploadToken(id: String): Boolean = id.startsWith(UPLOAD_PREFIX)
+    fun decodeUpload(id: String): String? =
+        if (isUploadToken(id)) id.removePrefix(UPLOAD_PREFIX) else null
 
     fun decode(id: String): Decoded? = when {
         id.startsWith(FOLDER_PREFIX) -> Decoded(Kind.FOLDER, id.removePrefix(FOLDER_PREFIX))

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
@@ -1,10 +1,15 @@
 package com.internxt.cloud.documents.api
 
+import com.internxt.cloud.documents.api.model.CreateFileEntry
 import com.internxt.cloud.documents.api.model.DownloadLinks
 import com.internxt.cloud.documents.api.model.DriveFile
 import com.internxt.cloud.documents.api.model.DriveFolder
+import com.internxt.cloud.documents.api.model.FinishUploadShard
 import com.internxt.cloud.documents.api.model.Shard
 import com.internxt.cloud.documents.api.model.TrashItem
+import com.internxt.cloud.documents.api.model.UploadFinishResponse
+import com.internxt.cloud.documents.api.model.UploadSlot
+import com.internxt.cloud.documents.api.model.UploadStartResponse
 import com.internxt.cloud.documents.crypto.HashUtil
 import com.internxt.cloud.documents.http.HttpClients
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -110,6 +115,104 @@ class InternxtApiClient(
             .post(payload.toString().toRequestBody(JSON))
             .build()
         executeApiRequest(req)
+    }
+
+    fun startUpload(bucketId: String, encryptedSize: Long, parts: Int = 1): UploadStartResponse {
+        require(parts >= 1) { "parts must be >= 1" }
+        val payload = JSONObject().put(
+            "uploads",
+            JSONArray().put(
+                JSONObject()
+                    .put("index", 0)
+                    .put("size", encryptedSize)
+            )
+        )
+        val url = bridgeUrl("v2/buckets/$bucketId/files/start")
+            .newBuilder()
+            .addQueryParameter("multiparts", parts.toString())
+            .build()
+        val req = bridgeRequest(url)
+            .post(payload.toString().toRequestBody(JSON))
+            .build()
+        return parseUploadStart(executeApiRequest(req))
+    }
+
+    fun finishUpload(
+        bucketId: String,
+        indexHex: String,
+        shards: List<FinishUploadShard>,
+    ): UploadFinishResponse {
+        require(shards.isNotEmpty()) { "shards cannot be empty" }
+        val shardsJson = JSONArray()
+        for (shard in shards) {
+            val obj = JSONObject()
+                .put("uuid", shard.uuid)
+                .put("hash", shard.hash)
+            if (shard.uploadId != null) obj.put("UploadId", shard.uploadId)
+            if (shard.parts != null) {
+                val parts = JSONArray()
+                shard.parts.sortedBy { it.partNumber }.forEach { part ->
+                    parts.put(
+                        JSONObject()
+                            .put("PartNumber", part.partNumber)
+                            .put("ETag", part.etag)
+                    )
+                }
+                obj.put("parts", parts)
+            }
+            shardsJson.put(obj)
+        }
+        val payload = JSONObject()
+            .put("index", indexHex)
+            .put("shards", shardsJson)
+        val req = bridgeRequest(bridgeUrl("v2/buckets/$bucketId/files/finish"))
+            .post(payload.toString().toRequestBody(JSON))
+            .build()
+        val body = executeApiRequest(req)
+        val id = body.optStringOrNull("id")
+            ?: throw InternxtApiException.MalformedResponse("Bridge /finish missing 'id'")
+        return UploadFinishResponse(id = id, bucket = body.optStringOrNull("bucket"))
+    }
+
+    fun createFileEntry(entry: CreateFileEntry): DriveFile {
+        val payload = JSONObject()
+            .put("fileId", entry.fileId)
+            .put("type", entry.type)
+            .put("size", entry.size)
+            .put("plainName", entry.plainName)
+            .put("bucket", entry.bucket)
+            .put("folderUuid", entry.folderUuid)
+            .put("encryptVersion", entry.encryptVersion)
+        entry.modificationTime?.let { payload.put("modificationTime", it) }
+        entry.creationTime?.let { payload.put("creationTime", it) }
+        val req = driveRequest(driveUrl("files"))
+            .post(payload.toString().toRequestBody(JSON))
+            .build()
+        return parseFile(executeApiRequest(req))
+    }
+
+    private fun parseUploadStart(body: JSONObject): UploadStartResponse {
+        val uploadsJson = body.optJSONArray("uploads")
+            ?: throw InternxtApiException.MalformedResponse("Bridge /start missing 'uploads'")
+        return UploadStartResponse(uploads = uploadsJson.map(::parseUploadSlot))
+    }
+
+    private fun parseUploadSlot(obj: JSONObject): UploadSlot {
+        val index = obj.optInt("index")
+        val uuid = obj.requireString("uuid")
+        return when (val urlsArr = obj.optJSONArray("urls")) {
+            null -> UploadSlot.Single(
+                index = index,
+                uuid = uuid,
+                url = obj.requireString("url"),
+            )
+            else -> UploadSlot.Multipart(
+                index = index,
+                uuid = uuid,
+                urls = urlsArr.toStringList(),
+                uploadId = obj.requireString("UploadId"),
+            )
+        }
     }
 
     fun getDownloadLinks(bucketId: String, fileId: String): DownloadLinks {

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/JsonExtensions.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/JsonExtensions.kt
@@ -14,6 +14,13 @@ internal inline fun <T> JSONArray.map(transform: (JSONObject) -> T): List<T> {
 internal fun JSONObject.optStringOrNull(key: String): String? =
     if (isNull(key)) null else optString(key).takeIf { it.isNotEmpty() }
 
+internal fun JSONObject.requireString(
+    key: String,
+    error: String = "Missing required field: $key",
+): String = optStringOrNull(key) ?: throw InternxtApiException.MalformedResponse(error)
+
+internal fun JSONArray.toStringList(): List<String> = List(length()) { getString(it) }
+
 internal fun JSONObject.optLongFlexible(key: String): Long = when (val v = opt(key)) {
     is Number -> v.toLong()
     is String -> v.toLongOrNull() ?: 0L

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/model/CreateFileEntry.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/model/CreateFileEntry.kt
@@ -1,0 +1,15 @@
+package com.internxt.cloud.documents.api.model
+
+const val ENCRYPT_VERSION_AES03 = "Aes03"
+
+data class CreateFileEntry(
+    val fileId: String,
+    val type: String,
+    val size: Long,
+    val plainName: String,
+    val bucket: String,
+    val folderUuid: String,
+    val encryptVersion: String = ENCRYPT_VERSION_AES03,
+    val modificationTime: String? = null,
+    val creationTime: String? = null,
+)

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/model/CreateFileEntry.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/model/CreateFileEntry.kt
@@ -1,6 +1,6 @@
 package com.internxt.cloud.documents.api.model
 
-const val ENCRYPT_VERSION_AES03 = "Aes03"
+const val ENCRYPT_VERSION_AES03 = "03-aes"
 
 data class CreateFileEntry(
     val fileId: String,

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/model/FinishUploadShard.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/model/FinishUploadShard.kt
@@ -1,0 +1,8 @@
+package com.internxt.cloud.documents.api.model
+
+data class FinishUploadShard(
+    val uuid: String,
+    val hash: String,
+    val uploadId: String? = null,
+    val parts: List<UploadedPart>? = null,
+)

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/model/UploadFinishResponse.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/model/UploadFinishResponse.kt
@@ -1,0 +1,6 @@
+package com.internxt.cloud.documents.api.model
+
+data class UploadFinishResponse(
+    val id: String,
+    val bucket: String?,
+)

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/model/UploadStartResponse.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/model/UploadStartResponse.kt
@@ -1,0 +1,23 @@
+package com.internxt.cloud.documents.api.model
+
+data class UploadStartResponse(
+    val uploads: List<UploadSlot>,
+)
+
+sealed class UploadSlot {
+    abstract val index: Int
+    abstract val uuid: String
+
+    data class Single(
+        override val index: Int,
+        override val uuid: String,
+        val url: String,
+    ) : UploadSlot()
+
+    data class Multipart(
+        override val index: Int,
+        override val uuid: String,
+        val urls: List<String>,
+        val uploadId: String,
+    ) : UploadSlot()
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/model/UploadedPart.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/model/UploadedPart.kt
@@ -1,0 +1,6 @@
+package com.internxt.cloud.documents.api.model
+
+data class UploadedPart(
+    val partNumber: Int,
+    val etag: String,
+)

--- a/android/app/src/main/java/com/internxt/cloud/documents/crypto/CryptoServiceAwait.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/crypto/CryptoServiceAwait.kt
@@ -1,0 +1,26 @@
+package com.internxt.cloud.documents.crypto
+
+import com.rncrypto.util.OnlyErrorCallback
+import java.io.IOException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
+
+/**
+ * Bridges `CryptoService.encryptFile` / `decryptFile` (callback-based) to a blocking call.
+ * Pass `runInBackground = false` to those methods — the caller is already on a background
+ * executor thread, so there's no point bouncing onto the rn-crypto thread pool just to
+ * block on it. Any [Throwable] surfaced by the callback is rethrown as [IOException]
+ * preserving the original cause.
+ */
+internal inline fun awaitCryptoService(
+    failureMessage: String,
+    invoke: (OnlyErrorCallback) -> Unit,
+) {
+    val done = CompletableFuture<Unit>()
+    invoke { err -> if (err != null) done.completeExceptionally(err) else done.complete(Unit) }
+    try {
+        done.get()
+    } catch (e: ExecutionException) {
+        throw (e.cause as? IOException) ?: IOException(failureMessage, e.cause)
+    }
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/crypto/Ripemd160.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/crypto/Ripemd160.kt
@@ -1,0 +1,14 @@
+package com.internxt.cloud.documents.crypto
+
+import org.bouncycastle.crypto.digests.RIPEMD160Digest
+
+object Ripemd160 {
+
+    fun digest(input: ByteArray): ByteArray {
+        val md = RIPEMD160Digest()
+        md.update(input, 0, input.size)
+        val out = ByteArray(md.digestSize)
+        md.doFinal(out, 0)
+        return out
+    }
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/http/HttpClients.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/http/HttpClients.kt
@@ -13,12 +13,14 @@ object HttpClients {
             .build()
     }
 
-    val download: OkHttpClient by lazy {
+    val download: OkHttpClient by lazy { largeTransferClient(writeTimeoutMinutes = 2L) }
+    val upload: OkHttpClient by lazy { largeTransferClient(writeTimeoutMinutes = 0L) }
+
+    private fun largeTransferClient(writeTimeoutMinutes: Long): OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(2, TimeUnit.MINUTES)
-            .writeTimeout(2, TimeUnit.MINUTES)
+            .writeTimeout(writeTimeoutMinutes, TimeUnit.MINUTES)
             .callTimeout(0, TimeUnit.MILLISECONDS)
             .build()
-    }
 }

--- a/android/app/src/main/java/com/internxt/cloud/documents/upload/EncryptedFileUploader.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/upload/EncryptedFileUploader.kt
@@ -1,0 +1,257 @@
+package com.internxt.cloud.documents.upload
+
+import android.os.CancellationSignal
+import android.os.OperationCanceledException
+import com.internxt.cloud.documents.api.model.UploadedPart
+import com.internxt.cloud.documents.crypto.Ripemd160
+import com.internxt.cloud.documents.crypto.awaitCryptoService
+import com.internxt.cloud.documents.crypto.toHex
+import com.rncrypto.util.CryptoService
+import okhttp3.Call
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
+import okio.BufferedSink
+import okio.source
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import java.io.RandomAccessFile
+import java.security.MessageDigest
+import java.util.concurrent.atomic.AtomicReference
+
+object EncryptedFileUploader {
+
+    internal const val COPY_BUFFER_SIZE = 16 * 1024
+    private val OCTET_STREAM = "application/octet-stream".toMediaType()
+
+    data class Encrypted(
+        val size: Long,
+        val wholeSha256Hex: String,
+    )
+
+    /**
+     * Encrypt [plain] → [tempEnc] using the official `@internxt/rn-crypto` CryptoService —
+     * the same code path the RN side calls into (NetworkFacade.ts -> encryptFile). The
+     * package does not return a digest, so SHA-256 over the ciphertext is computed here
+     * by streaming the produced file back through MessageDigest.
+     */
+    fun encryptFile(plain: File, tempEnc: File, key: ByteArray, iv: ByteArray): Encrypted {
+        prepareTarget(tempEnc)
+        awaitCryptoService("Encryption failed") { cb ->
+            CryptoService.getInstance().encryptFile(
+                plain.absolutePath,
+                tempEnc.absolutePath,
+                key.toHex(),
+                iv.toHex(),
+                /* runInBackground = */ false,
+                cb,
+            )
+        }
+        return Encrypted(size = tempEnc.length(), wholeSha256Hex = computeSha256Hex(tempEnc))
+    }
+
+    private fun computeSha256Hex(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val buffer = ByteArray(COPY_BUFFER_SIZE)
+        file.inputStream().use { input ->
+            while (true) {
+                val n = input.read(buffer)
+                if (n == -1) break
+                digest.update(buffer, 0, n)
+            }
+        }
+        return digest.digest().toHex()
+    }
+
+    fun computePartSha256(tempEnc: File, partSize: Long): List<String> {
+        require(partSize > 0) { "partSize must be > 0" }
+        val total = tempEnc.length()
+        if (total == 0L) return emptyList()
+        val hashes = mutableListOf<String>()
+        val buffer = ByteArray(COPY_BUFFER_SIZE)
+        RandomAccessFile(tempEnc, "r").use { raf ->
+            var consumed = 0L
+            while (consumed < total) {
+                val partEnd = (consumed + partSize).coerceAtMost(total)
+                val digest = MessageDigest.getInstance("SHA-256")
+                var partRemaining = partEnd - consumed
+                while (partRemaining > 0) {
+                    val toRead = partRemaining.coerceAtMost(buffer.size.toLong()).toInt()
+                    val n = raf.read(buffer, 0, toRead)
+                    if (n == -1) throw IOException("Unexpected EOF computing part hashes")
+                    digest.update(buffer, 0, n)
+                    partRemaining -= n
+                    consumed += n
+                }
+                hashes.add(digest.digest().toHex())
+            }
+        }
+        return hashes
+    }
+
+    fun uploadSingle(
+        client: OkHttpClient,
+        tempEnc: File,
+        url: String,
+        signal: CancellationSignal?,
+        onProgress: ((Long) -> Unit)? = null,
+    ) {
+        val active = AtomicReference<Call?>(null)
+        signal?.setOnCancelListener { active.get()?.cancel() }
+        val body = fileRangeBody(tempEnc, 0L, tempEnc.length(), onProgress, baseSent = 0L)
+        val request = Request.Builder().url(url).put(body).build()
+        runCall(client, request, signal, active) { /* ETag not needed for single */ }
+    }
+
+    fun uploadMultipart(
+        client: OkHttpClient,
+        tempEnc: File,
+        urls: List<String>,
+        partSize: Long,
+        signal: CancellationSignal?,
+        onProgress: ((Long) -> Unit)? = null,
+    ): List<UploadedPart> {
+        require(urls.isNotEmpty()) { "urls cannot be empty" }
+        val total = tempEnc.length()
+        val active = AtomicReference<Call?>(null)
+        signal?.setOnCancelListener { active.get()?.cancel() }
+
+        val parts = ArrayList<UploadedPart>(urls.size)
+        var offset = 0L
+        urls.forEachIndexed { index, url ->
+            signal?.throwIfCanceled()
+            val length = (total - offset).coerceAtMost(partSize)
+            require(length > 0) { "Computed empty part for index $index" }
+            val body = fileRangeBody(tempEnc, offset, length, onProgress, baseSent = offset)
+            val request = Request.Builder().url(url).put(body).build()
+            var etag: String? = null
+            runCall(client, request, signal, active) { response ->
+                etag = response.header("ETag") ?: response.header("Etag")
+                    ?: throw IOException("Part ${index + 1} missing ETag in response")
+            }
+            parts.add(UploadedPart(partNumber = index + 1, etag = etag!!))
+            offset += length
+        }
+        return parts
+    }
+
+    /**
+     * `ripemd160(hex_decode(concat(sha256_hex_per_part)))`. For single-part upload,
+     * pass a 1-element list with the whole-file SHA-256.
+     */
+    fun computeShardHash(partHashesHex: List<String>): String {
+        require(partHashesHex.isNotEmpty()) { "no part hashes" }
+        val concatenated = partHashesHex.joinToString(separator = "")
+        return Ripemd160.digest(hexDecode(concatenated)).toHex()
+    }
+
+    private inline fun runCall(
+        client: OkHttpClient,
+        request: Request,
+        signal: CancellationSignal?,
+        active: AtomicReference<Call?>,
+        onResponse: (okhttp3.Response) -> Unit,
+    ) {
+        val call = client.newCall(request)
+        active.set(call)
+        try {
+            call.execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IOException("PUT failed HTTP ${response.code}")
+                }
+                onResponse(response)
+            }
+        } catch (e: IOException) {
+            if (signal != null && signal.isCanceled) {
+                throw OperationCanceledException("Upload cancelled").apply { initCause(e) }
+            }
+            throw e
+        } finally {
+            active.set(null)
+        }
+    }
+
+    private fun fileRangeBody(
+        file: File,
+        offset: Long,
+        length: Long,
+        onProgress: ((Long) -> Unit)? = null,
+        baseSent: Long = 0L,
+    ): RequestBody =
+        object : RequestBody() {
+            override fun contentType() = OCTET_STREAM
+            override fun contentLength(): Long = length
+            override fun writeTo(sink: BufferedSink) {
+                RandomAccessFile(file, "r").use { raf ->
+                    raf.seek(offset)
+                    if (onProgress == null) {
+                        val limited = LimitedInputStream(raf, length)
+                        limited.source().use { sink.writeAll(it) }
+                    } else {
+                        val buffer = ByteArray(COPY_BUFFER_SIZE)
+                        var remaining = length
+                        var sent = 0L
+                        while (remaining > 0) {
+                            val toRead = remaining.coerceAtMost(buffer.size.toLong()).toInt()
+                            val n = raf.read(buffer, 0, toRead)
+                            if (n == -1) throw IOException("Unexpected EOF reading upload body")
+                            sink.write(buffer, 0, n)
+                            remaining -= n
+                            sent += n
+                            onProgress(baseSent + sent)
+                        }
+                    }
+                }
+            }
+        }
+
+    private fun prepareTarget(target: File) {
+        target.parentFile?.mkdirs()
+        if (target.exists() && !target.delete()) {
+            throw IOException("Failed to delete existing temp file: ${target.absolutePath}")
+        }
+    }
+
+    private fun hexDecode(hex: String): ByteArray {
+        require(hex.length % 2 == 0) { "Invalid hex length" }
+        val out = ByteArray(hex.length / 2)
+        for (i in out.indices) {
+            val hi = Character.digit(hex[i * 2], 16)
+            val lo = Character.digit(hex[i * 2 + 1], 16)
+            require(hi >= 0 && lo >= 0) { "Invalid hex char" }
+            out[i] = ((hi shl 4) or lo).toByte()
+        }
+        return out
+    }
+
+    private class LimitedInputStream(
+        private val raf: RandomAccessFile,
+        private var remaining: Long,
+    ) : InputStream() {
+
+        override fun read(): Int {
+            if (remaining <= 0) return -1
+            val b = raf.read()
+            if (b == -1) {
+                remaining = 0
+                return -1
+            }
+            remaining--
+            return b
+        }
+
+        override fun read(b: ByteArray, off: Int, len: Int): Int {
+            if (remaining <= 0) return -1
+            val toRead = remaining.coerceAtMost(len.toLong()).toInt()
+            val n = raf.read(b, off, toRead)
+            if (n == -1) {
+                remaining = 0
+                return -1
+            }
+            remaining -= n
+            return n
+        }
+    }
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/upload/EncryptedFileUploader.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/upload/EncryptedFileUploader.kt
@@ -126,12 +126,11 @@ object EncryptedFileUploader {
             require(length > 0) { "Computed empty part for index $index" }
             val body = fileRangeBody(tempEnc, offset, length, onProgress, baseSent = offset)
             val request = Request.Builder().url(url).put(body).build()
-            var etag: String? = null
-            runCall(client, request, signal, active) { response ->
-                etag = response.header("ETag") ?: response.header("Etag")
+            val etag = runCall(client, request, signal, active) { response ->
+                response.header("ETag") ?: response.header("Etag")
                     ?: throw IOException("Part ${index + 1} missing ETag in response")
             }
-            parts.add(UploadedPart(partNumber = index + 1, etag = etag!!))
+            parts.add(UploadedPart(partNumber = index + 1, etag = etag))
             offset += length
         }
         return parts
@@ -147,17 +146,17 @@ object EncryptedFileUploader {
         return Ripemd160.digest(hexDecode(concatenated)).toHex()
     }
 
-    private inline fun runCall(
+    private inline fun <T> runCall(
         client: OkHttpClient,
         request: Request,
         signal: CancellationSignal?,
         active: AtomicReference<Call?>,
-        onResponse: (okhttp3.Response) -> Unit,
-    ) {
+        onResponse: (okhttp3.Response) -> T,
+    ): T {
         val call = client.newCall(request)
         active.set(call)
         try {
-            call.execute().use { response ->
+            return call.execute().use { response ->
                 if (!response.isSuccessful) {
                     throw IOException("PUT failed HTTP ${response.code}")
                 }

--- a/android/app/src/main/java/com/internxt/cloud/documents/upload/PendingUpload.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/upload/PendingUpload.kt
@@ -1,0 +1,8 @@
+package com.internxt.cloud.documents.upload
+
+data class PendingUpload(
+    val parentUuid: String,
+    val plainName: String,
+    val mimeType: String,
+    val createdAtMillis: Long = System.currentTimeMillis(),
+)


### PR DESCRIPTION
- add bridge API methods/models for upload start, multipart finish, and file entry creation
- introduce encrypted uploader with SHA-256 part hashing and RIPEMD160 shard hash
- add upload token helpers in DocumentId and JSON parsing utilities
- add upload HTTP client config and Bouncy Castle RIPEMD160 dependency
- add crypto callback await helper and pending upload model