### PR TITLE
[PB-6378] feature/Detect and mark photos deleted from cloud backup

### DIFF
--- a/src/screens/PhotosScreen/hooks/useCloudAssets.ts
+++ b/src/screens/PhotosScreen/hooks/useCloudAssets.ts
@@ -11,7 +11,7 @@ export interface CloudAssetsResult {
 
 export const useCloudAssets = (): CloudAssetsResult => {
   const [cloudItems, setCloudItems] = useState<CloudPhotoItem[]>([]);
-  const { cloudFetchRevision } = useAppSelector((state) => state.photos);
+  const { cloudFetchRevision, sessionUploadedAssets } = useAppSelector((state) => state.photos);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const reloadCloudFromDB = useCallback(async () => {
@@ -24,7 +24,6 @@ export const useCloudAssets = (): CloudAssetsResult => {
     setCloudItems(deduplicated.map(cloudEntryToPhotoItem));
   }, []);
 
-  // Initial load on mount
   useEffect(() => {
     reloadCloudFromDB();
   }, [reloadCloudFromDB]);
@@ -37,7 +36,7 @@ export const useCloudAssets = (): CloudAssetsResult => {
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [reloadCloudFromDB, cloudFetchRevision]);
+  }, [reloadCloudFromDB, cloudFetchRevision, sessionUploadedAssets]);
 
   return { cloudItems, reloadCloud: reloadCloudFromDB };
 };

--- a/src/screens/PhotosScreen/hooks/useLocalAssets.spec.ts
+++ b/src/screens/PhotosScreen/hooks/useLocalAssets.spec.ts
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react-native';
 import * as MediaLibrary from 'expo-media-library';
 import { AppState } from 'react-native';
 import { photosLocalDB } from 'src/services/photos/database/photosLocalDB';
+import { useAppSelector } from 'src/store/hooks';
 import { useLocalAssets } from './useLocalAssets';
 
 jest.mock('expo-media-library', () => ({
@@ -22,11 +23,13 @@ jest.mock('src/store/hooks', () => ({
     syncStatus: 'idle',
     uploadingAssetIds: [],
     sessionUploadedAssets: 0,
+    isFetchingCloudHistory: false,
   }),
 }));
 
 const mockMediaLibrary = MediaLibrary as jest.Mocked<typeof MediaLibrary>;
 const mockPhotosLocalDB = photosLocalDB as jest.Mocked<typeof photosLocalDB>;
+const mockUseAppSelector = useAppSelector as jest.Mock;
 
 const makeAsset = (id: string): MediaLibrary.Asset =>
   ({ id, uri: `file://${id}.jpg`, creationTime: 1000, mediaType: 'photo' }) as never;
@@ -54,18 +57,6 @@ describe('useLocalAssets', () => {
     });
 
     expect(result.current.assets).toEqual(assets);
-    expect(result.current.isLoading).toBe(false);
-  });
-
-  test('when the first page loads, then loading is set to false', async () => {
-    mockMediaLibrary.getAssetsAsync.mockResolvedValueOnce(makePage([]));
-
-    const { result } = renderHook(() => useLocalAssets());
-
-    await act(async () => {
-      await Promise.resolve();
-    });
-
     expect(result.current.isLoading).toBe(false);
   });
 
@@ -184,7 +175,9 @@ describe('useLocalAssets', () => {
 
   test('when sync status changes and there are assets loaded, then synced ids refresh from the database', async () => {
     mockMediaLibrary.getAssetsAsync.mockResolvedValueOnce(makePage([makeAsset('a1')]));
-    mockPhotosLocalDB.getSyncedEntries.mockResolvedValue(new Map([['a1', { modificationTime: null }]]));
+    mockPhotosLocalDB.getSyncedEntries.mockResolvedValue(
+      new Map([['a1', { modificationTime: null, status: 'synced' as const }]]),
+    );
 
     const { result } = renderHook(() => useLocalAssets());
 
@@ -194,5 +187,59 @@ describe('useLocalAssets', () => {
 
     expect(mockPhotosLocalDB.getSyncedEntries).toHaveBeenCalledWith(['a1']);
     expect(result.current.syncedIds.has('a1')).toBe(true);
+    expect(result.current.cloudDeletedIds.has('a1')).toBe(false);
+  });
+
+  test('when the cloud history sync finishes, then synced ids refresh so cloud-deleted assets are reflected immediately', async () => {
+    mockMediaLibrary.getAssetsAsync.mockResolvedValue(makePage([makeAsset('a1')]));
+    mockPhotosLocalDB.getSyncedEntries
+      .mockResolvedValueOnce(new Map([['a1', { modificationTime: null, status: 'synced' as const }]]))
+      .mockResolvedValueOnce(new Map([['a1', { modificationTime: null, status: 'cloud_deleted' as const }]]));
+
+    mockUseAppSelector.mockReturnValue({
+      syncStatus: 'idle',
+      uploadingAssetIds: [],
+      sessionUploadedAssets: 0,
+      isFetchingCloudHistory: true,
+    });
+
+    const { result, rerender } = renderHook(() => useLocalAssets());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.syncedIds.has('a1')).toBe(true);
+
+    mockUseAppSelector.mockReturnValue({
+      syncStatus: 'idle',
+      uploadingAssetIds: [],
+      sessionUploadedAssets: 0,
+      isFetchingCloudHistory: false,
+    });
+
+    await act(async () => {
+      rerender({});
+      await Promise.resolve();
+    });
+
+    expect(result.current.syncedIds.has('a1')).toBe(false);
+    expect(result.current.cloudDeletedIds.has('a1')).toBe(true);
+  });
+
+  test('when an asset is cloud deleted, then it appears in cloudDeletedIds and not in syncedIds', async () => {
+    mockMediaLibrary.getAssetsAsync.mockResolvedValueOnce(makePage([makeAsset('a1')]));
+    mockPhotosLocalDB.getSyncedEntries.mockResolvedValue(
+      new Map([['a1', { modificationTime: null, status: 'cloud_deleted' as const }]]),
+    );
+
+    const { result } = renderHook(() => useLocalAssets());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.cloudDeletedIds.has('a1')).toBe(true);
+    expect(result.current.syncedIds.has('a1')).toBe(false);
   });
 });

--- a/src/screens/PhotosScreen/hooks/useLocalAssets.ts
+++ b/src/screens/PhotosScreen/hooks/useLocalAssets.ts
@@ -12,6 +12,7 @@ export interface LocalAssetsResult {
   assets: MediaLibrary.Asset[];
   isLoading: boolean;
   syncedIds: Set<string>;
+  cloudDeletedIds: Set<string>;
   uploadingIdSet: Set<string>;
   loadNextPage: () => void;
   reload: () => Promise<void>;
@@ -21,13 +22,17 @@ export const useLocalAssets = (): LocalAssetsResult => {
   const [assets, setAssets] = useState<MediaLibrary.Asset[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [syncedIds, setSyncedIds] = useState<Set<string>>(new Set());
+  // TODO: Reserved for show a distinct icon for cloud-deleted vs never-backed assets. Remove if finally will be the same.
+  const [cloudDeletedIds, setCloudDeletedIds] = useState<Set<string>>(new Set());
 
   const cursorRef = useRef<string | undefined>(undefined);
   const hasMoreRef = useRef(true);
   const isLoadingMoreRef = useRef(false);
   const appStateRef = useRef(AppState.currentState);
 
-  const { syncStatus, uploadingAssetIds, sessionUploadedAssets } = useAppSelector((state) => state.photos);
+  const { syncStatus, uploadingAssetIds, sessionUploadedAssets, isFetchingCloudHistory } = useAppSelector(
+    (state) => state.photos,
+  );
 
   const uploadingIdSet = useMemo(() => new Set(uploadingAssetIds), [uploadingAssetIds]);
 
@@ -88,7 +93,17 @@ export const useLocalAssets = (): LocalAssetsResult => {
     const assetIds = assets.map((a) => a.id);
     await photosLocalDB.init();
     const entries = await photosLocalDB.getSyncedEntries(assetIds);
-    setSyncedIds(new Set(entries.keys()));
+    const synced = new Set<string>();
+    const cloudDeleted = new Set<string>();
+    for (const [id, info] of entries) {
+      if (info.status === 'cloud_deleted') {
+        cloudDeleted.add(id);
+      } else {
+        synced.add(id);
+      }
+    }
+    setSyncedIds(synced);
+    setCloudDeletedIds(cloudDeleted);
   }, [assets]);
 
   const reloadFromStart = useCallback(async () => {
@@ -129,7 +144,7 @@ export const useLocalAssets = (): LocalAssetsResult => {
 
   useEffect(() => {
     refreshSyncStatusFromDB();
-  }, [refreshSyncStatusFromDB, syncStatus, sessionUploadedAssets]);
+  }, [refreshSyncStatusFromDB, syncStatus, sessionUploadedAssets, isFetchingCloudHistory]);
 
-  return { assets, isLoading, syncedIds, uploadingIdSet, loadNextPage, reload: reloadFromStart };
+  return { assets, isLoading, syncedIds, cloudDeletedIds, uploadingIdSet, loadNextPage, reload: reloadFromStart };
 };

--- a/src/screens/PhotosScreen/utils/photoTimelineGroups.spec.ts
+++ b/src/screens/PhotosScreen/utils/photoTimelineGroups.spec.ts
@@ -56,7 +56,7 @@ const makeTimelineGroup = (
   syncStatus: GroupSyncStatus = { type: 'count', count: group.photos.length },
 ): TimelineDateGroup => ({ group, syncStatus });
 
-describe('formatVideoDuration', () => {
+describe('video duration formatter', () => {
   test('when the video is shorter than a minute, then formats seconds with a zero-padded two-digit field', () => {
     expect(formatVideoDuration(45)).toBe('0:45');
   });
@@ -78,7 +78,7 @@ describe('formatVideoDuration', () => {
   });
 });
 
-describe('getDateLabel', () => {
+describe('date label formatting', () => {
   const now = new Date('2024-06-15T12:00:00');
 
   test('when the date is the same day as now, then returns Today', () => {
@@ -103,7 +103,7 @@ describe('getDateLabel', () => {
   });
 });
 
-describe('assetToPhotoItem', () => {
+describe('local asset to photo item conversion', () => {
   test('when the asset is not synced and not uploading, then its backup state is not-backed', () => {
     const asset = makeAsset();
     const item = assetToPhotoItem(asset, new Set(), new Set());
@@ -137,7 +137,7 @@ describe('assetToPhotoItem', () => {
   });
 });
 
-describe('groupAssetsByDate', () => {
+describe('grouping assets by date', () => {
   test('when all assets are on the same day, then a single group is returned', () => {
     const assets = [
       makeAsset({ id: 'a1', creationTime: new Date('2024-06-15T08:00:00').getTime() }),
@@ -169,7 +169,7 @@ describe('groupAssetsByDate', () => {
   });
 });
 
-describe('getGroupSyncStatus', () => {
+describe('group sync status', () => {
   const group = makeDateGroup({ photos: [makePhotoItem(), makePhotoItem()] });
 
   test('when sync status is scanning, then returns a scanning status', () => {
@@ -320,7 +320,7 @@ describe('getGroupSyncStatus', () => {
   });
 });
 
-describe('buildTimelineItems', () => {
+describe('building flat timeline item list', () => {
   test('when a single group with two photos is provided, then three items are produced', () => {
     const group = makeDateGroup({ photos: [makePhotoItem({ id: 'p1' }), makePhotoItem({ id: 'p2' })] });
     const { items } = buildTimelineItems([makeTimelineGroup(group)]);
@@ -373,7 +373,7 @@ const makeCloudEntry = (overrides: Partial<CloudAssetEntry> = {}): CloudAssetEnt
   ...overrides,
 });
 
-describe('cloudEntryToPhotoItem', () => {
+describe('cloud entry to photo item conversion', () => {
   test('when the entry has a jpg filename, then media type is photo', () => {
     const item = cloudEntryToPhotoItem(makeCloudEntry({ fileName: 'photo.jpg' }));
     expect(item.mediaType).toBe('photo');
@@ -406,7 +406,7 @@ describe('cloudEntryToPhotoItem', () => {
   });
 });
 
-describe('mergeCloudIntoGroups', () => {
+describe('merging cloud items into local groups', () => {
   test('when there are no cloud items, then the local groups are returned unchanged', () => {
     const localGroups = [makeDateGroup()];
     const result = mergeCloudIntoGroups(localGroups, []);

--- a/src/services/photos/PhotoCloudBrowser.spec.ts
+++ b/src/services/photos/PhotoCloudBrowser.spec.ts
@@ -83,8 +83,8 @@ describe('PhotoCloudBrowser.listDeviceFolders', () => {
     const firstBatch = Array.from({ length: 50 }, (_, i) => makeFolder(`d${i}`, `device-${i}`));
     const secondBatch = [makeFolder('d50', 'device-50'), makeFolder('d51', 'device-51')];
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: firstBatch } as never)
-      .mockResolvedValueOnce({ folders: secondBatch } as never);
+      .mockResolvedValueOnce({ folders: firstBatch })
+      .mockResolvedValueOnce({ folders: secondBatch });
 
     const result = await photoCloudBrowser.listDeviceFolders();
 
@@ -119,9 +119,9 @@ describe('PhotoCloudBrowser.fetchMonth', () => {
     const file = makeFile('file-uuid', 'IMG_20240615_120000.jpg');
 
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [yearFolder] } as never)
-      .mockResolvedValueOnce({ folders: [monthFolder] } as never)
-      .mockResolvedValueOnce({ folders: [dayFolder] } as never);
+      .mockResolvedValueOnce({ folders: [yearFolder] })
+      .mockResolvedValueOnce({ folders: [monthFolder] })
+      .mockResolvedValueOnce({ folders: [dayFolder] });
 
     mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
 
@@ -148,7 +148,7 @@ describe('PhotoCloudBrowser.fetchMonth', () => {
   test('when there is no cache entry for the month, then the drive folder tree is traversed', async () => {
     mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValueOnce(null);
 
-    mockFolderService.getFolderFolders.mockResolvedValue({ folders: [] } as never);
+    mockFolderService.getFolderFolders.mockResolvedValue({ folders: [] });
 
     await photoCloudBrowser.fetchMonth({
       deviceId: 'device-1',
@@ -162,7 +162,7 @@ describe('PhotoCloudBrowser.fetchMonth', () => {
 
   test('when the year folder does not exist in drive, then no assets are upserted', async () => {
     mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValueOnce(null);
-    mockFolderService.getFolderFolders.mockResolvedValueOnce({ folders: [] } as never);
+    mockFolderService.getFolderFolders.mockResolvedValueOnce({ folders: [] });
 
     await photoCloudBrowser.fetchMonth({
       deviceId: 'device-1',
@@ -183,9 +183,9 @@ describe('PhotoCloudBrowser.fetchMonth', () => {
     const file = makeFile('file-uuid', 'photo.jpg');
 
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [yearFolder] } as never)
-      .mockResolvedValueOnce({ folders: [monthFolder] } as never)
-      .mockResolvedValueOnce({ folders: [dayFolder] } as never);
+      .mockResolvedValueOnce({ folders: [yearFolder] })
+      .mockResolvedValueOnce({ folders: [monthFolder] })
+      .mockResolvedValueOnce({ folders: [dayFolder] });
 
     mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
 
@@ -218,7 +218,7 @@ describe('PhotoCloudBrowser.fetchMonth — return value', () => {
 
   test('when the year folder does not exist, then zero is returned', async () => {
     mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValueOnce(null);
-    mockFolderService.getFolderFolders.mockResolvedValueOnce({ folders: [] } as never);
+    mockFolderService.getFolderFolders.mockResolvedValueOnce({ folders: [] });
 
     const result = await photoCloudBrowser.fetchMonth({
       deviceId: 'device-1',
@@ -240,9 +240,9 @@ describe('PhotoCloudBrowser.fetchMonth — return value', () => {
     const fileB = makeFile('file-b', 'photo-b.jpg');
 
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [yearFolder] } as never)
-      .mockResolvedValueOnce({ folders: [monthFolder] } as never)
-      .mockResolvedValueOnce({ folders: [dayFolder] } as never);
+      .mockResolvedValueOnce({ folders: [yearFolder] })
+      .mockResolvedValueOnce({ folders: [monthFolder] })
+      .mockResolvedValueOnce({ folders: [dayFolder] });
 
     mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [fileA, fileB] } as never);
 
@@ -277,11 +277,11 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     const file = makeFile('file-uuid', 'photo.jpg');
     mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
-      .mockResolvedValueOnce({ folders: [yearFolder] } as never)
-      .mockResolvedValueOnce({ folders: [monthA, monthB] } as never)
-      .mockResolvedValueOnce({ folders: [day] } as never)
-      .mockResolvedValueOnce({ folders: [day] } as never);
+      .mockResolvedValueOnce({ folders: [device] })
+      .mockResolvedValueOnce({ folders: [yearFolder] })
+      .mockResolvedValueOnce({ folders: [monthA, monthB] })
+      .mockResolvedValueOnce({ folders: [day] })
+      .mockResolvedValueOnce({ folders: [day] });
     mockFolderService.getFolderContentByUuid.mockResolvedValue({ files: [file] } as never);
 
     await photoCloudBrowser.syncAllHistory({});
@@ -298,11 +298,11 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     const m3_2024 = makeFolder('m3-24', '03');
     mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
-      .mockResolvedValueOnce({ folders: [year2023, year2024] } as never)
-      .mockResolvedValueOnce({ folders: [m6_2023] } as never)
-      .mockResolvedValueOnce({ folders: [m3_2024] } as never)
-      .mockResolvedValue({ folders: [] } as never);
+      .mockResolvedValueOnce({ folders: [device] })
+      .mockResolvedValueOnce({ folders: [year2023, year2024] })
+      .mockResolvedValueOnce({ folders: [m6_2023] })
+      .mockResolvedValueOnce({ folders: [m3_2024] })
+      .mockResolvedValue({ folders: [] });
 
     await photoCloudBrowser.syncAllHistory({});
 
@@ -319,10 +319,10 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     const m3 = makeFolder('m3', '04');
     mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
-      .mockResolvedValueOnce({ folders: [year] } as never)
-      .mockResolvedValueOnce({ folders: [m1, m2, m3] } as never)
-      .mockResolvedValue({ folders: [] } as never);
+      .mockResolvedValueOnce({ folders: [device] })
+      .mockResolvedValueOnce({ folders: [year] })
+      .mockResolvedValueOnce({ folders: [m1, m2, m3] })
+      .mockResolvedValue({ folders: [] });
 
     await photoCloudBrowser.syncAllHistory({ isCancelled: () => true });
 
@@ -341,10 +341,10 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     const fresh = Date.now() - 1000;
     mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValueOnce(fresh).mockResolvedValueOnce(null);
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
-      .mockResolvedValueOnce({ folders: [year] } as never)
-      .mockResolvedValueOnce({ folders: [m1, m2] } as never)
-      .mockResolvedValueOnce({ folders: [day] } as never);
+      .mockResolvedValueOnce({ folders: [device] })
+      .mockResolvedValueOnce({ folders: [year] })
+      .mockResolvedValueOnce({ folders: [m1, m2] })
+      .mockResolvedValueOnce({ folders: [day] });
     mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
 
     await photoCloudBrowser.syncAllHistory({});
@@ -362,10 +362,10 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     const file = makeFile('file-uuid', 'photo.jpg');
     mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
-      .mockResolvedValueOnce({ folders: [year] } as never)
-      .mockResolvedValueOnce({ folders: months } as never)
-      .mockResolvedValue({ folders: [day] } as never);
+      .mockResolvedValueOnce({ folders: [device] })
+      .mockResolvedValueOnce({ folders: [year] })
+      .mockResolvedValueOnce({ folders: months })
+      .mockResolvedValue({ folders: [day] });
     mockFolderService.getFolderContentByUuid.mockResolvedValue({ files: [file] } as never);
 
     const onMonthFetched = jest.fn();
@@ -384,10 +384,10 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     const fresh = Date.now() - 1000;
     mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(fresh);
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
-      .mockResolvedValueOnce({ folders: [year] } as never)
-      .mockResolvedValueOnce({ folders: [month] } as never)
-      .mockResolvedValueOnce({ folders: [day] } as never);
+      .mockResolvedValueOnce({ folders: [device] })
+      .mockResolvedValueOnce({ folders: [year] })
+      .mockResolvedValueOnce({ folders: [month] })
+      .mockResolvedValueOnce({ folders: [day] });
     mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
 
     await photoCloudBrowser.syncAllHistory({ force: true });
@@ -407,10 +407,10 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
       new Set(['file-uuid', 'deleted-file-uuid']),
     );
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
-      .mockResolvedValueOnce({ folders: [year] } as never)
-      .mockResolvedValueOnce({ folders: [month] } as never)
-      .mockResolvedValueOnce({ folders: [day] } as never);
+      .mockResolvedValueOnce({ folders: [device] })
+      .mockResolvedValueOnce({ folders: [year] })
+      .mockResolvedValueOnce({ folders: [month] })
+      .mockResolvedValueOnce({ folders: [day] });
     mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
 
     await photoCloudBrowser.syncAllHistory({});
@@ -430,10 +430,10 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
     mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth.mockResolvedValue(new Set(['file-uuid']));
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
-      .mockResolvedValueOnce({ folders: [year] } as never)
-      .mockResolvedValueOnce({ folders: [month] } as never)
-      .mockResolvedValueOnce({ folders: [day] } as never);
+      .mockResolvedValueOnce({ folders: [device] })
+      .mockResolvedValueOnce({ folders: [year] })
+      .mockResolvedValueOnce({ folders: [month] })
+      .mockResolvedValueOnce({ folders: [day] });
     mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
 
     await photoCloudBrowser.syncAllHistory({});
@@ -449,10 +449,10 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
     mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth.mockResolvedValue(new Set(['file-a', 'file-b']));
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
-      .mockResolvedValueOnce({ folders: [year] } as never)
-      .mockResolvedValueOnce({ folders: [month] } as never)
-      .mockResolvedValueOnce({ folders: [] } as never);
+      .mockResolvedValueOnce({ folders: [device] })
+      .mockResolvedValueOnce({ folders: [year] })
+      .mockResolvedValueOnce({ folders: [month] })
+      .mockResolvedValueOnce({ folders: [] });
 
     await photoCloudBrowser.syncAllHistory({});
 
@@ -471,10 +471,10 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth.mockResolvedValue(new Set());
     mockPhotosLocalDB.getSyncedRemoteIdsByCreationMonth.mockResolvedValue(new Set(['synced-remote-uuid']));
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
-      .mockResolvedValueOnce({ folders: [year] } as never)
-      .mockResolvedValueOnce({ folders: [month] } as never)
-      .mockResolvedValueOnce({ folders: [day] } as never);
+      .mockResolvedValueOnce({ folders: [device] })
+      .mockResolvedValueOnce({ folders: [year] })
+      .mockResolvedValueOnce({ folders: [month] })
+      .mockResolvedValueOnce({ folders: [day] });
     mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [] } as never);
 
     await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'device-1' });
@@ -493,10 +493,10 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
     mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth.mockResolvedValue(new Set());
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
-      .mockResolvedValueOnce({ folders: [year] } as never)
-      .mockResolvedValueOnce({ folders: [month] } as never)
-      .mockResolvedValueOnce({ folders: [day] } as never);
+      .mockResolvedValueOnce({ folders: [device] })
+      .mockResolvedValueOnce({ folders: [year] })
+      .mockResolvedValueOnce({ folders: [month] })
+      .mockResolvedValueOnce({ folders: [day] });
     mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [] } as never);
 
     await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'device-other' });
@@ -515,10 +515,10 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth.mockResolvedValue(new Set());
     mockPhotosLocalDB.getSyncedRemoteIdsByCreationMonth.mockResolvedValue(new Set());
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
-      .mockResolvedValueOnce({ folders: [year] } as never)
-      .mockResolvedValueOnce({ folders: [month] } as never)
-      .mockResolvedValueOnce({ folders: [day] } as never);
+      .mockResolvedValueOnce({ folders: [device] })
+      .mockResolvedValueOnce({ folders: [year] })
+      .mockResolvedValueOnce({ folders: [month] })
+      .mockResolvedValueOnce({ folders: [day] });
     mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [] } as never);
 
     await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'device-1' });
@@ -543,10 +543,10 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
       .mockResolvedValueOnce(new Set(['file-uuid'])) // 2024/06 — present
       .mockResolvedValueOnce(new Set(['deleted-a', 'deleted-b'])); // 2024/04 — absent
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
-      .mockResolvedValueOnce({ folders: [year] } as never)
-      .mockResolvedValueOnce({ folders: [month] } as never)
-      .mockResolvedValueOnce({ folders: [day] } as never);
+      .mockResolvedValueOnce({ folders: [device] })
+      .mockResolvedValueOnce({ folders: [year] })
+      .mockResolvedValueOnce({ folders: [month] })
+      .mockResolvedValueOnce({ folders: [day] });
     mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
 
     await photoCloudBrowser.syncAllHistory({});
@@ -575,10 +575,10 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
       .mockResolvedValueOnce(new Set()) // 2024/06 fetchMonthFromFolder
       .mockResolvedValueOnce(new Set(['synced-april-uuid'])); // 2024/04 reconcileDeletedMonths
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
-      .mockResolvedValueOnce({ folders: [year] } as never)
-      .mockResolvedValueOnce({ folders: [month] } as never)
-      .mockResolvedValueOnce({ folders: [day] } as never);
+      .mockResolvedValueOnce({ folders: [device] })
+      .mockResolvedValueOnce({ folders: [year] })
+      .mockResolvedValueOnce({ folders: [month] })
+      .mockResolvedValueOnce({ folders: [day] });
     mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
 
     await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'device-1' });
@@ -597,8 +597,8 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
       .mockResolvedValueOnce(new Set(['file-a']))
       .mockResolvedValueOnce(new Set(['file-b']));
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
-      .mockResolvedValueOnce({ folders: [] } as never); // no year folders
+      .mockResolvedValueOnce({ folders: [device] })
+      .mockResolvedValueOnce({ folders: [] }); // no year folders
 
     await photoCloudBrowser.syncAllHistory({});
 
@@ -618,10 +618,10 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     mockPhotosLocalDB.getCloudAssetMonthsByDevice.mockResolvedValue([{ year: 2024, month: 6 }]);
     mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth.mockResolvedValue(new Set(['file-uuid']));
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
-      .mockResolvedValueOnce({ folders: [year] } as never)
-      .mockResolvedValueOnce({ folders: [month] } as never)
-      .mockResolvedValueOnce({ folders: [day] } as never);
+      .mockResolvedValueOnce({ folders: [device] })
+      .mockResolvedValueOnce({ folders: [year] })
+      .mockResolvedValueOnce({ folders: [month] })
+      .mockResolvedValueOnce({ folders: [day] });
     mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
 
     await photoCloudBrowser.syncAllHistory({});
@@ -640,11 +640,11 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     const file = makeFile('file-uuid', 'photo.jpg');
     mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
-      .mockResolvedValueOnce({ folders: [year] } as never)
-      .mockResolvedValueOnce({ folders: [monthWithFiles, monthEmpty] } as never)
-      .mockResolvedValueOnce({ folders: [day] } as never)
-      .mockResolvedValueOnce({ folders: [] } as never);
+      .mockResolvedValueOnce({ folders: [device] })
+      .mockResolvedValueOnce({ folders: [year] })
+      .mockResolvedValueOnce({ folders: [monthWithFiles, monthEmpty] })
+      .mockResolvedValueOnce({ folders: [day] })
+      .mockResolvedValueOnce({ folders: [] });
     mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
 
     const onMonthFetched = jest.fn();

--- a/src/services/photos/PhotoCloudBrowser.spec.ts
+++ b/src/services/photos/PhotoCloudBrowser.spec.ts
@@ -411,7 +411,7 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
       .mockResolvedValueOnce({ folders: [year] })
       .mockResolvedValueOnce({ folders: [month] })
       .mockResolvedValueOnce({ folders: [day] });
-    mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
+    (mockFolderService.getFolderContentByUuid as jest.Mock).mockResolvedValueOnce({ files: [file] });
 
     await photoCloudBrowser.syncAllHistory({});
 
@@ -434,7 +434,7 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
       .mockResolvedValueOnce({ folders: [year] })
       .mockResolvedValueOnce({ folders: [month] })
       .mockResolvedValueOnce({ folders: [day] });
-    mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
+    (mockFolderService.getFolderContentByUuid as jest.Mock).mockResolvedValueOnce({ files: [file] });
 
     await photoCloudBrowser.syncAllHistory({});
 
@@ -475,7 +475,7 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
       .mockResolvedValueOnce({ folders: [year] })
       .mockResolvedValueOnce({ folders: [month] })
       .mockResolvedValueOnce({ folders: [day] });
-    mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [] } as never);
+    (mockFolderService.getFolderContentByUuid as jest.Mock).mockResolvedValueOnce({ files: [] });
 
     await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'device-1' });
 
@@ -497,7 +497,7 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
       .mockResolvedValueOnce({ folders: [year] })
       .mockResolvedValueOnce({ folders: [month] })
       .mockResolvedValueOnce({ folders: [day] });
-    mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [] } as never);
+    (mockFolderService.getFolderContentByUuid as jest.Mock).mockResolvedValueOnce({ files: [] });
 
     await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'device-other' });
 
@@ -519,7 +519,7 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
       .mockResolvedValueOnce({ folders: [year] })
       .mockResolvedValueOnce({ folders: [month] })
       .mockResolvedValueOnce({ folders: [day] });
-    mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [] } as never);
+    (mockFolderService.getFolderContentByUuid as jest.Mock).mockResolvedValueOnce({ files: [] });
 
     await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'device-1' });
 
@@ -547,7 +547,7 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
       .mockResolvedValueOnce({ folders: [year] })
       .mockResolvedValueOnce({ folders: [month] })
       .mockResolvedValueOnce({ folders: [day] });
-    mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
+    (mockFolderService.getFolderContentByUuid as jest.Mock).mockResolvedValueOnce({ files: [file] });
 
     await photoCloudBrowser.syncAllHistory({});
 
@@ -579,7 +579,7 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
       .mockResolvedValueOnce({ folders: [year] })
       .mockResolvedValueOnce({ folders: [month] })
       .mockResolvedValueOnce({ folders: [day] });
-    mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
+    (mockFolderService.getFolderContentByUuid as jest.Mock).mockResolvedValueOnce({ files: [file] });
 
     await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'device-1' });
 
@@ -622,7 +622,7 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
       .mockResolvedValueOnce({ folders: [year] })
       .mockResolvedValueOnce({ folders: [month] })
       .mockResolvedValueOnce({ folders: [day] });
-    mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
+    (mockFolderService.getFolderContentByUuid as jest.Mock).mockResolvedValueOnce({ files: [file] });
 
     await photoCloudBrowser.syncAllHistory({});
 

--- a/src/services/photos/PhotoCloudBrowser.spec.ts
+++ b/src/services/photos/PhotoCloudBrowser.spec.ts
@@ -20,6 +20,12 @@ jest.mock('./database/photosLocalDB', () => ({
   photosLocalDB: {
     getCloudFetchCacheAge: jest.fn(),
     upsertCloudAsset: jest.fn(),
+    getCloudAssetRemoteIdsByDeviceAndMonth: jest.fn(),
+    getSyncedRemoteIdsByCreationMonth: jest.fn(),
+    markCloudDeleted: jest.fn(),
+    deleteCloudAsset: jest.fn(),
+    getCloudAssetMonthsByDevice: jest.fn(),
+    getSyncedMonths: jest.fn(),
   },
 }));
 
@@ -40,6 +46,12 @@ const makeFile = (uuid: string, plainName: string) =>
 beforeEach(() => {
   jest.clearAllMocks();
   mockPhotosLocalDB.upsertCloudAsset.mockResolvedValue(undefined);
+  mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth.mockResolvedValue(new Set());
+  mockPhotosLocalDB.getSyncedRemoteIdsByCreationMonth.mockResolvedValue(new Set());
+  mockPhotosLocalDB.markCloudDeleted.mockResolvedValue(undefined);
+  mockPhotosLocalDB.deleteCloudAsset.mockResolvedValue(undefined);
+  mockPhotosLocalDB.getCloudAssetMonthsByDevice.mockResolvedValue([]);
+  mockPhotosLocalDB.getSyncedMonths.mockResolvedValue([]);
 });
 
 describe('PhotoCloudBrowser.listDeviceFolders', () => {
@@ -66,10 +78,10 @@ describe('PhotoCloudBrowser.listDeviceFolders', () => {
     ]);
   });
 
-  test('when the root has exactly 50 device folders, then a second page is fetched to check for more', async () => {
+  test('when the root has exactly 50 device folders and a second page has more, then all folders from both pages are returned', async () => {
     mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
     const firstBatch = Array.from({ length: 50 }, (_, i) => makeFolder(`d${i}`, `device-${i}`));
-    const secondBatch: never[] = [];
+    const secondBatch = [makeFolder('d50', 'device-50'), makeFolder('d51', 'device-51')];
     mockFolderService.getFolderFolders
       .mockResolvedValueOnce({ folders: firstBatch } as never)
       .mockResolvedValueOnce({ folders: secondBatch } as never);
@@ -77,7 +89,7 @@ describe('PhotoCloudBrowser.listDeviceFolders', () => {
     const result = await photoCloudBrowser.listDeviceFolders();
 
     expect(mockFolderService.getFolderFolders).toHaveBeenCalledTimes(2);
-    expect(result).toHaveLength(50);
+    expect(result).toHaveLength(52);
   });
 });
 
@@ -341,7 +353,7 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     expect(mockFolderService.getFolderFolders).toHaveBeenCalledTimes(4);
   });
 
-  test('when six months each have files, then onMonthFetched is invoked six times', async () => {
+  test('when six months each have files, then the caller is notified once per month', async () => {
     mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
     const device = makeFolder('d1-uuid', 'device-1');
     const year = makeFolder('y-uuid', '2024');
@@ -383,7 +395,242 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     expect(mockPhotosLocalDB.upsertCloudAsset).toHaveBeenCalledTimes(1);
   });
 
-  test('when a discovered month has no files, then onMonthFetched is not invoked for that month', async () => {
+  test('when a month fetch finds a previously known file missing from the cloud, then it is marked as cloud_deleted', async () => {
+    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
+    const device = makeFolder('d1-uuid', 'device-1');
+    const year = makeFolder('y-uuid', '2024');
+    const month = makeFolder('m-uuid', '06');
+    const day = makeFolder('day-uuid', '15');
+    const file = makeFile('file-uuid', 'photo.jpg');
+    mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
+    mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth.mockResolvedValue(
+      new Set(['file-uuid', 'deleted-file-uuid']),
+    );
+    mockFolderService.getFolderFolders
+      .mockResolvedValueOnce({ folders: [device] } as never)
+      .mockResolvedValueOnce({ folders: [year] } as never)
+      .mockResolvedValueOnce({ folders: [month] } as never)
+      .mockResolvedValueOnce({ folders: [day] } as never);
+    mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
+
+    await photoCloudBrowser.syncAllHistory({});
+
+    expect(mockPhotosLocalDB.markCloudDeleted).toHaveBeenCalledTimes(1);
+    expect(mockPhotosLocalDB.markCloudDeleted).toHaveBeenCalledWith('deleted-file-uuid');
+    expect(mockPhotosLocalDB.deleteCloudAsset).toHaveBeenCalledWith('deleted-file-uuid');
+  });
+
+  test('when a month fetch finds all previously known files still present, then no file is marked as cloud_deleted', async () => {
+    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
+    const device = makeFolder('d1-uuid', 'device-1');
+    const year = makeFolder('y-uuid', '2024');
+    const month = makeFolder('m-uuid', '06');
+    const day = makeFolder('day-uuid', '15');
+    const file = makeFile('file-uuid', 'photo.jpg');
+    mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
+    mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth.mockResolvedValue(new Set(['file-uuid']));
+    mockFolderService.getFolderFolders
+      .mockResolvedValueOnce({ folders: [device] } as never)
+      .mockResolvedValueOnce({ folders: [year] } as never)
+      .mockResolvedValueOnce({ folders: [month] } as never)
+      .mockResolvedValueOnce({ folders: [day] } as never);
+    mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
+
+    await photoCloudBrowser.syncAllHistory({});
+
+    expect(mockPhotosLocalDB.markCloudDeleted).not.toHaveBeenCalled();
+  });
+
+  test('when a month becomes empty in the cloud, then all previously known files are marked as cloud_deleted', async () => {
+    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
+    const device = makeFolder('d1-uuid', 'device-1');
+    const year = makeFolder('y-uuid', '2024');
+    const month = makeFolder('m-uuid', '06');
+    mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
+    mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth.mockResolvedValue(new Set(['file-a', 'file-b']));
+    mockFolderService.getFolderFolders
+      .mockResolvedValueOnce({ folders: [device] } as never)
+      .mockResolvedValueOnce({ folders: [year] } as never)
+      .mockResolvedValueOnce({ folders: [month] } as never)
+      .mockResolvedValueOnce({ folders: [] } as never);
+
+    await photoCloudBrowser.syncAllHistory({});
+
+    expect(mockPhotosLocalDB.markCloudDeleted).toHaveBeenCalledTimes(2);
+    expect(mockPhotosLocalDB.markCloudDeleted).toHaveBeenCalledWith('file-a');
+    expect(mockPhotosLocalDB.markCloudDeleted).toHaveBeenCalledWith('file-b');
+  });
+
+  test('when the current device has a synced asset whose remote file is no longer in the cloud folder, then it is marked as cloud_deleted', async () => {
+    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
+    const device = makeFolder('d1-uuid', 'device-1');
+    const year = makeFolder('y-uuid', '2024');
+    const month = makeFolder('m-uuid', '06');
+    const day = makeFolder('day-uuid', '15');
+    mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
+    mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth.mockResolvedValue(new Set());
+    mockPhotosLocalDB.getSyncedRemoteIdsByCreationMonth.mockResolvedValue(new Set(['synced-remote-uuid']));
+    mockFolderService.getFolderFolders
+      .mockResolvedValueOnce({ folders: [device] } as never)
+      .mockResolvedValueOnce({ folders: [year] } as never)
+      .mockResolvedValueOnce({ folders: [month] } as never)
+      .mockResolvedValueOnce({ folders: [day] } as never);
+    mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [] } as never);
+
+    await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'device-1' });
+
+    expect(mockPhotosLocalDB.markCloudDeleted).toHaveBeenCalledTimes(1);
+    expect(mockPhotosLocalDB.markCloudDeleted).toHaveBeenCalledWith('synced-remote-uuid');
+    expect(mockPhotosLocalDB.deleteCloudAsset).toHaveBeenCalledWith('synced-remote-uuid');
+  });
+
+  test('when synced assets from a different device are missing from that device cloud folder, then they are not looked up via asset_sync', async () => {
+    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
+    const device = makeFolder('d1-uuid', 'device-1');
+    const year = makeFolder('y-uuid', '2024');
+    const month = makeFolder('m-uuid', '06');
+    const day = makeFolder('day-uuid', '15');
+    mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
+    mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth.mockResolvedValue(new Set());
+    mockFolderService.getFolderFolders
+      .mockResolvedValueOnce({ folders: [device] } as never)
+      .mockResolvedValueOnce({ folders: [year] } as never)
+      .mockResolvedValueOnce({ folders: [month] } as never)
+      .mockResolvedValueOnce({ folders: [day] } as never);
+    mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [] } as never);
+
+    await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'device-other' });
+
+    expect(mockPhotosLocalDB.getSyncedRemoteIdsByCreationMonth).not.toHaveBeenCalled();
+    expect(mockPhotosLocalDB.markCloudDeleted).not.toHaveBeenCalled();
+  });
+
+  test('when the current device matches the folder being synced, then synced remote ids are looked up to detect cloud deletions', async () => {
+    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
+    const device = makeFolder('d1-uuid', 'device-1');
+    const year = makeFolder('y-uuid', '2024');
+    const month = makeFolder('m-uuid', '06');
+    const day = makeFolder('day-uuid', '15');
+    mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
+    mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth.mockResolvedValue(new Set());
+    mockPhotosLocalDB.getSyncedRemoteIdsByCreationMonth.mockResolvedValue(new Set());
+    mockFolderService.getFolderFolders
+      .mockResolvedValueOnce({ folders: [device] } as never)
+      .mockResolvedValueOnce({ folders: [year] } as never)
+      .mockResolvedValueOnce({ folders: [month] } as never)
+      .mockResolvedValueOnce({ folders: [day] } as never);
+    mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [] } as never);
+
+    await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'device-1' });
+
+    expect(mockPhotosLocalDB.getSyncedRemoteIdsByCreationMonth).toHaveBeenCalled();
+  });
+
+  test('when a month known in the DB is no longer present in the cloud, then all its files are marked as cloud_deleted', async () => {
+    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
+    const device = makeFolder('d1-uuid', 'device-1');
+    const year = makeFolder('y-uuid', '2024');
+    const month = makeFolder('m-uuid', '06');
+    const day = makeFolder('day-uuid', '15');
+    const file = makeFile('file-uuid', 'photo.jpg');
+    mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
+    // Drive has only 2024/06; DB also knows 2024/04 (deleted month)
+    mockPhotosLocalDB.getCloudAssetMonthsByDevice.mockResolvedValue([
+      { year: 2024, month: 6 },
+      { year: 2024, month: 4 },
+    ]);
+    mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth
+      .mockResolvedValueOnce(new Set(['file-uuid'])) // 2024/06 — present
+      .mockResolvedValueOnce(new Set(['deleted-a', 'deleted-b'])); // 2024/04 — absent
+    mockFolderService.getFolderFolders
+      .mockResolvedValueOnce({ folders: [device] } as never)
+      .mockResolvedValueOnce({ folders: [year] } as never)
+      .mockResolvedValueOnce({ folders: [month] } as never)
+      .mockResolvedValueOnce({ folders: [day] } as never);
+    mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
+
+    await photoCloudBrowser.syncAllHistory({});
+
+    expect(mockPhotosLocalDB.markCloudDeleted).toHaveBeenCalledTimes(2);
+    expect(mockPhotosLocalDB.markCloudDeleted).toHaveBeenCalledWith('deleted-a');
+    expect(mockPhotosLocalDB.markCloudDeleted).toHaveBeenCalledWith('deleted-b');
+  });
+
+  test('when the current device has synced assets in a month with no cloud folder, then those assets are marked as cloud_deleted', async () => {
+    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
+    const device = makeFolder('d1-uuid', 'device-1');
+    const year = makeFolder('y-uuid', '2024');
+    const month = makeFolder('m-uuid', '06');
+    const day = makeFolder('day-uuid', '15');
+    const file = makeFile('file-uuid', 'photo.jpg');
+    mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
+    // cloud_asset knows nothing about 2024/04, but asset_sync does (uploaded from this device)
+    mockPhotosLocalDB.getCloudAssetMonthsByDevice.mockResolvedValue([{ year: 2024, month: 6 }]);
+    mockPhotosLocalDB.getSyncedMonths.mockResolvedValue([
+      { year: 2024, month: 6 },
+      { year: 2024, month: 4 },
+    ]);
+    mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth.mockResolvedValue(new Set());
+    mockPhotosLocalDB.getSyncedRemoteIdsByCreationMonth
+      .mockResolvedValueOnce(new Set()) // 2024/06 fetchMonthFromFolder
+      .mockResolvedValueOnce(new Set(['synced-april-uuid'])); // 2024/04 reconcileDeletedMonths
+    mockFolderService.getFolderFolders
+      .mockResolvedValueOnce({ folders: [device] } as never)
+      .mockResolvedValueOnce({ folders: [year] } as never)
+      .mockResolvedValueOnce({ folders: [month] } as never)
+      .mockResolvedValueOnce({ folders: [day] } as never);
+    mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
+
+    await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'device-1' });
+
+    expect(mockPhotosLocalDB.markCloudDeleted).toHaveBeenCalledWith('synced-april-uuid');
+  });
+
+  test('when the cloud has no months at all and the DB has known months, then every known month is reconciled', async () => {
+    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
+    const device = makeFolder('d1-uuid', 'device-1');
+    mockPhotosLocalDB.getCloudAssetMonthsByDevice.mockResolvedValue([
+      { year: 2024, month: 6 },
+      { year: 2024, month: 5 },
+    ]);
+    mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth
+      .mockResolvedValueOnce(new Set(['file-a']))
+      .mockResolvedValueOnce(new Set(['file-b']));
+    mockFolderService.getFolderFolders
+      .mockResolvedValueOnce({ folders: [device] } as never)
+      .mockResolvedValueOnce({ folders: [] } as never); // no year folders
+
+    await photoCloudBrowser.syncAllHistory({});
+
+    expect(mockPhotosLocalDB.markCloudDeleted).toHaveBeenCalledTimes(2);
+    expect(mockPhotosLocalDB.markCloudDeleted).toHaveBeenCalledWith('file-a');
+    expect(mockPhotosLocalDB.markCloudDeleted).toHaveBeenCalledWith('file-b');
+  });
+
+  test('when every month in the DB is still present in the cloud, then no extra reconciliation runs for deleted months', async () => {
+    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
+    const device = makeFolder('d1-uuid', 'device-1');
+    const year = makeFolder('y-uuid', '2024');
+    const month = makeFolder('m-uuid', '06');
+    const day = makeFolder('day-uuid', '15');
+    const file = makeFile('file-uuid', 'photo.jpg');
+    mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
+    mockPhotosLocalDB.getCloudAssetMonthsByDevice.mockResolvedValue([{ year: 2024, month: 6 }]);
+    mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth.mockResolvedValue(new Set(['file-uuid']));
+    mockFolderService.getFolderFolders
+      .mockResolvedValueOnce({ folders: [device] } as never)
+      .mockResolvedValueOnce({ folders: [year] } as never)
+      .mockResolvedValueOnce({ folders: [month] } as never)
+      .mockResolvedValueOnce({ folders: [day] } as never);
+    mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
+
+    await photoCloudBrowser.syncAllHistory({});
+
+    // Only the file-level reconciliation for 2024/06 runs — no extra calls for deleted months
+    expect(mockPhotosLocalDB.markCloudDeleted).not.toHaveBeenCalled();
+  });
+
+  test('when a discovered month has no files, then the caller is not notified for that month', async () => {
     mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
     const device = makeFolder('d1-uuid', 'device-1');
     const year = makeFolder('y-uuid', '2024');

--- a/src/services/photos/PhotoCloudBrowser.ts
+++ b/src/services/photos/PhotoCloudBrowser.ts
@@ -71,8 +71,9 @@ class PhotoCloudBrowserService {
     onMonthFetched?: () => void;
     isCancelled?: () => boolean;
     force?: boolean;
+    currentDeviceId?: string;
   }): Promise<void> {
-    const { onMonthFetched, isCancelled, force } = options;
+    const { onMonthFetched, isCancelled, force, currentDeviceId } = options;
     const devices = await this.listDeviceFolders();
     if (devices.length === 0) {
       logger.info('[CloudBrowser] No device folders found — skipping sync');
@@ -80,31 +81,36 @@ class PhotoCloudBrowserService {
     }
 
     const months = await this.discoverAvailableMonths(devices);
-    if (months.length === 0) {
-      logger.info('[CloudBrowser] Discovery found no months — skipping sync');
-      return;
-    }
-    logger.info(
-      `[CloudBrowser] Discovered ${months.length} months across ${devices.length} device(s)${force ? ' — TTL bypassed (force refresh)' : ''}`,
-    );
 
-    const CONCURRENCY = 3;
-    let cursor = 0;
-    const worker = async (): Promise<void> => {
-      while (cursor < months.length) {
-        if (isCancelled?.()) return;
-        const target = months[cursor++];
-        await this.fetchMonthFromFolder({
-          deviceId: target.deviceId,
-          monthFolderUuid: target.monthFolderUuid,
-          year: target.year,
-          month: target.month,
-          onMonthFetched,
-          force,
-        });
-      }
-    };
-    await Promise.all(Array.from({ length: CONCURRENCY }, () => worker()));
+    if (months.length === 0) {
+      logger.info('[CloudBrowser] Discovery found no months in cloud');
+    } else {
+      logger.info(
+        `[CloudBrowser] Discovered ${months.length} months across ${devices.length} device(s)${force ? ' — TTL bypassed (force refresh)' : ''}`,
+      );
+      const CONCURRENCY = 3;
+      let cursor = 0;
+      const worker = async (): Promise<void> => {
+        while (cursor < months.length) {
+          if (isCancelled?.()) {
+            return;
+          }
+          const target = months[cursor++];
+          await this.fetchMonthFromFolder({
+            deviceId: target.deviceId,
+            monthFolderUuid: target.monthFolderUuid,
+            year: target.year,
+            month: target.month,
+            onMonthFetched,
+            force,
+            currentDeviceId,
+          });
+        }
+      };
+      await Promise.all(Array.from({ length: CONCURRENCY }, () => worker()));
+    }
+
+    await this.reconcileDeletedMonths({ devices, discoveredMonths: months, currentDeviceId });
   }
 
   private async fetchMonthFromFolder(params: {
@@ -114,8 +120,9 @@ class PhotoCloudBrowserService {
     month: number;
     onMonthFetched?: () => void;
     force?: boolean;
+    currentDeviceId?: string;
   }): Promise<number> {
-    const { deviceId, monthFolderUuid, year, month, onMonthFetched, force } = params;
+    const { deviceId, monthFolderUuid, year, month, onMonthFetched, force, currentDeviceId } = params;
     if (!force) {
       const cacheAge = await this.localDB.getCloudFetchCacheAge(deviceId, year, month);
       if (cacheAge !== null && Date.now() - cacheAge < CACHE_TTL_MS) return 0;
@@ -124,6 +131,7 @@ class PhotoCloudBrowserService {
     const dayFolders = await this.listAllFolders(monthFolderUuid);
     const now = Date.now();
     let count = 0;
+    const foundIds = new Set<string>();
 
     for (const dayFolder of dayFolders) {
       const day = Number.parseInt(dayFolder.plainName ?? '', 10);
@@ -131,6 +139,7 @@ class PhotoCloudBrowserService {
 
       const files = await this.listFilesWithThumbnails(dayFolder.uuid);
       for (const file of files) {
+        if (file.status && file.status.toLowerCase() !== 'exists') continue;
         const baseName = file.plainName ?? file.name;
         const fileName = file.type ? `${baseName}.${file.type}` : baseName;
         const createdAt = folderDate;
@@ -158,9 +167,12 @@ class PhotoCloudBrowserService {
           status: file.status ?? null,
           encryptVersion: file.encrypt_version ?? null,
         });
+        foundIds.add(file.uuid);
         count++;
       }
     }
+
+    await this.reconcileCloudDeletions({ deviceId, year, month, foundIds, currentDeviceId });
 
     if (count > 0) {
       logger.info(
@@ -171,6 +183,67 @@ class PhotoCloudBrowserService {
       logger.info(`[CloudBrowser] Device "${deviceId}" ${year}/${String(month).padStart(2, '0')} — empty`);
     }
     return count;
+  }
+
+  private async reconcileCloudDeletions(params: {
+    deviceId: string;
+    year: number;
+    month: number;
+    foundIds: Set<string>;
+    currentDeviceId?: string;
+  }): Promise<void> {
+    const { deviceId, year, month, foundIds, currentDeviceId } = params;
+    const knownFromCloud = await this.localDB.getCloudAssetRemoteIdsByDeviceAndMonth(deviceId, year, month);
+    const knownIds = new Set(knownFromCloud);
+
+    if (currentDeviceId && deviceId === currentDeviceId) {
+      const knownFromSync = await this.localDB.getSyncedRemoteIdsByCreationMonth(year, month);
+      for (const id of knownFromSync) knownIds.add(id);
+    }
+
+    let removedCount = 0;
+    for (const knownId of knownIds) {
+      if (!foundIds.has(knownId)) {
+        await this.localDB.markCloudDeleted(knownId);
+        await this.localDB.deleteCloudAsset(knownId);
+        removedCount++;
+      }
+    }
+    if (removedCount > 0) {
+      logger.info(
+        `[CloudBrowser] Device "${deviceId}" ${year}/${String(month).padStart(2, '0')} — ${removedCount} file(s) cloud_deleted`,
+      );
+    }
+  }
+
+  private async reconcileDeletedMonths(params: {
+    devices: { uuid: string; name: string }[];
+    discoveredMonths: { deviceId: string; year: number; month: number; monthFolderUuid: string }[];
+    currentDeviceId?: string;
+  }): Promise<void> {
+    const { devices, discoveredMonths, currentDeviceId } = params;
+    const discoveredSet = new Set(discoveredMonths.map((m) => `${m.deviceId}:${m.year}:${m.month}`));
+
+    for (const device of devices) {
+      const deviceId = device.name;
+      const cloudMonths = await this.localDB.getCloudAssetMonthsByDevice(deviceId);
+      const monthSet = new Set(cloudMonths.map((m) => `${m.year}:${m.month}`));
+
+      if (currentDeviceId && deviceId === currentDeviceId) {
+        const syncedMonths = await this.localDB.getSyncedMonths();
+        for (const m of syncedMonths) monthSet.add(`${m.year}:${m.month}`);
+      }
+
+      for (const key of monthSet) {
+        const [year, month] = key.split(':').map(Number);
+        if (!discoveredSet.has(`${deviceId}:${year}:${month}`)) {
+          logger.info(
+            `[CloudBrowser] Device "${deviceId}" ${year}/${String(month).padStart(2, '0')} — month no longer in cloud`,
+          );
+          await this.reconcileCloudDeletions({ deviceId, year, month, foundIds: new Set(), currentDeviceId });
+        }
+      }
+    }
   }
 
   private async discoverMonthsForDevice(device: {

--- a/src/services/photos/PhotoDeduplicator.spec.ts
+++ b/src/services/photos/PhotoDeduplicator.spec.ts
@@ -31,9 +31,9 @@ describe('PhotoDeduplicator', () => {
   test('when all photos are already synced and unmodified, then nothing is queued', async () => {
     mockDB.getSyncedEntries.mockResolvedValueOnce(
       new Map([
-        ['a', { modificationTime: 1000 }],
-        ['b', { modificationTime: 1000 }],
-        ['c', { modificationTime: 1000 }],
+        ['a', { modificationTime: 1000, status: 'synced' as const }],
+        ['b', { modificationTime: 1000, status: 'synced' as const }],
+        ['c', { modificationTime: 1000, status: 'synced' as const }],
       ]),
     );
 
@@ -48,7 +48,9 @@ describe('PhotoDeduplicator', () => {
   });
 
   test('when some photos are already synced, then only the unsynced ones are queued as new', async () => {
-    mockDB.getSyncedEntries.mockResolvedValueOnce(new Map([['b', { modificationTime: 1000 }]]));
+    mockDB.getSyncedEntries.mockResolvedValueOnce(
+      new Map([['b', { modificationTime: 1000, status: 'synced' as const }]]),
+    );
 
     const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([
       makeAsset('a'),
@@ -61,7 +63,9 @@ describe('PhotoDeduplicator', () => {
   });
 
   test('when a previously synced photo has been edited on the device, then it is queued as an edit', async () => {
-    mockDB.getSyncedEntries.mockResolvedValueOnce(new Map([['a', { modificationTime: 500 }]]));
+    mockDB.getSyncedEntries.mockResolvedValueOnce(
+      new Map([['a', { modificationTime: 500, status: 'synced' as const }]]),
+    );
 
     const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([makeAsset('a', 1000)]);
 
@@ -70,7 +74,9 @@ describe('PhotoDeduplicator', () => {
   });
 
   test('when a synced photo has no recorded modification time, then it is not re-queued', async () => {
-    mockDB.getSyncedEntries.mockResolvedValueOnce(new Map([['a', { modificationTime: null }]]));
+    mockDB.getSyncedEntries.mockResolvedValueOnce(
+      new Map([['a', { modificationTime: null, status: 'synced' as const }]]),
+    );
 
     const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([makeAsset('a', 1000)]);
 
@@ -97,8 +103,43 @@ describe('PhotoDeduplicator', () => {
   });
 
   test('when a previously synced photo was explicitly deleted from cloud, then it is excluded from edited assets', async () => {
-    mockDB.getSyncedEntries.mockResolvedValueOnce(new Map([['a', { modificationTime: 500 }]]));
+    mockDB.getSyncedEntries.mockResolvedValueOnce(
+      new Map([['a', { modificationTime: 500, status: 'synced' as const }]]),
+    );
     mockDB.getDeletedAssetIds.mockResolvedValueOnce(new Set(['a']));
+
+    const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([makeAsset('a', 1000)]);
+
+    expect(newAssets).toHaveLength(0);
+    expect(editedAssets).toHaveLength(0);
+  });
+
+  test('when a photo is marked cloud_deleted and not edited on device, then it is not re-queued', async () => {
+    mockDB.getSyncedEntries.mockResolvedValueOnce(
+      new Map([['a', { modificationTime: 1000, status: 'cloud_deleted' as const }]]),
+    );
+
+    const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([makeAsset('a', 1000)]);
+
+    expect(newAssets).toHaveLength(0);
+    expect(editedAssets).toHaveLength(0);
+  });
+
+  test('when a photo is marked cloud_deleted and was later edited on device, then it is treated as a new upload', async () => {
+    mockDB.getSyncedEntries.mockResolvedValueOnce(
+      new Map([['a', { modificationTime: 500, status: 'cloud_deleted' as const }]]),
+    );
+
+    const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([makeAsset('a', 1000)]);
+
+    expect(newAssets.map((asset) => asset.id)).toEqual(['a']);
+    expect(editedAssets).toHaveLength(0);
+  });
+
+  test('when a photo is marked cloud_deleted with no modification time and was edited, then it is not re-queued', async () => {
+    mockDB.getSyncedEntries.mockResolvedValueOnce(
+      new Map([['a', { modificationTime: null, status: 'cloud_deleted' as const }]]),
+    );
 
     const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([makeAsset('a', 1000)]);
 

--- a/src/services/photos/PhotoDeduplicator.ts
+++ b/src/services/photos/PhotoDeduplicator.ts
@@ -36,6 +36,10 @@ export const PhotoDeduplicator = {
       const syncedInfo = syncedEntries.get(asset.id);
       if (!syncedInfo) {
         newAssets.push(asset);
+      } else if (syncedInfo.status === 'cloud_deleted') {
+        if (hasBeenEdited(asset, syncedInfo.modificationTime)) {
+          newAssets.push(asset);
+        }
       } else if (hasBeenEdited(asset, syncedInfo.modificationTime)) {
         editedAssets.push(asset);
       }

--- a/src/services/photos/database/photosLocalDB.spec.ts
+++ b/src/services/photos/database/photosLocalDB.spec.ts
@@ -44,9 +44,9 @@ describe('photosLocalDB', () => {
 
     expect(mockSqlite.executeSql).toHaveBeenCalledTimes(1);
     const [, stmt, params] = mockSqlite.executeSql.mock.calls[0];
-    expect(stmt).toContain("'pending'");
+    expect(stmt).toContain('\'pending\'');
     expect(stmt).toContain('ON CONFLICT');
-    expect(stmt).toContain("status != 'synced'");
+    expect(stmt).toContain('status != \'synced\'');
     expect(params).toEqual(['asset-1', null, null, null, null, null, null]);
   });
 
@@ -69,8 +69,8 @@ describe('photosLocalDB', () => {
 
     expect(mockSqlite.executeSql).toHaveBeenCalledTimes(1);
     const [, stmt, params] = mockSqlite.executeSql.mock.calls[0];
-    expect(stmt).toContain("'pending_edit'");
-    expect(stmt).toContain("status = 'synced'");
+    expect(stmt).toContain('\'pending_edit\'');
+    expect(stmt).toContain('status = \'synced\'');
     expect(params).toEqual(['asset-1', null, null, null, null, null, null]);
   });
 
@@ -102,7 +102,7 @@ describe('photosLocalDB', () => {
 
     expect(mockSqlite.executeSql).toHaveBeenCalledTimes(1);
     const [, stmt, params] = mockSqlite.executeSql.mock.calls[0];
-    expect(stmt).toContain("'synced'");
+    expect(stmt).toContain('\'synced\'');
     expect(stmt).toContain('unixepoch()');
     expect(params).toEqual(['asset-1', 'remote-file-id', 1714000000]);
   });
@@ -119,7 +119,7 @@ describe('photosLocalDB', () => {
 
     expect(mockSqlite.executeSql).toHaveBeenCalledTimes(1);
     const [, stmt, params] = mockSqlite.executeSql.mock.calls[0];
-    expect(stmt).toContain("'error'");
+    expect(stmt).toContain('\'error\'');
     expect(params).toEqual(['asset-2', null]);
   });
 
@@ -136,7 +136,7 @@ describe('photosLocalDB', () => {
     const [, stmt] = mockSqlite.executeSql.mock.calls[0];
     expect(stmt).toContain('attempt_count + 1');
     expect(stmt).toContain('ON CONFLICT');
-    expect(stmt).toContain("status != 'synced'");
+    expect(stmt).toContain('status != \'synced\'');
   });
 
   test('when looking up synced photos, then both synced and cloud_deleted statuses are queried', async () => {
@@ -145,7 +145,7 @@ describe('photosLocalDB', () => {
     await photosLocalDB.getSyncedEntries(['asset-1']);
 
     const [, stmt] = mockSqlite.getAllAsync.mock.calls[0];
-    expect(stmt).toContain("status IN ('synced', 'cloud_deleted')");
+    expect(stmt).toContain('status IN (\'synced\', \'cloud_deleted\')');
   });
 
   test('when looking up 300 photos at once, then a single database query is made with all ids', async () => {

--- a/src/services/photos/database/photosLocalDB.spec.ts
+++ b/src/services/photos/database/photosLocalDB.spec.ts
@@ -25,6 +25,9 @@ describe('photosLocalDB', () => {
 
     expect(mockSqlite.open).toHaveBeenCalledWith('photos_sync.db');
     expect(mockSqlite.executeSql).toHaveBeenCalledTimes(6);
+    const statements = mockSqlite.executeSql.mock.calls.map(([, stmt]) => stmt as string);
+    expect(statements.some((s) => s.includes('CREATE TABLE IF NOT EXISTS asset_sync'))).toBe(true);
+    expect(statements.some((s) => s.includes('CREATE TABLE IF NOT EXISTS cloud_asset'))).toBe(true);
   });
 
   test('when the database is initialized a second time, then no database calls are made', async () => {
@@ -41,8 +44,9 @@ describe('photosLocalDB', () => {
 
     expect(mockSqlite.executeSql).toHaveBeenCalledTimes(1);
     const [, stmt, params] = mockSqlite.executeSql.mock.calls[0];
-    expect(stmt).toContain('\'pending\'');
-    expect(stmt).toContain('status != \'synced\'');
+    expect(stmt).toContain("'pending'");
+    expect(stmt).toContain('ON CONFLICT');
+    expect(stmt).toContain("status != 'synced'");
     expect(params).toEqual(['asset-1', null, null, null, null, null, null]);
   });
 
@@ -65,8 +69,8 @@ describe('photosLocalDB', () => {
 
     expect(mockSqlite.executeSql).toHaveBeenCalledTimes(1);
     const [, stmt, params] = mockSqlite.executeSql.mock.calls[0];
-    expect(stmt).toContain('\'pending_edit\'');
-    expect(stmt).toContain('status = \'synced\'');
+    expect(stmt).toContain("'pending_edit'");
+    expect(stmt).toContain("status = 'synced'");
     expect(params).toEqual(['asset-1', null, null, null, null, null, null]);
   });
 
@@ -98,7 +102,7 @@ describe('photosLocalDB', () => {
 
     expect(mockSqlite.executeSql).toHaveBeenCalledTimes(1);
     const [, stmt, params] = mockSqlite.executeSql.mock.calls[0];
-    expect(stmt).toContain('\'synced\'');
+    expect(stmt).toContain("'synced'");
     expect(stmt).toContain('unixepoch()');
     expect(params).toEqual(['asset-1', 'remote-file-id', 1714000000]);
   });
@@ -115,7 +119,7 @@ describe('photosLocalDB', () => {
 
     expect(mockSqlite.executeSql).toHaveBeenCalledTimes(1);
     const [, stmt, params] = mockSqlite.executeSql.mock.calls[0];
-    expect(stmt).toContain('\'error\'');
+    expect(stmt).toContain("'error'");
     expect(params).toEqual(['asset-2', null]);
   });
 
@@ -131,34 +135,41 @@ describe('photosLocalDB', () => {
 
     const [, stmt] = mockSqlite.executeSql.mock.calls[0];
     expect(stmt).toContain('attempt_count + 1');
-    expect(stmt).toContain('status != \'synced\'');
+    expect(stmt).toContain('ON CONFLICT');
+    expect(stmt).toContain("status != 'synced'");
   });
 
-  test('when looking up synced photos, then only photos with synced status are queried', async () => {
+  test('when looking up synced photos, then both synced and cloud_deleted statuses are queried', async () => {
     mockSqlite.getAllAsync.mockResolvedValueOnce([]);
 
     await photosLocalDB.getSyncedEntries(['asset-1']);
 
     const [, stmt] = mockSqlite.getAllAsync.mock.calls[0];
-    expect(stmt).toContain('status = \'synced\'');
+    expect(stmt).toContain("status IN ('synced', 'cloud_deleted')");
   });
 
-  test('when looking up 300 photos at once, then a single database query is made', async () => {
+  test('when looking up 300 photos at once, then a single database query is made with all ids', async () => {
     const ids = Array.from({ length: 300 }, (_, i) => `asset-${i}`);
     mockSqlite.getAllAsync.mockResolvedValue([]);
 
     await photosLocalDB.getSyncedEntries(ids);
 
     expect(mockSqlite.getAllAsync).toHaveBeenCalledTimes(1);
+    const allPassedIds = mockSqlite.getAllAsync.mock.calls.flatMap((call) => call[2] as string[]);
+    expect(allPassedIds).toEqual(expect.arrayContaining(ids));
+    expect(allPassedIds).toHaveLength(300);
   });
 
-  test('when looking up 301 photos at once, then two database queries are made', async () => {
+  test('when looking up 301 photos at once, then two database queries are made covering all ids', async () => {
     const ids = Array.from({ length: 301 }, (_, i) => `asset-${i}`);
     mockSqlite.getAllAsync.mockResolvedValue([]);
 
     await photosLocalDB.getSyncedEntries(ids);
 
     expect(mockSqlite.getAllAsync).toHaveBeenCalledTimes(2);
+    const allPassedIds = mockSqlite.getAllAsync.mock.calls.flatMap((call) => call[2] as string[]);
+    expect(allPassedIds).toEqual(expect.arrayContaining(ids));
+    expect(allPassedIds).toHaveLength(301);
   });
 
   test('when looking up synced photos, then each result includes the modification time', async () => {
@@ -190,13 +201,16 @@ describe('photosLocalDB', () => {
     expect(result).toEqual(new Map());
   });
 
-  test('when looking up 650 photos at once, then three database queries are made', async () => {
+  test('when looking up 650 photos at once, then three database queries are made covering all ids', async () => {
     const ids = Array.from({ length: 650 }, (_, i) => `asset-${i}`);
     mockSqlite.getAllAsync.mockResolvedValue([]);
 
     await photosLocalDB.getSyncedEntries(ids);
 
     expect(mockSqlite.getAllAsync).toHaveBeenCalledTimes(3);
+    const allPassedIds = mockSqlite.getAllAsync.mock.calls.flatMap((call) => call[2] as string[]);
+    expect(allPassedIds).toEqual(expect.arrayContaining(ids));
+    expect(allPassedIds).toHaveLength(650);
   });
 
   test('when checking the status of a pending photo, then the full pending record is returned', async () => {
@@ -484,15 +498,15 @@ describe('photosLocalDB cloud asset methods', () => {
       'file-1',
       'jpg',
       1718100000000,
-      'photo',       // plainName
-      'jpg',         // extension
-      'bucket-abc',  // bucket
+      'photo', // plainName
+      'jpg', // extension
+      'bucket-abc', // bucket
       'folder-uuid-1', // folderUuid
       1718000000000, // creationTimeApi
       1718050000000, // modificationTime
       1718060000000, // updatedAt
-      'EXISTS',      // status
-      'aes-2',       // encryptVersion
+      'EXISTS', // status
+      'aes-2', // encryptVersion
     ]);
   });
 
@@ -584,10 +598,7 @@ describe('photosLocalDB cloud asset methods', () => {
   });
 
   test('when synced remote file ids are fetched, then the result is a set of all returned ids', async () => {
-    mockSqlite.getAllAsync.mockResolvedValueOnce([
-      { remote_file_id: 'r1' },
-      { remote_file_id: 'r2' },
-    ]);
+    mockSqlite.getAllAsync.mockResolvedValueOnce([{ remote_file_id: 'r1' }, { remote_file_id: 'r2' }]);
 
     const result = await photosLocalDB.getSyncedRemoteFileIds();
 

--- a/src/services/photos/database/photosLocalDB.ts
+++ b/src/services/photos/database/photosLocalDB.ts
@@ -50,7 +50,7 @@ interface CloudAssetRow {
   encrypt_version: string | null;
 }
 
-export type AssetSyncStatus = 'pending' | 'pending_edit' | 'synced' | 'error' | 'deleted';
+export type AssetSyncStatus = 'pending' | 'pending_edit' | 'synced' | 'error' | 'deleted' | 'cloud_deleted';
 
 export interface AssetSyncEntry {
   assetId: string;
@@ -94,6 +94,7 @@ interface AssetSyncRow {
 
 export interface SyncedAssetInfo {
   modificationTime: number | null;
+  status: 'synced' | 'cloud_deleted';
 }
 
 export interface AssetMediaInfo {
@@ -219,18 +220,18 @@ class PhotosLocalDB {
     const results = await Promise.all(
       chunks.map((chunk) => {
         const placeholders = chunk.map(() => '?').join(', ');
-        return sqliteService.getAllAsync<{ asset_id: string; modification_time: number | null }>(
-          DB_NAME,
-          assetSyncTable.statements.getSyncedInList(placeholders),
-          chunk,
-        );
+        return sqliteService.getAllAsync<{
+          asset_id: string;
+          modification_time: number | null;
+          status: 'synced' | 'cloud_deleted';
+        }>(DB_NAME, assetSyncTable.statements.getSyncedInList(placeholders), chunk);
       }),
     );
 
     const synced = new Map<string, SyncedAssetInfo>();
     for (const chunk of results) {
       for (const row of chunk) {
-        synced.set(row.asset_id, { modificationTime: row.modification_time });
+        synced.set(row.asset_id, { modificationTime: row.modification_time, status: row.status });
       }
     }
     return synced;
@@ -254,6 +255,47 @@ class PhotosLocalDB {
       status: asset.status,
       remoteFileId: asset.remote_file_id,
     }));
+  }
+
+  async getSyncedRemoteIdsByCreationMonth(year: number, month: number): Promise<Set<string>> {
+    const startMs = new Date(year, month - 1, 1).getTime();
+    const endMs = new Date(year, month, 1).getTime();
+    const rows = await sqliteService.getAllAsync<{ remote_file_id: string }>(
+      DB_NAME,
+      assetSyncTable.statements.getSyncedRemoteIdsByCreationMonth,
+      [startMs, endMs],
+    );
+    return new Set(rows.map((r) => r.remote_file_id));
+  }
+
+  async markCloudDeleted(remoteFileId: string): Promise<void> {
+    await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.markCloudDeleted, [remoteFileId]);
+  }
+
+  async getCloudAssetMonthsByDevice(deviceId: string): Promise<{ year: number; month: number }[]> {
+    return sqliteService.getAllAsync<{ year: number; month: number }>(
+      DB_NAME,
+      cloudAssetTable.statements.getMonthsByDevice,
+      [deviceId],
+    );
+  }
+
+  async getSyncedMonths(): Promise<{ year: number; month: number }[]> {
+    return sqliteService.getAllAsync<{ year: number; month: number }>(
+      DB_NAME,
+      assetSyncTable.statements.getSyncedMonths,
+    );
+  }
+
+  async getCloudAssetRemoteIdsByDeviceAndMonth(deviceId: string, year: number, month: number): Promise<Set<string>> {
+    const startMs = new Date(year, month - 1, 1).getTime();
+    const endMs = new Date(year, month, 1).getTime();
+    const rows = await sqliteService.getAllAsync<{ remote_file_id: string }>(
+      DB_NAME,
+      cloudAssetTable.statements.getRemoteIdsByDeviceAndMonth,
+      [deviceId, startMs, endMs],
+    );
+    return new Set(rows.map((r) => r.remote_file_id));
   }
 
   async markAssetDeleted(assetId: string): Promise<void> {

--- a/src/services/photos/database/tables/asset_sync.ts
+++ b/src/services/photos/database/tables/asset_sync.ts
@@ -4,7 +4,7 @@ const statements = {
   createTable: `
     CREATE TABLE IF NOT EXISTS ${TABLE_NAME} (
       asset_id          TEXT    PRIMARY KEY NOT NULL,
-      status            TEXT    NOT NULL CHECK (status IN ('pending', 'pending_edit', 'synced', 'error', 'deleted')),
+      status            TEXT    NOT NULL CHECK (status IN ('pending', 'pending_edit', 'synced', 'error', 'deleted', 'cloud_deleted')),
       remote_file_id    TEXT,
       error_message     TEXT,
       attempt_count     INTEGER NOT NULL DEFAULT 0,
@@ -86,8 +86,15 @@ const statements = {
     FROM ${TABLE_NAME} WHERE asset_id = ?;
   `,
   getSyncedInList: (placeholders: string) =>
-    `SELECT asset_id, modification_time FROM ${TABLE_NAME} WHERE asset_id IN (${placeholders}) AND status = 'synced';`,
-  getPendingAssets: `SELECT asset_id, status, remote_file_id FROM ${TABLE_NAME} WHERE status NOT IN ('synced', 'deleted');`,
+    `SELECT asset_id, modification_time, status FROM ${TABLE_NAME} WHERE asset_id IN (${placeholders}) AND status IN ('synced', 'cloud_deleted');`,
+  getSyncedRemoteIdsByCreationMonth: `
+    SELECT remote_file_id FROM ${TABLE_NAME}
+    WHERE status = 'synced'
+      AND remote_file_id IS NOT NULL
+      AND creation_time >= ?
+      AND creation_time < ?;
+  `,
+  getPendingAssets: `SELECT asset_id, status, remote_file_id FROM ${TABLE_NAME} WHERE status NOT IN ('synced', 'deleted', 'cloud_deleted');`,
   markDeleted: `
     INSERT INTO ${TABLE_NAME} (asset_id, status, deleted_at)
     VALUES (?, 'deleted', (unixepoch() * 1000))
@@ -96,9 +103,20 @@ const statements = {
       deleted_at = (unixepoch() * 1000);
   `,
   getDeletedIds: `SELECT asset_id FROM ${TABLE_NAME} WHERE status = 'deleted';`,
+  markCloudDeleted: `UPDATE ${TABLE_NAME} SET status = 'cloud_deleted' WHERE remote_file_id = ?;`,
   deleteById: `DELETE FROM ${TABLE_NAME} WHERE asset_id = ?;`,
   reset: `DELETE FROM ${TABLE_NAME};`,
   getSyncedRemoteFileIds: `SELECT remote_file_id FROM ${TABLE_NAME} WHERE status = 'synced' AND remote_file_id IS NOT NULL;`,
+
+  getSyncedMonths: `
+    SELECT DISTINCT
+      CAST(strftime('%Y', creation_time / 1000, 'unixepoch') AS INTEGER) AS year,
+      CAST(strftime('%m', creation_time / 1000, 'unixepoch') AS INTEGER) AS month
+    FROM ${TABLE_NAME}
+    WHERE status = 'synced'
+      AND creation_time IS NOT NULL
+      AND remote_file_id IS NOT NULL;
+  `,
 };
 
 export default { TABLE_NAME, statements };

--- a/src/services/photos/database/tables/cloud_asset.ts
+++ b/src/services/photos/database/tables/cloud_asset.ts
@@ -87,12 +87,25 @@ const statements = {
   delete: `DELETE FROM ${TABLE_NAME} WHERE remote_file_id = ?;`,
   reset: `DELETE FROM ${TABLE_NAME};`,
 
+  getRemoteIdsByDeviceAndMonth: `
+    SELECT remote_file_id FROM ${TABLE_NAME}
+    WHERE device_id = ? AND created_at >= ? AND created_at < ?;
+  `,
+
   getLatestDiscoveredAt: `
     SELECT MAX(discovered_at) AS latest
     FROM ${TABLE_NAME}
     WHERE device_id = ?
       AND created_at >= ?
       AND created_at <  ?;
+  `,
+
+  getMonthsByDevice: `
+    SELECT DISTINCT
+      CAST(strftime('%Y', created_at / 1000, 'unixepoch') AS INTEGER) AS year,
+      CAST(strftime('%m', created_at / 1000, 'unixepoch') AS INTEGER) AS month
+    FROM ${TABLE_NAME}
+    WHERE device_id = ?;
   `,
 };
 

--- a/src/store/slices/photos/index.ts
+++ b/src/store/slices/photos/index.ts
@@ -308,6 +308,7 @@ export const runFullCloudHistorySyncThunk = createAsyncThunk<void, { force?: boo
         force,
         onMonthFetched: () => dispatch(photosSlice.actions.incrementCloudFetchRevision()),
         isCancelled: () => !getState().photos.enabled,
+        currentDeviceId: getState().photos.deviceId ?? undefined,
       });
       logger.info('[CloudHistorySync] Full history sync complete');
     } catch (error) {


### PR DESCRIPTION
Detect photos deleted from the cloud backup and mark them locally so the UI accurately reflects which photos are no longer backed up, and prevent them from being reuploaded automatically.

  ## Summary

  - **`reconcileCloudDeletions`** (`PhotoCloudBrowser.ts`): after fetching each month from Drive, compares found `remote_file_id`s against `asset_sync` and `cloud_asset` tables for that device/month. Any file absent in Drive is marked `cloud_deleted` in `asset_sync` and its `cloud_asset` row is removed.

  - **`reconcileDeletedMonths`** (`PhotoCloudBrowser.ts`): new pass that runs after all months are fetched. Queries the DB for months the device has uploaded (`cloud_asset` + `asset_sync synced`) and calls`reconcileCloudDeletions` with `foundIds` for any month that no longer exists in cloud Photos (this covers the case where an entire month folder is deleted).

  - **`cloud_deleted` status** added to `asset_sync` CHECK constraint. `PhotoDeduplicator.ts` skips assets with this status so they are never requeued unless the user edits them (in which case they are re-uploaded as new).

  - **`useLocalAssets`**: exposes `cloudDeletedIds` (separate from `syncedIds`) and reacts to `isFetchingCloudHistory` so the `CloudSlashIcon` appears automatically when the sync cycle finishes, without requiring the user to navigate away.

  - **`useCloudAssets`**: adds `sessionUploadedAssets` to the debounced reload effect so cloud-only items are 
  deduped correctly of an upload completing.