### PR TITLE
[PB-6081] feature/Added actions to more button in preview screen

### DIFF
--- a/assets/lang/strings.ts
+++ b/assets/lang/strings.ts
@@ -236,10 +236,10 @@ const translations = {
             info: 'Info',
           },
           more: {
+            info: 'Info',
             back: 'Back',
             export: 'Export',
             copy: 'Copy',
-            duplicate: 'Duplicate',
             save: 'Save',
             addToFavorites: 'Add to favorites',
             removeFromFavorites: 'Remove from favorites',
@@ -1210,10 +1210,10 @@ const translations = {
             info: 'Info',
           },
           more: {
+            info: 'Info',
             back: 'Volver',
             export: 'Exportar',
             copy: 'Copiar',
-            duplicate: 'Duplicar',
             save: 'Guardar',
             addToFavorites: 'Añadir a favoritos',
             removeFromFavorites: 'Quitar de favoritos',

--- a/src/screens/PhotoPreviewScreen/components/PreviewCarousel.tsx
+++ b/src/screens/PhotoPreviewScreen/components/PreviewCarousel.tsx
@@ -1,5 +1,5 @@
 import { LinearGradient } from 'expo-linear-gradient';
-import { DotsThreeOutlineIcon, ExportIcon, StarIcon, TrashIcon } from 'phosphor-react-native';
+import { DotsThreeOutlineIcon, ExportIcon, TrashIcon } from 'phosphor-react-native';
 import { memo, useCallback, useEffect, useRef } from 'react';
 import { FlatList, Image, ListRenderItem, TouchableOpacity, View } from 'react-native';
 import Animated, { Easing, useAnimatedStyle, withTiming } from 'react-native-reanimated';
@@ -86,12 +86,18 @@ interface ActionButtonProps {
   icon: JSX.Element;
   label: string;
   onPress: () => void;
+  disabled?: boolean;
 }
 
-const ActionButton = ({ icon, label, onPress }: ActionButtonProps) => {
+const ActionButton = ({ icon, label, onPress, disabled }: ActionButtonProps) => {
   const tailwind = useTailwind();
   return (
-    <TouchableOpacity onPress={onPress} activeOpacity={0.7} style={[tailwind('flex-1 items-center py-2'), { gap: 4 }]}>
+    <TouchableOpacity
+      onPress={onPress}
+      disabled={disabled}
+      activeOpacity={0.7}
+      style={[tailwind('flex-1 items-center py-2'), { gap: 4, opacity: disabled ? 0.35 : 1 }]}
+    >
       {icon}
       <AppText style={tailwind('text-white text-supporting-2')}>{label}</AppText>
     </TouchableOpacity>
@@ -106,6 +112,7 @@ interface PreviewCarouselProps {
   onExport: () => void;
   onMore: () => void;
   onDelete: () => void;
+  isSynced: boolean;
 }
 
 export const PreviewCarousel = ({
@@ -116,6 +123,7 @@ export const PreviewCarousel = ({
   onExport,
   onMore,
   onDelete,
+  isSynced,
 }: PreviewCarouselProps): JSX.Element => {
   const tailwind = useTailwind();
   const insets = useSafeAreaInsets();
@@ -185,10 +193,20 @@ export const PreviewCarousel = ({
         </View>
 
         <View style={[tailwind('flex-row'), { paddingBottom: insets.bottom + 8 }]}>
-          <ActionButton icon={<ExportIcon size={26} color="white" />} label="Export" onPress={onExport} />
+          <ActionButton
+            icon={<ExportIcon size={26} color="white" />}
+            label="Export"
+            onPress={onExport}
+            disabled={!isSynced}
+          />
           {/* <ActionButton icon={<StarIcon size={26} color="white" />} label="Favorite" onPress={() => undefined} /> */}
           <ActionButton icon={<DotsThreeOutlineIcon size={26} color="white" />} label="More" onPress={onMore} />
-          <ActionButton icon={<TrashIcon size={26} color="white" />} label="Delete" onPress={onDelete} />
+          <ActionButton
+            icon={<TrashIcon size={26} color="white" />}
+            label="Delete"
+            onPress={onDelete}
+            disabled={!isSynced}
+          />
         </View>
       </LinearGradient>
     </Animated.View>

--- a/src/screens/PhotoPreviewScreen/index.tsx
+++ b/src/screens/PhotoPreviewScreen/index.tsx
@@ -10,6 +10,8 @@ import { photoActionsService } from 'src/services/photos/PhotoActionsService';
 import { PhotoAssetFetchService } from 'src/services/photos/PhotoAssetFetchService';
 import { RootStackScreenProps } from 'src/types/navigation';
 import { useTailwind } from 'tailwind-rn';
+import MoreActionsBottomSheet from '../PhotosScreen/components/MoreActionsBottomSheet';
+import { isItemBacked } from '../PhotosScreen/utils/photoUtils';
 import { MetadataPanel } from './components/MetadataPanel';
 import { PreviewCarousel } from './components/PreviewCarousel';
 import { PreviewHeader } from './components/PreviewHeader';
@@ -26,6 +28,7 @@ export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
 
   const [isUiVisible, setIsUiVisible] = useState(true);
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
+  const [isMoreActionsOpen, setIsMoreActionsOpen] = useState(false);
   const [zoomActive, setZoomActive] = useState(false);
   const [metadataOpen, setMetadataOpen] = useState(false);
   const [hasVideoStarted, setHasVideoStarted] = useState(false);
@@ -117,8 +120,51 @@ export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
     }
   }, [items, currentIndex]);
 
+  const handleCopy = useCallback(async () => {
+    const item = items[currentIndex];
+    if (!item) {
+      return;
+    }
+    const controller = new AbortController();
+    setIsMoreActionsOpen(false);
+    try {
+      await photoActionsService.copyToClipboard(item, controller.signal);
+    } catch (error) {
+      logger.error(`[PhotoPreview] Copy failed: ${error}`);
+    }
+  }, [items, currentIndex]);
+
+  const handleSave = useCallback(async () => {
+    const item = items[currentIndex];
+    if (!item) {
+      return;
+    }
+    const controller = new AbortController();
+    setIsMoreActionsOpen(false);
+    try {
+      await photoActionsService.saveToDevice(item, controller.signal);
+    } catch (error) {
+      logger.error(`[PhotoPreview] Save failed: ${error}`);
+    }
+  }, [items, currentIndex]);
+
+  const handleRestore = useCallback(async () => {
+    const item = items[currentIndex];
+    if (!item || item.type !== 'local') {
+      return;
+    }
+    const controller = new AbortController();
+    setIsMoreActionsOpen(false);
+    try {
+      await photoActionsService.restoreToCloud([item], controller.signal);
+    } catch (error) {
+      logger.error(`[PhotoPreview] Restore failed: ${error}`);
+    }
+  }, [items, currentIndex]);
+
   const showCarousel = isUiVisible && !zoomActive && !hasVideoStarted;
   const currentItem = items[currentIndex];
+  const isSynced = currentItem ? isItemBacked(currentItem) : false;
 
   return (
     <View style={tailwind('flex-1 bg-black')}>
@@ -141,7 +187,7 @@ export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
         visible={isUiVisible}
         item={currentItem}
         onClose={handleClose}
-        onMore={() => setMetadataOpen(true)}
+        onMore={() => setIsMoreActionsOpen(true)}
       />
       {showCarousel && (
         <PreviewCarousel
@@ -150,11 +196,30 @@ export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
           onPress={setCurrentIndex}
           visible={isUiVisible}
           onExport={handleExport}
-          onMore={() => setMetadataOpen(true)}
+          onMore={() => setIsMoreActionsOpen(true)}
           onDelete={handleDeletePress}
+          isSynced={isSynced}
         />
       )}
       {metadataOpen && currentItem && <MetadataPanel item={currentItem} onClose={() => setMetadataOpen(false)} />}
+      <MoreActionsBottomSheet
+        isOpen={isMoreActionsOpen}
+        selectedItems={currentItem ? [currentItem] : []}
+        onClose={() => setIsMoreActionsOpen(false)}
+        onInfo={() => {
+          setIsMoreActionsOpen(false);
+          setMetadataOpen(true);
+        }}
+        onExport={handleExport}
+        onCopy={handleCopy}
+        onSave={handleSave}
+        onFavorite={() => {
+          logger.info('[PhotoPreview] Favorite: not implemented');
+          setIsMoreActionsOpen(false);
+        }}
+        onTrash={handleDeletePress}
+        onRestore={handleRestore}
+      />
       <ConfirmModal
         isOpen={isDeleteConfirmOpen}
         onClose={() => setIsDeleteConfirmOpen(false)}

--- a/src/screens/PhotosScreen/components/MoreActionsBottomSheet.tsx
+++ b/src/screens/PhotosScreen/components/MoreActionsBottomSheet.tsx
@@ -4,7 +4,7 @@ import {
   CopyIcon,
   DownloadSimpleIcon,
   ExportIcon,
-  PlusSquareIcon,
+  InfoIcon,
   TrashIcon,
 } from 'phosphor-react-native';
 import { useEffect, useMemo, useRef } from 'react';
@@ -21,9 +21,9 @@ interface MoreActionsBottomSheetProps {
   isOpen: boolean;
   selectedItems: TimelinePhotoItem[];
   onClose: () => void;
+  onInfo?: () => void;
   onExport: () => void;
   onCopy: () => void;
-  onDuplicate: () => void;
   onSave: () => void;
   onFavorite: () => void;
   onTrash: () => void;
@@ -71,9 +71,9 @@ const MoreActionsBottomSheet = ({
   isOpen,
   selectedItems,
   onClose,
+  onInfo,
   onExport,
   onCopy,
-  onDuplicate,
   onSave,
   onFavorite,
   onTrash,
@@ -134,13 +134,6 @@ const MoreActionsBottomSheet = ({
             icon: <CopyIcon size={22} color={iconColor} />,
             onPress: onCopy,
           },
-        areAllSelectedItemsBacked &&
-          isOneItemSelected && {
-            key: 'duplicate',
-            label: actionStrings.duplicate,
-            icon: <PlusSquareIcon size={22} color={iconColor} />,
-            onPress: onDuplicate,
-          },
         areAllSelectedNotBacked && {
           key: 'restore',
           label: actionStrings.uploadToCloud,
@@ -184,7 +177,6 @@ const MoreActionsBottomSheet = ({
       actionStrings,
       onExport,
       onCopy,
-      onDuplicate,
       onSave,
       onFavorite,
       onTrash,
@@ -221,6 +213,18 @@ const MoreActionsBottomSheet = ({
             </AppText>
           </View>
         </TouchableOpacity>
+
+        {onInfo && (
+          <ActionRow
+            icon={<InfoIcon size={22} color={iconColor} />}
+            label={actionStrings.info}
+            onPress={() => {
+              onInfo();
+              onClose();
+            }}
+            isLast={visibleActions.length === 0}
+          />
+        )}
 
         {visibleActions.map((action, index) => (
           <ActionRow

--- a/src/screens/PhotosScreen/components/SelectionToolbar.tsx
+++ b/src/screens/PhotosScreen/components/SelectionToolbar.tsx
@@ -1,4 +1,4 @@
-import { DotsThreeIcon, ExportIcon, InfoIcon, TrashIcon } from 'phosphor-react-native';
+import { DotsThreeIcon, ExportIcon, TrashIcon } from 'phosphor-react-native';
 import { useEffect, useRef } from 'react';
 import { Animated, Easing, StyleSheet, TouchableOpacity, View } from 'react-native';
 import AppText from 'src/components/AppText';
@@ -23,7 +23,6 @@ interface SelectionToolbarProps {
   onFavorite: () => void;
   onMore: () => void;
   onDelete: () => void;
-  onInfo: () => void;
 }
 
 interface ToolbarButtonProps {
@@ -47,7 +46,6 @@ const SelectionToolbar = ({
   onFavorite,
   onMore,
   onDelete,
-  onInfo,
 }: SelectionToolbarProps): JSX.Element => {
   const tailwind = useTailwind();
   const getColor = useGetColor();
@@ -127,12 +125,6 @@ const SelectionToolbar = ({
                 icon={<DotsThreeIcon size={26} color={iconColor} />}
                 label={toolbarTexts.more}
                 onPress={onMore}
-                color={iconColor}
-              />
-              <ToolbarButton
-                icon={<InfoIcon size={26} color={iconColor} />}
-                label={toolbarTexts.info}
-                onPress={onInfo}
                 color={iconColor}
               />
             </>

--- a/src/screens/PhotosScreen/hooks/usePhotoActions.ts
+++ b/src/screens/PhotosScreen/hooks/usePhotoActions.ts
@@ -20,7 +20,6 @@ export interface UsePhotoActionsReturn {
   handleRestore: () => Promise<void>;
   handleMore: () => void;
   handleMoreClose: () => void;
-  todoAction: (name: string) => () => void;
 }
 
 interface UsePhotoActionsOpts {
@@ -137,15 +136,6 @@ export const usePhotoActions = (
     }
   }, [startAction, finishAction, selection.selectedItems, dispatch, reloadLocal, reloadCloud]);
 
-  const todoAction = useCallback(
-    (name: string) => () => {
-      logger.info(`[usePhotoActions] action not yet implemented: ${name}`);
-      selection.exitSelectMode();
-      setIsMoreActionsSheetOpen(false);
-    },
-    [selection],
-  );
-
   const handleMore = useCallback(() => setIsMoreActionsSheetOpen(true), []);
   const handleMoreClose = useCallback(() => setIsMoreActionsSheetOpen(false), []);
 
@@ -163,6 +153,5 @@ export const usePhotoActions = (
     handleRestore,
     handleMore,
     handleMoreClose,
-    todoAction,
   };
 };

--- a/src/screens/PhotosScreen/index.tsx
+++ b/src/screens/PhotosScreen/index.tsx
@@ -168,10 +168,9 @@ const PhotosScreen = (): JSX.Element => {
         visible={selection.selectMode && selection.selectedIds.size > 0}
         selectedItems={selection.selectedItems}
         onExport={actions.handleExport}
-        onFavorite={actions.todoAction('favorite')}
+        onFavorite={() => undefined}
         onMore={actions.handleMore}
         onDelete={actions.handleDelete}
-        onInfo={actions.todoAction('info')}
       />
 
       <MoreActionsBottomSheet
@@ -180,9 +179,8 @@ const PhotosScreen = (): JSX.Element => {
         onClose={actions.handleMoreClose}
         onExport={actions.handleExport}
         onCopy={actions.handleCopy}
-        onDuplicate={actions.todoAction('duplicate')}
         onSave={actions.handleSave}
-        onFavorite={actions.todoAction('favorite')}
+        onFavorite={() => undefined}
         onTrash={actions.handleTrash}
         onRestore={actions.handleRestore}
       />


### PR DESCRIPTION
 Connect the preview screen's action bar to the existing `MoreActionsBottomSheet`, add an Info entry that opens `MetadataPanel`, and visually disable Export and Delete when the current item is not backed up.

## Summary

  - **`MoreActionsBottomSheet`**: added optional `onInfo` prop. When provided, renders an "Info" `ActionRow` as
  the first item in the sheet

  - **`PreviewCarousel`**: added `isSynced: boolean` prop and `disabled?: boolean` to `ActionButton`

  - **`PhotoPreviewScreen`**: rewired `onMore` calls to open`MoreActionsBottomSheet` instead of `MetadataPanel` directly. `MetadataPanel` now opens via the Info row in the sheet.

  - duplicate action removed: dead code