### PR TITLE
[PB-6281]: add foreground upload notifications with cancel and progress tracking

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,9 @@
   <uses-permission android:name="android.permission.USE_FINGERPRINT"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
+  <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
   <queries>
     <intent>
       <action android:name="android.intent.action.VIEW"/>
@@ -58,6 +61,13 @@
         <category android:name="android.intent.category.DEFAULT"/>
       </intent-filter>
     </activity>
+    <service
+      android:name="com.internxt.cloud.documents.upload.UploadForegroundService"
+      android:foregroundServiceType="dataSync"
+      android:exported="false"/>
+    <receiver
+      android:name="com.internxt.cloud.documents.upload.CancelUploadReceiver"
+      android:exported="false"/>
     <provider
       android:name="com.internxt.cloud.documents.InternxtDocumentsProvider"
       android:authorities="com.internxt.cloud.documents"

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -33,6 +33,7 @@ import com.internxt.cloud.documents.download.EncryptedFileDownloader
 import com.internxt.cloud.documents.http.HttpClients
 import com.internxt.cloud.documents.upload.EncryptedFileUploader
 import com.internxt.cloud.documents.upload.PendingUpload
+import com.internxt.cloud.documents.upload.UploadForegroundService
 import com.rncrypto.util.CryptoService
 import java.io.File
 import java.io.FileNotFoundException
@@ -605,13 +606,17 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         signal: CancellationSignal?,
     ) {
         val temps = uploadTempsFor(ctx, token)
+        val uploadSignal = CancellationSignal()
+        signal?.setOnCancelListener { uploadSignal.cancel() }
+        UploadForegroundService.start(ctx, token, pending.plainName, uploadSignal)
+
         var failure: Throwable? = null
         try {
             val api = InternxtApiClient(cfg)
             val bucketId = resolveBucket(api, pending.parentUuid)
             val crypto = prepareEncryption(cfg.mnemonic, bucketId)
-            val encrypted = encryptInputToTemp(temps, readEnd, crypto, signal)
-            val outcome = uploadEncryptedFile(api, temps.enc, bucketId, encrypted, signal)
+            val encrypted = encryptInputToTemp(token, temps, readEnd, crypto, uploadSignal)
+            val outcome = uploadEncryptedFile(token, api, temps.enc, bucketId, encrypted, uploadSignal)
             finalizeAndRecordFile(api, pending, bucketId, crypto.indexHex, encrypted.size, outcome)
             invalidateChildren(DocumentId.encodeFolder(pending.parentUuid))
         } catch (t: Throwable) {
@@ -624,6 +629,7 @@ class InternxtDocumentsProvider : DocumentsProvider() {
             deleteTempQuietly(temps.plain)
             deleteTempQuietly(temps.enc)
             pendingUploads.remove(token)
+            notifyServiceOfOutcome(ctx, token, failure)
         }
     }
 
@@ -653,16 +659,22 @@ class InternxtDocumentsProvider : DocumentsProvider() {
     }
 
     private fun encryptInputToTemp(
+        token: String,
         temps: UploadTemps,
         readEnd: ParcelFileDescriptor,
         crypto: EncryptionContext,
-        signal: CancellationSignal?,
+        signal: CancellationSignal,
     ): EncryptedFileUploader.Encrypted {
         // Phase 1: drain the pipe into a plaintext file on disk — CryptoService is
-        // path-based, so we must materialize before encrypting. Cancellation lives here
-        // because this is the long-running streaming phase.
-        drainPipeToFile(readEnd, temps.plain, signal)
-        signal?.throwIfCanceled()
+        // path-based, so we must materialize before encrypting. Cancellation + per-byte
+        // progress live here because this is the long-running streaming phase.
+        val onProgress = throttledProgress { bytes ->
+            UploadForegroundService.reportProgress(
+                token, UploadForegroundService.Phase.ENCRYPTING, bytes, 0L,
+            )
+        }
+        drainPipeToFile(readEnd, temps.plain, signal, onProgress)
+        signal.throwIfCanceled()
         // Phase 2: hand the plaintext file to the official rn-crypto CryptoService — same
         // call the RN side makes from NetworkFacade.ts, identical AES-CTR pipeline.
         return EncryptedFileUploader.encryptFile(temps.plain, temps.enc, crypto.key, crypto.iv)
@@ -671,19 +683,23 @@ class InternxtDocumentsProvider : DocumentsProvider() {
     private fun drainPipeToFile(
         readEnd: ParcelFileDescriptor,
         target: File,
-        signal: CancellationSignal?,
+        signal: CancellationSignal,
+        onProgress: (Long) -> Unit,
     ) {
         val buffer = ByteArray(EncryptedFileUploader.COPY_BUFFER_SIZE)
+        var written = 0L
         // dup() so the InputStream owns its own FD; the original `readEnd` survives for
         // the eventual close()/closeWithError() in `runUpload`'s finally.
         readEnd.dup().use { dup ->
             ParcelFileDescriptor.AutoCloseInputStream(dup).use { source ->
                 target.outputStream().use { sink ->
                     while (true) {
-                        signal?.throwIfCanceled()
+                        signal.throwIfCanceled()
                         val n = source.read(buffer)
                         if (n == -1) break
                         sink.write(buffer, 0, n)
+                        written += n
+                        onProgress(written)
                     }
                     sink.flush()
                 }
@@ -692,11 +708,12 @@ class InternxtDocumentsProvider : DocumentsProvider() {
     }
 
     private fun uploadEncryptedFile(
+        token: String,
         api: InternxtApiClient,
         tempEnc: File,
         bucketId: String,
         encrypted: EncryptedFileUploader.Encrypted,
-        signal: CancellationSignal?,
+        signal: CancellationSignal,
     ): UploadOutcome {
         val partsCount = if (encrypted.size >= MULTIPART_THRESHOLD) {
             ((encrypted.size + MULTIPART_PART_SIZE - 1) / MULTIPART_PART_SIZE).toInt().coerceAtLeast(1)
@@ -705,15 +722,23 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         val slot = api.startUpload(bucketId, encrypted.size, partsCount).uploads.firstOrNull()
             ?: throw IOException("Bridge /start returned no upload slot")
 
+        val onProgress = throttledProgress { bytes ->
+            UploadForegroundService.reportProgress(
+                token, UploadForegroundService.Phase.UPLOADING, bytes, encrypted.size,
+            )
+        }
+
         return when (slot) {
             is UploadSlot.Single -> {
-                EncryptedFileUploader.uploadSingle(HttpClients.upload, tempEnc, slot.url, signal)
+                EncryptedFileUploader.uploadSingle(
+                    HttpClients.upload, tempEnc, slot.url, signal, onProgress,
+                )
                 UploadOutcome.Single(slot.uuid, listOf(encrypted.wholeSha256Hex))
             }
             is UploadSlot.Multipart -> {
                 val partHashes = EncryptedFileUploader.computePartSha256(tempEnc, MULTIPART_PART_SIZE)
                 val parts = EncryptedFileUploader.uploadMultipart(
-                    HttpClients.upload, tempEnc, slot.urls, MULTIPART_PART_SIZE, signal,
+                    HttpClients.upload, tempEnc, slot.urls, MULTIPART_PART_SIZE, signal, onProgress,
                 )
                 UploadOutcome.Multipart(slot.uuid, partHashes, parts, slot.uploadId)
             }
@@ -771,6 +796,45 @@ class InternxtDocumentsProvider : DocumentsProvider() {
     private fun deleteTempQuietly(tempEnc: File) {
         if (!tempEnc.delete() && tempEnc.exists()) {
             Log.w(TAG, "Failed to delete temp upload file: ${tempEnc.absolutePath}")
+        }
+    }
+
+    private fun notifyServiceOfOutcome(ctx: Context, token: String, failure: Throwable?) {
+        when {
+            failure == null -> UploadForegroundService.complete(token)
+            failure is OperationCanceledException -> UploadForegroundService.complete(token)
+            else -> UploadForegroundService.fail(token, friendlyUploadError(ctx, failure))
+        }
+    }
+
+    private fun friendlyUploadError(ctx: Context, t: Throwable): String {
+        if (t is InternxtApiException.ApiError) {
+            val body = t.body.orEmpty()
+            if (t.code == 420 || body.contains("Max space used", ignoreCase = true)) {
+                return ctx.getString(R.string.upload_error_storage_full)
+            }
+            if (t.code == 413) return ctx.getString(R.string.upload_error_too_large)
+            if (t.code in 500..599) return ctx.getString(R.string.upload_error_server)
+        }
+        if (t is InternxtApiException.UnauthorizedException) {
+            return ctx.getString(R.string.upload_error_signed_out)
+        }
+        if (t is InternxtApiException.NetworkException) {
+            return ctx.getString(R.string.upload_error_network)
+        }
+        return ctx.getString(R.string.upload_error_generic)
+    }
+
+    private fun throttledProgress(emit: (Long) -> Unit): (Long) -> Unit {
+        var lastEmittedMs = 0L
+        var lastEmittedBytes = -1L
+        return { bytes ->
+            val now = System.currentTimeMillis()
+            if (bytes != lastEmittedBytes && now - lastEmittedMs >= PROGRESS_THROTTLE_MS) {
+                lastEmittedMs = now
+                lastEmittedBytes = bytes
+                emit(bytes)
+            }
         }
     }
 
@@ -832,6 +896,7 @@ class InternxtDocumentsProvider : DocumentsProvider() {
 
         private const val MULTIPART_THRESHOLD = 100L * 1024L * 1024L
         private const val MULTIPART_PART_SIZE = 30L * 1024L * 1024L
+        private const val PROGRESS_THROTTLE_MS = 300L
         private const val MAX_SUFFIX_ATTEMPTS = 1000
         private const val PENDING_UPLOAD_TTL_MS = 60L * 60L * 1000L
         private const val NOT_AUTHENTICATED = "Not authenticated"

--- a/android/app/src/main/java/com/internxt/cloud/documents/upload/CancelUploadReceiver.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/upload/CancelUploadReceiver.kt
@@ -1,0 +1,17 @@
+package com.internxt.cloud.documents.upload
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.ContextCompat
+
+class CancelUploadReceiver : BroadcastReceiver() {
+
+    override fun onReceive(ctx: Context, intent: Intent) {
+        val token = intent.getStringExtra(UploadForegroundService.EXTRA_TOKEN) ?: return
+        val forward = Intent(ctx, UploadForegroundService::class.java)
+            .setAction(UploadForegroundService.ACTION_CANCEL)
+            .putExtra(UploadForegroundService.EXTRA_TOKEN, token)
+        ContextCompat.startForegroundService(ctx, forward)
+    }
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/upload/UploadForegroundService.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/upload/UploadForegroundService.kt
@@ -1,0 +1,245 @@
+package com.internxt.cloud.documents.upload
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.CancellationSignal
+import android.os.IBinder
+import android.text.format.Formatter
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+import com.internxt.cloud.R
+import java.util.concurrent.ConcurrentHashMap
+
+class UploadForegroundService : Service() {
+
+    private val notificationManager: NotificationManager by lazy {
+        getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        instance = this
+        ensureChannel(this)
+        cancelOrphanedNotifications()
+    }
+
+    /**
+     * After process death, the static `uploads` map is empty but any in-flight foreground
+     * notification posted by a previous incarnation survives. Cancel anything in our channel
+     * that isn't backed by a live upload state so the tray doesn't show ghost progress bars.
+     */
+    private fun cancelOrphanedNotifications() {
+        val live = uploads.values
+            .flatMap { listOf(it.notificationId, it.errorNotificationId) }
+            .toHashSet()
+        notificationManager.activeNotifications
+            .filter { it.notification.channelId == CHANNEL_ID && it.id !in live }
+            .forEach { notificationManager.cancel(it.id) }
+    }
+
+    override fun onDestroy() {
+        if (instance === this) instance = null
+        isForeground = false
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val action = intent?.action
+        val token = intent?.getStringExtra(EXTRA_TOKEN)
+        when (action) {
+            ACTION_START -> {
+                val state = token?.let { uploads[it] }
+                if (state != null) {
+                    intent.getStringExtra(EXTRA_DISPLAY_NAME)?.takeIf { it.isNotEmpty() }
+                        ?.let { state.displayName = it }
+                    postNotification(state, foregroundOnFirst = true)
+                } else {
+                    ensureForeground()
+                    maybeStop()
+                }
+            }
+            ACTION_CANCEL -> {
+                token?.let { signals[it]?.cancel() }
+                ensureForeground()
+                maybeStop()
+            }
+            else -> {
+                ensureForeground()
+                maybeStop()
+            }
+        }
+        return START_NOT_STICKY
+    }
+
+    private fun ensureForeground() {
+        if (isForeground) return
+        val state = uploads.values.firstOrNull() ?: UploadState("placeholder", "")
+        postNotification(state, foregroundOnFirst = true)
+    }
+
+    private fun postNotification(state: UploadState, foregroundOnFirst: Boolean) {
+        val notification = buildProgressNotification(state)
+        if (foregroundOnFirst && !isForeground) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                startForeground(
+                    state.notificationId,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+                )
+            } else {
+                startForeground(state.notificationId, notification)
+            }
+            isForeground = true
+        } else {
+            notificationManager.notify(state.notificationId, notification)
+        }
+    }
+
+    private fun postFailure(state: UploadState, message: String) {
+        // Use a distinct id so stopForeground(STOP_FOREGROUND_REMOVE) doesn't tear this down.
+        notificationManager.notify(state.errorNotificationId, buildErrorNotification(state, message))
+    }
+
+    private fun buildProgressNotification(state: UploadState): Notification {
+        val cancelPi = PendingIntent.getBroadcast(
+            this,
+            state.notificationId,
+            Intent(this, CancelUploadReceiver::class.java)
+                .setAction(ACTION_CANCEL)
+                .putExtra(EXTRA_TOKEN, state.token),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val title = when (state.phase) {
+            Phase.ENCRYPTING -> getString(R.string.upload_notification_encrypting, state.displayName)
+            Phase.UPLOADING -> getString(R.string.upload_notification_uploading, state.displayName)
+        }
+
+        val builder = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle(title)
+            .setContentText(formatProgressText(state))
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+            .addAction(0, getString(R.string.upload_notification_cancel), cancelPi)
+
+        if (state.phase == Phase.UPLOADING && state.total > 0) {
+            val pct = ((state.bytes * 100L) / state.total).toInt().coerceIn(0, 100)
+            builder.setProgress(100, pct, false)
+        } else {
+            builder.setProgress(0, 0, true)
+        }
+        return builder.build()
+    }
+
+    private fun buildErrorNotification(state: UploadState, message: String): Notification {
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle(getString(R.string.upload_notification_failed, state.displayName))
+            .setContentText(message)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(message))
+            .setOngoing(false)
+            .setAutoCancel(true)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .build()
+    }
+
+    private fun formatProgressText(state: UploadState): String = when {
+        state.phase == Phase.UPLOADING && state.total > 0 ->
+            "${Formatter.formatShortFileSize(this, state.bytes)} / " +
+                Formatter.formatShortFileSize(this, state.total)
+        state.bytes > 0 -> Formatter.formatShortFileSize(this, state.bytes)
+        else -> ""
+    }
+
+    private fun maybeStop() {
+        if (uploads.isEmpty()) {
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            stopSelf()
+            isForeground = false
+        }
+    }
+
+    enum class Phase { ENCRYPTING, UPLOADING }
+
+    private class UploadState(val token: String, var displayName: String) {
+        @Volatile var bytes: Long = 0L
+        @Volatile var total: Long = 0L
+        @Volatile var phase: Phase = Phase.ENCRYPTING
+        val notificationId: Int = stableNotificationId(token)
+        val errorNotificationId: Int = stableNotificationId("err:$token")
+    }
+
+    companion object {
+        const val CHANNEL_ID = "internxt_uploads"
+
+        const val ACTION_START = "com.internxt.cloud.documents.upload.START"
+        const val ACTION_CANCEL = "com.internxt.cloud.documents.upload.CANCEL"
+        const val EXTRA_TOKEN = "token"
+        const val EXTRA_DISPLAY_NAME = "display_name"
+
+        @Volatile private var instance: UploadForegroundService? = null
+        @Volatile private var isForeground = false
+
+        private val signals = ConcurrentHashMap<String, CancellationSignal>()
+        private val uploads = ConcurrentHashMap<String, UploadState>()
+
+        fun start(ctx: Context, token: String, displayName: String, signal: CancellationSignal) {
+            signals[token] = signal
+            uploads.getOrPut(token) { UploadState(token, displayName) }
+            val intent = Intent(ctx, UploadForegroundService::class.java)
+                .setAction(ACTION_START)
+                .putExtra(EXTRA_TOKEN, token)
+                .putExtra(EXTRA_DISPLAY_NAME, displayName)
+            ContextCompat.startForegroundService(ctx, intent)
+        }
+
+        fun reportProgress(token: String, phase: Phase, bytes: Long, total: Long) {
+            val state = uploads[token] ?: return
+            state.phase = phase
+            state.bytes = bytes
+            state.total = total
+            instance?.postNotification(state, foregroundOnFirst = false)
+        }
+
+        fun complete(token: String) {
+            val state = uploads.remove(token) ?: run { signals.remove(token); return }
+            signals.remove(token)
+            instance?.notificationManager?.cancel(state.notificationId)
+            instance?.maybeStop()
+        }
+
+        fun fail(token: String, message: String) {
+            val state = uploads.remove(token) ?: run { signals.remove(token); return }
+            signals.remove(token)
+            instance?.postFailure(state, message)
+            instance?.maybeStop()
+        }
+
+        private fun ensureChannel(ctx: Context) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+            val nm = ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            if (nm.getNotificationChannel(CHANNEL_ID) != null) return
+            val name = ctx.getString(R.string.upload_notification_channel_name)
+            nm.createNotificationChannel(
+                NotificationChannel(CHANNEL_ID, name, NotificationManager.IMPORTANCE_LOW)
+            )
+        }
+
+        private fun stableNotificationId(token: String): Int {
+            val h = token.hashCode()
+            return if (h == Int.MIN_VALUE) 1 else (h and Int.MAX_VALUE).coerceAtLeast(1)
+        }
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -5,4 +5,15 @@
   <string name="expo_runtime_version">1.8.7</string>
   <string name="expo_splash_screen_resize_mode" translatable="false">contain</string>
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
+  <string name="upload_notification_channel_name">Internxt uploads</string>
+  <string name="upload_notification_encrypting">Encrypting %1$s</string>
+  <string name="upload_notification_uploading">Uploading %1$s</string>
+  <string name="upload_notification_failed">Upload failed: %1$s</string>
+  <string name="upload_notification_cancel">Cancel</string>
+  <string name="upload_error_storage_full">Your Internxt Drive is full. Free up space or upgrade your plan.</string>
+  <string name="upload_error_signed_out">You\'ve been signed out. Open Internxt to sign in again.</string>
+  <string name="upload_error_too_large">This file is too large to upload.</string>
+  <string name="upload_error_server">Internxt is having trouble right now. Please try again in a moment.</string>
+  <string name="upload_error_network">No internet connection. The upload will not complete until you reconnect.</string>
+  <string name="upload_error_generic">Couldn\'t upload the file. Please try again.</string>
 </resources>

--- a/src/components/modals/AddModal/index.tsx
+++ b/src/components/modals/AddModal/index.tsx
@@ -46,7 +46,7 @@ import { isValidFilename } from '../../../helpers';
 import useGetColor from '../../../hooks/useColor';
 import network from '../../../network';
 import analytics, { DriveAnalyticsEvent } from '../../../services/AnalyticsService';
-import { constants } from '../../../services/AppService';
+import appService, { constants } from '../../../services/AppService';
 import { uploadQueueService } from '../../../services/drive/file/uploadQueue.service';
 import {
   createUploadingFiles,
@@ -141,6 +141,17 @@ function AddModal(): JSX.Element {
         Alert.alert('Can not upload files. Grant permissions to upload files');
         throw new Error('Storage permissions not granted');
       }
+    }
+
+    // Android 13+ requires runtime permission for POST_NOTIFICATIONS.
+    // Fire-and-forget: a denial only hides the progress UI, the upload itself still runs.
+    if (appService.isAndroidApiAtLeast(33)) {
+      await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS, {
+        title: 'Notifications Permission',
+        message: 'Internxt needs to show notifications to display upload progress',
+        buttonNegative: strings.buttons.cancel,
+        buttonPositive: strings.buttons.grant,
+      });
     }
     const fileExtension = fileToUpload.type;
 

--- a/src/services/AppService.ts
+++ b/src/services/AppService.ts
@@ -69,6 +69,10 @@ class AppService {
   public get isIOS() {
     return Platform.OS === 'ios';
   }
+
+  public isAndroidApiAtLeast(api: number): boolean {
+    return this.isAndroid && (Platform.Version as number) >= api;
+  }
 }
 
 const appService = new AppService();


### PR DESCRIPTION
- add UploadForegroundService + CancelUploadReceiver and manifest declarations
- request Android 13+ POST_NOTIFICATIONS permission before uploads
- wire DocumentsProvider upload flow to foreground service with throttled encrypt/upload progress
- map upload failures to user-friendly localized error messages
- add upload notification/error string resources and Android API helper in AppService