### PR TITLE
[PB-6281]: add unit tests for upload API and encrypted uploader

### DIFF
--- a/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientUploadTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientUploadTest.kt
@@ -1,0 +1,196 @@
+package com.internxt.cloud.documents.api
+
+import com.internxt.cloud.documents.api.model.CreateFileEntry
+import com.internxt.cloud.documents.api.model.ENCRYPT_VERSION_AES03
+import com.internxt.cloud.documents.api.model.FinishUploadShard
+import com.internxt.cloud.documents.api.model.UploadSlot
+import com.internxt.cloud.documents.api.model.UploadedPart
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class InternxtApiClientUploadTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: InternxtApiClient
+
+    companion object {
+        private const val BUCKET_ID = "bucket-123"
+        private const val PARENT_UUID = "parent-uuid-1"
+        private const val SLOT_UUID = "slot-uuid"
+        private const val BUCKET_FILE_ID = "bucket-file-id"
+        private const val TIMESTAMP = "2026-05-25T00:00:00Z"
+    }
+
+    @Before
+    fun setUp() {
+        server = MockWebServer().apply { start() }
+        val base = server.url("/").toString().trimEnd('/')
+        client = InternxtApiClient(
+            AuthConfig(
+                driveBaseUrl = base,
+                bridgeBaseUrl = base,
+                bearerToken = "test-token",
+                bridgeUser = "user@example.com",
+                userId = "1234567890",
+                mnemonic = "test mnemonic phrase",
+                clientName = "drive-mobile",
+                clientVersion = "v1.9.0",
+                desktopToken = null,
+            )
+        )
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun enqueue(body: String, code: Int = 200) {
+        server.enqueue(MockResponse().setResponseCode(code).setBody(body))
+    }
+
+    @Test
+    fun startUploadSinglePostsExpectedBodyAndParsesSlot() {
+        enqueue(
+            """{"uploads":[{"index":0,"uuid":"$SLOT_UUID","url":"https://shard/up"}]}"""
+        )
+
+        val response = client.startUpload(BUCKET_ID, encryptedSize = 4096, parts = 1)
+
+        assertEquals(1, response.uploads.size)
+        val slot = response.uploads[0]
+        assertTrue("expected Single slot, got ${slot::class.simpleName}", slot is UploadSlot.Single)
+        slot as UploadSlot.Single
+        assertEquals(SLOT_UUID, slot.uuid)
+        assertEquals("https://shard/up", slot.url)
+
+        val recorded = server.takeRequest()
+        assertEquals("POST", recorded.method)
+        assertEquals("/v2/buckets/$BUCKET_ID/files/start?multiparts=1", recorded.path)
+        val sent = JSONObject(recorded.body.readUtf8())
+        val uploads = sent.getJSONArray("uploads")
+        assertEquals(1, uploads.length())
+        assertEquals(0, uploads.getJSONObject(0).getInt("index"))
+        assertEquals(4096L, uploads.getJSONObject(0).getLong("size"))
+        assertNotNull(recorded.getHeader("Authorization"))
+        assertEquals(true, recorded.getHeader("Authorization")!!.startsWith("Basic "))
+    }
+
+    @Test
+    fun startUploadMultipartPassesPartsCountAndParsesUrls() {
+        enqueue(
+            """{"uploads":[{"index":0,"uuid":"$SLOT_UUID","urls":["https://p/1","https://p/2","https://p/3"],"UploadId":"up-1"}]}"""
+        )
+
+        val response = client.startUpload(BUCKET_ID, encryptedSize = 300L * 1024L * 1024L, parts = 4)
+
+        val slot = response.uploads.single()
+        assertTrue("expected Multipart slot, got ${slot::class.simpleName}", slot is UploadSlot.Multipart)
+        slot as UploadSlot.Multipart
+        assertEquals(listOf("https://p/1", "https://p/2", "https://p/3"), slot.urls)
+        assertEquals("up-1", slot.uploadId)
+
+        val recorded = server.takeRequest()
+        assertEquals("/v2/buckets/$BUCKET_ID/files/start?multiparts=4", recorded.path)
+    }
+
+    @Test
+    fun finishUploadSingleShardBody() {
+        enqueue("""{"id":"$BUCKET_FILE_ID","bucket":"$BUCKET_ID"}""")
+
+        val finish = client.finishUpload(
+            BUCKET_ID,
+            indexHex = "ab".repeat(32),
+            shards = listOf(FinishUploadShard(uuid = SLOT_UUID, hash = "deadbeef")),
+        )
+
+        assertEquals(BUCKET_FILE_ID, finish.id)
+        assertEquals(BUCKET_ID, finish.bucket)
+
+        val recorded = server.takeRequest()
+        assertEquals("POST", recorded.method)
+        assertEquals("/v2/buckets/$BUCKET_ID/files/finish", recorded.path)
+        val sent = JSONObject(recorded.body.readUtf8())
+        assertEquals("ab".repeat(32), sent.getString("index"))
+        val shards = sent.getJSONArray("shards")
+        assertEquals(1, shards.length())
+        val shard = shards.getJSONObject(0)
+        assertEquals(SLOT_UUID, shard.getString("uuid"))
+        assertEquals("deadbeef", shard.getString("hash"))
+        assertEquals(false, shard.has("UploadId"))
+        assertEquals(false, shard.has("parts"))
+    }
+
+    @Test
+    fun finishUploadMultipartIncludesUploadIdAndParts() {
+        enqueue("""{"id":"$BUCKET_FILE_ID"}""")
+
+        client.finishUpload(
+            BUCKET_ID,
+            indexHex = "cd".repeat(32),
+            shards = listOf(
+                FinishUploadShard(
+                    uuid = SLOT_UUID,
+                    hash = "deadbeef",
+                    uploadId = "up-1",
+                    parts = listOf(
+                        UploadedPart(partNumber = 2, etag = "etag-2"),
+                        UploadedPart(partNumber = 1, etag = "etag-1"),
+                    ),
+                )
+            ),
+        )
+
+        val recorded = server.takeRequest()
+        val shard = JSONObject(recorded.body.readUtf8()).getJSONArray("shards").getJSONObject(0)
+        assertEquals("up-1", shard.getString("UploadId"))
+        val parts = shard.getJSONArray("parts")
+        assertEquals(2, parts.length())
+        assertEquals(1, parts.getJSONObject(0).getInt("PartNumber"))
+        assertEquals("etag-1", parts.getJSONObject(0).getString("ETag"))
+        assertEquals(2, parts.getJSONObject(1).getInt("PartNumber"))
+        assertEquals("etag-2", parts.getJSONObject(1).getString("ETag"))
+    }
+
+    @Test
+    fun createFileEntryPostsToDriveFilesWithBearer() {
+        enqueue("""{"uuid":"new-file-uuid","plainName":"report.pdf","type":"pdf","size":4096}""")
+
+        val created = client.createFileEntry(
+            CreateFileEntry(
+                fileId = BUCKET_FILE_ID,
+                type = "pdf",
+                size = 4096L,
+                plainName = "report.pdf",
+                bucket = BUCKET_ID,
+                folderUuid = PARENT_UUID,
+                modificationTime = TIMESTAMP,
+                creationTime = TIMESTAMP,
+            )
+        )
+
+        assertEquals("new-file-uuid", created.uuid)
+
+        val recorded = server.takeRequest()
+        assertEquals("POST", recorded.method)
+        assertEquals("/files", recorded.path)
+        assertEquals("Bearer test-token", recorded.getHeader("Authorization"))
+        val sent = JSONObject(recorded.body.readUtf8())
+        assertEquals(BUCKET_FILE_ID, sent.getString("fileId"))
+        assertEquals("pdf", sent.getString("type"))
+        assertEquals(4096L, sent.getLong("size"))
+        assertEquals("report.pdf", sent.getString("plainName"))
+        assertEquals(BUCKET_ID, sent.getString("bucket"))
+        assertEquals(PARENT_UUID, sent.getString("folderUuid"))
+        assertEquals(ENCRYPT_VERSION_AES03, sent.getString("encryptVersion"))
+        assertEquals(TIMESTAMP, sent.getString("modificationTime"))
+        assertEquals(TIMESTAMP, sent.getString("creationTime"))
+    }
+}

--- a/android/app/src/test/java/com/internxt/cloud/documents/upload/EncryptedFileUploaderTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/upload/EncryptedFileUploaderTest.kt
@@ -1,0 +1,143 @@
+package com.internxt.cloud.documents.upload
+
+import com.internxt.cloud.documents.crypto.Ripemd160
+import com.internxt.cloud.documents.crypto.toHex
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.nio.file.Files
+import java.security.MessageDigest
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Encryption itself is exercised by the `@internxt/rn-crypto` package's own test suite
+ * (`EncryptFileRepositoryTest`) — we don't re-verify the cipher here. These tests cover
+ * the upload + hashing logic, building the encrypted input with a control AES-CTR call
+ * so we know exactly what bytes the uploader is meant to PUT.
+ */
+class EncryptedFileUploaderTest {
+
+    companion object {
+        private const val SHA_256 = "SHA-256"
+    }
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: OkHttpClient
+    private lateinit var tempDir: File
+
+    private val key = ByteArray(32) { it.toByte() }
+    private val iv = ByteArray(16) { (it + 1).toByte() }
+
+    @Before
+    fun setUp() {
+        server = MockWebServer().apply { start() }
+        client = OkHttpClient()
+        tempDir = Files.createTempDirectory("uploader-test").toFile()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+        tempDir.deleteRecursively()
+    }
+
+    private fun controlEncrypt(plain: ByteArray): ByteArray {
+        val cipher = Cipher.getInstance("AES/CTR/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, SecretKeySpec(key, "AES"), IvParameterSpec(iv))
+        return cipher.doFinal(plain)
+    }
+
+    private fun writeEncrypted(name: String, plain: ByteArray): File =
+        File(tempDir, name).apply { writeBytes(controlEncrypt(plain)) }
+
+    @Test
+    fun uploadSinglePutsTempFileContentsAndReportsCorrectHash() {
+        val plain = ByteArray(8_000) { it.toByte() }
+        val tempEnc = writeEncrypted("single.enc", plain)
+        val encBytes = tempEnc.readBytes()
+        val sha = MessageDigest.getInstance(SHA_256).digest(encBytes)
+
+        server.enqueue(MockResponse().setResponseCode(200))
+        val url = server.url("/upload").toString()
+        EncryptedFileUploader.uploadSingle(client, tempEnc, url, signal = null)
+
+        val recorded = server.takeRequest()
+        assertEquals("PUT", recorded.method)
+        assertEquals("/upload", recorded.path)
+        assertArrayEquals(encBytes, recorded.body.readByteArray())
+
+        val computed = EncryptedFileUploader.computeShardHash(listOf(sha.toHex()))
+        val expected = Ripemd160.digest(sha).toHex()
+        assertEquals(expected, computed)
+    }
+
+    @Test
+    fun uploadMultipartCollectsEtagsAndPartHashesMatchSlices() {
+        val partSize = 4_000L
+        val plain = ByteArray(13_000) { it.toByte() }
+        val tempEnc = writeEncrypted("multi.enc", plain)
+        val totalSize = tempEnc.length()
+
+        val urls = (1..4).map { idx ->
+            server.enqueue(MockResponse().setResponseCode(200).setHeader("ETag", "etag-$idx"))
+            server.url("/part-$idx").toString()
+        }
+
+        val parts = EncryptedFileUploader.uploadMultipart(
+            client = client,
+            tempEnc = tempEnc,
+            urls = urls,
+            partSize = partSize,
+            signal = null,
+        )
+
+        assertEquals(listOf(1, 2, 3, 4), parts.map { it.partNumber })
+        assertEquals(listOf("etag-1", "etag-2", "etag-3", "etag-4"), parts.map { it.etag })
+
+        val sentParts = (1..4).map { server.takeRequest() }
+        var offset = 0
+        sentParts.forEachIndexed { i, req: RecordedRequest ->
+            val expectedLength = ((offset + partSize).coerceAtMost(totalSize) - offset).toInt()
+            val body = req.body.readByteArray()
+            assertEquals("part ${i + 1} length", expectedLength, body.size)
+            assertArrayEquals(
+                "part ${i + 1} bytes",
+                tempEnc.readBytes().copyOfRange(offset, offset + expectedLength),
+                body,
+            )
+            offset += expectedLength
+        }
+
+        // hash parity with the RN multipart formula
+        val partHashes = EncryptedFileUploader.computePartSha256(tempEnc, partSize)
+        val bytes = tempEnc.readBytes()
+        val expected = partHashes.mapIndexed { i, h ->
+            val start = (i * partSize).toInt()
+            val end = (start + partSize.toInt()).coerceAtMost(bytes.size)
+            assertEquals(MessageDigest.getInstance(SHA_256).digest(bytes.copyOfRange(start, end)).toHex(), h)
+            h
+        }
+        val computed = EncryptedFileUploader.computeShardHash(expected)
+        val expectedHash = Ripemd160.digest(hexDecode(expected.joinToString(""))).toHex()
+        assertEquals(expectedHash, computed)
+    }
+
+    private fun hexDecode(hex: String): ByteArray {
+        val out = ByteArray(hex.length / 2)
+        for (i in out.indices) {
+            val hi = Character.digit(hex[i * 2], 16)
+            val lo = Character.digit(hex[i * 2 + 1], 16)
+            out[i] = ((hi shl 4) or lo).toByte()
+        }
+        return out
+    }
+}


### PR DESCRIPTION
- add MockWebServer tests for start/finish upload and createFileEntry requests/parsing
- verify single and multipart upload request bodies, ETag collection, and part ordering
- validate SHA-256 part hashing and RIPEMD160 shard hash computation parity