### PR TITLE
[PB-6280]: create folders from DocumentsProvider createDocument

### DIFF
--- a/android/app/src/main/java/com/internxt/cloud/documents/DocumentNaming.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/DocumentNaming.kt
@@ -1,0 +1,34 @@
+package com.internxt.cloud.documents
+
+import java.util.UUID
+
+/** Pure naming helpers shared by the folder and file branches of [InternxtDocumentsProvider.createDocument]. */
+object DocumentNaming {
+
+    private const val MAX_SUFFIX_ATTEMPTS = 1000
+
+    /**
+     * Returns [requested] if it is not already in [existing]; otherwise appends a
+     * ` (n)` suffix (preserving any file extension) until a free name is found.
+     */
+    fun uniqueName(requested: String, existing: Set<String>): String {
+        if (requested !in existing) return requested
+        val (base, ext) = splitNameExt(requested)
+        for (i in 1..MAX_SUFFIX_ATTEMPTS) {
+            val candidate = "$base ($i)$ext"
+            if (candidate !in existing) return candidate
+        }
+        // Backstop for the (practically impossible) case where 1..1000 are all taken —
+        // the backend permits duplicate names, so a UUID-suffixed name is always safe.
+        return "$base (${UUID.randomUUID()})$ext"
+    }
+
+    fun splitNameExt(name: String): Pair<String, String> {
+        val dot = name.lastIndexOf('.')
+        val hasExt = dot > 0 && dot < name.length - 1
+        return if (hasExt) name.substring(0, dot) to name.substring(dot) else name to ""
+    }
+
+    fun joinNameType(plainName: String, type: String?): String =
+        if (type.isNullOrBlank()) plainName else "$plainName.$type"
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -579,10 +579,6 @@ class InternxtDocumentsProvider : DocumentsProvider() {
             it.plainName
         }
 
-    /**
-     * Resolves [requested] to a name that does not collide with the parent's existing children
-     * (listed via [listPage], named via [nameOf]). Falls back to [requested] if the listing fails.
-     */
     private inline fun <T> uniqueChildName(
         op: String,
         requested: String,

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -509,8 +509,38 @@ class InternxtDocumentsProvider : DocumentsProvider() {
             throw FileNotFoundException("Parent lookup failed: ${e.message}")
         }
 
+        return if (mimeType == Document.MIME_TYPE_DIR) {
+            createFolderDocument(api, parentDocumentId, parentUuid, displayName)
+        } else {
+            createPendingFileDocument(api, parentUuid, mimeType, displayName)
+        }
+    }
+
+    private fun createFolderDocument(
+        api: InternxtApiClient,
+        parentDocumentId: String,
+        parentUuid: String,
+        displayName: String,
+    ): String {
+        val resolvedName = uniqueFolderName(api, parentUuid, displayName)
+        val folder = try {
+            api.createFolder(parentUuid, resolvedName)
+        } catch (e: InternxtApiException) {
+            Log.w(TAG, "createDocument folder failed parent=$parentDocumentId: ${e.javaClass.simpleName}: ${e.message}")
+            throw FileNotFoundException("Folder creation failed: ${e.message}")
+        }
+        invalidateChildren(parentDocumentId)
+        return DocumentId.encodeFolder(folder.uuid)
+    }
+
+    private fun createPendingFileDocument(
+        api: InternxtApiClient,
+        parentUuid: String,
+        mimeType: String,
+        displayName: String,
+    ): String {
         val normalized = collapseRedundantExtensions(displayName, mimeType)
-        val resolvedName = pickUniqueName(api, parentUuid, normalized)
+        val resolvedName = uniqueFileName(api, parentUuid, normalized)
         evictStalePendingUploads()
         val token = UUID.randomUUID().toString()
         pendingUploads[token] = PendingUpload(parentUuid, resolvedName, mimeType)
@@ -539,35 +569,35 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         return name
     }
 
-    private fun pickUniqueName(api: InternxtApiClient, parentUuid: String, requested: String): String {
+    private fun uniqueFileName(api: InternxtApiClient, parentUuid: String, requested: String): String =
+        uniqueChildName("uniqueFileName", requested, { offset, size -> api.listFolderFiles(parentUuid, offset, size) }) {
+            DocumentNaming.joinNameType(it.plainName, it.type)
+        }
+
+    private fun uniqueFolderName(api: InternxtApiClient, parentUuid: String, requested: String): String =
+        uniqueChildName("uniqueFolderName", requested, { offset, size -> api.listFolderFolders(parentUuid, offset, size) }) {
+            it.plainName
+        }
+
+    /**
+     * Resolves [requested] to a name that does not collide with the parent's existing children
+     * (listed via [listPage], named via [nameOf]). Falls back to [requested] if the listing fails.
+     */
+    private inline fun <T> uniqueChildName(
+        op: String,
+        requested: String,
+        listPage: (offset: Int, size: Int) -> List<T>,
+        nameOf: (T) -> String,
+    ): String {
         val existing = HashSet<String>()
         try {
-            streamPages({ offset, size -> api.listFolderFiles(parentUuid, offset, size) }) { page ->
-                page.forEach { existing.add(joinNameType(it.plainName, it.type)) }
-            }
+            streamPages(listPage) { page -> page.forEach { existing.add(nameOf(it)) } }
         } catch (e: InternxtApiException) {
-            Log.w(TAG, "pickUniqueName: listing failed, using requested name. ${e.message}")
+            Log.w(TAG, "$op: listing failed, using requested name. ${e.message}")
             return requested
         }
-        if (requested !in existing) return requested
-        val (base, ext) = splitNameExt(requested)
-        for (i in 1..MAX_SUFFIX_ATTEMPTS) {
-            val candidate = "$base ($i)$ext"
-            if (candidate !in existing) return candidate
-        }
-        // Backstop for the (practically impossible) case where 1..1000 are all taken —
-        // the backend permits duplicate names, so a UUID-suffixed name is always safe.
-        return "$base (${UUID.randomUUID()})$ext"
+        return DocumentNaming.uniqueName(requested, existing)
     }
-
-    private fun splitNameExt(name: String): Pair<String, String> {
-        val dot = name.lastIndexOf('.')
-        val hasExt = dot > 0 && dot < name.length - 1
-        return if (hasExt) name.substring(0, dot) to name.substring(dot) else name to ""
-    }
-
-    private fun joinNameType(plainName: String, type: String?): String =
-        if (type.isNullOrBlank()) plainName else "$plainName.$type"
 
     private fun openForWrite(
         ctx: Context,
@@ -766,7 +796,7 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         val finish = api.finishUpload(bucketId, indexHex, listOf(shard))
 
         val nowIso = Instant.now().toString()
-        val (basePlain, ext) = splitNameExt(pending.plainName)
+        val (basePlain, ext) = DocumentNaming.splitNameExt(pending.plainName)
         api.createFileEntry(
             CreateFileEntry(
                 fileId = finish.id,
@@ -897,7 +927,6 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         private const val MULTIPART_THRESHOLD = 100L * 1024L * 1024L
         private const val MULTIPART_PART_SIZE = 30L * 1024L * 1024L
         private const val PROGRESS_THROTTLE_MS = 300L
-        private const val MAX_SUFFIX_ATTEMPTS = 1000
         private const val PENDING_UPLOAD_TTL_MS = 60L * 60L * 1000L
         private const val NOT_AUTHENTICATED = "Not authenticated"
 

--- a/android/app/src/test/java/com/internxt/cloud/documents/DocumentNamingTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/DocumentNamingTest.kt
@@ -23,12 +23,12 @@ class DocumentNamingTest {
 
     @Test
     fun uniqueNamePreservesFileExtension() {
-        assertEquals("report (1).pdf", DocumentNaming.uniqueName("report.pdf", setOf("report.pdf")))
+        assertEquals("report (1).pdf", DocumentNaming.uniqueName(REPORT_PDF, setOf(REPORT_PDF)))
     }
 
     @Test
     fun uniqueNameForFolderHasNoExtension() {
-        assertEquals("My Folder (1)", DocumentNaming.uniqueName("My Folder", setOf("My Folder")))
+        assertEquals("$FOLDER_NAME (1)", DocumentNaming.uniqueName(FOLDER_NAME, setOf(FOLDER_NAME)))
     }
 
     @Test
@@ -38,7 +38,7 @@ class DocumentNamingTest {
 
     @Test
     fun splitNameExtNoExtension() {
-        assertEquals("My Folder" to "", DocumentNaming.splitNameExt("My Folder"))
+        assertEquals(FOLDER_NAME to "", DocumentNaming.splitNameExt(FOLDER_NAME))
     }
 
     @Test
@@ -53,12 +53,17 @@ class DocumentNamingTest {
 
     @Test
     fun joinNameTypeAppendsType() {
-        assertEquals("report.pdf", DocumentNaming.joinNameType("report", "pdf"))
+        assertEquals(REPORT_PDF, DocumentNaming.joinNameType("report", "pdf"))
     }
 
     @Test
     fun joinNameTypeWithoutTypeReturnsName() {
         assertEquals("report", DocumentNaming.joinNameType("report", null))
         assertEquals("report", DocumentNaming.joinNameType("report", ""))
+    }
+
+    companion object {
+        private const val FOLDER_NAME = "My Folder"
+        private const val REPORT_PDF = "report.pdf"
     }
 }

--- a/android/app/src/test/java/com/internxt/cloud/documents/DocumentNamingTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/DocumentNamingTest.kt
@@ -1,0 +1,64 @@
+package com.internxt.cloud.documents
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DocumentNamingTest {
+
+    @Test
+    fun uniqueNameReturnsRequestedWhenNoCollision() {
+        assertEquals("Reports", DocumentNaming.uniqueName("Reports", setOf("Photos", "Music")))
+    }
+
+    @Test
+    fun uniqueNameAppendsSuffixOnCollision() {
+        assertEquals("Reports (1)", DocumentNaming.uniqueName("Reports", setOf("Reports")))
+    }
+
+    @Test
+    fun uniqueNameSkipsTakenSuffixes() {
+        val existing = setOf("Reports", "Reports (1)", "Reports (2)")
+        assertEquals("Reports (3)", DocumentNaming.uniqueName("Reports", existing))
+    }
+
+    @Test
+    fun uniqueNamePreservesFileExtension() {
+        assertEquals("report (1).pdf", DocumentNaming.uniqueName("report.pdf", setOf("report.pdf")))
+    }
+
+    @Test
+    fun uniqueNameForFolderHasNoExtension() {
+        assertEquals("My Folder (1)", DocumentNaming.uniqueName("My Folder", setOf("My Folder")))
+    }
+
+    @Test
+    fun splitNameExtSplitsOnLastDot() {
+        assertEquals("archive.tar" to ".gz", DocumentNaming.splitNameExt("archive.tar.gz"))
+    }
+
+    @Test
+    fun splitNameExtNoExtension() {
+        assertEquals("My Folder" to "", DocumentNaming.splitNameExt("My Folder"))
+    }
+
+    @Test
+    fun splitNameExtLeadingDotIsNotAnExtension() {
+        assertEquals(".gitignore" to "", DocumentNaming.splitNameExt(".gitignore"))
+    }
+
+    @Test
+    fun splitNameExtTrailingDotIsNotAnExtension() {
+        assertEquals("name." to "", DocumentNaming.splitNameExt("name."))
+    }
+
+    @Test
+    fun joinNameTypeAppendsType() {
+        assertEquals("report.pdf", DocumentNaming.joinNameType("report", "pdf"))
+    }
+
+    @Test
+    fun joinNameTypeWithoutTypeReturnsName() {
+        assertEquals("report", DocumentNaming.joinNameType("report", null))
+        assertEquals("report", DocumentNaming.joinNameType("report", ""))
+    }
+}


### PR DESCRIPTION
Implement the folder branch of InternxtDocumentsProvider.createDocument so users can create folders from the Android system file picker (SAF "New folder"). When the requested mimeType is MIME_TYPE_DIR, the provider resolves a non-colliding name, POSTs via InternxtApiClient.createFolder, invalidates the parent's cached children, and returns the encoded folder document id. The existing pending-upload path is preserved for files.

Extract the pure naming logic (uniqueName, splitNameExt, joinNameType) into a standalone DocumentNaming object and collapse the duplicated file/folder name resolvers into a single generic uniqueChildName helper, so the only difference between them is the list endpoint and name extractor.

Add DocumentNaming unit tests covering collision suffixing, extension preservation, the bare-folder case, and the split/join edge cases.