### PR TITLE
[PB-6467: feature/Migrate Photos backup to use new Photos enpdoints

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,6 +1,8 @@
 PODS:
   - EASClient (1.0.8):
     - ExpoModulesCore
+  - EXApplication (7.0.8):
+    - ExpoModulesCore
   - EXConstants (18.0.13):
     - ExpoModulesCore
   - EXImageLoader (6.0.0):
@@ -2450,6 +2452,7 @@ PODS:
 
 DEPENDENCIES:
   - EASClient (from `../node_modules/expo-eas-client/ios`)
+  - EXApplication (from `../node_modules/expo-application/ios`)
   - EXConstants (from `../node_modules/expo-constants/ios`)
   - EXImageLoader (from `../node_modules/expo-image-loader/ios`)
   - EXJSONUtils (from `../node_modules/expo-json-utils/ios`)
@@ -2587,6 +2590,8 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   EASClient:
     :path: "../node_modules/expo-eas-client/ios"
+  EXApplication:
+    :path: "../node_modules/expo-application/ios"
   EXConstants:
     :path: "../node_modules/expo-constants/ios"
   EXImageLoader:
@@ -2839,6 +2844,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   EASClient: 40dd9e740684782610c49becab2643782ea1a20c
+  EXApplication: 1e98d4b1dccdf30627f92917f4b2c5a53c330e5f
   EXConstants: fce59a631a06c4151602843667f7cfe35f81e271
   EXImageLoader: 189e3476581efe3ad4d1d3fb4735b7179eb26f05
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "dayjs": "^1.11.19",
     "events": "^3.3.0",
     "expo": "^54",
+    "expo-application": "~7.0.8",
     "expo-asset": "~12.0.12",
     "expo-clipboard": "~8.0.8",
     "expo-constants": "~18.0.13",

--- a/src/screens/HomeScreen/useDiscoverPhotosSheet.spec.tsx
+++ b/src/screens/HomeScreen/useDiscoverPhotosSheet.spec.tsx
@@ -38,6 +38,7 @@ const makeWrapper = (photosState?: Partial<PhotosState>) => {
         currentUploadProgress: 0,
         uploadingAssetIds: [],
         deviceId: null,
+        photosBucket: null,
         sessionTotalAssets: 0,
         sessionUploadedAssets: 0,
         cloudFetchRevision: 0,

--- a/src/services/photos/PhotoBackupFolders.spec.ts
+++ b/src/services/photos/PhotoBackupFolders.spec.ts
@@ -1,88 +1,68 @@
 import { createFolderWithMerge } from 'src/services/drive/folder/folderOrchestration.service';
 import { photoBackupFolders } from './PhotoBackupFolders';
 
-jest.mock('src/services/AsyncStorageService', () => ({
-  __esModule: true,
-  default: {
-    getUser: jest.fn().mockResolvedValue({ rootFolderId: 'root-uuid' }),
-  },
-}));
-
 jest.mock('src/services/drive/folder/folderOrchestration.service', () => ({
   createFolderWithMerge: jest.fn(),
 }));
 
 const mockCreateFolder = createFolderWithMerge as jest.Mock;
 
-const DEVICE_ID = 'device-123';
+const DEVICE_FOLDER_UUID = 'device-folder-uuid';
 
 beforeEach(() => {
   jest.clearAllMocks();
   photoBackupFolders.clearCache();
   mockCreateFolder
-    .mockResolvedValueOnce('photos-root-uuid')
-    .mockResolvedValueOnce('device-uuid')
     .mockResolvedValueOnce('year-uuid')
     .mockResolvedValueOnce('month-uuid')
     .mockResolvedValueOnce('day-uuid');
 });
 
 describe('PhotoBackupFolders.getOrCreateFolderForDate', () => {
-  test('when called for a date, then creates the full folder hierarchy and returns the day folder uuid', async () => {
-    const uuid = await photoBackupFolders.getOrCreateFolderForDate(DEVICE_ID, new Date('2024-06-15'));
-    expect(uuid).toBe('day-uuid');
-    expect(mockCreateFolder).toHaveBeenCalledTimes(5);
+  test('when called for a date, then creates year / month / day folders under the device folder and returns the day uuid', async () => {
+    const uuid = await photoBackupFolders.getOrCreateFolderForDate(DEVICE_FOLDER_UUID, new Date('2024-06-15'));
 
-    // Verify the folder names at each level of the hierarchy
+    expect(uuid).toBe('day-uuid');
+    expect(mockCreateFolder).toHaveBeenCalledTimes(3);
+
     const calls = mockCreateFolder.mock.calls;
-    // 1st call: Photos root folder, parent is user root
-    expect(calls[0][0]).toBe('root-uuid');
-    expect(calls[0][1]).toBe('Photos Backup');
-    // 2nd call: device folder under photos root
-    expect(calls[1][1]).toBe(DEVICE_ID);
-    expect(calls[1][0]).toBe('photos-root-uuid');
-    // 3rd call: year folder under device folder
-    expect(calls[2][1]).toBe('2024');
-    expect(calls[2][0]).toBe('device-uuid');
-    // 4th call: month folder under year folder
-    expect(calls[3][1]).toBe('06');
-    expect(calls[3][0]).toBe('year-uuid');
-    // 5th call: day folder under month folder
-    expect(calls[4][1]).toBe('15');
-    expect(calls[4][0]).toBe('month-uuid');
+    // Year folder directly under the device folder
+    expect(calls[0][0]).toBe(DEVICE_FOLDER_UUID);
+    expect(calls[0][1]).toBe('2024');
+    // Month folder under year
+    expect(calls[1][0]).toBe('year-uuid');
+    expect(calls[1][1]).toBe('06');
+    // Day folder under month
+    expect(calls[2][0]).toBe('month-uuid');
+    expect(calls[2][1]).toBe('15');
   });
 
-  test('when called twice for the same date, then creates folders only once', async () => {
-    await photoBackupFolders.getOrCreateFolderForDate(DEVICE_ID, new Date('2024-06-15'));
-    await photoBackupFolders.getOrCreateFolderForDate(DEVICE_ID, new Date('2024-06-15'));
+  test('when called twice for the same date, then folders are created only once', async () => {
+    await photoBackupFolders.getOrCreateFolderForDate(DEVICE_FOLDER_UUID, new Date('2024-06-15'));
+    await photoBackupFolders.getOrCreateFolderForDate(DEVICE_FOLDER_UUID, new Date('2024-06-15'));
 
-    expect(mockCreateFolder).toHaveBeenCalledTimes(5);
+    expect(mockCreateFolder).toHaveBeenCalledTimes(3);
   });
 
   test('when called for two dates in the same month, then the month folder is created only once', async () => {
     mockCreateFolder
       .mockReset()
-      .mockResolvedValueOnce('photos-root-uuid')
-      .mockResolvedValueOnce('device-uuid')
       .mockResolvedValueOnce('year-uuid')
       .mockResolvedValueOnce('month-uuid')
       .mockResolvedValueOnce('day-15-uuid')
       .mockResolvedValueOnce('day-20-uuid');
 
-    await photoBackupFolders.getOrCreateFolderForDate(DEVICE_ID, new Date('2024-06-15'));
-    await photoBackupFolders.getOrCreateFolderForDate(DEVICE_ID, new Date('2024-06-20'));
+    await photoBackupFolders.getOrCreateFolderForDate(DEVICE_FOLDER_UUID, new Date('2024-06-15'));
+    await photoBackupFolders.getOrCreateFolderForDate(DEVICE_FOLDER_UUID, new Date('2024-06-20'));
 
     const folderNames = mockCreateFolder.mock.calls.map((call) => call[1]);
-    const monthCalls = folderNames.filter((name) => name === '06');
-    expect(monthCalls).toHaveLength(1);
-    expect(mockCreateFolder).toHaveBeenCalledTimes(6);
+    expect(folderNames.filter((name) => name === '06')).toHaveLength(1);
+    expect(mockCreateFolder).toHaveBeenCalledTimes(4);
   });
 
   test('when called for two dates in different years, then separate year folders are created', async () => {
     mockCreateFolder
       .mockReset()
-      .mockResolvedValueOnce('photos-root-uuid')
-      .mockResolvedValueOnce('device-uuid')
       .mockResolvedValueOnce('year-2023-uuid')
       .mockResolvedValueOnce('month-uuid')
       .mockResolvedValueOnce('day-uuid')
@@ -90,8 +70,8 @@ describe('PhotoBackupFolders.getOrCreateFolderForDate', () => {
       .mockResolvedValueOnce('month-uuid-2')
       .mockResolvedValueOnce('day-uuid-2');
 
-    await photoBackupFolders.getOrCreateFolderForDate(DEVICE_ID, new Date('2023-06-15'));
-    await photoBackupFolders.getOrCreateFolderForDate(DEVICE_ID, new Date('2024-06-15'));
+    await photoBackupFolders.getOrCreateFolderForDate(DEVICE_FOLDER_UUID, new Date('2023-06-15'));
+    await photoBackupFolders.getOrCreateFolderForDate(DEVICE_FOLDER_UUID, new Date('2024-06-15'));
 
     const folderNames = mockCreateFolder.mock.calls.map((call) => call[1]);
     expect(folderNames.filter((name) => name === '2023')).toHaveLength(1);
@@ -99,18 +79,16 @@ describe('PhotoBackupFolders.getOrCreateFolderForDate', () => {
   });
 
   test('when the cache is cleared and called again, then folders are created from scratch', async () => {
-    await photoBackupFolders.getOrCreateFolderForDate(DEVICE_ID, new Date('2024-06-15'));
+    await photoBackupFolders.getOrCreateFolderForDate(DEVICE_FOLDER_UUID, new Date('2024-06-15'));
     const callsAfterFirst = mockCreateFolder.mock.calls.length;
 
     photoBackupFolders.clearCache();
     mockCreateFolder
-      .mockResolvedValueOnce('photos-root-uuid')
-      .mockResolvedValueOnce('device-uuid')
       .mockResolvedValueOnce('year-uuid')
       .mockResolvedValueOnce('month-uuid')
       .mockResolvedValueOnce('day-uuid');
 
-    await photoBackupFolders.getOrCreateFolderForDate(DEVICE_ID, new Date('2024-06-15'));
+    await photoBackupFolders.getOrCreateFolderForDate(DEVICE_FOLDER_UUID, new Date('2024-06-15'));
     expect(mockCreateFolder).toHaveBeenCalledTimes(callsAfterFirst * 2);
   });
 });

--- a/src/services/photos/PhotoBackupFolders.ts
+++ b/src/services/photos/PhotoBackupFolders.ts
@@ -1,29 +1,29 @@
-import asyncStorageService from 'src/services/AsyncStorageService';
 import { logger } from 'src/services/common';
 import { createFolderWithMerge } from 'src/services/drive/folder/folderOrchestration.service';
 
-const PHOTOS_BACKUP_ROOT_NAME = 'Photos Backup';
-
 class PhotoBackupFolderService {
-  private photosRootUuid: string | null = null;
-  private readonly deviceFolderUuid = new Map<string, string>();
   private readonly yearFolderUuid = new Map<string, string>();
   private readonly monthFolderUuid = new Map<string, string>();
   private readonly dayFolderUuid = new Map<string, string>();
 
-  async getOrCreateFolderForDate(deviceId: string, date: Date): Promise<string> {
+  /**
+   * Returns the uuid of the day folder under the given device folder, creating
+   * the year / month / day sub-folders if needed.
+   *
+   * @param deviceFolderUuid - uuid of the device folder returned by /photos/devices
+   * @param date - date of the asset being backed up
+   */
+  async getOrCreateFolderForDate(deviceFolderUuid: string, date: Date): Promise<string> {
     const year = date.getFullYear().toString();
     const month = String(date.getMonth() + 1).padStart(2, '0');
     const day = String(date.getDate()).padStart(2, '0');
 
-    const dayKey = `${deviceId}/${year}/${month}/${day}`;
+    const dayKey = `${deviceFolderUuid}/${year}/${month}/${day}`;
     const localDayFolderUuid = this.dayFolderUuid.get(dayKey);
     if (localDayFolderUuid) return localDayFolderUuid;
 
-    const photosRootUuid = await this.getOrCreatePhotosRoot();
-    const deviceUuid = await this.getOrCreateDeviceFolder(deviceId, photosRootUuid);
-    const yearUuid = await this.getOrCreateYearFolder(deviceId, year, deviceUuid);
-    const monthUuid = await this.getOrCreateMonthFolder(deviceId, year, month, yearUuid);
+    const yearUuid = await this.getOrCreateYearFolder(deviceFolderUuid, year);
+    const monthUuid = await this.getOrCreateMonthFolder(deviceFolderUuid, year, month, yearUuid);
 
     logger.info(`[PhotoBackupFolders] Creating day folder ${dayKey}`);
     const dayUuid = await createFolderWithMerge(monthUuid, day);
@@ -31,28 +31,10 @@ class PhotoBackupFolderService {
     return dayUuid;
   }
 
-  async getRootFolderUuid(): Promise<string | null> {
-    try {
-      return await this.getOrCreatePhotosRoot();
-    } catch {
-      return null;
-    }
-  }
-
   clearCache(): void {
-    this.photosRootUuid = null;
-    this.deviceFolderUuid.clear();
     this.yearFolderUuid.clear();
     this.monthFolderUuid.clear();
     this.dayFolderUuid.clear();
-  }
-
-  private async getOrCreatePhotosRoot(): Promise<string> {
-    if (this.photosRootUuid) return this.photosRootUuid;
-
-    const user = await asyncStorageService.getUser();
-    this.photosRootUuid = await createFolderWithMerge(user.rootFolderId, PHOTOS_BACKUP_ROOT_NAME);
-    return this.photosRootUuid;
   }
 
   private async getOrCreateFolder(
@@ -62,24 +44,23 @@ class PhotoBackupFolderService {
     name: string,
   ): Promise<string> {
     const cached = cache.get(key);
-    if (cached) {
-      return cached;
-    }
+    if (cached) return cached;
     const uuid = await createFolderWithMerge(parentUuid, name);
     cache.set(key, uuid);
     return uuid;
   }
 
-  private getOrCreateDeviceFolder(deviceId: string, photosRootUuid: string): Promise<string> {
-    return this.getOrCreateFolder(this.deviceFolderUuid, deviceId, photosRootUuid, deviceId);
+  private getOrCreateYearFolder(deviceFolderUuid: string, year: string): Promise<string> {
+    return this.getOrCreateFolder(this.yearFolderUuid, `${deviceFolderUuid}/${year}`, deviceFolderUuid, year);
   }
 
-  private getOrCreateYearFolder(deviceId: string, year: string, deviceUuid: string): Promise<string> {
-    return this.getOrCreateFolder(this.yearFolderUuid, `${deviceId}/${year}`, deviceUuid, year);
-  }
-
-  private getOrCreateMonthFolder(deviceId: string, year: string, month: string, yearUuid: string): Promise<string> {
-    return this.getOrCreateFolder(this.monthFolderUuid, `${deviceId}/${year}/${month}`, yearUuid, month);
+  private getOrCreateMonthFolder(
+    deviceFolderUuid: string,
+    year: string,
+    month: string,
+    yearUuid: string,
+  ): Promise<string> {
+    return this.getOrCreateFolder(this.monthFolderUuid, `${deviceFolderUuid}/${year}/${month}`, yearUuid, month);
   }
 }
 

--- a/src/services/photos/PhotoCloudBrowser.spec.ts
+++ b/src/services/photos/PhotoCloudBrowser.spec.ts
@@ -514,7 +514,7 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth
       .mockResolvedValueOnce(new Set(['file-a']))
       .mockResolvedValueOnce(new Set(['file-b']));
-    mockFolderService.getFolderFolders.mockResolvedValueOnce({ folders: [] } as never); // no year folders
+    mockFolderService.getFolderFolders.mockResolvedValueOnce({ folders: [] }); // no year folders
 
     await photoCloudBrowser.syncAllHistory({});
 

--- a/src/services/photos/PhotoCloudBrowser.spec.ts
+++ b/src/services/photos/PhotoCloudBrowser.spec.ts
@@ -1,6 +1,6 @@
 import { driveFolderService } from 'src/services/drive/folder/driveFolder.service';
 import { photosLocalDB } from './database/photosLocalDB';
-import { photoBackupFolders } from './PhotoBackupFolders';
+import { photosDeviceService } from './photosDeviceService';
 import { photoCloudBrowser } from './PhotoCloudBrowser';
 
 jest.mock('src/services/drive/folder/driveFolder.service', () => ({
@@ -10,9 +10,9 @@ jest.mock('src/services/drive/folder/driveFolder.service', () => ({
   },
 }));
 
-jest.mock('./PhotoBackupFolders', () => ({
-  photoBackupFolders: {
-    getRootFolderUuid: jest.fn(),
+jest.mock('./photosDeviceService', () => ({
+  photosDeviceService: {
+    listDevices: jest.fn(),
   },
 }));
 
@@ -30,7 +30,7 @@ jest.mock('./database/photosLocalDB', () => ({
 }));
 
 const mockFolderService = driveFolderService as jest.Mocked<typeof driveFolderService>;
-const mockBackupFolders = photoBackupFolders as jest.Mocked<typeof photoBackupFolders>;
+const mockDeviceService = photosDeviceService as jest.Mocked<typeof photosDeviceService>;
 const mockPhotosLocalDB = photosLocalDB as jest.Mocked<typeof photosLocalDB>;
 
 const makeFolder = (uuid: string, plainName: string) => ({ uuid, plainName, name: plainName }) as never;
@@ -42,6 +42,12 @@ const makeFile = (uuid: string, plainName: string) =>
     size: 1024,
     thumbnails: [{ bucket_id: 'bucket-1', bucket_file: 'file-1', type: 'jpg' }],
   }) as never;
+const makeDevice = (uuid: string, plainName: string, status: 'EXISTS' | 'TRASHED' | 'DELETED' = 'EXISTS') => ({
+  uuid,
+  plainName,
+  bucket: 'photos-bucket',
+  status,
+});
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -55,8 +61,8 @@ beforeEach(() => {
 });
 
 describe('PhotoCloudBrowser.listDeviceFolders', () => {
-  test('when the root folder does not exist, then an empty list is returned without calling the drive API', async () => {
-    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce(null);
+  test('when the device service returns no devices, then an empty list is returned without calling the drive API', async () => {
+    mockDeviceService.listDevices.mockResolvedValueOnce([]);
 
     const result = await photoCloudBrowser.listDeviceFolders();
 
@@ -64,32 +70,30 @@ describe('PhotoCloudBrowser.listDeviceFolders', () => {
     expect(mockFolderService.getFolderFolders).not.toHaveBeenCalled();
   });
 
-  test('when the root folder has two device subfolders, then both devices are returned', async () => {
-    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
-    mockFolderService.getFolderFolders.mockResolvedValueOnce({
-      folders: [makeFolder('d1-uuid', 'device-1'), makeFolder('d2-uuid', 'device-2')],
-    } as never);
+  test('when the device service returns two devices, then both are mapped with uuid as name', async () => {
+    mockDeviceService.listDevices.mockResolvedValueOnce([
+      makeDevice('d1-uuid', 'Internxt iPhone'),
+      makeDevice('d2-uuid', 'Internxt iPad'),
+    ]);
 
     const result = await photoCloudBrowser.listDeviceFolders();
 
     expect(result).toEqual([
-      { uuid: 'd1-uuid', name: 'device-1' },
-      { uuid: 'd2-uuid', name: 'device-2' },
+      { uuid: 'd1-uuid' },
+      { uuid: 'd2-uuid' },
     ]);
   });
 
-  test('when the root has exactly 50 device folders and a second page has more, then all folders from both pages are returned', async () => {
-    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
-    const firstBatch = Array.from({ length: 50 }, (_, i) => makeFolder(`d${i}`, `device-${i}`));
-    const secondBatch = [makeFolder('d50', 'device-50'), makeFolder('d51', 'device-51')];
-    mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: firstBatch } as never)
-      .mockResolvedValueOnce({ folders: secondBatch } as never);
+  test('when the device service returns a deleted device, then it is excluded from the list', async () => {
+    mockDeviceService.listDevices.mockResolvedValueOnce([
+      makeDevice('d1-uuid', 'Internxt iPhone', 'EXISTS'),
+      makeDevice('d2-uuid', 'Old Phone', 'DELETED'),
+    ]);
 
     const result = await photoCloudBrowser.listDeviceFolders();
 
-    expect(mockFolderService.getFolderFolders).toHaveBeenCalledTimes(2);
-    expect(result).toHaveLength(52);
+    expect(result).toHaveLength(1);
+    expect(result[0].uuid).toBe('d1-uuid');
   });
 });
 
@@ -99,8 +103,8 @@ describe('PhotoCloudBrowser.fetchMonth', () => {
     mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValueOnce(freshTimestamp);
 
     await photoCloudBrowser.fetchMonth({
-      deviceId: 'device-1',
-      deviceFolderUuid: 'device-folder-uuid',
+      deviceId: 'd1-uuid',
+      deviceFolderUuid: 'd1-uuid',
       year: 2024,
       month: 6,
     });
@@ -126,8 +130,8 @@ describe('PhotoCloudBrowser.fetchMonth', () => {
     mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
 
     await photoCloudBrowser.fetchMonth({
-      deviceId: 'device-1',
-      deviceFolderUuid: 'device-folder-uuid',
+      deviceId: 'd1-uuid',
+      deviceFolderUuid: 'd1-uuid',
       year: 2024,
       month: 6,
     });
@@ -136,7 +140,7 @@ describe('PhotoCloudBrowser.fetchMonth', () => {
     expect(mockPhotosLocalDB.upsertCloudAsset).toHaveBeenCalledWith(
       expect.objectContaining({
         remoteFileId: 'file-uuid',
-        deviceId: 'device-1',
+        deviceId: 'd1-uuid',
         fileName: 'IMG_20240615_120000.jpg',
         thumbnailBucketId: 'bucket-1',
         thumbnailBucketFile: 'file-1',
@@ -151,8 +155,8 @@ describe('PhotoCloudBrowser.fetchMonth', () => {
     mockFolderService.getFolderFolders.mockResolvedValue({ folders: [] } as never);
 
     await photoCloudBrowser.fetchMonth({
-      deviceId: 'device-1',
-      deviceFolderUuid: 'device-folder-uuid',
+      deviceId: 'd1-uuid',
+      deviceFolderUuid: 'd1-uuid',
       year: 2024,
       month: 6,
     });
@@ -165,8 +169,8 @@ describe('PhotoCloudBrowser.fetchMonth', () => {
     mockFolderService.getFolderFolders.mockResolvedValueOnce({ folders: [] } as never);
 
     await photoCloudBrowser.fetchMonth({
-      deviceId: 'device-1',
-      deviceFolderUuid: 'device-folder-uuid',
+      deviceId: 'd1-uuid',
+      deviceFolderUuid: 'd1-uuid',
       year: 2024,
       month: 6,
     });
@@ -174,65 +178,8 @@ describe('PhotoCloudBrowser.fetchMonth', () => {
     expect(mockPhotosLocalDB.upsertCloudAsset).not.toHaveBeenCalled();
   });
 
-  test('when a file is inside a day folder, then the created at timestamp is derived from the folder hierarchy', async () => {
+  test('when a folder has two files, then the count returned is two', async () => {
     mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValueOnce(null);
-
-    const yearFolder = makeFolder('year-uuid', '2024');
-    const monthFolder = makeFolder('month-uuid', '06');
-    const dayFolder = makeFolder('day-uuid', '15');
-    const file = makeFile('file-uuid', 'photo.jpg');
-
-    mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [yearFolder] } as never)
-      .mockResolvedValueOnce({ folders: [monthFolder] } as never)
-      .mockResolvedValueOnce({ folders: [dayFolder] } as never);
-
-    mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
-
-    await photoCloudBrowser.fetchMonth({
-      deviceId: 'device-1',
-      deviceFolderUuid: 'device-folder-uuid',
-      year: 2024,
-      month: 6,
-    });
-
-    const upsertCall = mockPhotosLocalDB.upsertCloudAsset.mock.calls[0][0];
-    expect(upsertCall.createdAt).toBe(new Date(2024, 5, 15).getTime());
-  });
-});
-
-describe('PhotoCloudBrowser.fetchMonth — return value', () => {
-  test('when the cache for the given month is still fresh, then zero is returned without fetching', async () => {
-    const freshTimestamp = Date.now() - 1000;
-    mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValueOnce(freshTimestamp);
-
-    const result = await photoCloudBrowser.fetchMonth({
-      deviceId: 'device-1',
-      deviceFolderUuid: 'device-folder-uuid',
-      year: 2024,
-      month: 6,
-    });
-
-    expect(result).toBe(0);
-  });
-
-  test('when the year folder does not exist, then zero is returned', async () => {
-    mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValueOnce(null);
-    mockFolderService.getFolderFolders.mockResolvedValueOnce({ folders: [] } as never);
-
-    const result = await photoCloudBrowser.fetchMonth({
-      deviceId: 'device-1',
-      deviceFolderUuid: 'device-folder-uuid',
-      year: 2024,
-      month: 6,
-    });
-
-    expect(result).toBe(0);
-  });
-
-  test('when a day folder has two files, then two is returned', async () => {
-    mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValueOnce(null);
-
     const yearFolder = makeFolder('year-uuid', '2024');
     const monthFolder = makeFolder('month-uuid', '06');
     const dayFolder = makeFolder('day-uuid', '15');
@@ -247,8 +194,8 @@ describe('PhotoCloudBrowser.fetchMonth — return value', () => {
     mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [fileA, fileB] } as never);
 
     const result = await photoCloudBrowser.fetchMonth({
-      deviceId: 'device-1',
-      deviceFolderUuid: 'device-folder-uuid',
+      deviceId: 'd1-uuid',
+      deviceFolderUuid: 'd1-uuid',
       year: 2024,
       month: 6,
     });
@@ -259,7 +206,7 @@ describe('PhotoCloudBrowser.fetchMonth — return value', () => {
 
 describe('PhotoCloudBrowser.syncAllHistory', () => {
   test('when there are no device folders, then no fetches happen', async () => {
-    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce(null);
+    mockDeviceService.listDevices.mockResolvedValueOnce([]);
 
     await photoCloudBrowser.syncAllHistory({});
 
@@ -268,8 +215,7 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
   });
 
   test('when devices have year and month subfolders, then every discovered month triggers an upsert flow', async () => {
-    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
-    const device = makeFolder('d1-uuid', 'device-1');
+    mockDeviceService.listDevices.mockResolvedValueOnce([makeDevice('d1-uuid', 'Internxt iPhone')]);
     const yearFolder = makeFolder('year-uuid', '2024');
     const monthA = makeFolder('mA-uuid', '06');
     const monthB = makeFolder('mB-uuid', '03');
@@ -277,7 +223,6 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     const file = makeFile('file-uuid', 'photo.jpg');
     mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
       .mockResolvedValueOnce({ folders: [yearFolder] } as never)
       .mockResolvedValueOnce({ folders: [monthA, monthB] } as never)
       .mockResolvedValueOnce({ folders: [day] } as never)
@@ -290,15 +235,13 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
   });
 
   test('when discovery returns months across two years, then results are processed in newest-first order', async () => {
-    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
-    const device = makeFolder('d1-uuid', 'device-1');
+    mockDeviceService.listDevices.mockResolvedValueOnce([makeDevice('d1-uuid', 'Internxt iPhone')]);
     const year2023 = makeFolder('y23-uuid', '2023');
     const year2024 = makeFolder('y24-uuid', '2024');
     const m6_2023 = makeFolder('m6-23', '06');
     const m3_2024 = makeFolder('m3-24', '03');
     mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
       .mockResolvedValueOnce({ folders: [year2023, year2024] } as never)
       .mockResolvedValueOnce({ folders: [m6_2023] } as never)
       .mockResolvedValueOnce({ folders: [m3_2024] } as never)
@@ -306,20 +249,18 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
 
     await photoCloudBrowser.syncAllHistory({});
 
-    expect(mockPhotosLocalDB.getCloudFetchCacheAge.mock.calls[0]).toEqual(['device-1', 2024, 3]);
-    expect(mockPhotosLocalDB.getCloudFetchCacheAge.mock.calls[1]).toEqual(['device-1', 2023, 6]);
+    expect(mockPhotosLocalDB.getCloudFetchCacheAge.mock.calls[0]).toEqual(['d1-uuid', 2024, 3]);
+    expect(mockPhotosLocalDB.getCloudFetchCacheAge.mock.calls[1]).toEqual(['d1-uuid', 2023, 6]);
   });
 
   test('when isCancelled returns true, then fewer months are fetched than discovered', async () => {
-    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
-    const device = makeFolder('d1-uuid', 'device-1');
+    mockDeviceService.listDevices.mockResolvedValueOnce([makeDevice('d1-uuid', 'Internxt iPhone')]);
     const year = makeFolder('y-uuid', '2024');
     const m1 = makeFolder('m1', '06');
     const m2 = makeFolder('m2', '05');
     const m3 = makeFolder('m3', '04');
     mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
       .mockResolvedValueOnce({ folders: [year] } as never)
       .mockResolvedValueOnce({ folders: [m1, m2, m3] } as never)
       .mockResolvedValue({ folders: [] } as never);
@@ -331,8 +272,7 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
   });
 
   test('when a discovered month is still within TTL, then it is skipped without listing day folders', async () => {
-    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
-    const device = makeFolder('d1-uuid', 'device-1');
+    mockDeviceService.listDevices.mockResolvedValueOnce([makeDevice('d1-uuid', 'Internxt iPhone')]);
     const year = makeFolder('y-uuid', '2024');
     const m1 = makeFolder('m1-uuid', '06');
     const m2 = makeFolder('m2-uuid', '05');
@@ -341,7 +281,6 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     const fresh = Date.now() - 1000;
     mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValueOnce(fresh).mockResolvedValueOnce(null);
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
       .mockResolvedValueOnce({ folders: [year] } as never)
       .mockResolvedValueOnce({ folders: [m1, m2] } as never)
       .mockResolvedValueOnce({ folders: [day] } as never);
@@ -350,19 +289,17 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     await photoCloudBrowser.syncAllHistory({});
 
     expect(mockPhotosLocalDB.upsertCloudAsset).toHaveBeenCalledTimes(1);
-    expect(mockFolderService.getFolderFolders).toHaveBeenCalledTimes(4);
+    expect(mockFolderService.getFolderFolders).toHaveBeenCalledTimes(3);
   });
 
   test('when six months each have files, then the caller is notified once per month', async () => {
-    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
-    const device = makeFolder('d1-uuid', 'device-1');
+    mockDeviceService.listDevices.mockResolvedValueOnce([makeDevice('d1-uuid', 'Internxt iPhone')]);
     const year = makeFolder('y-uuid', '2024');
     const months = Array.from({ length: 6 }, (_, i) => makeFolder(`m${i}`, String(i + 1).padStart(2, '0')));
     const day = makeFolder('day-uuid', '15');
     const file = makeFile('file-uuid', 'photo.jpg');
     mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
       .mockResolvedValueOnce({ folders: [year] } as never)
       .mockResolvedValueOnce({ folders: months } as never)
       .mockResolvedValue({ folders: [day] } as never);
@@ -375,8 +312,7 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
   });
 
   test('when force is true and cache is fresh, then the month is re-fetched ignoring the TTL', async () => {
-    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
-    const device = makeFolder('d1-uuid', 'device-1');
+    mockDeviceService.listDevices.mockResolvedValueOnce([makeDevice('d1-uuid', 'Internxt iPhone')]);
     const year = makeFolder('y-uuid', '2024');
     const month = makeFolder('m1-uuid', '06');
     const day = makeFolder('day-uuid', '15');
@@ -384,7 +320,6 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     const fresh = Date.now() - 1000;
     mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(fresh);
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
       .mockResolvedValueOnce({ folders: [year] } as never)
       .mockResolvedValueOnce({ folders: [month] } as never)
       .mockResolvedValueOnce({ folders: [day] } as never);
@@ -396,8 +331,7 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
   });
 
   test('when a month fetch finds a previously known file missing from the cloud, then it is marked as cloud_deleted', async () => {
-    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
-    const device = makeFolder('d1-uuid', 'device-1');
+    mockDeviceService.listDevices.mockResolvedValueOnce([makeDevice('d1-uuid', 'Internxt iPhone')]);
     const year = makeFolder('y-uuid', '2024');
     const month = makeFolder('m-uuid', '06');
     const day = makeFolder('day-uuid', '15');
@@ -407,7 +341,6 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
       new Set(['file-uuid', 'deleted-file-uuid']),
     );
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
       .mockResolvedValueOnce({ folders: [year] } as never)
       .mockResolvedValueOnce({ folders: [month] } as never)
       .mockResolvedValueOnce({ folders: [day] } as never);
@@ -421,8 +354,7 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
   });
 
   test('when a month fetch finds all previously known files still present, then no file is marked as cloud_deleted', async () => {
-    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
-    const device = makeFolder('d1-uuid', 'device-1');
+    mockDeviceService.listDevices.mockResolvedValueOnce([makeDevice('d1-uuid', 'Internxt iPhone')]);
     const year = makeFolder('y-uuid', '2024');
     const month = makeFolder('m-uuid', '06');
     const day = makeFolder('day-uuid', '15');
@@ -430,7 +362,6 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
     mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth.mockResolvedValue(new Set(['file-uuid']));
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
       .mockResolvedValueOnce({ folders: [year] } as never)
       .mockResolvedValueOnce({ folders: [month] } as never)
       .mockResolvedValueOnce({ folders: [day] } as never);
@@ -442,14 +373,12 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
   });
 
   test('when a month becomes empty in the cloud, then all previously known files are marked as cloud_deleted', async () => {
-    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
-    const device = makeFolder('d1-uuid', 'device-1');
+    mockDeviceService.listDevices.mockResolvedValueOnce([makeDevice('d1-uuid', 'Internxt iPhone')]);
     const year = makeFolder('y-uuid', '2024');
     const month = makeFolder('m-uuid', '06');
     mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
     mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth.mockResolvedValue(new Set(['file-a', 'file-b']));
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
       .mockResolvedValueOnce({ folders: [year] } as never)
       .mockResolvedValueOnce({ folders: [month] } as never)
       .mockResolvedValueOnce({ folders: [] } as never);
@@ -462,8 +391,7 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
   });
 
   test('when the current device has a synced asset whose remote file is no longer in the cloud folder, then it is marked as cloud_deleted', async () => {
-    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
-    const device = makeFolder('d1-uuid', 'device-1');
+    mockDeviceService.listDevices.mockResolvedValueOnce([makeDevice('d1-uuid', 'Internxt iPhone')]);
     const year = makeFolder('y-uuid', '2024');
     const month = makeFolder('m-uuid', '06');
     const day = makeFolder('day-uuid', '15');
@@ -471,13 +399,12 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth.mockResolvedValue(new Set());
     mockPhotosLocalDB.getSyncedRemoteIdsByCreationMonth.mockResolvedValue(new Set(['synced-remote-uuid']));
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
       .mockResolvedValueOnce({ folders: [year] } as never)
       .mockResolvedValueOnce({ folders: [month] } as never)
       .mockResolvedValueOnce({ folders: [day] } as never);
     mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [] } as never);
 
-    await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'device-1' });
+    await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'd1-uuid' });
 
     expect(mockPhotosLocalDB.markCloudDeleted).toHaveBeenCalledTimes(1);
     expect(mockPhotosLocalDB.markCloudDeleted).toHaveBeenCalledWith('synced-remote-uuid');
@@ -485,29 +412,26 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
   });
 
   test('when synced assets from a different device are missing from that device cloud folder, then they are not looked up via asset_sync', async () => {
-    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
-    const device = makeFolder('d1-uuid', 'device-1');
+    mockDeviceService.listDevices.mockResolvedValueOnce([makeDevice('d1-uuid', 'Internxt iPhone')]);
     const year = makeFolder('y-uuid', '2024');
     const month = makeFolder('m-uuid', '06');
     const day = makeFolder('day-uuid', '15');
     mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
     mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth.mockResolvedValue(new Set());
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
       .mockResolvedValueOnce({ folders: [year] } as never)
       .mockResolvedValueOnce({ folders: [month] } as never)
       .mockResolvedValueOnce({ folders: [day] } as never);
     mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [] } as never);
 
-    await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'device-other' });
+    await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'other-device-uuid' });
 
     expect(mockPhotosLocalDB.getSyncedRemoteIdsByCreationMonth).not.toHaveBeenCalled();
     expect(mockPhotosLocalDB.markCloudDeleted).not.toHaveBeenCalled();
   });
 
   test('when the current device matches the folder being synced, then synced remote ids are looked up to detect cloud deletions', async () => {
-    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
-    const device = makeFolder('d1-uuid', 'device-1');
+    mockDeviceService.listDevices.mockResolvedValueOnce([makeDevice('d1-uuid', 'Internxt iPhone')]);
     const year = makeFolder('y-uuid', '2024');
     const month = makeFolder('m-uuid', '06');
     const day = makeFolder('day-uuid', '15');
@@ -515,20 +439,18 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth.mockResolvedValue(new Set());
     mockPhotosLocalDB.getSyncedRemoteIdsByCreationMonth.mockResolvedValue(new Set());
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
       .mockResolvedValueOnce({ folders: [year] } as never)
       .mockResolvedValueOnce({ folders: [month] } as never)
       .mockResolvedValueOnce({ folders: [day] } as never);
     mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [] } as never);
 
-    await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'device-1' });
+    await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'd1-uuid' });
 
     expect(mockPhotosLocalDB.getSyncedRemoteIdsByCreationMonth).toHaveBeenCalled();
   });
 
   test('when a month known in the DB is no longer present in the cloud, then all its files are marked as cloud_deleted', async () => {
-    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
-    const device = makeFolder('d1-uuid', 'device-1');
+    mockDeviceService.listDevices.mockResolvedValueOnce([makeDevice('d1-uuid', 'Internxt iPhone')]);
     const year = makeFolder('y-uuid', '2024');
     const month = makeFolder('m-uuid', '06');
     const day = makeFolder('day-uuid', '15');
@@ -543,7 +465,6 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
       .mockResolvedValueOnce(new Set(['file-uuid'])) // 2024/06 — present
       .mockResolvedValueOnce(new Set(['deleted-a', 'deleted-b'])); // 2024/04 — absent
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
       .mockResolvedValueOnce({ folders: [year] } as never)
       .mockResolvedValueOnce({ folders: [month] } as never)
       .mockResolvedValueOnce({ folders: [day] } as never);
@@ -557,8 +478,7 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
   });
 
   test('when the current device has synced assets in a month with no cloud folder, then those assets are marked as cloud_deleted', async () => {
-    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
-    const device = makeFolder('d1-uuid', 'device-1');
+    mockDeviceService.listDevices.mockResolvedValueOnce([makeDevice('d1-uuid', 'Internxt iPhone')]);
     const year = makeFolder('y-uuid', '2024');
     const month = makeFolder('m-uuid', '06');
     const day = makeFolder('day-uuid', '15');
@@ -575,20 +495,18 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
       .mockResolvedValueOnce(new Set()) // 2024/06 fetchMonthFromFolder
       .mockResolvedValueOnce(new Set(['synced-april-uuid'])); // 2024/04 reconcileDeletedMonths
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
       .mockResolvedValueOnce({ folders: [year] } as never)
       .mockResolvedValueOnce({ folders: [month] } as never)
       .mockResolvedValueOnce({ folders: [day] } as never);
     mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
 
-    await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'device-1' });
+    await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'd1-uuid' });
 
     expect(mockPhotosLocalDB.markCloudDeleted).toHaveBeenCalledWith('synced-april-uuid');
   });
 
   test('when the cloud has no months at all and the DB has known months, then every known month is reconciled', async () => {
-    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
-    const device = makeFolder('d1-uuid', 'device-1');
+    mockDeviceService.listDevices.mockResolvedValueOnce([makeDevice('d1-uuid', 'Internxt iPhone')]);
     mockPhotosLocalDB.getCloudAssetMonthsByDevice.mockResolvedValue([
       { year: 2024, month: 6 },
       { year: 2024, month: 5 },
@@ -596,9 +514,7 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth
       .mockResolvedValueOnce(new Set(['file-a']))
       .mockResolvedValueOnce(new Set(['file-b']));
-    mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
-      .mockResolvedValueOnce({ folders: [] } as never); // no year folders
+    mockFolderService.getFolderFolders.mockResolvedValueOnce({ folders: [] } as never); // no year folders
 
     await photoCloudBrowser.syncAllHistory({});
 
@@ -608,8 +524,7 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
   });
 
   test('when every month in the DB is still present in the cloud, then no extra reconciliation runs for deleted months', async () => {
-    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
-    const device = makeFolder('d1-uuid', 'device-1');
+    mockDeviceService.listDevices.mockResolvedValueOnce([makeDevice('d1-uuid', 'Internxt iPhone')]);
     const year = makeFolder('y-uuid', '2024');
     const month = makeFolder('m-uuid', '06');
     const day = makeFolder('day-uuid', '15');
@@ -618,7 +533,6 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     mockPhotosLocalDB.getCloudAssetMonthsByDevice.mockResolvedValue([{ year: 2024, month: 6 }]);
     mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth.mockResolvedValue(new Set(['file-uuid']));
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
       .mockResolvedValueOnce({ folders: [year] } as never)
       .mockResolvedValueOnce({ folders: [month] } as never)
       .mockResolvedValueOnce({ folders: [day] } as never);
@@ -631,8 +545,7 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
   });
 
   test('when a discovered month has no files, then the caller is not notified for that month', async () => {
-    mockBackupFolders.getRootFolderUuid.mockResolvedValueOnce('root-uuid');
-    const device = makeFolder('d1-uuid', 'device-1');
+    mockDeviceService.listDevices.mockResolvedValueOnce([makeDevice('d1-uuid', 'Internxt iPhone')]);
     const year = makeFolder('y-uuid', '2024');
     const monthWithFiles = makeFolder('m1-uuid', '06');
     const monthEmpty = makeFolder('m2-uuid', '05');
@@ -640,7 +553,6 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     const file = makeFile('file-uuid', 'photo.jpg');
     mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
     mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [device] } as never)
       .mockResolvedValueOnce({ folders: [year] } as never)
       .mockResolvedValueOnce({ folders: [monthWithFiles, monthEmpty] } as never)
       .mockResolvedValueOnce({ folders: [day] } as never)

--- a/src/services/photos/PhotoCloudBrowser.ts
+++ b/src/services/photos/PhotoCloudBrowser.ts
@@ -3,7 +3,7 @@ import { FetchPaginatedFolder } from '@internxt/sdk/dist/drive/storage/types';
 import { logger } from 'src/services/common';
 import { driveFolderService } from 'src/services/drive/folder/driveFolder.service';
 import { photosLocalDB } from './database/photosLocalDB';
-import { photoBackupFolders } from './PhotoBackupFolders';
+import { photosDeviceService } from './photosDeviceService';
 
 const HOUR_MS = 60 * 60 * 1000;
 const CACHE_TTL_MS = 24 * HOUR_MS;
@@ -25,19 +25,15 @@ const fetchAllPages = async <T>(fetcher: (offset: number) => Promise<T[]>): Prom
 
 class PhotoCloudBrowserService {
   constructor(
-    private readonly backupFolders: typeof photoBackupFolders,
     private readonly folderService: typeof driveFolderService,
     private readonly localDB: typeof photosLocalDB,
   ) {}
 
-  async listDeviceFolders(): Promise<{ uuid: string; name: string }[]> {
-    const rootUuid = await this.backupFolders.getRootFolderUuid();
-    if (!rootUuid) return [];
-
-    const folders = await fetchAllPages((offset) =>
-      this.folderService.getFolderFolders(rootUuid, offset, PAGE_SIZE).then((r) => r.folders),
-    );
-    return folders.map((f) => ({ uuid: f.uuid, name: f.plainName ?? '' }));
+  async listDeviceFolders(): Promise<{ uuid: string }[]> {
+    const devices = await photosDeviceService.listDevices();
+    return devices
+      .filter((device) => device.status === 'EXISTS')
+      .map((device) => ({ uuid: device.uuid }));
   }
 
   async fetchMonth(params: {
@@ -217,7 +213,7 @@ class PhotoCloudBrowserService {
   }
 
   private async reconcileDeletedMonths(params: {
-    devices: { uuid: string; name: string }[];
+    devices: { uuid: string }[];
     discoveredMonths: { deviceId: string; year: number; month: number; monthFolderUuid: string }[];
     currentDeviceId?: string;
   }): Promise<void> {
@@ -225,7 +221,7 @@ class PhotoCloudBrowserService {
     const discoveredSet = new Set(discoveredMonths.map((m) => `${m.deviceId}:${m.year}:${m.month}`));
 
     for (const device of devices) {
-      const deviceId = device.name;
+      const deviceId = device.uuid;
       const cloudMonths = await this.localDB.getCloudAssetMonthsByDevice(deviceId);
       const monthSet = new Set(cloudMonths.map((m) => `${m.year}:${m.month}`));
 
@@ -248,7 +244,6 @@ class PhotoCloudBrowserService {
 
   private async discoverMonthsForDevice(device: {
     uuid: string;
-    name: string;
   }): Promise<{ deviceId: string; year: number; month: number; monthFolderUuid: string }[]> {
     const monthsForDevice: { deviceId: string; year: number; month: number; monthFolderUuid: string }[] = [];
     const yearFolders = await this.listAllFolders(device.uuid);
@@ -259,14 +254,14 @@ class PhotoCloudBrowserService {
       for (const monthFolder of monthFolders) {
         const month = Number.parseInt(monthFolder.plainName ?? '', 10);
         if (Number.isNaN(month) || month < MIN_MONTH_NUMBER || month > MAX_MONTH_NUMBER) continue;
-        monthsForDevice.push({ deviceId: device.name, year, month, monthFolderUuid: monthFolder.uuid });
+        monthsForDevice.push({ deviceId: device.uuid, year, month, monthFolderUuid: monthFolder.uuid });
       }
     }
     return monthsForDevice;
   }
 
   private async discoverAvailableMonths(
-    devices: { uuid: string; name: string }[],
+    devices: { uuid: string }[],
   ): Promise<{ deviceId: string; year: number; month: number; monthFolderUuid: string }[]> {
     const monthsPerDevice = await Promise.all(devices.map((device) => this.discoverMonthsForDevice(device)));
     const allMonths = monthsPerDevice.flat();
@@ -293,4 +288,4 @@ class PhotoCloudBrowserService {
   }
 }
 
-export const photoCloudBrowser = new PhotoCloudBrowserService(photoBackupFolders, driveFolderService, photosLocalDB);
+export const photoCloudBrowser = new PhotoCloudBrowserService(driveFolderService, photosLocalDB);

--- a/src/services/photos/PhotoDeviceId.spec.ts
+++ b/src/services/photos/PhotoDeviceId.spec.ts
@@ -1,7 +1,23 @@
+import * as Application from 'expo-application';
+import { Platform } from 'react-native';
 import secureStorageService from 'src/services/SecureStorageService';
-import { PhotoDeviceId } from './PhotoDeviceId';
+import { PhotoDeviceNameConflictError } from './errors';
+import { PhotoDeviceManager } from './PhotoDeviceId';
+import { photosDeviceService } from './photosDeviceService';
 
-jest.mock('react-native-uuid', () => ({ v4: jest.fn(() => 'generated-uuid') }));
+jest.mock('expo-application', () => ({
+  getAndroidId: jest.fn(() => 'test-android-id'),
+}));
+
+jest.mock('react-native-uuid', () => ({
+  __esModule: true,
+  default: { v4: jest.fn(() => 'generated-uuid-fallback') },
+}));
+
+jest.mock('expo-device', () => ({
+  deviceName: 'Internxt iPhone',
+  modelName: 'iPhone 15',
+}));
 
 jest.mock('src/services/SecureStorageService', () => ({
   __esModule: true,
@@ -11,41 +27,167 @@ jest.mock('src/services/SecureStorageService', () => ({
   },
 }));
 
+jest.mock('./photosDeviceService', () => ({
+  photosDeviceService: {
+    getDevice: jest.fn(),
+    createDevice: jest.fn(),
+    listDevices: jest.fn(),
+  },
+}));
+
 const mockGetItem = secureStorageService.getItem as jest.Mock;
 const mockSetItem = secureStorageService.setItem as jest.Mock;
+const mockGetDevice = photosDeviceService.getDevice as jest.Mock;
+const mockCreateDevice = photosDeviceService.createDevice as jest.Mock;
+const mockListDevices = photosDeviceService.listDevices as jest.Mock;
+const mockGetAndroidId = Application.getAndroidId as jest.Mock;
+
+const setPlatform = (os: 'android' | 'ios') =>
+  Object.defineProperty(Platform, 'OS', { value: os, writable: true, configurable: true });
+
+const makeDevice = (plainName: string) => ({
+  uuid: 'folder-uuid-123',
+  plainName,
+  bucket: 'photos-bucket',
+  status: 'EXISTS' as const,
+});
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockSetItem.mockResolvedValue(undefined);
+  setPlatform('android');
 });
 
-describe('PhotoDeviceId', () => {
-  test('when a device ID is already stored, then it is returned without creating a new one', async () => {
-    mockGetItem.mockResolvedValue('existing-device-id');
+describe('PhotoDeviceManager.ensureDeviceFolder', () => {
+  describe('when a folder uuid is stored in secure storage', () => {
+    test('when the stored folder still exists, then it is returned without creating a new one', async () => {
+      mockGetItem.mockResolvedValue('folder-uuid-123');
+      mockGetDevice.mockResolvedValue(makeDevice('test-android-id'));
 
-    const id = await PhotoDeviceId.getOrCreate();
+      const result = await PhotoDeviceManager.ensureDeviceFolder();
 
-    expect(id).toBe('existing-device-id');
-    expect(mockSetItem).not.toHaveBeenCalled();
+      expect(result).toEqual({ deviceId: 'folder-uuid-123', plainName: 'test-android-id', bucket: 'photos-bucket' });
+      expect(mockCreateDevice).not.toHaveBeenCalled();
+      expect(mockSetItem).not.toHaveBeenCalled();
+    });
+
+    test('when the stored folder has been deleted on the backend, then a new one is created by device key', async () => {
+      mockGetItem.mockResolvedValue('folder-uuid-old');
+      mockGetDevice.mockResolvedValue({ ...makeDevice('test-android-id'), uuid: 'folder-uuid-old', status: 'DELETED' });
+      mockCreateDevice.mockResolvedValue(makeDevice('test-android-id'));
+
+      const result = await PhotoDeviceManager.ensureDeviceFolder();
+
+      expect(result.deviceId).toBe('folder-uuid-123');
+      expect(mockCreateDevice).toHaveBeenCalledWith('test-android-id');
+      expect(mockSetItem).toHaveBeenCalledWith(expect.any(String), 'folder-uuid-123');
+    });
+
+    test('when the stored folder is not found on the backend, then a new one is created by device key', async () => {
+      mockGetItem.mockResolvedValue('folder-uuid-gone');
+      mockGetDevice.mockResolvedValue(null);
+      mockCreateDevice.mockResolvedValue(makeDevice('test-android-id'));
+
+      await PhotoDeviceManager.ensureDeviceFolder();
+
+      expect(mockCreateDevice).toHaveBeenCalledWith('test-android-id');
+    });
   });
 
-  test('when no device ID is stored, then a new one is generated and saved', async () => {
-    mockGetItem.mockResolvedValue(null);
-    mockSetItem.mockResolvedValue(undefined);
+  describe('when no folder uuid is stored on Android', () => {
+    beforeEach(() => {
+      setPlatform('android');
+      mockGetItem.mockResolvedValue(null);
+    });
 
-    const id = await PhotoDeviceId.getOrCreate();
+    test('when no folder exists yet, then a new device folder is created using the android hardware id', async () => {
+      mockCreateDevice.mockResolvedValue(makeDevice('test-android-id'));
 
-    expect(id).toBe('generated-uuid');
-    expect(mockSetItem).toHaveBeenCalledTimes(1);
-    expect(mockSetItem).toHaveBeenCalledWith(expect.any(String), 'generated-uuid');
+      const result = await PhotoDeviceManager.ensureDeviceFolder();
+
+      expect(result).toEqual({ deviceId: 'folder-uuid-123', plainName: 'test-android-id', bucket: 'photos-bucket' });
+      expect(mockCreateDevice).toHaveBeenCalledWith('test-android-id');
+      expect(mockSetItem).toHaveBeenCalledWith(expect.any(String), 'folder-uuid-123');
+    });
+
+    test('when creation returns 409, then the existing folder matching the android hardware id is adopted', async () => {
+      mockCreateDevice.mockRejectedValue(new PhotoDeviceNameConflictError('test-android-id'));
+      mockListDevices.mockResolvedValue([makeDevice('test-android-id')]);
+
+      const result = await PhotoDeviceManager.ensureDeviceFolder();
+
+      expect(result).toEqual({ deviceId: 'folder-uuid-123', plainName: 'test-android-id', bucket: 'photos-bucket' });
+      expect(mockSetItem).toHaveBeenCalledWith(expect.any(String), 'folder-uuid-123');
+    });
+
+    test('when creation returns 409 but no folder matches the android hardware id, then the error is rethrown', async () => {
+      mockCreateDevice.mockRejectedValue(new PhotoDeviceNameConflictError('test-android-id'));
+      mockListDevices.mockResolvedValue([makeDevice('other-device-id')]);
+
+      await expect(PhotoDeviceManager.ensureDeviceFolder()).rejects.toThrow(PhotoDeviceNameConflictError);
+    });
+
+    test('when creation returns 409 and the matching folder is deleted, then the error is rethrown', async () => {
+      mockCreateDevice.mockRejectedValue(new PhotoDeviceNameConflictError('test-android-id'));
+      mockListDevices.mockResolvedValue([{ ...makeDevice('test-android-id'), status: 'DELETED' }]);
+
+      await expect(PhotoDeviceManager.ensureDeviceFolder()).rejects.toThrow(PhotoDeviceNameConflictError);
+    });
   });
 
-  test('when no device ID is stored, then successive calls generate only one ID per call', async () => {
-    mockGetItem.mockResolvedValue(null);
-    mockSetItem.mockResolvedValue(undefined);
+  describe('when no folder uuid is stored on iOS', () => {
+    beforeEach(() => {
+      setPlatform('ios');
+      mockGetItem.mockResolvedValue(null);
+    });
 
-    await PhotoDeviceId.getOrCreate();
-    await PhotoDeviceId.getOrCreate();
+    test('when no folder exists yet, then a new device folder is created using the device name', async () => {
+      mockCreateDevice.mockResolvedValue(makeDevice('Internxt iPhone'));
 
-    expect(mockSetItem).toHaveBeenCalledTimes(2);
+      const result = await PhotoDeviceManager.ensureDeviceFolder();
+
+      expect(result.deviceId).toBe('folder-uuid-123');
+      expect(mockCreateDevice).toHaveBeenCalledWith('Internxt iPhone');
+    });
+
+    test('when creation returns 409, then the existing folder matching the device name is adopted', async () => {
+      mockCreateDevice.mockRejectedValue(new PhotoDeviceNameConflictError('Internxt iPhone'));
+      mockListDevices.mockResolvedValue([makeDevice('Internxt iPhone')]);
+
+      const result = await PhotoDeviceManager.ensureDeviceFolder();
+
+      expect(result.deviceId).toBe('folder-uuid-123');
+      expect(mockSetItem).toHaveBeenCalledWith(expect.any(String), 'folder-uuid-123');
+    });
+  });
+
+  describe('when no hardware id or device name is available', () => {
+    beforeEach(() => {
+      setPlatform('android');
+      mockGetAndroidId.mockReturnValue(null);
+      // mockGetItem: first call for PhotosDeviceId (null), second call for PhotosDeviceKey (null)
+      mockGetItem.mockResolvedValue(null);
+    });
+
+    test('when no device key is stored either, then a uuid is generated, persisted and used as device key', async () => {
+      mockCreateDevice.mockResolvedValue(makeDevice('generated-uuid-fallback'));
+
+      await PhotoDeviceManager.ensureDeviceFolder();
+
+      expect(mockCreateDevice).toHaveBeenCalledWith('generated-uuid-fallback');
+      expect(mockSetItem).toHaveBeenCalledWith('photos-device-key', 'generated-uuid-fallback');
+    });
+
+    test('when a previously generated key is already stored, then it is reused without generating a new one', async () => {
+      mockGetItem
+        .mockResolvedValueOnce(null) // PhotosDeviceId
+        .mockResolvedValueOnce('previously-generated-key'); // PhotosDeviceKey
+      mockCreateDevice.mockResolvedValue(makeDevice('previously-generated-key'));
+
+      await PhotoDeviceManager.ensureDeviceFolder();
+
+      expect(mockCreateDevice).toHaveBeenCalledWith('previously-generated-key');
+      expect(mockSetItem).not.toHaveBeenCalledWith('photos-device-key', expect.anything());
+    });
   });
 });

--- a/src/services/photos/PhotoDeviceId.ts
+++ b/src/services/photos/PhotoDeviceId.ts
@@ -1,14 +1,101 @@
+import * as Application from 'expo-application';
+import * as Device from 'expo-device';
+import { Platform } from 'react-native';
 import uuid from 'react-native-uuid';
+import { logger } from 'src/services/common';
 import secureStorageService from 'src/services/SecureStorageService';
 import { AsyncStorageKey } from 'src/types';
+import { PhotoDevice } from 'src/types/photos';
+import { PhotoDeviceNameConflictError } from './errors';
+import { photosDeviceService } from './photosDeviceService';
 
-export const PhotoDeviceId = {
-  async getOrCreate(): Promise<string> {
-    const existing = await secureStorageService.getItem(AsyncStorageKey.PhotosDeviceId);
-    if (existing) return existing;
+const TAG = '[PhotoDeviceManager]';
 
-    const id = uuid.v4() as string;
-    await secureStorageService.setItem(AsyncStorageKey.PhotosDeviceId, id);
-    return id;
+export interface PhotoDeviceInfo {
+  deviceId: string;
+  plainName: string; // device key used as backend name
+  bucket: string;
+}
+
+const getOrGenerateFallbackKey = async (): Promise<string> => {
+  const stored = await secureStorageService.getItem(AsyncStorageKey.PhotosDeviceKey);
+  if (stored) {
+    return stored;
+  }
+  const generated = uuid.v4() as string;
+  await secureStorageService.setItem(AsyncStorageKey.PhotosDeviceKey, generated);
+  logger.warn(TAG, `No stable device key available — generated fallback key=${generated}`);
+  return generated;
+};
+
+/**
+ * Returns a stable, opaque key used as the backend device name.
+ * - Android: androidId (survives reinstalls, unique per device + signing key)
+ * - iOS: human-readable device name (Keychain survives reinstalls, name is stable)
+ * - Fallback: UUID generated once and persisted in SecureStorage (collision-proof)
+ */
+const getDeviceKey = async (): Promise<string> => {
+  if (Platform.OS === 'android') {
+    const androidId = Application.getAndroidId?.();
+    if (androidId) return androidId;
+  } else {
+    const name = Device.deviceName ?? Device.modelName;
+    if (name) return name;
+  }
+  return getOrGenerateFallbackKey();
+};
+
+const persist = (uuid: string): Promise<void> => secureStorageService.setItem(AsyncStorageKey.PhotosDeviceId, uuid);
+
+const parseDeviceInfo = (device: PhotoDevice): PhotoDeviceInfo => ({
+  deviceId: device.uuid,
+  plainName: device.plainName,
+  bucket: device.bucket,
+});
+
+/**
+ * Ensures the current device has a folder in the Photos bucket.
+ * - iOS: Keychain survives uninstall → uuid is recovered directly.
+ * - Android: EncryptedSharedPreferences is wiped on uninstall, device is re-identified
+ *   by androidId (stable hardware key); on a 409 the existing folder is adopted by key.
+ */
+export const PhotoDeviceManager = {
+  async ensureDeviceFolder(): Promise<PhotoDeviceInfo> {
+    const storedUuid = await secureStorageService.getItem(AsyncStorageKey.PhotosDeviceId);
+
+    if (storedUuid) {
+      const existingDevice = await photosDeviceService.getDevice(storedUuid);
+      if (existingDevice && existingDevice.status === 'EXISTS') {
+        logger.info(
+          TAG,
+          `Reusing device folder uuid=${existingDevice.uuid} key="${existingDevice.plainName}" bucket=${existingDevice.bucket}`,
+        );
+        return parseDeviceInfo(existingDevice);
+      }
+      logger.warn(TAG, `Stored uuid=${storedUuid} not found or DELETED — recreating by key`);
+    }
+
+    const deviceKey = await getDeviceKey();
+    try {
+      const createdDevice = await photosDeviceService.createDevice(deviceKey);
+      await persist(createdDevice.uuid);
+      logger.info(
+        TAG,
+        `Created device folder uuid=${createdDevice.uuid} key="${createdDevice.plainName}" bucket=${createdDevice.bucket}`,
+      );
+      return parseDeviceInfo(createdDevice);
+    } catch (err) {
+      if (err instanceof PhotoDeviceNameConflictError) {
+        logger.info(TAG, `Device key "${deviceKey}" already exists (409) — adopting by key`);
+        const devices = await photosDeviceService.listDevices();
+        const device = devices.find((device) => device.plainName === deviceKey && device.status === 'EXISTS');
+        if (device) {
+          await persist(device.uuid);
+          logger.info(TAG, `Adopted device folder uuid=${device.uuid} bucket=${device.bucket}`);
+          return parseDeviceInfo(device);
+        }
+      }
+      throw err;
+    }
   },
 };

--- a/src/services/photos/PhotoDeviceId.ts
+++ b/src/services/photos/PhotoDeviceId.ts
@@ -65,7 +65,7 @@ export const PhotoDeviceManager = {
 
     if (storedUuid) {
       const existingDevice = await photosDeviceService.getDevice(storedUuid);
-      if (existingDevice && existingDevice.status === 'EXISTS') {
+      if (existingDevice?.status === 'EXISTS') {
         logger.info(
           TAG,
           `Reusing device folder uuid=${existingDevice.uuid} key="${existingDevice.plainName}" bucket=${existingDevice.bucket}`,

--- a/src/services/photos/PhotoUploadQueue.spec.ts
+++ b/src/services/photos/PhotoUploadQueue.spec.ts
@@ -26,6 +26,7 @@ const makeAsset = (id: string): MediaLibrary.Asset =>
   }) as MediaLibrary.Asset;
 
 const DEVICE_ID = 'device-123';
+const PHOTOS_BUCKET = 'photos-bucket-456';
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -39,7 +40,7 @@ describe('PhotoUploadQueue.start', () => {
     const onAssetStart = jest.fn();
     const onAssetDone = jest.fn();
 
-    await PhotoUploadQueue.start([{ asset }], DEVICE_ID, { onAssetStart, onAssetDone });
+    await PhotoUploadQueue.start([{ asset }], DEVICE_ID, PHOTOS_BUCKET, { onAssetStart, onAssetDone });
 
     expect(onAssetStart).toHaveBeenCalledWith('a1');
     expect(onAssetDone).toHaveBeenCalledWith('a1', 'remote-file-id', asset.modificationTime);
@@ -52,7 +53,7 @@ describe('PhotoUploadQueue.start', () => {
 
     const onAssetError = jest.fn();
 
-    await PhotoUploadQueue.start([{ asset }], DEVICE_ID, { onAssetError });
+    await PhotoUploadQueue.start([{ asset }], DEVICE_ID, PHOTOS_BUCKET, { onAssetError });
 
     expect(onAssetError).toHaveBeenCalledWith('a1', error);
   });
@@ -65,7 +66,7 @@ describe('PhotoUploadQueue.start', () => {
     const onAssetDone = jest.fn();
     const onAssetError = jest.fn();
 
-    await PhotoUploadQueue.start([{ asset: a1 }, { asset: a2 }], DEVICE_ID, { onAssetDone, onAssetError });
+    await PhotoUploadQueue.start([{ asset: a1 }, { asset: a2 }], DEVICE_ID, PHOTOS_BUCKET, { onAssetDone, onAssetError });
 
     expect(onAssetError).toHaveBeenCalledWith('a1', expect.any(Error));
     expect(onAssetDone).toHaveBeenCalledWith('a2', 'remote-id', a2.modificationTime);
@@ -78,12 +79,13 @@ describe('PhotoUploadQueue.start', () => {
 
     const onAssetDone = jest.fn();
 
-    await PhotoUploadQueue.start([job], DEVICE_ID, { onAssetDone });
+    await PhotoUploadQueue.start([job], DEVICE_ID, PHOTOS_BUCKET, { onAssetDone });
 
     expect(mockReplace).toHaveBeenCalledWith(
       asset,
       'existing-remote-id',
       DEVICE_ID,
+      PHOTOS_BUCKET,
       expect.any(Function),
       expect.any(AbortSignal),
     );
@@ -95,7 +97,7 @@ describe('PhotoUploadQueue.start', () => {
     const onAssetStart = jest.fn();
     const onAssetDone = jest.fn();
 
-    await expect(PhotoUploadQueue.start([], DEVICE_ID, { onAssetStart, onAssetDone })).resolves.toBeUndefined();
+    await expect(PhotoUploadQueue.start([], DEVICE_ID, PHOTOS_BUCKET, { onAssetStart, onAssetDone })).resolves.toBeUndefined();
     expect(onAssetStart).not.toHaveBeenCalled();
     expect(onAssetDone).not.toHaveBeenCalled();
   });
@@ -106,7 +108,7 @@ describe('PhotoUploadQueue.start', () => {
 
     const onAssetDone = jest.fn();
 
-    await PhotoUploadQueue.start(jobs, DEVICE_ID, { onAssetDone });
+    await PhotoUploadQueue.start(jobs, DEVICE_ID, PHOTOS_BUCKET, { onAssetDone });
 
     expect(onAssetDone).toHaveBeenCalledTimes(3);
   });
@@ -115,9 +117,9 @@ describe('PhotoUploadQueue.start', () => {
     const asset = makeAsset('a1');
     mockUpload.mockResolvedValue('remote-id');
 
-    await PhotoUploadQueue.start([{ asset }], DEVICE_ID, {});
+    await PhotoUploadQueue.start([{ asset }], DEVICE_ID, PHOTOS_BUCKET, {});
 
-    expect(mockUpload).toHaveBeenCalledWith(asset, DEVICE_ID, expect.any(Function), expect.any(AbortSignal));
+    expect(mockUpload).toHaveBeenCalledWith(asset, DEVICE_ID, PHOTOS_BUCKET, expect.any(Function), expect.any(AbortSignal));
   });
 });
 
@@ -132,7 +134,7 @@ describe('PhotoUploadQueue.abortAll', () => {
     });
 
     const onAssetError = jest.fn();
-    await PhotoUploadQueue.start([{ asset }], DEVICE_ID, { onAssetError });
+    await PhotoUploadQueue.start([{ asset }], DEVICE_ID, PHOTOS_BUCKET, { onAssetError });
 
     expect(onAssetError).toHaveBeenCalledWith('a1', abortError);
     expect((onAssetError.mock.calls[0][1] as Error).name).toBe('AbortError');
@@ -149,7 +151,7 @@ describe('PhotoUploadQueue.abortAll', () => {
     const secondAsset = makeAsset('a2');
     mockUpload.mockResolvedValueOnce('remote-id-2');
 
-    await PhotoUploadQueue.start([{ asset }, { asset: secondAsset }], DEVICE_ID, { onAssetStart });
+    await PhotoUploadQueue.start([{ asset }, { asset: secondAsset }], DEVICE_ID, PHOTOS_BUCKET, { onAssetStart });
 
     // First job ran, second was skipped because signal was aborted after first job
     expect(onAssetStart).toHaveBeenCalledWith('a1');
@@ -162,15 +164,15 @@ describe('PhotoUploadQueue.abortAll', () => {
     mockUpload.mockResolvedValue('remote-id');
 
     // First run — capture the signal that gets passed
-    await PhotoUploadQueue.start([{ asset }], DEVICE_ID, {});
-    const firstSignal = (mockUpload.mock.calls[0] as [unknown, unknown, unknown, AbortSignal])[3];
+    await PhotoUploadQueue.start([{ asset }], DEVICE_ID, PHOTOS_BUCKET, {});
+    const firstSignal = (mockUpload.mock.calls[0] as [unknown, unknown, unknown, unknown, AbortSignal])[4];
 
     // Abort and start a second run
     PhotoUploadQueue.abortAll();
     jest.clearAllMocks();
     mockUpload.mockResolvedValue('remote-id');
-    await PhotoUploadQueue.start([{ asset }], DEVICE_ID, {});
-    const secondSignal = (mockUpload.mock.calls[0] as [unknown, unknown, unknown, AbortSignal])[3];
+    await PhotoUploadQueue.start([{ asset }], DEVICE_ID, PHOTOS_BUCKET, {});
+    const secondSignal = (mockUpload.mock.calls[0] as [unknown, unknown, unknown, unknown, AbortSignal])[4];
 
     expect(secondSignal).toBeDefined();
     expect(secondSignal.aborted).toBe(false);

--- a/src/services/photos/PhotoUploadQueue.ts
+++ b/src/services/photos/PhotoUploadQueue.ts
@@ -20,7 +20,12 @@ let currentController: AbortController | null = null;
 
 // TODO: MAKE IT CLASS
 export const PhotoUploadQueue = {
-  async start(jobs: AssetUploadJob[], deviceId: string, callbacks: UploadQueueCallbacks): Promise<void> {
+  async start(
+    jobs: AssetUploadJob[],
+    deviceId: string,
+    photosBucket: string,
+    callbacks: UploadQueueCallbacks,
+  ): Promise<void> {
     currentController = new AbortController();
     const { signal } = currentController;
 
@@ -42,12 +47,14 @@ export const PhotoUploadQueue = {
                     asset,
                     existingRemoteFileId,
                     deviceId,
+                    photosBucket,
                     (ratio) => callbacks.onAssetProgress?.(asset.id, ratio),
                     signal,
                   )
                 : await PhotoUploadService.upload(
                     asset,
                     deviceId,
+                    photosBucket,
                     (ratio) => callbacks.onAssetProgress?.(asset.id, ratio),
                     signal,
                   );

--- a/src/services/photos/PhotoUploadService.spec.ts
+++ b/src/services/photos/PhotoUploadService.spec.ts
@@ -82,6 +82,7 @@ const mockCreateThumbnailEntry = uploadService.createThumbnailEntry as jest.Mock
 const mockGetOrCreateFolder = photoBackupFolders.getOrCreateFolderForDate as jest.Mock;
 
 const DEVICE_ID = 'device-123';
+const PHOTOS_BUCKET = 'photos-bucket-456';
 const LOCAL_PATH = '/var/mobile/Media/DCIM/photo.jpg';
 const LOCAL_URI = `file://${LOCAL_PATH}`;
 
@@ -129,7 +130,7 @@ describe('PhotoUploadService.upload', () => {
   test('when uploading a supported image, then a thumbnail is generated and registered with the drive file uuid', async () => {
     const asset = makeAsset();
 
-    await PhotoUploadService.upload(asset, DEVICE_ID);
+    await PhotoUploadService.upload(asset, DEVICE_ID, PHOTOS_BUCKET);
 
     expect(mockGenerateThumbnail).toHaveBeenCalledWith(LOCAL_PATH, 'jpg');
     expect(mockCreateThumbnailEntry).toHaveBeenCalledWith({
@@ -138,21 +139,21 @@ describe('PhotoUploadService.upload', () => {
       size: 40_000,
       maxWidth: 512,
       maxHeight: 288,
-      bucketId: 'bucket-id',
+      bucketId: PHOTOS_BUCKET,
       bucketFile: 'thumb-bucket-file-id',
       encryptVersion: EncryptionVersion.Aes03,
     });
   });
 
   test('when uploading a supported image, then the drive file uuid is returned', async () => {
-    const result = await PhotoUploadService.upload(makeAsset(), DEVICE_ID);
+    const result = await PhotoUploadService.upload(makeAsset(), DEVICE_ID, PHOTOS_BUCKET);
     expect(result).toBe('drive-file-uuid');
   });
 
   test('when the photo already exists in Drive, then its existing uuid is returned without uploading again', async () => {
     mockCheckFileExistence.mockResolvedValue({ existentFiles: [{ uuid: 'existing-uuid' }] });
 
-    const result = await PhotoUploadService.upload(makeAsset(), DEVICE_ID);
+    const result = await PhotoUploadService.upload(makeAsset(), DEVICE_ID, PHOTOS_BUCKET);
 
     expect(result).toBe('existing-uuid');
     expect(mockUploadFile).not.toHaveBeenCalled();
@@ -162,7 +163,7 @@ describe('PhotoUploadService.upload', () => {
   test('when the network layer throws an abort error, then the abort error propagates with its name intact and is not wrapped', async () => {
     mockUploadFile.mockReset().mockRejectedValueOnce(new AbortError());
 
-    await expect(PhotoUploadService.upload(makeAsset(), DEVICE_ID)).rejects.toMatchObject({
+    await expect(PhotoUploadService.upload(makeAsset(), DEVICE_ID, PHOTOS_BUCKET)).rejects.toMatchObject({
       name: AbortError.errorName,
     });
   });
@@ -170,7 +171,9 @@ describe('PhotoUploadService.upload', () => {
   test('when the network layer throws a generic error, then it is wrapped with bucket upload context', async () => {
     mockUploadFile.mockReset().mockRejectedValueOnce(new Error('network timeout'));
 
-    await expect(PhotoUploadService.upload(makeAsset(), DEVICE_ID)).rejects.toThrow('Bucket upload failed');
+    await expect(PhotoUploadService.upload(makeAsset(), DEVICE_ID, PHOTOS_BUCKET)).rejects.toThrow(
+      'Bucket upload failed',
+    );
     expect(mockCreateFileEntry).not.toHaveBeenCalled();
   });
 
@@ -178,7 +181,7 @@ describe('PhotoUploadService.upload', () => {
     mockIsThumbnailSupported.mockReturnValue(false);
     mockUploadFile.mockReset().mockResolvedValueOnce('bucket-file-id');
 
-    const result = await PhotoUploadService.upload(makeAsset({ filename: 'photo.dng' }), DEVICE_ID);
+    const result = await PhotoUploadService.upload(makeAsset({ filename: 'photo.dng' }), DEVICE_ID, PHOTOS_BUCKET);
 
     expect(mockGenerateThumbnail).not.toHaveBeenCalled();
     expect(mockCreateThumbnailEntry).not.toHaveBeenCalled();
@@ -190,7 +193,7 @@ describe('PhotoUploadService.upload', () => {
     // Only one uploadFile call for the main file
     mockUploadFile.mockReset().mockResolvedValueOnce('bucket-file-id');
 
-    const result = await PhotoUploadService.upload(makeAsset(), DEVICE_ID);
+    const result = await PhotoUploadService.upload(makeAsset(), DEVICE_ID, PHOTOS_BUCKET);
 
     expect(result).toBe('drive-file-uuid');
     expect(mockCreateThumbnailEntry).not.toHaveBeenCalled();
@@ -202,7 +205,7 @@ describe('PhotoUploadService.upload', () => {
       .mockResolvedValueOnce('bucket-file-id')
       .mockRejectedValueOnce(new Error('network error'));
 
-    const result = await PhotoUploadService.upload(makeAsset(), DEVICE_ID);
+    const result = await PhotoUploadService.upload(makeAsset(), DEVICE_ID, PHOTOS_BUCKET);
 
     expect(result).toBe('drive-file-uuid');
     expect(mockCreateThumbnailEntry).not.toHaveBeenCalled();
@@ -214,16 +217,46 @@ describe('PhotoUploadService.upload', () => {
       .mockResolvedValueOnce('bucket-file-id')
       .mockRejectedValueOnce(new Error('network error'));
 
-    await PhotoUploadService.upload(makeAsset(), DEVICE_ID);
+    await PhotoUploadService.upload(makeAsset(), DEVICE_ID, PHOTOS_BUCKET);
 
     expect(mockRnfsUnlink).toHaveBeenCalledWith('/tmp/thumb.jpg');
+  });
+
+  test('when createFileEntry returns a 409 conflict, then the existing uuid is recovered via checkFileExistence', async () => {
+    mockCheckFileExistence
+      .mockResolvedValueOnce({ existentFiles: [] })
+      .mockResolvedValueOnce({ existentFiles: [{ uuid: 'recovered-uuid' }] });
+    mockCreateFileEntry.mockRejectedValueOnce({ status: 409 });
+    mockUploadFile.mockReset().mockResolvedValueOnce('bucket-file-id');
+
+    const result = await PhotoUploadService.upload(makeAsset(), DEVICE_ID, PHOTOS_BUCKET);
+
+    expect(result).toBe('recovered-uuid');
+  });
+
+  test('when createFileEntry returns a 409 conflict and checkFileExistence finds nothing, then the original error is rethrown', async () => {
+    mockCheckFileExistence.mockResolvedValueOnce({ existentFiles: [] }).mockResolvedValueOnce({ existentFiles: [] });
+    mockCreateFileEntry.mockRejectedValueOnce({ status: 409 });
+    mockUploadFile.mockReset().mockResolvedValueOnce('bucket-file-id');
+
+    await expect(PhotoUploadService.upload(makeAsset(), DEVICE_ID, PHOTOS_BUCKET)).rejects.toMatchObject({
+      status: 409,
+    });
   });
 
   test('when the asset has no local URI, then the upload still proceeds using the asset URI as fallback', async () => {
     mockGetAssetInfoAsync.mockResolvedValue({ localUri: null });
 
-    const result = PhotoUploadService.upload(makeAsset(), DEVICE_ID);
-    await expect(result).resolves.toBeDefined();
+    await PhotoUploadService.upload(makeAsset(), DEVICE_ID, PHOTOS_BUCKET);
+
+    expect(mockUploadFile).toHaveBeenCalledWith(
+      LOCAL_PATH,
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
   });
 });
 
@@ -231,14 +264,14 @@ describe('PhotoUploadService.replace', () => {
   test('when replacing an asset, then a thumbnail is regenerated and registered against the existing file uuid', async () => {
     const asset = makeAsset();
 
-    await PhotoUploadService.replace(asset, 'existing-remote-id', DEVICE_ID);
+    await PhotoUploadService.replace(asset, 'existing-remote-id', DEVICE_ID, PHOTOS_BUCKET);
 
     expect(mockGenerateThumbnail).toHaveBeenCalledWith(LOCAL_PATH, 'jpg');
     expect(mockCreateThumbnailEntry).toHaveBeenCalledWith(expect.objectContaining({ fileUuid: 'existing-remote-id' }));
   });
 
   test('when replacing an asset, then the existing remote file id is returned', async () => {
-    const result = await PhotoUploadService.replace(makeAsset(), 'existing-remote-id', DEVICE_ID);
+    const result = await PhotoUploadService.replace(makeAsset(), 'existing-remote-id', DEVICE_ID, PHOTOS_BUCKET);
     expect(result).toBe('existing-remote-id');
   });
 
@@ -246,7 +279,7 @@ describe('PhotoUploadService.replace', () => {
     mockGenerateThumbnail.mockRejectedValue(new Error('codec error'));
     mockUploadFile.mockReset().mockResolvedValueOnce('bucket-file-id');
 
-    const result = await PhotoUploadService.replace(makeAsset(), 'existing-remote-id', DEVICE_ID);
+    const result = await PhotoUploadService.replace(makeAsset(), 'existing-remote-id', DEVICE_ID, PHOTOS_BUCKET);
 
     expect(result).toBe('existing-remote-id');
   });
@@ -255,7 +288,7 @@ describe('PhotoUploadService.replace', () => {
     mockReplaceFileEntry.mockRejectedValue(new AppError('file can not be replaced', 400));
     mockCreateFileEntry.mockResolvedValue({ uuid: 'new-drive-uuid' });
 
-    const result = await PhotoUploadService.replace(makeAsset(), 'deleted-remote-id', DEVICE_ID);
+    const result = await PhotoUploadService.replace(makeAsset(), 'deleted-remote-id', DEVICE_ID, PHOTOS_BUCKET);
 
     expect(mockCreateFileEntry).toHaveBeenCalledTimes(1);
     expect(result).toBe('new-drive-uuid');
@@ -265,7 +298,7 @@ describe('PhotoUploadService.replace', () => {
     mockReplaceFileEntry.mockRejectedValue(new AppError('file can not be replaced', 400));
     mockCreateFileEntry.mockResolvedValue({ uuid: 'new-drive-uuid' });
 
-    await PhotoUploadService.replace(makeAsset(), 'deleted-remote-id', DEVICE_ID);
+    await PhotoUploadService.replace(makeAsset(), 'deleted-remote-id', DEVICE_ID, PHOTOS_BUCKET);
 
     expect(mockCreateThumbnailEntry).toHaveBeenCalledWith(expect.objectContaining({ fileUuid: 'new-drive-uuid' }));
   });
@@ -273,7 +306,7 @@ describe('PhotoUploadService.replace', () => {
   test('when the server rejects the replace with a non-400 error, then the error is propagated without creating a new entry', async () => {
     mockReplaceFileEntry.mockRejectedValue(new AppError('internal server error', 500));
 
-    await expect(PhotoUploadService.replace(makeAsset(), 'remote-id', DEVICE_ID)).rejects.toThrow();
+    await expect(PhotoUploadService.replace(makeAsset(), 'remote-id', DEVICE_ID, PHOTOS_BUCKET)).rejects.toThrow();
     expect(mockCreateFileEntry).not.toHaveBeenCalled();
   });
 });

--- a/src/services/photos/PhotoUploadService.ts
+++ b/src/services/photos/PhotoUploadService.ts
@@ -5,7 +5,7 @@ import { getEnvironmentConfigFromUser } from 'src/lib/network';
 import { uploadFile } from 'src/network/upload';
 import { constants } from 'src/services/AppService';
 import asyncStorageService from 'src/services/AsyncStorageService';
-import { HTTP_BAD_REQUEST } from 'src/services/common/httpStatusCodes';
+import { HTTP_BAD_REQUEST, HTTP_CONFLICT } from 'src/services/common/httpStatusCodes';
 import { isThumbnailSupported } from 'src/services/common/media/thumbnail.constants';
 import { generateThumbnail } from 'src/services/common/media/thumbnail.generation';
 import { uploadService } from 'src/services/common/network/upload/upload.service';
@@ -70,6 +70,7 @@ const resolveLocalPath = async (asset: MediaLibrary.Asset): Promise<{ localPath:
 const uploadAssetToBucket = async (
   asset: MediaLibrary.Asset,
   deviceId: string,
+  photosBucket: string,
   onProgress?: (ratio: number) => void,
   signal?: AbortSignal,
 ): Promise<FileUploadResult> => {
@@ -85,7 +86,8 @@ const uploadAssetToBucket = async (
     asyncStorageService.getUser(),
     photoBackupFolders.getOrCreateFolderForDate(deviceId, createdDate),
   ]);
-  const { bucketId, encryptionKey, bridgeUser, bridgePass } = getEnvironmentConfigFromUser(user);
+  const { encryptionKey, bridgeUser, bridgePass } = getEnvironmentConfigFromUser(user);
+  const bucketId = photosBucket;
   const { plainName, fileExtension } = splitFileNameAndExtension(fileName);
 
   const { existentFiles } = await uploadService.checkFileExistence(folderUuid, [{ plainName, type: fileExtension }]);
@@ -177,16 +179,46 @@ const uploadThumbnailForAsset = async (
   }
 };
 
+const createFileEntryOrFetchExisting = async (params: {
+  fileId: string;
+  type: string;
+  size: number;
+  plainName: string;
+  bucket: string;
+  folderUuid: string;
+  modificationTime: string;
+  creationTime: string;
+}): Promise<string> => {
+  const { plainName, type, folderUuid } = params;
+  try {
+    const driveFile = await uploadService.createFileEntry({
+      ...params,
+      encryptVersion: EncryptionVersion.Aes03,
+    });
+    return driveFile.uuid;
+  } catch (err) {
+    if ((err as { status?: number })?.status !== HTTP_CONFLICT) {
+      throw err;
+    }
+    const { existentFiles } = await uploadService.checkFileExistence(folderUuid, [{ plainName, type }]);
+    if (!existentFiles[0]?.uuid) {
+      throw err;
+    }
+    return existentFiles[0].uuid;
+  }
+};
+
 export const PhotoUploadService = {
   async upload(
     asset: MediaLibrary.Asset,
     deviceId: string,
+    photosBucket: string,
     onProgress?: (ratio: number) => void,
     signal?: AbortSignal,
   ): Promise<string> {
     let fileUploadResult: FileUploadResult;
     try {
-      fileUploadResult = await uploadAssetToBucket(asset, deviceId, onProgress, signal);
+      fileUploadResult = await uploadAssetToBucket(asset, deviceId, photosBucket, onProgress, signal);
     } catch (err) {
       if (err instanceof FileAlreadyExistsError) {
         return err.existingUuid;
@@ -209,21 +241,20 @@ export const PhotoUploadService = {
     } = fileUploadResult;
 
     try {
-      const driveFile = await uploadService.createFileEntry({
+      const fileUuid = await createFileEntryOrFetchExisting({
         fileId,
         type: fileExtension,
         size: fileSize,
         plainName,
         bucket: bucketId,
         folderUuid,
-        encryptVersion: EncryptionVersion.Aes03,
         modificationTime: modificationIso,
         creationTime: creationIso,
       });
 
-      await uploadThumbnailForAsset(localFilePath, fileExtension, driveFile.uuid, credentials);
+      await uploadThumbnailForAsset(localFilePath, fileExtension, fileUuid, credentials);
 
-      return driveFile.uuid;
+      return fileUuid;
     } finally {
       await cleanupTempFile(tempPath);
     }
@@ -233,6 +264,7 @@ export const PhotoUploadService = {
     asset: MediaLibrary.Asset,
     existingRemoteFileId: string,
     deviceId: string,
+    photosBucket: string,
     onProgress?: (ratio: number) => void,
     signal?: AbortSignal,
   ): Promise<string> {
@@ -248,7 +280,7 @@ export const PhotoUploadService = {
       folderUuid,
       modificationIso,
       creationIso,
-    } = await uploadAssetToBucket(asset, deviceId, onProgress, signal);
+    } = await uploadAssetToBucket(asset, deviceId, photosBucket, onProgress, signal);
 
     try {
       try {

--- a/src/services/photos/errors.ts
+++ b/src/services/photos/errors.ts
@@ -14,3 +14,10 @@ export class FileAlreadyExistsError extends Error {
     this.name = 'FileAlreadyExistsError';
   }
 }
+
+export class PhotoDeviceNameConflictError extends Error {
+  constructor(deviceName: string) {
+    super(`A photos device folder with name "${deviceName}" already exists`);
+    this.name = 'PhotoDeviceNameConflictError';
+  }
+}

--- a/src/services/photos/photosDeviceService.spec.ts
+++ b/src/services/photos/photosDeviceService.spec.ts
@@ -25,7 +25,7 @@ const existingDevice = {
 };
 
 const mockFetch = (status: number, body: unknown): void => {
-  global.fetch = jest.fn().mockResolvedValue({
+  globalThis.fetch = jest.fn().mockResolvedValue({
     ok: status >= 200 && status < 300,
     status,
     json: jest.fn().mockResolvedValue(body),
@@ -44,7 +44,7 @@ describe('photosDeviceService.listDevices', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual(existingDevice);
-    expect(global.fetch).toHaveBeenCalledWith(
+    expect(globalThis.fetch).toHaveBeenCalledWith(
       expect.stringContaining('/photos/devices'),
       expect.objectContaining({ method: 'GET' }),
     );
@@ -64,7 +64,7 @@ describe('photosDeviceService.createDevice', () => {
     const result = await photosDeviceService.createDevice('Internxt iPhone');
 
     expect(result).toEqual(existingDevice);
-    expect(global.fetch).toHaveBeenCalledWith(
+    expect(globalThis.fetch).toHaveBeenCalledWith(
       expect.stringContaining('/photos/devices'),
       expect.objectContaining({
         method: 'POST',
@@ -93,7 +93,7 @@ describe('photosDeviceService.getDevice', () => {
     const result = await photosDeviceService.getDevice('device-uuid-1');
 
     expect(result).toEqual(existingDevice);
-    expect(global.fetch).toHaveBeenCalledWith(
+    expect(globalThis.fetch).toHaveBeenCalledWith(
       expect.stringContaining('/photos/devices/device-uuid-1'),
       expect.objectContaining({ method: 'GET' }),
     );
@@ -119,7 +119,7 @@ describe('photosDeviceService.deleteDevice', () => {
     mockFetch(200, {});
 
     await expect(photosDeviceService.deleteDevice('device-uuid-1')).resolves.toBeUndefined();
-    expect(global.fetch).toHaveBeenCalledWith(
+    expect(globalThis.fetch).toHaveBeenCalledWith(
       expect.stringContaining('/photos/devices/device-uuid-1'),
       expect.objectContaining({ method: 'DELETE' }),
     );
@@ -140,7 +140,7 @@ describe('photosDeviceService.renameDevice', () => {
     const result = await photosDeviceService.renameDevice('device-uuid-1', 'New name');
 
     expect(result).toEqual(updatedDevice);
-    expect(global.fetch).toHaveBeenCalledWith(
+    expect(globalThis.fetch).toHaveBeenCalledWith(
       expect.stringContaining('/photos/devices/device-uuid-1'),
       expect.objectContaining({
         method: 'PATCH',

--- a/src/services/photos/photosDeviceService.spec.ts
+++ b/src/services/photos/photosDeviceService.spec.ts
@@ -1,0 +1,157 @@
+import { PhotoDeviceNameConflictError } from './errors';
+import { photosDeviceService } from './photosDeviceService';
+
+jest.mock('src/services/common/sdk/SdkManager', () => ({
+  SdkManager: {
+    getInstance: jest.fn().mockReturnValue({
+      getApiSecurity: jest.fn().mockReturnValue({ newToken: 'test-token' }),
+    }),
+  },
+}));
+
+jest.mock('src/services/AppService', () => ({
+  constants: { DRIVE_NEW_API_URL: 'https://api.test.com/drive' },
+}));
+
+jest.mock('src/helpers/headers', () => ({
+  getHeaders: jest.fn().mockResolvedValue(new Headers({ Authorization: 'Bearer test-token' })),
+}));
+
+const existingDevice = {
+  uuid: 'device-uuid-1',
+  plainName: 'Internxt iPhone',
+  bucket: 'photos-bucket',
+  status: 'EXISTS',
+};
+
+const mockFetch = (status: number, body: unknown): void => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: jest.fn().mockResolvedValue(body),
+  });
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('photosDeviceService.listDevices', () => {
+  test('when the server returns a list of devices, then they are parsed and returned', async () => {
+    mockFetch(200, [existingDevice]);
+
+    const result = await photosDeviceService.listDevices();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(existingDevice);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/photos/devices'),
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  test('when the server returns an error, then an error is thrown', async () => {
+    mockFetch(500, {});
+
+    await expect(photosDeviceService.listDevices()).rejects.toThrow('listDevices failed');
+  });
+});
+
+describe('photosDeviceService.createDevice', () => {
+  test('when a device is created successfully, then the created device is returned', async () => {
+    mockFetch(200, existingDevice);
+
+    const result = await photosDeviceService.createDevice('Internxt iPhone');
+
+    expect(result).toEqual(existingDevice);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/photos/devices'),
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ deviceName: 'Internxt iPhone' }),
+      }),
+    );
+  });
+
+  test('when the server returns 409, then a PhotoDeviceNameConflictError is thrown', async () => {
+    mockFetch(409, {});
+
+    await expect(photosDeviceService.createDevice('Internxt iPhone')).rejects.toThrow(PhotoDeviceNameConflictError);
+  });
+
+  test('when the server returns another error, then a generic error is thrown', async () => {
+    mockFetch(500, {});
+
+    await expect(photosDeviceService.createDevice('Internxt iPhone')).rejects.toThrow('createDevice failed');
+  });
+});
+
+describe('photosDeviceService.getDevice', () => {
+  test('when the device is found, then it is returned', async () => {
+    mockFetch(200, existingDevice);
+
+    const result = await photosDeviceService.getDevice('device-uuid-1');
+
+    expect(result).toEqual(existingDevice);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/photos/devices/device-uuid-1'),
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  test('when the device is not found, then null is returned', async () => {
+    mockFetch(404, {});
+
+    const result = await photosDeviceService.getDevice('device-uuid-missing');
+
+    expect(result).toBeNull();
+  });
+
+  test('when the server returns an error, then an error is thrown', async () => {
+    mockFetch(500, {});
+
+    await expect(photosDeviceService.getDevice('device-uuid-1')).rejects.toThrow('getDevice failed');
+  });
+});
+
+describe('photosDeviceService.deleteDevice', () => {
+  test('when the device is deleted successfully, then the call resolves without error', async () => {
+    mockFetch(200, {});
+
+    await expect(photosDeviceService.deleteDevice('device-uuid-1')).resolves.toBeUndefined();
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/photos/devices/device-uuid-1'),
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+
+  test('when the server returns an error, then an error is thrown', async () => {
+    mockFetch(500, {});
+
+    await expect(photosDeviceService.deleteDevice('device-uuid-1')).rejects.toThrow('deleteDevice failed');
+  });
+});
+
+describe('photosDeviceService.renameDevice', () => {
+  test('when the device is renamed successfully, then the updated device is returned', async () => {
+    const updatedDevice = { ...existingDevice, plainName: 'New name' };
+    mockFetch(200, updatedDevice);
+
+    const result = await photosDeviceService.renameDevice('device-uuid-1', 'New name');
+
+    expect(result).toEqual(updatedDevice);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/photos/devices/device-uuid-1'),
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ deviceName: 'New name' }),
+      }),
+    );
+  });
+
+  test('when the server returns an error, then an error is thrown', async () => {
+    mockFetch(500, {});
+
+    await expect(photosDeviceService.renameDevice('device-uuid-1', 'New name')).rejects.toThrow('renameDevice failed');
+  });
+});

--- a/src/services/photos/photosDeviceService.spec.ts
+++ b/src/services/photos/photosDeviceService.spec.ts
@@ -32,126 +32,130 @@ const mockFetch = (status: number, body: unknown): void => {
   });
 };
 
-beforeEach(() => {
-  jest.clearAllMocks();
-});
-
-describe('photosDeviceService.listDevices', () => {
-  test('when the server returns a list of devices, then they are parsed and returned', async () => {
-    mockFetch(200, [existingDevice]);
-
-    const result = await photosDeviceService.listDevices();
-
-    expect(result).toHaveLength(1);
-    expect(result[0]).toEqual(existingDevice);
-    expect(globalThis.fetch).toHaveBeenCalledWith(
-      expect.stringContaining('/photos/devices'),
-      expect.objectContaining({ method: 'GET' }),
-    );
+describe('photosDeviceService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
-  test('when the server returns an error, then an error is thrown', async () => {
-    mockFetch(500, {});
+  describe('listDevices', () => {
+    test('when the server returns a list of devices, then they are parsed and returned', async () => {
+      mockFetch(200, [existingDevice]);
 
-    await expect(photosDeviceService.listDevices()).rejects.toThrow('listDevices failed');
-  });
-});
+      const result = await photosDeviceService.listDevices();
 
-describe('photosDeviceService.createDevice', () => {
-  test('when a device is created successfully, then the created device is returned', async () => {
-    mockFetch(200, existingDevice);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(existingDevice);
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/photos/devices'),
+        expect.objectContaining({ method: 'GET' }),
+      );
+    });
 
-    const result = await photosDeviceService.createDevice('Internxt iPhone');
+    test('when the server returns an error, then an error is thrown', async () => {
+      mockFetch(500, {});
 
-    expect(result).toEqual(existingDevice);
-    expect(globalThis.fetch).toHaveBeenCalledWith(
-      expect.stringContaining('/photos/devices'),
-      expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({ deviceName: 'Internxt iPhone' }),
-      }),
-    );
+      await expect(photosDeviceService.listDevices()).rejects.toThrow('listDevices failed');
+    });
   });
 
-  test('when the server returns 409, then a PhotoDeviceNameConflictError is thrown', async () => {
-    mockFetch(409, {});
+  describe('createDevice', () => {
+    test('when a device is created successfully, then the created device is returned', async () => {
+      mockFetch(200, existingDevice);
 
-    await expect(photosDeviceService.createDevice('Internxt iPhone')).rejects.toThrow(PhotoDeviceNameConflictError);
+      const result = await photosDeviceService.createDevice('Internxt iPhone');
+
+      expect(result).toEqual(existingDevice);
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/photos/devices'),
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ deviceName: 'Internxt iPhone' }),
+        }),
+      );
+    });
+
+    test('when the server returns 409, then a PhotoDeviceNameConflictError is thrown', async () => {
+      mockFetch(409, {});
+
+      await expect(photosDeviceService.createDevice('Internxt iPhone')).rejects.toThrow(PhotoDeviceNameConflictError);
+    });
+
+    test('when the server returns another error, then a generic error is thrown', async () => {
+      mockFetch(500, {});
+
+      await expect(photosDeviceService.createDevice('Internxt iPhone')).rejects.toThrow('createDevice failed');
+    });
   });
 
-  test('when the server returns another error, then a generic error is thrown', async () => {
-    mockFetch(500, {});
+  describe('getDevice', () => {
+    test('when the device is found, then it is returned', async () => {
+      mockFetch(200, existingDevice);
 
-    await expect(photosDeviceService.createDevice('Internxt iPhone')).rejects.toThrow('createDevice failed');
-  });
-});
+      const result = await photosDeviceService.getDevice('device-uuid-1');
 
-describe('photosDeviceService.getDevice', () => {
-  test('when the device is found, then it is returned', async () => {
-    mockFetch(200, existingDevice);
+      expect(result).toEqual(existingDevice);
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/photos/devices/device-uuid-1'),
+        expect.objectContaining({ method: 'GET' }),
+      );
+    });
 
-    const result = await photosDeviceService.getDevice('device-uuid-1');
+    test('when the device is not found, then null is returned', async () => {
+      mockFetch(404, {});
 
-    expect(result).toEqual(existingDevice);
-    expect(globalThis.fetch).toHaveBeenCalledWith(
-      expect.stringContaining('/photos/devices/device-uuid-1'),
-      expect.objectContaining({ method: 'GET' }),
-    );
-  });
+      const result = await photosDeviceService.getDevice('device-uuid-missing');
 
-  test('when the device is not found, then null is returned', async () => {
-    mockFetch(404, {});
+      expect(result).toBeNull();
+    });
 
-    const result = await photosDeviceService.getDevice('device-uuid-missing');
+    test('when the server returns an error, then an error is thrown', async () => {
+      mockFetch(500, {});
 
-    expect(result).toBeNull();
-  });
-
-  test('when the server returns an error, then an error is thrown', async () => {
-    mockFetch(500, {});
-
-    await expect(photosDeviceService.getDevice('device-uuid-1')).rejects.toThrow('getDevice failed');
-  });
-});
-
-describe('photosDeviceService.deleteDevice', () => {
-  test('when the device is deleted successfully, then the call resolves without error', async () => {
-    mockFetch(200, {});
-
-    await expect(photosDeviceService.deleteDevice('device-uuid-1')).resolves.toBeUndefined();
-    expect(globalThis.fetch).toHaveBeenCalledWith(
-      expect.stringContaining('/photos/devices/device-uuid-1'),
-      expect.objectContaining({ method: 'DELETE' }),
-    );
+      await expect(photosDeviceService.getDevice('device-uuid-1')).rejects.toThrow('getDevice failed');
+    });
   });
 
-  test('when the server returns an error, then an error is thrown', async () => {
-    mockFetch(500, {});
+  describe('deleteDevice', () => {
+    test('when the device is deleted successfully, then the call resolves without error', async () => {
+      mockFetch(200, {});
 
-    await expect(photosDeviceService.deleteDevice('device-uuid-1')).rejects.toThrow('deleteDevice failed');
-  });
-});
+      await expect(photosDeviceService.deleteDevice('device-uuid-1')).resolves.toBeUndefined();
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/photos/devices/device-uuid-1'),
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+    });
 
-describe('photosDeviceService.renameDevice', () => {
-  test('when the device is renamed successfully, then the updated device is returned', async () => {
-    const updatedDevice = { ...existingDevice, plainName: 'New name' };
-    mockFetch(200, updatedDevice);
+    test('when the server returns an error, then an error is thrown', async () => {
+      mockFetch(500, {});
 
-    const result = await photosDeviceService.renameDevice('device-uuid-1', 'New name');
-
-    expect(result).toEqual(updatedDevice);
-    expect(globalThis.fetch).toHaveBeenCalledWith(
-      expect.stringContaining('/photos/devices/device-uuid-1'),
-      expect.objectContaining({
-        method: 'PATCH',
-        body: JSON.stringify({ deviceName: 'New name' }),
-      }),
-    );
+      await expect(photosDeviceService.deleteDevice('device-uuid-1')).rejects.toThrow('deleteDevice failed');
+    });
   });
 
-  test('when the server returns an error, then an error is thrown', async () => {
-    mockFetch(500, {});
+  describe('renameDevice', () => {
+    test('when the device is renamed successfully, then the updated device is returned', async () => {
+      const updatedDevice = { ...existingDevice, plainName: 'New name' };
+      mockFetch(200, updatedDevice);
 
-    await expect(photosDeviceService.renameDevice('device-uuid-1', 'New name')).rejects.toThrow('renameDevice failed');
+      const result = await photosDeviceService.renameDevice('device-uuid-1', 'New name');
+
+      expect(result).toEqual(updatedDevice);
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/photos/devices/device-uuid-1'),
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ deviceName: 'New name' }),
+        }),
+      );
+    });
+
+    test('when the server returns an error, then an error is thrown', async () => {
+      mockFetch(500, {});
+
+      await expect(photosDeviceService.renameDevice('device-uuid-1', 'New name')).rejects.toThrow(
+        'renameDevice failed',
+      );
+    });
   });
 });

--- a/src/services/photos/photosDeviceService.ts
+++ b/src/services/photos/photosDeviceService.ts
@@ -1,0 +1,89 @@
+import { getHeaders } from 'src/helpers/headers';
+import { constants } from 'src/services/AppService';
+import { HTTP_CONFLICT, HTTP_NOT_FOUND } from 'src/services/common/httpStatusCodes';
+import { SdkManager } from 'src/services/common/sdk/SdkManager';
+import { PhotoDevice } from 'src/types/photos';
+import { PhotoDeviceNameConflictError } from './errors';
+
+const BASE_URL = `${constants.DRIVE_NEW_API_URL}/photos/devices`;
+
+const headers = async (): Promise<Headers> => {
+  const token = SdkManager.getInstance().getApiSecurity().newToken;
+  return getHeaders(token);
+};
+
+const parseDevice = (raw: Record<string, unknown>): PhotoDevice => ({
+  uuid: raw.uuid as string,
+  plainName: raw.plainName as string,
+  bucket: raw.bucket as string,
+  status: raw.status as PhotoDevice['status'],
+});
+
+// TODO: pending use sdk
+export const photosDeviceService = {
+  async listDevices(): Promise<PhotoDevice[]> {
+    const response = await fetch(BASE_URL, {
+      method: 'GET',
+      headers: await headers(),
+    });
+    if (!response.ok) {
+      throw new Error(`[photosDeviceService] listDevices failed: ${response.status}`);
+    }
+    const data: Record<string, unknown>[] = await response.json();
+    return data.map(parseDevice);
+  },
+
+  async createDevice(deviceName: string): Promise<PhotoDevice> {
+    const response = await fetch(BASE_URL, {
+      method: 'POST',
+      headers: await headers(),
+      body: JSON.stringify({ deviceName }),
+    });
+    if (response.status === HTTP_CONFLICT) {
+      throw new PhotoDeviceNameConflictError(deviceName);
+    }
+    if (!response.ok) {
+      throw new Error(`[photosDeviceService] createDevice failed: ${response.status}`);
+    }
+    const data: Record<string, unknown> = await response.json();
+    return parseDevice(data);
+  },
+
+  async getDevice(uuid: string): Promise<PhotoDevice | null> {
+    const response = await fetch(`${BASE_URL}/${uuid}`, {
+      method: 'GET',
+      headers: await headers(),
+    });
+    if (response.status === HTTP_NOT_FOUND) {
+      return null;
+    }
+    if (!response.ok) {
+      throw new Error(`[photosDeviceService] getDevice failed: ${response.status}`);
+    }
+    const data: Record<string, unknown> = await response.json();
+    return parseDevice(data);
+  },
+
+  async deleteDevice(uuid: string): Promise<void> {
+    const response = await fetch(`${BASE_URL}/${uuid}`, {
+      method: 'DELETE',
+      headers: await headers(),
+    });
+    if (!response.ok) {
+      throw new Error(`[photosDeviceService] deleteDevice failed: ${response.status}`);
+    }
+  },
+
+  async renameDevice(uuid: string, deviceName: string): Promise<PhotoDevice> {
+    const response = await fetch(`${BASE_URL}/${uuid}`, {
+      method: 'PATCH',
+      headers: await headers(),
+      body: JSON.stringify({ deviceName }),
+    });
+    if (!response.ok) {
+      throw new Error(`[photosDeviceService] renameDevice failed: ${response.status}`);
+    }
+    const data: Record<string, unknown> = await response.json();
+    return parseDevice(data);
+  },
+};

--- a/src/store/slices/photos/index.spec.ts
+++ b/src/store/slices/photos/index.spec.ts
@@ -5,7 +5,7 @@ import asyncStorageService from 'src/services/AsyncStorageService';
 import { PhotoAssetScanner } from 'src/services/photos/PhotoAssetScanner';
 import { photoCloudBrowser } from 'src/services/photos/PhotoCloudBrowser';
 import { PhotoDeduplicator } from 'src/services/photos/PhotoDeduplicator';
-import { PhotoDeviceId } from 'src/services/photos/PhotoDeviceId';
+import { PhotoDeviceManager } from 'src/services/photos/PhotoDeviceId';
 import { PhotoUploadQueue } from 'src/services/photos/PhotoUploadQueue';
 import { photosLocalDB } from 'src/services/photos/database/photosLocalDB';
 import { AppDispatch } from 'src/store';
@@ -45,7 +45,9 @@ jest.mock('@internxt-mobile/services/photos/photoPermissionService', () => ({
 }));
 
 jest.mock('src/services/photos/PhotoDeviceId', () => ({
-  PhotoDeviceId: { getOrCreate: jest.fn().mockResolvedValue('mock-device-id') },
+  PhotoDeviceManager: {
+    ensureDeviceFolder: jest.fn().mockResolvedValue({ deviceId: 'mock-device-id', plainName: 'Mock Device' }),
+  },
 }));
 
 jest.mock('src/services/photos/PhotoAssetScanner', () => ({
@@ -91,7 +93,7 @@ const mockStorageSelectors = storageSelectors as jest.Mocked<typeof storageSelec
 const mockAsyncStorage = asyncStorageService as jest.Mocked<typeof asyncStorageService>;
 const mockCloudBrowser = photoCloudBrowser as jest.Mocked<typeof photoCloudBrowser>;
 const mockPermissionService = photoPermissionService as jest.Mocked<typeof photoPermissionService>;
-const mockPhotoDeviceId = PhotoDeviceId as jest.Mocked<typeof PhotoDeviceId>;
+const mockPhotoDeviceManager = PhotoDeviceManager as jest.Mocked<typeof PhotoDeviceManager>;
 const mockScanner = PhotoAssetScanner as jest.Mocked<typeof PhotoAssetScanner>;
 const mockDeduplicator = PhotoDeduplicator as jest.Mocked<typeof PhotoDeduplicator>;
 const mockPhotosLocalDB = photosLocalDB as jest.Mocked<typeof photosLocalDB>;
@@ -115,7 +117,7 @@ describe('photos slice', () => {
     // Re-set default implementations after reset clears them
     mockAsyncStorage.saveItem.mockResolvedValue(undefined);
     mockAsyncStorage.getItem.mockResolvedValue(null);
-    mockPhotoDeviceId.getOrCreate.mockResolvedValue('mock-device-id');
+    mockPhotoDeviceManager.ensureDeviceFolder.mockResolvedValue({ deviceId: 'mock-device-id', plainName: 'Mock Device', bucket: 'mock-photos-bucket' });
     mockScanner.scanAll.mockResolvedValue([]);
     mockScanner.getAssetsByIds.mockResolvedValue([]);
     mockUploadQueue.start.mockResolvedValue(undefined);
@@ -154,6 +156,7 @@ describe('photos slice', () => {
       currentUploadProgress: 0,
       uploadingAssetIds: [],
       deviceId: null,
+      photosBucket: null,
       sessionTotalAssets: 0,
       sessionUploadedAssets: 0,
       cloudFetchRevision: 0,
@@ -348,23 +351,24 @@ describe('photos slice', () => {
     expect(getPersistedState()).toMatchObject({ networkCondition: 'wifi-only' });
   });
 
-  test('when the device is first registered for backup, then a new device identifier is created', async () => {
-    mockPhotoDeviceId.getOrCreate.mockResolvedValueOnce('new-device-id');
+  test('when the device is first registered for backup, then a new device identifier is created and the photos bucket is stored', async () => {
+    mockPhotoDeviceManager.ensureDeviceFolder.mockResolvedValueOnce({ deviceId: 'new-device-id', plainName: 'New Device', bucket: 'mock-photos-bucket' });
 
     const store = makeStore();
     await store.dispatch(initDeviceIdThunk());
 
     expect(store.getState().photos.deviceId).toBe('new-device-id');
+    expect(store.getState().photos.photosBucket).toBe('mock-photos-bucket');
   });
 
   test('when the device was already registered for backup, then the existing identifier is reused', async () => {
-    mockPhotoDeviceId.getOrCreate.mockResolvedValueOnce('existing-device-id');
+    mockPhotoDeviceManager.ensureDeviceFolder.mockResolvedValueOnce({ deviceId: 'existing-device-id', plainName: 'Existing Device', bucket: 'mock-photos-bucket' });
 
     const store = makeStore();
     await store.dispatch(initDeviceIdThunk());
 
     expect(store.getState().photos.deviceId).toBe('existing-device-id');
-    expect(mockPhotoDeviceId.getOrCreate).toHaveBeenCalledTimes(1);
+    expect(mockPhotoDeviceManager.ensureDeviceFolder).toHaveBeenCalledTimes(1);
   });
 
   test('when backup is disabled and discovery runs, then no photos are scanned', async () => {
@@ -425,7 +429,7 @@ describe('photos slice', () => {
     await store.dispatch(runBackupCycleThunk());
 
     expect(mockScanner.scanAll).not.toHaveBeenCalled();
-    expect(mockPhotoDeviceId.getOrCreate).not.toHaveBeenCalled();
+    expect(mockPhotoDeviceManager.ensureDeviceFolder).not.toHaveBeenCalled();
   });
 
   test('when a backup cycle starts and the user has revoked permission, then no photos are scanned and backup is disabled', async () => {
@@ -443,7 +447,7 @@ describe('photos slice', () => {
     const store = makeStore();
     store.dispatch(photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted' }));
     mockPermissionService.getStatus.mockResolvedValueOnce('granted');
-    mockPhotoDeviceId.getOrCreate.mockResolvedValueOnce('device-id');
+    mockPhotoDeviceManager.ensureDeviceFolder.mockResolvedValueOnce({ deviceId: 'device-id', plainName: 'Device', bucket: 'mock-photos-bucket' });
     const assets = Array.from({ length: 5 }, (_, i) => ({ id: `asset-${i}` }));
     mockScanner.scanAll.mockResolvedValueOnce(assets as never);
     mockDeduplicator.getAssetsToSync.mockResolvedValueOnce({ newAssets: assets, editedAssets: [] } as never);
@@ -456,7 +460,7 @@ describe('photos slice', () => {
     await store.dispatch(runBackupCycleThunk());
     await Promise.resolve();
 
-    expect(mockPhotoDeviceId.getOrCreate).toHaveBeenCalledTimes(1);
+    expect(mockPhotoDeviceManager.ensureDeviceFolder).toHaveBeenCalledTimes(1);
     expect(mockScanner.scanAll).toHaveBeenCalledTimes(1);
     expect(store.getState().photos.pendingBackupAssets).toBe(5);
     expect(store.getState().photos.syncStatus).toBe('synced');
@@ -593,7 +597,7 @@ describe('photos slice', () => {
 
       const store = makeStore();
       store.dispatch(
-        photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted', deviceId: 'device-1' }),
+        photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted', deviceId: 'device-1', photosBucket: 'photos-bucket-1' }),
       );
 
       await store.dispatch(forceRefreshThunk());
@@ -613,7 +617,7 @@ describe('photos slice', () => {
 
   describe('backup cycle', () => {
     test('when the backup cycle runs, then cloud history sync and discovery both run', async () => {
-      mockPhotoDeviceId.getOrCreate.mockResolvedValue('device-id');
+      mockPhotoDeviceManager.ensureDeviceFolder.mockResolvedValue({ deviceId: 'device-id', plainName: 'Device', bucket: 'mock-photos-bucket' });
 
       const store = makeStore();
       store.dispatch(photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted' }));
@@ -626,7 +630,7 @@ describe('photos slice', () => {
     });
 
     test('when the backup cycle runs while paused, then discovery runs but the upload is skipped and sync status is paused', async () => {
-      mockPhotoDeviceId.getOrCreate.mockResolvedValue('device-id');
+      mockPhotoDeviceManager.ensureDeviceFolder.mockResolvedValue({ deviceId: 'device-id', plainName: 'Device', bucket: 'mock-photos-bucket' });
       mockDeduplicator.getAssetsToSync.mockResolvedValueOnce({ newAssets: [{ id: 'a1' } as never], editedAssets: [] });
 
       const store = makeStore();
@@ -690,7 +694,7 @@ describe('photos slice', () => {
 
   describe('resuming backup', () => {
     test('when the user resumes the backup, then is paused flag clears and the backup cycle is dispatched', async () => {
-      mockPhotoDeviceId.getOrCreate.mockResolvedValue('device-id');
+      mockPhotoDeviceManager.ensureDeviceFolder.mockResolvedValue({ deviceId: 'device-id', plainName: 'Device', bucket: 'mock-photos-bucket' });
       mockPermissionService.getStatus.mockResolvedValue('granted');
 
       const store = makeStore();
@@ -719,7 +723,7 @@ describe('photos slice', () => {
 
     test('when the upload loop finishes while paused, then sync status remains paused', async () => {
       mockPhotosLocalDB.getPendingAssets.mockResolvedValueOnce([{ assetId: 'a1', status: 'pending' }] as never);
-      mockUploadQueue.start.mockImplementationOnce(async (_jobs, _deviceId, callbacks) => {
+      mockUploadQueue.start.mockImplementationOnce(async (_jobs, _deviceId, _photosBucket, callbacks) => {
         // Simulate pause being set mid-upload
         store.dispatch(photosSlice.actions.setIsPaused(true));
         await callbacks.onAssetDone?.('a1', 'remote-1', Date.now());
@@ -727,7 +731,7 @@ describe('photos slice', () => {
 
       const store = makeStore();
       store.dispatch(
-        photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted', deviceId: 'device-1' }),
+        photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted', deviceId: 'device-1', photosBucket: 'photos-bucket-1' }),
       );
 
       await store.dispatch(runUploadThunk());
@@ -738,13 +742,13 @@ describe('photos slice', () => {
     test('when an asset fails with abort error, then it is not marked as errored in the local database', async () => {
       const abortError = new AbortError();
       mockPhotosLocalDB.getPendingAssets.mockResolvedValueOnce([{ assetId: 'a1', status: 'pending' }] as never);
-      mockUploadQueue.start.mockImplementationOnce(async (_jobs, _deviceId, callbacks) => {
+      mockUploadQueue.start.mockImplementationOnce(async (_jobs, _deviceId, _photosBucket, callbacks) => {
         await callbacks.onAssetError?.('a1', abortError);
       });
 
       const store = makeStore();
       store.dispatch(
-        photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted', deviceId: 'device-1' }),
+        photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted', deviceId: 'device-1', photosBucket: 'photos-bucket-1' }),
       );
 
       await store.dispatch(runUploadThunk());
@@ -754,13 +758,13 @@ describe('photos slice', () => {
 
     test('when an asset fails with a quota exceeded error from the backend, then the backup is paused and the asset is not marked as failed in the database', async () => {
       mockPhotosLocalDB.getPendingAssets.mockResolvedValueOnce([{ assetId: 'a1', status: 'pending' }] as never);
-      mockUploadQueue.start.mockImplementationOnce(async (_jobs, _deviceId, callbacks) => {
+      mockUploadQueue.start.mockImplementationOnce(async (_jobs, _deviceId, _photosBucket, callbacks) => {
         await callbacks.onAssetError?.('a1', quotaError);
       });
 
       const store = makeStore();
       store.dispatch(
-        photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted', deviceId: 'device-1' }),
+        photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted', deviceId: 'device-1', photosBucket: 'photos-bucket-1' }),
       );
 
       await store.dispatch(runUploadThunk());
@@ -773,13 +777,13 @@ describe('photos slice', () => {
     test('when an asset fails with a quota exceeded error from the backend, then the upload queue is aborted to prevent further attempts', async () => {
       jest.spyOn(mockUploadQueue, 'abortAll');
       mockPhotosLocalDB.getPendingAssets.mockResolvedValueOnce([{ assetId: 'a1', status: 'pending' }] as never);
-      mockUploadQueue.start.mockImplementationOnce(async (_jobs, _deviceId, callbacks) => {
+      mockUploadQueue.start.mockImplementationOnce(async (_jobs, _deviceId, _photosBucket, callbacks) => {
         await callbacks.onAssetError?.('a1', quotaError);
       });
 
       const store = makeStore();
       store.dispatch(
-        photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted', deviceId: 'device-1' }),
+        photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted', deviceId: 'device-1', photosBucket: 'photos-bucket-1' }),
       );
 
       await store.dispatch(runUploadThunk());
@@ -789,7 +793,7 @@ describe('photos slice', () => {
 
     test('when an asset fails with a quota exceeded error from the backend, then the backup cycle is not restarted', async () => {
       mockPhotosLocalDB.getPendingAssets.mockResolvedValueOnce([{ assetId: 'a1', status: 'pending' }] as never);
-      mockUploadQueue.start.mockImplementationOnce(async (_jobs, _deviceId, callbacks) => {
+      mockUploadQueue.start.mockImplementationOnce(async (_jobs, _deviceId, _photosBucket, callbacks) => {
         await callbacks.onAssetError?.('a1', quotaError);
       });
       const remainingAssets = Array.from({ length: 5 }, (_, i) => ({ assetId: `asset-${i}`, status: 'pending' }));
@@ -797,7 +801,7 @@ describe('photos slice', () => {
 
       const store = makeStore();
       store.dispatch(
-        photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted', deviceId: 'device-1' }),
+        photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted', deviceId: 'device-1', photosBucket: 'photos-bucket-1' }),
       );
 
       await store.dispatch(runUploadThunk());
@@ -810,7 +814,7 @@ describe('photos slice', () => {
 
       const store = makeStore();
       store.dispatch(
-        photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted', deviceId: 'device-1' }),
+        photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted', deviceId: 'device-1', photosBucket: 'photos-bucket-1' }),
       );
 
       await store.dispatch(runUploadThunk());
@@ -825,7 +829,7 @@ describe('photos slice', () => {
 
       const store = makeStore();
       store.dispatch(
-        photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted', deviceId: 'device-1' }),
+        photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted', deviceId: 'device-1', photosBucket: 'photos-bucket-1' }),
       );
 
       await store.dispatch(runUploadThunk());
@@ -844,6 +848,7 @@ describe('photos slice', () => {
           enabled: true,
           permissionStatus: 'granted',
           deviceId: 'device-1',
+          photosBucket: 'photos-bucket-1',
           disabledReason: 'quota-exceeded',
         }),
       );

--- a/src/store/slices/photos/index.ts
+++ b/src/store/slices/photos/index.ts
@@ -6,7 +6,7 @@ import { HTTP_QUOTA_EXCEEDED } from 'src/services/common/httpStatusCodes';
 import { PhotoAssetScanner } from 'src/services/photos/PhotoAssetScanner';
 import { photoCloudBrowser } from 'src/services/photos/PhotoCloudBrowser';
 import { PhotoDeduplicator } from 'src/services/photos/PhotoDeduplicator';
-import { PhotoDeviceId } from 'src/services/photos/PhotoDeviceId';
+import { PhotoDeviceManager } from 'src/services/photos/PhotoDeviceId';
 import { PhotoUploadQueue } from 'src/services/photos/PhotoUploadQueue';
 import { photosLocalDB } from 'src/services/photos/database/photosLocalDB';
 import {
@@ -35,6 +35,7 @@ export interface PhotosState {
   currentUploadProgress: number;
   uploadingAssetIds: string[];
   deviceId: string | null;
+  photosBucket: string | null;
   sessionTotalAssets: number;
   sessionUploadedAssets: number;
   cloudFetchRevision: number;
@@ -54,6 +55,7 @@ const initialState: PhotosState = {
   currentUploadProgress: 0,
   uploadingAssetIds: [],
   deviceId: null,
+  photosBucket: null,
   sessionTotalAssets: 0,
   sessionUploadedAssets: 0,
   cloudFetchRevision: 0,
@@ -164,9 +166,10 @@ export const checkPermissionRevocationThunk = createAsyncThunk<void, void, { sta
 export const initDeviceIdThunk = createAsyncThunk<string, void, { state: RootState }>(
   'photos/initDeviceId',
   async (_, { dispatch }) => {
-    const id = await PhotoDeviceId.getOrCreate();
-    dispatch(photosSlice.actions.setDeviceId(id));
-    return id;
+    const { deviceId, bucket } = await PhotoDeviceManager.ensureDeviceFolder();
+    dispatch(photosSlice.actions.setDeviceId(deviceId));
+    dispatch(photosSlice.actions.setPhotosBucket(bucket));
+    return deviceId;
   },
 );
 
@@ -226,8 +229,14 @@ export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean }
   'photos/runUpload',
   async (args, { getState, dispatch }) => {
     const bypassEnabled = args?.bypassEnabled ?? false;
-    const { enabled, permissionStatus, deviceId, isPaused } = getState().photos;
-    if ((!enabled && !bypassEnabled) || !isPermissionActive(permissionStatus) || !deviceId || isPaused) {
+    const { enabled, permissionStatus, deviceId, photosBucket, isPaused } = getState().photos;
+    if (
+      (!enabled && !bypassEnabled) ||
+      !isPermissionActive(permissionStatus) ||
+      !deviceId ||
+      !photosBucket ||
+      isPaused
+    ) {
       return;
     }
 
@@ -267,7 +276,7 @@ export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean }
     dispatch(photosSlice.actions.setSyncStatus('uploading'));
     dispatch(photosSlice.actions.setSessionUploadTotalAssets(uploadAssetJobs.length));
 
-    await PhotoUploadQueue.start(uploadAssetJobs, deviceId, {
+    await PhotoUploadQueue.start(uploadAssetJobs, deviceId, photosBucket, {
       onAssetStart: (assetId) => {
         dispatch(photosSlice.actions.addUploadingAssetId(assetId));
       },
@@ -464,6 +473,9 @@ export const photosSlice = createSlice({
     },
     setDeviceId: (state, action: PayloadAction<string>) => {
       state.deviceId = action.payload;
+    },
+    setPhotosBucket: (state, action: PayloadAction<string>) => {
+      state.photosBucket = action.payload;
     },
     setDiscoveryResult: (state, action: PayloadAction<{ pendingBackupAssets: number; totalScannedAssets: number }>) => {
       state.pendingBackupAssets = action.payload.pendingBackupAssets;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -103,6 +103,7 @@ export enum AsyncStorageKey {
   PhotosSettings = 'photosSettings',
   PhotosDiscoverSeen = 'photosDiscoverSeen',
   PhotosDeviceId = 'photos-device-id',
+  PhotosDeviceKey = 'photos-device-key',
 }
 
 export type ProgressCallback = (progress: number) => void;

--- a/src/types/photos.ts
+++ b/src/types/photos.ts
@@ -1,0 +1,6 @@
+export interface PhotoDevice {
+  uuid: string;
+  plainName: string;
+  bucket: string;
+  status: 'EXISTS' | 'TRASHED' | 'DELETED';
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4434,6 +4434,11 @@ expect@^29.0.0, expect@^29.7.0:
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
 
+expo-application@~7.0.8:
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/expo-application/-/expo-application-7.0.8.tgz#320af0d6c39b331456d3bc833b25763c702d23db"
+  integrity sha512-qFGyxk7VJbrNOQWBbE09XUuGuvkOgFS9QfToaK2FdagM2aQ+x3CvGV2DuVgl/l4ZxPgIf3b/MNh9xHpwSwn74Q==
+
 expo-asset@~12.0.12:
   version "12.0.12"
   resolved "https://registry.yarnpkg.com/expo-asset/-/expo-asset-12.0.12.tgz#15eb7d92cd43cc81c37149e5bbcdc3091875a85b"


### PR DESCRIPTION
Replace photos folder creation logic with the new `Photos` backend endpoints

  ## Summary

  - **`photosDeviceService.ts`**: HTTP client for `photos`endpoints (To use sdk functions we will need to merge https://github.com/internxt/drive-mobile/pull/473 first, will be done in another task)
  
  - **`PhotoDeviceId.ts`**: **`PhotoDeviceManager`**: replaces client generated UUID with `ensureDeviceFolder()`, which calls the new endpoint and returns `{ deviceId, plainName, bucket }` where `deviceId` is the backend folder uuid. iOS recovery via Keychain; Android recovery via `androidId` on 409 conflict
  - **`PhotoBackupFolders.ts`**: removed root and device folder creation. Now only manages `year/month/day` hierarchy under the `deviceFolderUuid` provided by the caller
  - **`PhotoCloudBrowser.ts`**: `listDeviceFolders()` now queries `photosDeviceService.listDevices()`
  - **`store/slices/photos/index.ts`**: `initDeviceIdThunk` uses `PhotoDeviceManager.ensureDeviceFolder()` and stores `photosBucket` alongside `deviceId`