### PR TITLE
[PB-6282]: refresh file picker after uploads and folder creation

### DIFF
--- a/android/app/src/main/java/com/internxt/cloud/MainApplication.kt
+++ b/android/app/src/main/java/com/internxt/cloud/MainApplication.kt
@@ -14,6 +14,7 @@ import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
 import com.facebook.react.defaults.DefaultReactNativeHost
 
 import com.internxt.cloud.auth.InternxtAuthCredentialsPackage
+import com.internxt.cloud.documents.signaling.InternxtSignalingPackage
 
 import expo.modules.ApplicationLifecycleDispatcher
 import expo.modules.ReactNativeHostWrapper
@@ -27,6 +28,7 @@ class MainApplication : Application(), ReactApplication {
             PackageList(this).packages.apply {
               add(ShareIntentPackage())
               add(InternxtAuthCredentialsPackage())
+              add(InternxtSignalingPackage())
             }
 
           override fun getJSMainModuleName(): String = ".expo/.virtual-metro-entry"

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -76,7 +76,13 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         authManager = InternxtAuthManager.create(ctx.applicationContext) ?: return false
         // Process-scoped: ContentProvider has no shutdown hook, so the thread lives until the process dies.
         closeHandler = Handler(HandlerThread("InternxtDocsClose").apply { start() }.looper)
+        activeInstance = this
         return true
+    }
+
+    override fun shutdown() {
+        if (activeInstance === this) activeInstance = null
+        super.shutdown()
     }
 
     override fun queryRoots(projection: Array<String>?): Cursor {
@@ -919,6 +925,20 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         const val AUTHORITY = "com.internxt.cloud.documents"
         private const val ROOT_ID = "internxt-root"
         private const val TAG = "InternxtDocsProvider"
+
+        @Volatile
+        private var activeInstance: InternxtDocumentsProvider? = null
+
+        /**
+         * Entry point for the React Native app to signal that a folder's children changed
+         * (e.g. after uploading a file or creating a folder from the app UI). Reuses the same
+         * cache invalidation + notifyChange path as in-picker mutations. No-op if the provider
+         * is not currently alive in this process.
+         */
+        fun signalParentChanged(folderUuid: String) {
+            if (folderUuid.isBlank()) return
+            activeInstance?.invalidateChildren(DocumentId.encodeFolder(folderUuid))
+        }
 
         private const val MULTIPART_THRESHOLD = 100L * 1024L * 1024L
         private const val MULTIPART_PART_SIZE = 30L * 1024L * 1024L

--- a/android/app/src/main/java/com/internxt/cloud/documents/signaling/InternxtSignalingModule.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/signaling/InternxtSignalingModule.kt
@@ -1,0 +1,35 @@
+package com.internxt.cloud.documents.signaling
+
+import android.util.Log
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.internxt.cloud.documents.InternxtDocumentsProvider
+
+class InternxtSignalingModule(ctx: ReactApplicationContext) :
+    ReactContextBaseJavaModule(ctx) {
+
+    override fun getName() = MODULE_NAME
+
+    @ReactMethod
+    fun notifyParentChanged(parentFolderUuid: String?, promise: Promise) {
+        val folderUuid = parentFolderUuid?.takeIf { it.isNotBlank() } ?: run {
+            promise.reject("E_INVALID_FOLDER", "parentFolderUuid must be a non-empty string")
+            return
+        }
+        try {
+            InternxtDocumentsProvider.signalParentChanged(folderUuid)
+            promise.resolve(null)
+        } catch (e: Exception) {
+            // Best-effort signal: never let a failed refresh break the JS caller.
+            Log.w(TAG, "notifyParentChanged failed for $folderUuid", e)
+            promise.resolve(null)
+        }
+    }
+
+    companion object {
+        const val MODULE_NAME = "InternxtSignalingModule"
+        private const val TAG = "InternxtSignaling"
+    }
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/signaling/InternxtSignalingPackage.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/signaling/InternxtSignalingPackage.kt
@@ -1,0 +1,14 @@
+package com.internxt.cloud.documents.signaling
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class InternxtSignalingPackage : ReactPackage {
+    override fun createNativeModules(context: ReactApplicationContext): List<NativeModule> =
+        listOf(InternxtSignalingModule(context))
+
+    override fun createViewManagers(context: ReactApplicationContext): List<ViewManager<*, *>> =
+        emptyList()
+}

--- a/src/services/drive/file/utils/uploadFileUtils.signaling.spec.ts
+++ b/src/services/drive/file/utils/uploadFileUtils.signaling.spec.ts
@@ -65,28 +65,22 @@ describe('uploadSingleFile — picker signaling', () => {
   });
 
   it('when a file upload succeeds, then it signals the destination folder uuid', async () => {
-    // given
     const file = buildUploadingFile({ parentUuid: 'destination-folder-uuid' });
     const uploadFile = jest.fn().mockResolvedValue(undefined);
     const uploadSuccess = jest.fn();
 
-    // when
     await uploadSingleFile(file, dispatch, uploadFile, uploadSuccess);
 
-    // then
     expect(mockNotifyParentChanged).toHaveBeenCalledWith('destination-folder-uuid');
   });
 
   it('when the file upload fails, then it does not signal the file picker', async () => {
-    // given
     const file = buildUploadingFile();
     const uploadFile = jest.fn().mockRejectedValue(new Error('network down'));
     const uploadSuccess = jest.fn();
 
-    // when
     await expect(uploadSingleFile(file, dispatch, uploadFile, uploadSuccess)).rejects.toThrow('network down');
 
-    // then
     expect(mockNotifyParentChanged).not.toHaveBeenCalled();
   });
 });

--- a/src/services/drive/file/utils/uploadFileUtils.signaling.spec.ts
+++ b/src/services/drive/file/utils/uploadFileUtils.signaling.spec.ts
@@ -1,0 +1,92 @@
+import { Action } from 'redux';
+import { Dispatch } from 'react';
+import { UploadingFile } from '../../../../types/drive/operations';
+
+const mockNotifyParentChanged = jest.fn().mockResolvedValue(undefined);
+
+// Sibling modules not exercised by `uploadSingleFile` but pulling in heavy native/network
+// chains at import time — stubbed so the unit under test loads in isolation.
+jest.mock('./checkDuplicatedFiles', () => ({ checkDuplicatedFiles: jest.fn() }));
+jest.mock('./prepareFilesToUpload', () => ({ prepareFilesToUpload: jest.fn() }));
+jest.mock('../../../common/network/upload/upload.service', () => ({
+  uploadService: { createFileEntry: jest.fn(), uploadFile: jest.fn() },
+}));
+
+jest.mock('../../../../store/slices/drive', () => ({
+  driveActions: {
+    uploadFileStart: jest.fn(),
+    uploadFileFailed: jest.fn(),
+    uploadFileFinished: jest.fn(),
+  },
+}));
+
+jest.mock('../../../native/InternxtSignalingModule', () => ({
+  notifyParentChanged: (...args: unknown[]) => mockNotifyParentChanged(...args),
+}));
+
+jest.mock('../../../ErrorService', () => ({
+  __esModule: true,
+  default: { reportError: jest.fn(), castError: (e: Error) => e },
+}));
+
+jest.mock('../../../AnalyticsService', () => ({
+  __esModule: true,
+  default: { track: jest.fn() },
+  DriveAnalyticsEvent: {},
+}));
+
+jest.mock('../../../common', () => ({
+  logger: { error: jest.fn(), info: jest.fn() },
+}));
+
+import { uploadSingleFile } from './uploadFileUtils';
+
+const buildUploadingFile = (overrides: Partial<UploadingFile> = {}): UploadingFile => ({
+  id: 1,
+  uuid: 'file-uuid',
+  uri: 'file:///tmp/file.txt',
+  name: 'file.txt',
+  type: 'txt',
+  parentId: 10,
+  parentUuid: 'destination-folder-uuid',
+  createdAt: '2024-01-01',
+  updatedAt: '2024-01-01',
+  size: 1024,
+  progress: 0,
+  uploaded: false,
+  ...overrides,
+});
+
+describe('uploadSingleFile — picker signaling', () => {
+  const dispatch = jest.fn() as unknown as Dispatch<Action>;
+
+  beforeEach(() => {
+    mockNotifyParentChanged.mockClear();
+  });
+
+  it('when a file upload succeeds, then it signals the destination folder uuid', async () => {
+    // given
+    const file = buildUploadingFile({ parentUuid: 'destination-folder-uuid' });
+    const uploadFile = jest.fn().mockResolvedValue(undefined);
+    const uploadSuccess = jest.fn();
+
+    // when
+    await uploadSingleFile(file, dispatch, uploadFile, uploadSuccess);
+
+    // then
+    expect(mockNotifyParentChanged).toHaveBeenCalledWith('destination-folder-uuid');
+  });
+
+  it('when the file upload fails, then it does not signal the file picker', async () => {
+    // given
+    const file = buildUploadingFile();
+    const uploadFile = jest.fn().mockRejectedValue(new Error('network down'));
+    const uploadSuccess = jest.fn();
+
+    // when
+    await expect(uploadSingleFile(file, dispatch, uploadFile, uploadSuccess)).rejects.toThrow('network down');
+
+    // then
+    expect(mockNotifyParentChanged).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/drive/file/utils/uploadFileUtils.signaling.spec.ts
+++ b/src/services/drive/file/utils/uploadFileUtils.signaling.spec.ts
@@ -64,7 +64,7 @@ describe('uploadSingleFile — picker signaling', () => {
     mockNotifyParentChanged.mockClear();
   });
 
-  it('when a file upload succeeds, then it signals the destination folder uuid', async () => {
+  test('when a file upload succeeds, then it signals the destination folder uuid', async () => {
     const file = buildUploadingFile({ parentUuid: 'destination-folder-uuid' });
     const uploadFile = jest.fn().mockResolvedValue(undefined);
     const uploadSuccess = jest.fn();
@@ -74,7 +74,7 @@ describe('uploadSingleFile — picker signaling', () => {
     expect(mockNotifyParentChanged).toHaveBeenCalledWith('destination-folder-uuid');
   });
 
-  it('when the file upload fails, then it does not signal the file picker', async () => {
+  test('when the file upload fails, then it does not signal the file picker', async () => {
     const file = buildUploadingFile();
     const uploadFile = jest.fn().mockRejectedValue(new Error('network down'));
     const uploadSuccess = jest.fn();

--- a/src/services/drive/file/utils/uploadFileUtils.ts
+++ b/src/services/drive/file/utils/uploadFileUtils.ts
@@ -23,6 +23,7 @@ import { getEnvironmentConfigFromUser } from '../../../../lib/network';
 import analyticsService, { DriveAnalyticsEvent } from '../../../AnalyticsService';
 import { logger } from '../../../common';
 import { uploadService } from '../../../common/network/upload/upload.service';
+import { notifyParentChanged } from '../../../native/InternxtSignalingModule';
 import { BucketNotFoundError } from './upload.errors';
 
 /**
@@ -264,6 +265,7 @@ export async function uploadSingleFile(
       await uploadFile(file, 'document');
     }
     uploadSuccess(file);
+    void notifyParentChanged(file.parentUuid).catch(() => undefined);
   } catch (e) {
     const err = e as Error;
     errorService.reportError(err, {

--- a/src/services/drive/file/utils/uploadFileUtils.ts
+++ b/src/services/drive/file/utils/uploadFileUtils.ts
@@ -265,7 +265,7 @@ export async function uploadSingleFile(
       await uploadFile(file, 'document');
     }
     uploadSuccess(file);
-    void notifyParentChanged(file.parentUuid).catch(() => undefined);
+    void notifyParentChanged(file.parentUuid);
   } catch (e) {
     const err = e as Error;
     errorService.reportError(err, {

--- a/src/services/drive/folder/driveFolder.service.signaling.spec.ts
+++ b/src/services/drive/folder/driveFolder.service.signaling.spec.ts
@@ -24,21 +24,16 @@ describe('driveFolderService.createFolder — picker signaling', () => {
   });
 
   it('when a folder is created, then it signals the parent folder uuid', async () => {
-    // given
     mockCreateFolderByUuid.mockReturnValue([Promise.resolve({ uuid: 'new-folder', name: 'docs' })]);
 
-    // when
     await driveFolderService.createFolder('parent-folder-uuid', 'docs');
 
-    // then
     expect(mockNotifyParentChanged).toHaveBeenCalledWith('parent-folder-uuid');
   });
 
   it('when the SDK returns no result, then it rejects and does not signal', async () => {
-    // given
     mockCreateFolderByUuid.mockReturnValue(undefined);
 
-    // when / then
     await expect(driveFolderService.createFolder('parent-folder-uuid', 'docs')).rejects.toBeDefined();
     expect(mockNotifyParentChanged).not.toHaveBeenCalled();
   });

--- a/src/services/drive/folder/driveFolder.service.signaling.spec.ts
+++ b/src/services/drive/folder/driveFolder.service.signaling.spec.ts
@@ -1,0 +1,45 @@
+const mockNotifyParentChanged = jest.fn().mockResolvedValue(undefined);
+const mockCreateFolderByUuid = jest.fn();
+
+jest.mock('../../native/InternxtSignalingModule', () => ({
+  notifyParentChanged: (...args: unknown[]) => mockNotifyParentChanged(...args),
+}));
+
+jest.mock('@internxt-mobile/services/common', () => ({
+  SdkManager: {
+    getInstance: () => ({
+      storageV2: {
+        createFolderByUuid: (...args: unknown[]) => mockCreateFolderByUuid(...args),
+      },
+    }),
+  },
+}));
+
+import { driveFolderService } from './driveFolder.service';
+
+describe('driveFolderService.createFolder — picker signaling', () => {
+  beforeEach(() => {
+    mockNotifyParentChanged.mockClear();
+    mockCreateFolderByUuid.mockReset();
+  });
+
+  it('when a folder is created, then it signals the parent folder uuid', async () => {
+    // given
+    mockCreateFolderByUuid.mockReturnValue([Promise.resolve({ uuid: 'new-folder', name: 'docs' })]);
+
+    // when
+    await driveFolderService.createFolder('parent-folder-uuid', 'docs');
+
+    // then
+    expect(mockNotifyParentChanged).toHaveBeenCalledWith('parent-folder-uuid');
+  });
+
+  it('when the SDK returns no result, then it rejects and does not signal', async () => {
+    // given
+    mockCreateFolderByUuid.mockReturnValue(undefined);
+
+    // when / then
+    await expect(driveFolderService.createFolder('parent-folder-uuid', 'docs')).rejects.toBeDefined();
+    expect(mockNotifyParentChanged).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/drive/folder/driveFolder.service.ts
+++ b/src/services/drive/folder/driveFolder.service.ts
@@ -37,7 +37,7 @@ class DriveFolderService {
       throw new Error('Sdk method did not return a valid result');
     }
     const folder = await sdkResult[0];
-    void notifyParentChanged(parentFolderId).catch(() => undefined);
+    void notifyParentChanged(parentFolderId);
     return folder;
   }
 

--- a/src/services/drive/folder/driveFolder.service.ts
+++ b/src/services/drive/folder/driveFolder.service.ts
@@ -34,7 +34,7 @@ class DriveFolderService {
       plainName: folderName,
     });
     if (!sdkResult) {
-      return Promise.reject('createFolder Sdk method did not return a valid result');
+      throw new Error('Sdk method did not return a valid result');
     }
     const folder = await sdkResult[0];
     void notifyParentChanged(parentFolderId).catch(() => undefined);

--- a/src/services/drive/folder/driveFolder.service.ts
+++ b/src/services/drive/folder/driveFolder.service.ts
@@ -5,6 +5,7 @@ import { FolderAncestor as SdkFolderAncestor } from '@internxt/sdk/dist/drive/st
 import { getHeaders } from '../../../helpers/headers';
 import { ModifiedFolder } from '../../../types/drive/folder';
 import { constants } from '../../AppService';
+import { notifyParentChanged } from '../../native/InternxtSignalingModule';
 
 export type FolderAncestor = SdkFolderAncestor & { parentUuid: string | null };
 
@@ -32,7 +33,12 @@ class DriveFolderService {
       parentFolderUuid: parentFolderId,
       plainName: folderName,
     });
-    return sdkResult ? sdkResult[0] : Promise.reject('createFolder Sdk method did not return a valid result');
+    if (!sdkResult) {
+      return Promise.reject('createFolder Sdk method did not return a valid result');
+    }
+    const folder = await sdkResult[0];
+    void notifyParentChanged(parentFolderId).catch(() => undefined);
+    return folder;
   }
 
   public async checkDuplicatedFolders(parentFolderUuid: string, folderNamesList: string[]) {

--- a/src/services/native/InternxtSignalingModule.spec.ts
+++ b/src/services/native/InternxtSignalingModule.spec.ts
@@ -1,0 +1,82 @@
+type Wrapper = typeof import('./InternxtSignalingModule');
+
+/**
+ * The wrapper resolves the native bridge at module-load time from `Platform.OS` and
+ * `NativeModules`, so each scenario loads a fresh copy of the module under a tailored
+ * `react-native` mock.
+ */
+const loadWrapper = (platformOS: 'android' | 'ios', nativeModule: unknown): { wrapper: Wrapper } => {
+  let wrapper!: Wrapper;
+  jest.isolateModules(() => {
+    jest.doMock('react-native', () => ({
+      Platform: { OS: platformOS },
+      NativeModules: nativeModule === undefined ? {} : { InternxtSignalingModule: nativeModule },
+    }));
+    wrapper = require('./InternxtSignalingModule');
+  });
+  return { wrapper };
+};
+
+describe('InternxtSignalingModule wrapper', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('when on Android with a valid uuid, then it invokes the native module with that uuid', async () => {
+    // given
+    const notifyParentChangedNative = jest.fn().mockResolvedValue(undefined);
+    const { wrapper } = loadWrapper('android', { notifyParentChanged: notifyParentChangedNative });
+
+    // when
+    await wrapper.notifyParentChanged('folder-uuid-123');
+
+    // then
+    expect(notifyParentChangedNative).toHaveBeenCalledWith('folder-uuid-123');
+  });
+
+  it('when on iOS, then it resolves without invoking the native module', async () => {
+    // given
+    const notifyParentChangedNative = jest.fn().mockResolvedValue(undefined);
+    const { wrapper } = loadWrapper('ios', { notifyParentChanged: notifyParentChangedNative });
+
+    // when
+    await expect(wrapper.notifyParentChanged('folder-uuid-123')).resolves.toBeUndefined();
+
+    // then
+    expect(notifyParentChangedNative).not.toHaveBeenCalled();
+  });
+
+  it('when the uuid is empty, then it resolves without invoking the native module', async () => {
+    // given
+    const notifyParentChangedNative = jest.fn().mockResolvedValue(undefined);
+    const { wrapper } = loadWrapper('android', { notifyParentChanged: notifyParentChangedNative });
+
+    // when
+    await expect(wrapper.notifyParentChanged('')).resolves.toBeUndefined();
+
+    // then
+    expect(notifyParentChangedNative).not.toHaveBeenCalled();
+  });
+
+  it('when the uuid is not a string, then it resolves without invoking the native module', async () => {
+    // given
+    const notifyParentChangedNative = jest.fn().mockResolvedValue(undefined);
+    const { wrapper } = loadWrapper('android', { notifyParentChanged: notifyParentChangedNative });
+
+    // when
+    await expect(
+      wrapper.notifyParentChanged(undefined as unknown as string),
+    ).resolves.toBeUndefined();
+
+    // then
+    expect(notifyParentChangedNative).not.toHaveBeenCalled();
+  });
+
+  it('when the native module is absent, then it resolves without throwing', async () => {
+    // given
+    const { wrapper } = loadWrapper('android', undefined);
+
+    // when / then
+    await expect(wrapper.notifyParentChanged('folder-uuid-123')).resolves.toBeUndefined();
+  });
+});

--- a/src/services/native/InternxtSignalingModule.spec.ts
+++ b/src/services/native/InternxtSignalingModule.spec.ts
@@ -23,60 +23,44 @@ describe('InternxtSignalingModule wrapper', () => {
   });
 
   it('when on Android with a valid uuid, then it invokes the native module with that uuid', async () => {
-    // given
     const notifyParentChangedNative = jest.fn().mockResolvedValue(undefined);
     const { wrapper } = loadWrapper('android', { notifyParentChanged: notifyParentChangedNative });
 
-    // when
     await wrapper.notifyParentChanged('folder-uuid-123');
 
-    // then
     expect(notifyParentChangedNative).toHaveBeenCalledWith('folder-uuid-123');
   });
 
   it('when on iOS, then it resolves without invoking the native module', async () => {
-    // given
     const notifyParentChangedNative = jest.fn().mockResolvedValue(undefined);
     const { wrapper } = loadWrapper('ios', { notifyParentChanged: notifyParentChangedNative });
 
-    // when
     await expect(wrapper.notifyParentChanged('folder-uuid-123')).resolves.toBeUndefined();
 
-    // then
     expect(notifyParentChangedNative).not.toHaveBeenCalled();
   });
 
   it('when the uuid is empty, then it resolves without invoking the native module', async () => {
-    // given
     const notifyParentChangedNative = jest.fn().mockResolvedValue(undefined);
     const { wrapper } = loadWrapper('android', { notifyParentChanged: notifyParentChangedNative });
 
-    // when
     await expect(wrapper.notifyParentChanged('')).resolves.toBeUndefined();
 
-    // then
     expect(notifyParentChangedNative).not.toHaveBeenCalled();
   });
 
   it('when the uuid is not a string, then it resolves without invoking the native module', async () => {
-    // given
     const notifyParentChangedNative = jest.fn().mockResolvedValue(undefined);
     const { wrapper } = loadWrapper('android', { notifyParentChanged: notifyParentChangedNative });
 
-    // when
-    await expect(
-      wrapper.notifyParentChanged(undefined as unknown as string),
-    ).resolves.toBeUndefined();
+    await expect(wrapper.notifyParentChanged(undefined as unknown as string)).resolves.toBeUndefined();
 
-    // then
     expect(notifyParentChangedNative).not.toHaveBeenCalled();
   });
 
   it('when the native module is absent, then it resolves without throwing', async () => {
-    // given
     const { wrapper } = loadWrapper('android', undefined);
 
-    // when / then
     await expect(wrapper.notifyParentChanged('folder-uuid-123')).resolves.toBeUndefined();
   });
 });

--- a/src/services/native/InternxtSignalingModule.spec.ts
+++ b/src/services/native/InternxtSignalingModule.spec.ts
@@ -1,3 +1,9 @@
+const mockLoggerWarn = jest.fn();
+
+jest.mock('../common', () => ({
+  logger: { info: jest.fn(), warn: mockLoggerWarn, error: jest.fn() },
+}));
+
 type Wrapper = typeof import('./InternxtSignalingModule');
 
 /**
@@ -30,6 +36,7 @@ const arrangePresentNative = (platformOS: 'android' | 'ios') => {
 describe('InternxtSignalingModule wrapper', () => {
   afterEach(() => {
     jest.resetModules();
+    mockLoggerWarn.mockReset();
   });
 
   it('when on Android with a valid uuid, then it invokes the native module with that uuid', async () => {
@@ -68,5 +75,14 @@ describe('InternxtSignalingModule wrapper', () => {
     const { wrapper } = loadWrapper('android', undefined);
 
     await expect(wrapper.notifyParentChanged('folder-uuid-123')).resolves.toBeUndefined();
+  });
+
+  it('when the native module rejects, then it resolves without throwing', async () => {
+    const { wrapper, native } = arrangePresentNative('android');
+    native.mockRejectedValueOnce(new Error('E_INVALID_FOLDER'));
+
+    await expect(wrapper.notifyParentChanged('folder-uuid-123')).resolves.toBeUndefined();
+
+    expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/native/InternxtSignalingModule.spec.ts
+++ b/src/services/native/InternxtSignalingModule.spec.ts
@@ -17,45 +17,51 @@ const loadWrapper = (platformOS: 'android' | 'ios', nativeModule: unknown): { wr
   return { wrapper };
 };
 
+/**
+ * Builds a native bridge mock and loads the wrapper against it, returning the spy so each
+ * test only states the platform and asserts the resulting behaviour.
+ */
+const arrangePresentNative = (platformOS: 'android' | 'ios') => {
+  const native = jest.fn().mockResolvedValue(undefined);
+  const { wrapper } = loadWrapper(platformOS, { notifyParentChanged: native });
+  return { wrapper, native };
+};
+
 describe('InternxtSignalingModule wrapper', () => {
   afterEach(() => {
     jest.resetModules();
   });
 
   it('when on Android with a valid uuid, then it invokes the native module with that uuid', async () => {
-    const notifyParentChangedNative = jest.fn().mockResolvedValue(undefined);
-    const { wrapper } = loadWrapper('android', { notifyParentChanged: notifyParentChangedNative });
+    const { wrapper, native } = arrangePresentNative('android');
 
     await wrapper.notifyParentChanged('folder-uuid-123');
 
-    expect(notifyParentChangedNative).toHaveBeenCalledWith('folder-uuid-123');
+    expect(native).toHaveBeenCalledWith('folder-uuid-123');
   });
 
   it('when on iOS, then it resolves without invoking the native module', async () => {
-    const notifyParentChangedNative = jest.fn().mockResolvedValue(undefined);
-    const { wrapper } = loadWrapper('ios', { notifyParentChanged: notifyParentChangedNative });
+    const { wrapper, native } = arrangePresentNative('ios');
 
     await expect(wrapper.notifyParentChanged('folder-uuid-123')).resolves.toBeUndefined();
 
-    expect(notifyParentChangedNative).not.toHaveBeenCalled();
+    expect(native).not.toHaveBeenCalled();
   });
 
   it('when the uuid is empty, then it resolves without invoking the native module', async () => {
-    const notifyParentChangedNative = jest.fn().mockResolvedValue(undefined);
-    const { wrapper } = loadWrapper('android', { notifyParentChanged: notifyParentChangedNative });
+    const { wrapper, native } = arrangePresentNative('android');
 
     await expect(wrapper.notifyParentChanged('')).resolves.toBeUndefined();
 
-    expect(notifyParentChangedNative).not.toHaveBeenCalled();
+    expect(native).not.toHaveBeenCalled();
   });
 
   it('when the uuid is not a string, then it resolves without invoking the native module', async () => {
-    const notifyParentChangedNative = jest.fn().mockResolvedValue(undefined);
-    const { wrapper } = loadWrapper('android', { notifyParentChanged: notifyParentChangedNative });
+    const { wrapper, native } = arrangePresentNative('android');
 
     await expect(wrapper.notifyParentChanged(undefined as unknown as string)).resolves.toBeUndefined();
 
-    expect(notifyParentChangedNative).not.toHaveBeenCalled();
+    expect(native).not.toHaveBeenCalled();
   });
 
   it('when the native module is absent, then it resolves without throwing', async () => {

--- a/src/services/native/InternxtSignalingModule.ts
+++ b/src/services/native/InternxtSignalingModule.ts
@@ -1,11 +1,11 @@
 import { NativeModules, Platform } from 'react-native';
+import { logger } from '../common';
 
 interface NativeBridge {
   notifyParentChanged(parentFolderUuid: string): Promise<void>;
 }
 
-const bridge: NativeBridge | undefined =
-  Platform.OS === 'android' ? NativeModules.InternxtSignalingModule : undefined;
+const bridge: NativeBridge | undefined = Platform.OS === 'android' ? NativeModules.InternxtSignalingModule : undefined;
 
 /**
  * Signals the Android file picker (SAF DocumentsProvider) that a folder's children changed
@@ -18,5 +18,9 @@ const bridge: NativeBridge | undefined =
 export async function notifyParentChanged(parentFolderUuid: string): Promise<void> {
   if (!bridge) return;
   if (typeof parentFolderUuid !== 'string' || parentFolderUuid.length === 0) return;
-  await bridge.notifyParentChanged(parentFolderUuid);
+  try {
+    await bridge.notifyParentChanged(parentFolderUuid);
+  } catch (error) {
+    logger.warn('InternxtSignalingModule.notifyParentChanged failed', error);
+  }
 }

--- a/src/services/native/InternxtSignalingModule.ts
+++ b/src/services/native/InternxtSignalingModule.ts
@@ -1,0 +1,22 @@
+import { NativeModules, Platform } from 'react-native';
+
+interface NativeBridge {
+  notifyParentChanged(parentFolderUuid: string): Promise<void>;
+}
+
+const bridge: NativeBridge | undefined =
+  Platform.OS === 'android' ? NativeModules.InternxtSignalingModule : undefined;
+
+/**
+ * Signals the Android file picker (SAF DocumentsProvider) that a folder's children changed
+ * after a mutation originated in the React Native app (file upload, folder creation), so it
+ * invalidates its cache and re-queries.
+ *
+ * Best-effort and cross-platform: no-op on iOS and when the native module is unavailable,
+ * never throws to the caller and never invokes the native side with a malformed uuid.
+ */
+export async function notifyParentChanged(parentFolderUuid: string): Promise<void> {
+  if (!bridge) return;
+  if (typeof parentFolderUuid !== 'string' || parentFolderUuid.length === 0) return;
+  await bridge.notifyParentChanged(parentFolderUuid);
+}


### PR DESCRIPTION
Add a native signaling bridge from React Native to the Android SAF provider.
Reuse provider cache invalidation for RN-originated parent folder changes.
Signal after successful file uploads and folder creation, with iOS/no-module no-op behavior.
Add Jest coverage for the wrapper, upload signaling, and folder signaling.