### PR TITLE
[PB-6480] feature/Filmstrip scrub and scroll restoration in photo viewer

### DIFF
--- a/src/screens/PhotoPreviewScreen/components/PreviewCarousel.tsx
+++ b/src/screens/PhotoPreviewScreen/components/PreviewCarousel.tsx
@@ -1,7 +1,7 @@
 import { LinearGradient } from 'expo-linear-gradient';
 import { DotsThreeOutlineIcon, ExportIcon, TrashIcon } from 'phosphor-react-native';
 import { memo, useCallback, useEffect, useRef } from 'react';
-import { FlatList, Image, ListRenderItem, TouchableOpacity, View } from 'react-native';
+import { FlatList, Image, ListRenderItem, TouchableOpacity, View, useWindowDimensions } from 'react-native';
 import Animated, { Easing, useAnimatedStyle, withTiming } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTailwind } from 'tailwind-rn';
@@ -15,6 +15,8 @@ const THUMB_W_INACTIVE = 17;
 const THUMB_W_ACTIVE = 26;
 const THUMB_H = 26;
 const THUMB_GAP = 4;
+const THUMB_ACTIVE_MARGIN = 4;
+const THUMB_ITEM_WIDTH = THUMB_W_INACTIVE + THUMB_GAP;
 
 const CarouselThumb = ({
   uri,
@@ -59,7 +61,7 @@ const CloudCarouselItem = ({
     <CarouselThumb
       uri={uri}
       width={isActive ? THUMB_W_ACTIVE : THUMB_W_INACTIVE}
-      marginHorizontal={isActive ? 4 : 0}
+      marginHorizontal={isActive ? THUMB_ACTIVE_MARGIN : 0}
       onPress={onPress}
       onError={onImageError}
     />
@@ -75,7 +77,7 @@ const CarouselItem = memo(
       <CarouselThumb
         uri={item.uri}
         width={isActive ? THUMB_W_ACTIVE : THUMB_W_INACTIVE}
-        marginHorizontal={isActive ? 4 : 0}
+        marginHorizontal={isActive ? THUMB_ACTIVE_MARGIN : 0}
         onPress={onPress}
       />
     );
@@ -108,6 +110,9 @@ interface PreviewCarouselProps {
   items: TimelinePhotoItem[];
   currentIndex: number;
   onPress: (index: number) => void;
+  onScrub: (index: number) => void;
+  onScrubStart: () => void;
+  onScrubEnd: () => void;
   visible: boolean;
   onExport: () => void;
   onMore: () => void;
@@ -119,6 +124,9 @@ export const PreviewCarousel = ({
   items,
   currentIndex,
   onPress,
+  onScrub,
+  onScrubStart,
+  onScrubEnd,
   visible,
   onExport,
   onMore,
@@ -127,17 +135,76 @@ export const PreviewCarousel = ({
 }: PreviewCarouselProps): JSX.Element => {
   const tailwind = useTailwind();
   const insets = useSafeAreaInsets();
+  const { width: screenWidth } = useWindowDimensions();
   const listRef = useRef<FlatList<TimelinePhotoItem>>(null);
   const currentIndexRef = useRef(currentIndex);
   currentIndexRef.current = currentIndex;
 
+  // True from onScrollBeginDrag until onMomentumScrollEnd (or timer fallback).
+  // Stays true during momentum so handleScroll keeps tracking the final settled position.
+  const isUserScrollingRef = useRef(false);
+  const endScrubTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isFirstRenderRef = useRef(true);
+
+  const filmstripPadding = Math.round(screenWidth / 2 - (THUMB_W_ACTIVE / 2 + THUMB_ACTIVE_MARGIN));
+
   useEffect(() => {
-    const isIndexOutOfBounds = currentIndex < 0 || currentIndex >= items.length;
-    if (isIndexOutOfBounds) {
+    if (currentIndex < 0 || currentIndex >= items.length) {
       return;
     }
-    listRef.current?.scrollToIndex({ index: currentIndex, animated: true, viewPosition: 0.5 });
+    if (isUserScrollingRef.current) {
+      return;
+    }
+
+    const animateAutoScroll = !isFirstRenderRef.current;
+    isFirstRenderRef.current = false;
+    listRef.current?.scrollToOffset({
+      offset: Math.max(0, currentIndex * THUMB_ITEM_WIDTH),
+      animated: animateAutoScroll,
+    });
   }, [currentIndex, items.length]);
+
+  const endScrub = useCallback(() => {
+    if (endScrubTimerRef.current) {
+      clearTimeout(endScrubTimerRef.current);
+      endScrubTimerRef.current = null;
+    }
+    isUserScrollingRef.current = false;
+    onScrubEnd();
+  }, [onScrubEnd]);
+
+  const handleScrollBeginDrag = useCallback(() => {
+    if (endScrubTimerRef.current) {
+      clearTimeout(endScrubTimerRef.current);
+      endScrubTimerRef.current = null;
+    }
+    isUserScrollingRef.current = true;
+    onScrubStart();
+  }, [onScrubStart]);
+
+  const handleScrollEndDrag = useCallback(() => {
+    // Don't end scrub yet — momentum may continue. Short fallback for the case
+    // where the user releases on an exact snap point (no momentum, onMomentumScrollEnd won't fire).
+    endScrubTimerRef.current = setTimeout(endScrub, 150);
+  }, [endScrub]);
+
+  const handleMomentumScrollEnd = useCallback(() => {
+    endScrub();
+  }, [endScrub]);
+
+  const handleScroll = useCallback(
+    (event: { nativeEvent: { contentOffset: { x: number } } }) => {
+      if (!isUserScrollingRef.current) {
+        return;
+      }
+      const contentOffsetX = event.nativeEvent.contentOffset.x;
+      const index = Math.round(Math.max(0, Math.min(items.length - 1, contentOffsetX / THUMB_ITEM_WIDTH)));
+      if (index !== currentIndexRef.current) {
+        onScrub(index);
+      }
+    },
+    [items.length, onScrub],
+  );
 
   const animatedStyle = useAnimatedStyle(() => ({
     opacity: withTiming(visible ? 1 : 0, { duration: 150, easing: Easing.out(Easing.quad) }),
@@ -146,8 +213,8 @@ export const PreviewCarousel = ({
 
   const getItemLayout = useCallback(
     (_: ArrayLike<TimelinePhotoItem> | null | undefined, index: number) => ({
-      length: THUMB_W_INACTIVE + THUMB_GAP,
-      offset: (THUMB_W_INACTIVE + THUMB_GAP) * index,
+      length: THUMB_ITEM_WIDTH,
+      offset: THUMB_ITEM_WIDTH * index,
       index,
     }),
     [],
@@ -181,11 +248,18 @@ export const PreviewCarousel = ({
             renderItem={renderItem}
             horizontal
             showsHorizontalScrollIndicator={false}
-            contentContainerStyle={{ paddingHorizontal: 12 }}
+            contentContainerStyle={{ paddingHorizontal: filmstripPadding }}
             getItemLayout={getItemLayout}
             windowSize={5}
             initialNumToRender={30}
             maxToRenderPerBatch={20}
+            scrollEventThrottle={16}
+            decelerationRate="normal"
+            snapToInterval={THUMB_ITEM_WIDTH}
+            onScroll={handleScroll}
+            onScrollBeginDrag={handleScrollBeginDrag}
+            onScrollEndDrag={handleScrollEndDrag}
+            onMomentumScrollEnd={handleMomentumScrollEnd}
             onScrollToIndexFailed={(info) => {
               logger.error('Scroll to index failed:', info);
             }}

--- a/src/screens/PhotoPreviewScreen/components/PreviewPage.tsx
+++ b/src/screens/PhotoPreviewScreen/components/PreviewPage.tsx
@@ -10,8 +10,9 @@ import { usePreviewSource } from '../hooks/usePreviewSource';
 
 interface PageContentProps {
   item: TimelinePhotoItem;
-  uri: string | null | undefined;
+  uri: string | null;
   thumbnailUri: string | null;
+  isLoading: boolean;
   onTap: () => void;
   onZoom: () => void;
   onReset: () => void;
@@ -25,6 +26,7 @@ const PageContent = ({
   item,
   uri,
   thumbnailUri,
+  isLoading,
   onTap,
   onZoom,
   onReset,
@@ -52,7 +54,7 @@ const PageContent = ({
         {thumbnailUri ? (
           <Image source={{ uri: thumbnailUri }} style={tailwind('w-full h-full')} resizeMode="contain" />
         ) : null}
-        {uri === undefined ? <ActivityIndicator style={tailwind('absolute')} color="white" size="large" /> : null}
+        {isLoading ? <ActivityIndicator style={tailwind('absolute')} color="white" size="large" /> : null}
       </View>
     );
   }
@@ -66,13 +68,14 @@ const PageContent = ({
       {thumbnailUri ? (
         <Image source={{ uri: thumbnailUri }} style={tailwind('w-full h-full')} resizeMode="contain" />
       ) : null}
-      {uri === undefined ? <ActivityIndicator style={tailwind('absolute')} color="white" size="large" /> : null}
+      {isLoading ? <ActivityIndicator style={tailwind('absolute')} color="white" size="large" /> : null}
     </View>
   );
 };
 
 interface PreviewPageProps {
   item: TimelinePhotoItem;
+  isScrubbing: boolean;
   onTap: () => void;
   onZoomChange: (zoomed: boolean) => void;
   onSwipeDown: () => void;
@@ -85,6 +88,7 @@ interface PreviewPageProps {
 
 export const PreviewPage = ({
   item,
+  isScrubbing,
   onTap,
   onZoomChange,
   onSwipeDown,
@@ -96,7 +100,7 @@ export const PreviewPage = ({
 }: PreviewPageProps): JSX.Element => {
   const tailwind = useTailwind();
   const { width: screenWidth } = useWindowDimensions();
-  const { uri, thumbnailUri } = usePreviewSource(item);
+  const { uri, thumbnailUri, isLoading } = usePreviewSource(item, isScrubbing);
   const [zoomed, setZoomed] = useState(false);
   const translateY = useSharedValue(0);
 
@@ -150,6 +154,7 @@ export const PreviewPage = ({
           item={item}
           uri={uri}
           thumbnailUri={thumbnailUri}
+          isLoading={isLoading}
           onTap={onTap}
           onZoom={handleZoom}
           onReset={handleReset}

--- a/src/screens/PhotoPreviewScreen/components/PreviewPager.tsx
+++ b/src/screens/PhotoPreviewScreen/components/PreviewPager.tsx
@@ -7,6 +7,7 @@ interface PreviewPagerProps {
   items: TimelinePhotoItem[];
   initialIndex: number;
   activeIndex: number;
+  isScrubbing: boolean;
   onIndexChange: (index: number) => void;
   onTap: () => void;
   onZoomChange: (zoomed: boolean) => void;
@@ -22,6 +23,7 @@ export const PreviewPager = ({
   items,
   initialIndex,
   activeIndex,
+  isScrubbing,
   onIndexChange,
   onTap,
   onZoomChange,
@@ -34,19 +36,25 @@ export const PreviewPager = ({
 }: PreviewPagerProps): JSX.Element => {
   const { width: screenWidth } = useWindowDimensions();
   const listRef = useRef<FlatList<TimelinePhotoItem>>(null);
+  // Use a ref so the effect only re-runs on index changes, not on isScrubbing changes.
+  // This prevents a spurious animated scroll (and its onMomentumScrollEnd) every time
+  // scrubbing ends, which was causing an oscillation loop.
+  const isScrubbingRef = useRef(isScrubbing);
+  isScrubbingRef.current = isScrubbing;
 
   useEffect(() => {
     const isIndexOutOfBounds = activeIndex < 0 || activeIndex >= items.length;
     if (isIndexOutOfBounds) {
       return;
     }
-    listRef.current?.scrollToIndex({ index: activeIndex, animated: true });
+    listRef.current?.scrollToIndex({ index: activeIndex, animated: !isScrubbingRef.current });
   }, [activeIndex, items.length]);
 
   const renderItem: ListRenderItem<TimelinePhotoItem> = useCallback(
     ({ item }) => (
       <PreviewPage
         item={item}
+        isScrubbing={isScrubbing}
         onTap={onTap}
         onZoomChange={onZoomChange}
         onSwipeDown={onSwipeDown}
@@ -57,7 +65,7 @@ export const PreviewPager = ({
         hasVideoStarted={hasVideoStarted}
       />
     ),
-    [onTap, onZoomChange, onSwipeDown, onVideoPlay, onVideoPause, onVideoEnd, videoResetKey, hasVideoStarted],
+    [isScrubbing, onTap, onZoomChange, onSwipeDown, onVideoPlay, onVideoPause, onVideoEnd, videoResetKey, hasVideoStarted],
   );
 
   const getItemLayout = useCallback(

--- a/src/screens/PhotoPreviewScreen/hooks/usePreviewSource.ts
+++ b/src/screens/PhotoPreviewScreen/hooks/usePreviewSource.ts
@@ -4,34 +4,42 @@ import { PhotoAssetFetchService } from '../../../services/photos/PhotoAssetFetch
 import { TimelinePhotoItem } from '../../PhotosScreen/types';
 
 export interface UsePreviewSourceResult {
-  uri: string | null | undefined;
+  uri: string | null;
   thumbnailUri: string | null;
+  isLoading: boolean;
 }
 
-export const usePreviewSource = (item: TimelinePhotoItem): UsePreviewSourceResult => {
+export const usePreviewSource = (item: TimelinePhotoItem, isScrubbing: boolean): UsePreviewSourceResult => {
   const thumbnailUri = item.type === 'cloud-only' ? item.thumbnailPath : (item.uri ?? null);
-  const [uri, setUri] = useState<string | null | undefined>(undefined);
+  const [uri, setUri] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
+    if (isScrubbing) {
+      return;
+    }
+
     abortRef.current?.abort();
     const controller = new AbortController();
     abortRef.current = controller;
 
-    setUri(undefined);
+    setUri(null);
+    setIsLoading(true);
     logger.info(`[usePreviewSource] fetching asset — id: ${item.id}, type: ${item.type}, mediaType: ${item.mediaType}`);
 
     PhotoAssetFetchService.fetchUri(item, controller.signal).then((fullUri) => {
       if (!controller.signal.aborted) {
         logger.info(`[usePreviewSource] asset ready — id: ${item.id}, uri: ${fullUri ?? 'null'}`);
         setUri(fullUri ?? null);
+        setIsLoading(false);
       }
     });
 
     return () => {
       controller.abort();
     };
-  }, [item.id]);
+  }, [item.id, isScrubbing]);
 
-  return { uri, thumbnailUri };
+  return { uri, thumbnailUri, isLoading };
 };

--- a/src/screens/PhotoPreviewScreen/index.tsx
+++ b/src/screens/PhotoPreviewScreen/index.tsx
@@ -1,6 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 import strings from 'assets/lang/strings';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { StatusBar, View } from 'react-native';
 import { ConfirmModal } from 'src/components/modals/ConfirmModal/ConfirmModal';
 import { logger } from 'src/services/common';
@@ -20,7 +20,7 @@ import { usePreviewItems } from './hooks/usePreviewItems';
 type Props = RootStackScreenProps<'PhotoPreview'>;
 
 export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
-  const { initialId, items: routeItems, onItemChanged } = route.params;
+  const { initialId, items: routeItems, onItemChanged, onCurrentItemChange } = route.params;
   const { items, currentIndex, setCurrentIndex } = usePreviewItems(initialId, routeItems);
   const tailwind = useTailwind();
   const navigation = useNavigation();
@@ -33,6 +33,7 @@ export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
   const [metadataOpen, setMetadataOpen] = useState(false);
   const [hasVideoStarted, setHasVideoStarted] = useState(false);
   const [videoResetKey, setVideoResetKey] = useState(0);
+  const [isScrubbing, setIsScrubbing] = useState(false);
 
   const resetVideoPlayer = useCallback(() => setVideoResetKey((key) => key + 1), []);
 
@@ -83,8 +84,17 @@ export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
     setIsUiVisible(true);
   }, []);
 
+  const handleScrubStart = useCallback(() => setIsScrubbing(true), []);
+  const handleScrubEnd = useCallback(() => setIsScrubbing(false), []);
+
   const currentItem = items[currentIndex];
   const actionItems = useMemo(() => (currentItem ? [currentItem] : []), [currentItem]);
+
+  useEffect(() => {
+    if (currentItem) {
+      onCurrentItemChange?.(currentItem.id);
+    }
+  }, [currentIndex, currentItem, onCurrentItemChange]);
 
   const { handleExport, handleSave, handleCopy, handleTrashConfirm, handleRestore } = usePhotoActionHandlers({
     items: actionItems,
@@ -118,6 +128,7 @@ export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
         items={items}
         initialIndex={currentIndex}
         activeIndex={currentIndex}
+        isScrubbing={isScrubbing}
         onIndexChange={setCurrentIndex}
         onTap={handleTap}
         onZoomChange={handleZoomChange}
@@ -139,6 +150,9 @@ export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
           items={items}
           currentIndex={currentIndex}
           onPress={setCurrentIndex}
+          onScrub={setCurrentIndex}
+          onScrubStart={handleScrubStart}
+          onScrubEnd={handleScrubEnd}
           visible={isUiVisible}
           onExport={handleExport}
           onMore={() => setIsMoreActionsOpen(true)}

--- a/src/screens/PhotosScreen/components/PhotosTimeline.tsx
+++ b/src/screens/PhotosScreen/components/PhotosTimeline.tsx
@@ -1,5 +1,5 @@
 import { FlashList, FlashListProps, ListRenderItem } from '@shopify/flash-list';
-import { useCallback, useMemo, useRef } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef } from 'react';
 import { Animated, Dimensions, View } from 'react-native';
 import { useTailwind } from 'tailwind-rn';
 import { PhotoBackupState, PhotoDateGroup } from '../types';
@@ -8,8 +8,12 @@ import PhotosGroupHeader, { GroupSyncStatus } from './GroupHeader/PhotosGroupHea
 import PhotoItem from './PhotoItem';
 import PhotosEmptyState from './PhotosEmptyState';
 
+export interface PhotosTimelineHandle {
+  scrollToAssetId: (id: string) => void;
+}
+
 const AnimatedFlashList = Animated.createAnimatedComponent(FlashList) as React.ComponentType<
-  FlashListProps<FlatItem> & { estimatedItemSize?: number }
+  FlashListProps<FlatItem> & { estimatedItemSize?: number; ref?: React.Ref<any> }
 >;
 
 export type TimelineDateGroup = { group: PhotoDateGroup; syncStatus: GroupSyncStatus };
@@ -57,96 +61,128 @@ const overrideItemLayout = (layout: { span?: number }, item: FlatItem) => {
 
 const keyExtractor = (item: FlatItem) => (item.type === 'header' ? `header-${item.id}` : item.photo.id);
 
-const PhotosTimeline = ({
-  assetsGroupsByDate,
-  isLoading,
-  onPhotoPress,
-  onPhotoLongPress,
-  isSelectMode,
-  selectedIds,
-  ListHeaderComponent,
-  onEndReached,
-  refreshing,
-  onRefresh,
-  onPausePress,
-  onResumePress,
-}: PhotosTimelineProps) => {
-  const tailwind = useTailwind();
-  const { items, headerIndices } = useMemo(() => {
-    const effectiveGroups = isLoading ? [...assetsGroupsByDate, SKELETON_GROUP] : assetsGroupsByDate;
-    return buildTimelineItems(effectiveGroups);
-  }, [assetsGroupsByDate, isLoading]);
-
-  const extraData = useMemo(
-    () => ({ isSelectMode, selectedIds, onPausePress, onResumePress }),
-    [isSelectMode, selectedIds, onPausePress, onResumePress],
-  );
-
-  const scrollY = useRef(new Animated.Value(0)).current;
-  // UIKit refuses to deliver touches to views with alpha < 0.01 (the internal threshold).
-  // Using 0.02 as the floor keeps the sticky header visually invisible at scrollY=0 while
-  // staying above the threshold, so pause/resume buttons are always touchable.
-  const stickyOpacity = useMemo(
-    () => scrollY.interpolate({ inputRange: [0, 24], outputRange: [0.02, 1], extrapolate: 'clamp' }),
-    [scrollY],
-  );
-
-  const renderItem: ListRenderItem<FlatItem> = useCallback(
-    ({ item, target }) => {
-      if (item.type === 'header') {
-        const isSticky = target === 'StickyHeader';
-        const showSyncStatus = isSticky || item.isFirst;
-        return (
-          <PhotosGroupHeader
-            label={item.label}
-            syncStatus={showSyncStatus ? item.syncStatus : { type: 'count', count: item.count }}
-            isSticky={isSticky}
-            stickyOpacity={isSticky ? stickyOpacity : undefined}
-            onPausePress={onPausePress}
-            onResumePress={onResumePress}
-          />
-        );
-      }
-      return (
-        <View style={[tailwind('flex-1'), { aspectRatio: 1, margin: 1 }]}>
-          <PhotoItem
-            item={item.photo}
-            isSelectMode={isSelectMode}
-            isSelected={selectedIds?.has(item.photo.id)}
-            onPress={onPhotoPress}
-            onLongPress={onPhotoLongPress}
-          />
-        </View>
-      );
+const PhotosTimeline = forwardRef<PhotosTimelineHandle, PhotosTimelineProps>(
+  (
+    {
+      assetsGroupsByDate,
+      isLoading,
+      onPhotoPress,
+      onPhotoLongPress,
+      isSelectMode,
+      selectedIds,
+      ListHeaderComponent,
+      onEndReached,
+      refreshing,
+      onRefresh,
+      onPausePress,
+      onResumePress,
     },
-    [isSelectMode, selectedIds, onPhotoPress, onPhotoLongPress, stickyOpacity, onPausePress, onResumePress],
-  );
+    ref,
+  ) => {
+    const tailwind = useTailwind();
+    const { items, headerIndices } = useMemo(() => {
+      const effectiveGroups = isLoading ? [...assetsGroupsByDate, SKELETON_GROUP] : assetsGroupsByDate;
+      return buildTimelineItems(effectiveGroups);
+    }, [assetsGroupsByDate, isLoading]);
 
-  const isEmpty = !isLoading && assetsGroupsByDate.length === 0;
+    const extraData = useMemo(
+      () => ({ isSelectMode, selectedIds, onPausePress, onResumePress }),
+      [isSelectMode, selectedIds, onPausePress, onResumePress],
+    );
 
-  return (
-    <AnimatedFlashList
-      data={items}
-      renderItem={renderItem}
-      keyExtractor={keyExtractor}
-      numColumns={NUM_COLUMNS}
-      estimatedItemSize={ESTIMATED_ITEM_SIZE}
-      stickyHeaderIndices={headerIndices}
-      getItemType={getItemType}
-      overrideItemLayout={overrideItemLayout}
-      extraData={extraData}
-      ListHeaderComponent={ListHeaderComponent}
-      ListEmptyComponent={isEmpty ? <PhotosEmptyState /> : undefined}
-      contentContainerStyle={isEmpty ? { paddingBottom: 80, flexGrow: 1 } : { paddingBottom: 80 }}
-      showsVerticalScrollIndicator={false}
-      onEndReached={onEndReached}
-      onEndReachedThreshold={0.5}
-      refreshing={refreshing}
-      onRefresh={onRefresh}
-      onScroll={Animated.event([{ nativeEvent: { contentOffset: { y: scrollY } } }], { useNativeDriver: false })}
-      scrollEventThrottle={16}
-    />
-  );
-};
+    const scrollY = useRef(new Animated.Value(0)).current;
+
+    const flashListRef = useRef<any>(null);
+
+    const idToIndex = useMemo(() => {
+      const map = new Map<string, number>();
+      items.forEach((item, index) => {
+        if (item.type === 'photo') {
+          map.set(item.photo.id, index);
+        }
+      });
+      return map;
+    }, [items]);
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        scrollToAssetId: (id: string) => {
+          const index = idToIndex.get(id);
+          if (index === undefined) {
+            return;
+          }
+          flashListRef.current?.scrollToIndex({ index, animated: false, viewPosition: 0.3 });
+        },
+      }),
+      [idToIndex],
+    );
+    // UIKit refuses to deliver touches to views with alpha < 0.01 (the internal threshold).
+    // Using 0.02 as the floor keeps the sticky header visually invisible at scrollY=0 while
+    // staying above the threshold, so pause/resume buttons are always touchable.
+    const stickyOpacity = useMemo(
+      () => scrollY.interpolate({ inputRange: [0, 24], outputRange: [0.02, 1], extrapolate: 'clamp' }),
+      [scrollY],
+    );
+
+    const renderItem: ListRenderItem<FlatItem> = useCallback(
+      ({ item, target }) => {
+        if (item.type === 'header') {
+          const isSticky = target === 'StickyHeader';
+          const showSyncStatus = isSticky || item.isFirst;
+          return (
+            <PhotosGroupHeader
+              label={item.label}
+              syncStatus={showSyncStatus ? item.syncStatus : { type: 'count', count: item.count }}
+              isSticky={isSticky}
+              stickyOpacity={isSticky ? stickyOpacity : undefined}
+              onPausePress={onPausePress}
+              onResumePress={onResumePress}
+            />
+          );
+        }
+        return (
+          <View style={[tailwind('flex-1'), { aspectRatio: 1, margin: 1 }]}>
+            <PhotoItem
+              item={item.photo}
+              isSelectMode={isSelectMode}
+              isSelected={selectedIds?.has(item.photo.id)}
+              onPress={onPhotoPress}
+              onLongPress={onPhotoLongPress}
+            />
+          </View>
+        );
+      },
+      [isSelectMode, selectedIds, onPhotoPress, onPhotoLongPress, stickyOpacity, onPausePress, onResumePress],
+    );
+
+    const isEmpty = !isLoading && assetsGroupsByDate.length === 0;
+
+    return (
+      <AnimatedFlashList
+        ref={flashListRef}
+        data={items}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        numColumns={NUM_COLUMNS}
+        estimatedItemSize={ESTIMATED_ITEM_SIZE}
+        stickyHeaderIndices={headerIndices}
+        getItemType={getItemType}
+        overrideItemLayout={overrideItemLayout}
+        extraData={extraData}
+        ListHeaderComponent={ListHeaderComponent}
+        ListEmptyComponent={isEmpty ? <PhotosEmptyState /> : undefined}
+        contentContainerStyle={isEmpty ? { paddingBottom: 80, flexGrow: 1 } : { paddingBottom: 80 }}
+        showsVerticalScrollIndicator={false}
+        onEndReached={onEndReached}
+        onEndReachedThreshold={0.5}
+        refreshing={refreshing}
+        onRefresh={onRefresh}
+        onScroll={Animated.event([{ nativeEvent: { contentOffset: { y: scrollY } } }], { useNativeDriver: false })}
+        scrollEventThrottle={16}
+      />
+    );
+  },
+);
 
 export default PhotosTimeline;

--- a/src/screens/PhotosScreen/index.tsx
+++ b/src/screens/PhotosScreen/index.tsx
@@ -1,6 +1,6 @@
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import strings from 'assets/lang/strings';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { View } from 'react-native';
 import AppScreen from 'src/components/AppScreen';
 import { ConfirmModal } from 'src/components/modals/ConfirmModal/ConfirmModal';
@@ -24,7 +24,7 @@ import LimitedAccessBanner from './components/LimitedAccessBanner';
 import MoreActionsBottomSheet from './components/MoreActionsBottomSheet';
 import PhotosHeader from './components/PhotosHeader';
 import PhotosLockedOverlay from './components/PhotosLockedOverlay';
-import PhotosTimeline from './components/PhotosTimeline';
+import PhotosTimeline, { PhotosTimelineHandle } from './components/PhotosTimeline';
 import SelectionHeader from './components/SelectionHeader';
 import SelectionToolbar from './components/SelectionToolbar';
 import EnableBackupBottomSheet from './EnableBackupBottomSheet';
@@ -43,6 +43,9 @@ const PhotosScreen = (): JSX.Element => {
   const [refreshing, setRefreshing] = useState(false);
   const { timelineDateGroups, isLoading, loadNextPage, reloadLocal, reloadCloud } = usePhotosTimeline();
 
+  const timelineRef = useRef<PhotosTimelineHandle>(null);
+  const lastViewedIdRef = useRef<string | null>(null);
+
   const allItems = useMemo<TimelinePhotoItem[]>(
     () => timelineDateGroups.flatMap((dateGroup) => dateGroup.group.photos),
     [timelineDateGroups],
@@ -55,6 +58,10 @@ const PhotosScreen = (): JSX.Element => {
     await Promise.all([reloadLocal(), reloadCloud()]);
   }, [reloadLocal, reloadCloud]);
 
+  const handleCurrentItemChange = useCallback((itemId: string) => {
+    lastViewedIdRef.current = itemId;
+  }, []);
+
   const handlePhotoPress = useCallback(
     (id: string) => {
       if (selection.selectMode) {
@@ -65,9 +72,10 @@ const PhotosScreen = (): JSX.Element => {
         initialId: id,
         items: allItems,
         onItemChanged: handleItemChangedFromPreview,
+        onCurrentItemChange: handleCurrentItemChange,
       });
     },
-    [selection, navigation, allItems, handleItemChangedFromPreview],
+    [selection, navigation, allItems, handleItemChangedFromPreview, handleCurrentItemChange],
   );
 
   const handlePhotoLongPress = useCallback(
@@ -157,6 +165,12 @@ const PhotosScreen = (): JSX.Element => {
       if (enabled) {
         dispatch(runBackupCycleThunk());
       }
+
+      const id = lastViewedIdRef.current;
+      if (id) {
+        lastViewedIdRef.current = null;
+        timelineRef.current?.scrollToAssetId(id);
+      }
     }, [enabled]),
   );
 
@@ -170,6 +184,7 @@ const PhotosScreen = (): JSX.Element => {
 
       <View style={tailwind('flex-1')}>
         <PhotosTimeline
+          ref={timelineRef}
           assetsGroupsByDate={timelineDateGroups}
           isLoading={isLoading}
           ListHeaderComponent={listHeader}

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -28,7 +28,12 @@ export type RootStackParamList = {
   TabExplorer: NavigatorScreenParams<TabExplorerStackParamList>;
   Trash: undefined;
   DrivePreview: undefined;
-  PhotoPreview: { initialId: string; items: TimelinePhotoItem[]; onItemChanged?: () => Promise<void> | void };
+  PhotoPreview: {
+    initialId: string;
+    items: TimelinePhotoItem[];
+    onItemChanged?: () => Promise<void> | void;
+    onCurrentItemChange?: (itemId: string) => void;
+  };
   Settings: undefined;
   AndroidShare: { files: SharedFile[] } | undefined;
   LargeShareUpload: { metadata: PendingShareMetadata };


### PR DESCRIPTION
Add filmstrip scrub and scroll restoration to the photo preview screen

  ## Summary

  - **`PreviewCarousel`**: drag on the thumbnail strip now changes the main preview photo in real time. Uses `isUserScrollingRef` to stay active through the momentum phase so the final settled index is captured correctly. `filmstripPadding` corrected to center the active thumb (`screenWidth/2 - (THUMB_W_ACTIVE/2 + THUMB_ACTIVE_MARGIN)`) instead of the inactive slot midpoint.
  - **`PreviewPager`**: receives `isScrubbing` prop and reads it via ref (`isScrubbingRef`) excluded from `useEffect` deps. Prevents an oscillation loop where scrub-end would trigger an animated scroll, fire `onMomentumScrollEnd`, and restart the cycle.
  - **`usePreviewSource`**: full resolution fetch is deferred while scrubbing. Replaced `uri: string | null | undefined` with `uri: string | null` + `isLoading: boolean` so loading state is explicit rather than encoded as `undefined`.
  - **`PreviewPage`**: drills `isScrubbing` to `usePreviewSource`. Passes `isLoading` to `PageContent` replacing the `uri === undefined` spinner check.
  - **`PhotoPreviewScreen/index`**: owns `isScrubbing` stat. Reports the current item id to `PhotosScreen` via `onCurrentItemChange` route param on every index change.
  - **`PhotosTimeline`**: converted to `forwardRef` exposing `scrollToAssetId(id)`.
  - **`PhotosScreen/index`**: stores the last viewed photo id in `lastViewedIdRef`. On `useFocusEffect` scrolls the grid back to that photo and clears the ref.