### PR TITLE
[PB-5919]: register File Provider domain on login/logout

### DIFF
--- a/ios/Internxt.xcodeproj/project.pbxproj
+++ b/ios/Internxt.xcodeproj/project.pbxproj
@@ -15,6 +15,11 @@
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
 		7D373856C83A43879BFBE604 /* InternxtShareExtension.appex in Copy Files */ = {isa = PBXBuildFile; fileRef = 7F5486528A7D46DD91A7910F /* InternxtShareExtension.appex */; };
 		8F8148045BC14A539BD1917D /* ShareExtensionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6F72E1B98D469883DAFB30 /* ShareExtensionViewController.swift */; };
+		AA0100012F87A94000E14783 /* SharedAuthKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100002F87A94000E14783 /* SharedAuthKeychain.swift */; };
+		AA0100032F87A94000E14783 /* FileProviderDomainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100022F87A94000E14783 /* FileProviderDomainManager.swift */; };
+		AA0100052F87A94000E14783 /* InternxtAuthCredentialsModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100042F87A94000E14783 /* InternxtAuthCredentialsModule.swift */; };
+		AA0100072F87A94000E14783 /* InternxtAuthCredentialsModule.m in Sources */ = {isa = PBXBuildFile; fileRef = AA0100062F87A94000E14783 /* InternxtAuthCredentialsModule.m */; };
+		AA0100082F87A94000E14783 /* SharedAuthKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100002F87A94000E14783 /* SharedAuthKeychain.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
 		DE1D47432F87A94000E14783 /* UniformTypeIdentifiers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE1D47422F87A94000E14783 /* UniformTypeIdentifiers.framework */; };
 		DE1D474F2F87A94000E14783 /* InternxtFileProvider.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = DE1D47412F87A94000E14783 /* InternxtFileProvider.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -85,6 +90,10 @@
 		7F5486528A7D46DD91A7910F /* InternxtShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; fileEncoding = 9; includeInIndex = 0; path = InternxtShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		8C48FB43821216C363EBF3FC /* Pods-InternxtFileProvider.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtFileProvider.release.xcconfig"; path = "Target Support Files/Pods-InternxtFileProvider/Pods-InternxtFileProvider.release.xcconfig"; sourceTree = "<group>"; };
 		A4921399A370F5CE6EE7EA0F /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-InternxtShareExtension/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
+		AA0100002F87A94000E14783 /* SharedAuthKeychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SharedAuthKeychain.swift; path = Internxt/SharedAuthKeychain.swift; sourceTree = "<group>"; };
+		AA0100022F87A94000E14783 /* FileProviderDomainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FileProviderDomainManager.swift; path = Internxt/FileProviderDomainManager.swift; sourceTree = "<group>"; };
+		AA0100042F87A94000E14783 /* InternxtAuthCredentialsModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = InternxtAuthCredentialsModule.swift; path = Internxt/InternxtAuthCredentialsModule.swift; sourceTree = "<group>"; };
+		AA0100062F87A94000E14783 /* InternxtAuthCredentialsModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = InternxtAuthCredentialsModule.m; path = Internxt/InternxtAuthCredentialsModule.m; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = Internxt/SplashScreen.storyboard; sourceTree = "<group>"; };
 		AC8B28CC3C9A8FDF21A8C1E7 /* Pods-InternxtFileProvider.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtFileProvider.debug.xcconfig"; path = "Target Support Files/Pods-InternxtFileProvider/Pods-InternxtFileProvider.debug.xcconfig"; sourceTree = "<group>"; };
 		B8AF05FC3A0730CCBD5A3D8F /* Pods-InternxtShareExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtShareExtension.release.xcconfig"; path = "Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension.release.xcconfig"; sourceTree = "<group>"; };
@@ -143,6 +152,10 @@
 			children = (
 				DEBEAEBD2F72E65B00A6E6D5 /* AppGroupPendingShareModule.m */,
 				DEBEAEBE2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift */,
+				AA0100002F87A94000E14783 /* SharedAuthKeychain.swift */,
+				AA0100022F87A94000E14783 /* FileProviderDomainManager.swift */,
+				AA0100042F87A94000E14783 /* InternxtAuthCredentialsModule.swift */,
+				AA0100062F87A94000E14783 /* InternxtAuthCredentialsModule.m */,
 				F11748412D0307B40044C1D9 /* AppDelegate.swift */,
 				F11748442D0722820044C1D9 /* Internxt-Bridging-Header.h */,
 				BB2F792B24A3F905000567C9 /* Supporting */,
@@ -352,7 +365,6 @@
 				LastUpgradeCheck = 1130;
 				TargetAttributes = {
 					13B07F861A680F5B00A75B9A = {
-						DevelopmentTeam = JR4S3SY396;
 						LastSwiftMigration = 1250;
 						ProvisioningStyle = Automatic;
 					};
@@ -698,6 +710,10 @@
 				1818AB341F31CC033FFF750B /* ExpoModulesProvider.swift in Sources */,
 				DEBEAEBF2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift in Sources */,
 				DEBEAEC02F72E65B00A6E6D5 /* AppGroupPendingShareModule.m in Sources */,
+				AA0100012F87A94000E14783 /* SharedAuthKeychain.swift in Sources */,
+				AA0100032F87A94000E14783 /* FileProviderDomainManager.swift in Sources */,
+				AA0100052F87A94000E14783 /* InternxtAuthCredentialsModule.swift in Sources */,
+				AA0100072F87A94000E14783 /* InternxtAuthCredentialsModule.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -717,6 +733,7 @@
 				DE1D47602F87A94000E14783 /* FileProviderExtension.swift in Sources */,
 				DE1D47612F87A94000E14783 /* FileProviderEnumerator.swift in Sources */,
 				DE1D47622F87A94000E14783 /* FileProviderItem.swift in Sources */,
+				AA0100082F87A94000E14783 /* SharedAuthKeychain.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1014,7 +1031,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.9.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
@@ -1064,7 +1081,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.9.0;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.internxt.snacks.InternxtFileProvider;

--- a/ios/Internxt/AppDelegate.swift
+++ b/ios/Internxt/AppDelegate.swift
@@ -1,7 +1,6 @@
 import Expo
 import React
 import ReactAppDependencyProvider
-import Security
 
 @UIApplicationMain
 public class AppDelegate: ExpoAppDelegate {
@@ -44,75 +43,7 @@ public class AppDelegate: ExpoAppDelegate {
   // MARK: - App Group auth sync
 
   private func syncAuthStatusToAppGroup() {
-    guard let sharedGroup = Bundle.main.object(forInfoDictionaryKey: "SharedKeychainGroup") as? String
-    else { return }
-
-    let isAuthenticated = privateKeychainItemExists(key: "photosToken")
-
-    if isAuthenticated {
-      copyToSharedKeychain(privateKey: "photosToken",        sharedKey: "shared_photosToken",   accessGroup: sharedGroup)
-      copyToSharedKeychain(privateKey: "xUser_mnemonic",     sharedKey: "shared_mnemonic",      accessGroup: sharedGroup)
-      copyToSharedKeychain(privateKey: "xUser_rootFolderId", sharedKey: "shared_rootFolderId",  accessGroup: sharedGroup)
-      copyToSharedKeychain(privateKey: "xUser_bucket",       sharedKey: "shared_bucket",        accessGroup: sharedGroup)
-      copyToSharedKeychain(privateKey: "xUser_bridgeUser",   sharedKey: "shared_bridgeUser",    accessGroup: sharedGroup)
-      copyToSharedKeychain(privateKey: "xUser_userId",       sharedKey: "shared_userId",        accessGroup: sharedGroup)
-    } else {
-      deleteFromSharedKeychain(key: "shared_photosToken",  accessGroup: sharedGroup)
-      deleteFromSharedKeychain(key: "shared_mnemonic",     accessGroup: sharedGroup)
-      deleteFromSharedKeychain(key: "shared_rootFolderId", accessGroup: sharedGroup)
-      deleteFromSharedKeychain(key: "shared_bucket",       accessGroup: sharedGroup)
-      deleteFromSharedKeychain(key: "shared_bridgeUser",   accessGroup: sharedGroup)
-      deleteFromSharedKeychain(key: "shared_userId",       accessGroup: sharedGroup)
-    }
-  }
-
-  private func privateKeychainItemExists(key: String) -> Bool {
-    return readFromPrivateKeychain(key: key) != nil
-  }
-
-  private func copyToSharedKeychain(privateKey: String, sharedKey: String, accessGroup: String) {
-    guard let data = readFromPrivateKeychain(key: privateKey) else { return }
-    writeToSharedKeychain(data: data, key: sharedKey, accessGroup: accessGroup)
-  }
-
-  private func readFromPrivateKeychain(key: String) -> Data? {
-    var result: AnyObject?
-    let query: [String: Any] = [
-      kSecClass as String: kSecClassGenericPassword,
-      kSecAttrService as String: "app:no-auth",
-      kSecAttrGeneric as String: Data(key.utf8),
-      kSecAttrAccount as String: Data(key.utf8),
-      kSecMatchLimit as String: kSecMatchLimitOne,
-      kSecReturnData as String: true,
-    ]
-    guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
-          let data = result as? Data else { return nil }
-    return data
-  }
-
-  private func writeToSharedKeychain(data: Data, key: String, accessGroup: String) {
-    deleteFromSharedKeychain(key: key, accessGroup: accessGroup)
-    let query: [String: Any] = [
-      kSecClass as String: kSecClassGenericPassword,
-      kSecAttrService as String: "app:no-auth",
-      kSecAttrGeneric as String: Data(key.utf8),
-      kSecAttrAccount as String: Data(key.utf8),
-      kSecAttrAccessGroup as String: accessGroup,
-      kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked,
-      kSecValueData as String: data,
-    ]
-    SecItemAdd(query as CFDictionary, nil)
-  }
-
-  private func deleteFromSharedKeychain(key: String, accessGroup: String) {
-    let query: [String: Any] = [
-      kSecClass as String: kSecClassGenericPassword,
-      kSecAttrService as String: "app:no-auth",
-      kSecAttrGeneric as String: Data(key.utf8),
-      kSecAttrAccount as String: Data(key.utf8),
-      kSecAttrAccessGroup as String: accessGroup,
-    ]
-    SecItemDelete(query as CFDictionary)
+    SharedAuthKeychain.syncFromPrivateKeychain()
   }
 
   // Linking API

--- a/ios/Internxt/FileProviderDomainManager.swift
+++ b/ios/Internxt/FileProviderDomainManager.swift
@@ -1,0 +1,34 @@
+import FileProvider
+import Foundation
+
+@available(iOS 16.0, *)
+enum FileProviderDomainManager {
+  static let domainIdentifier = NSFileProviderDomainIdentifier("com.internxt.drive")
+  static let displayName = "Internxt Drive"
+
+  private static var domain: NSFileProviderDomain {
+    NSFileProviderDomain(identifier: domainIdentifier, displayName: displayName)
+  }
+
+  static func registerDomain(completion: @escaping (Error?) -> Void) {
+    NSFileProviderManager.add(domain) { error in
+      completion(isAlreadyExists(error) ? nil : error)
+    }
+  }
+
+  static func unregisterDomain(completion: @escaping (Error?) -> Void) {
+    NSFileProviderManager.removeAllDomains { removeError in
+      completion(isNotFound(removeError) ? nil : removeError)
+    }
+  }
+
+  private static func isAlreadyExists(_ error: Error?) -> Bool {
+    guard let error = error as NSError? else { return false }
+    return error.domain == NSCocoaErrorDomain && error.code == NSFileWriteFileExistsError
+  }
+
+  private static func isNotFound(_ error: Error?) -> Bool {
+    guard let error = error as NSError? else { return false }
+    return error.domain == NSCocoaErrorDomain && error.code == NSFileNoSuchFileError
+  }
+}

--- a/ios/Internxt/InternxtAuthCredentialsModule.m
+++ b/ios/Internxt/InternxtAuthCredentialsModule.m
@@ -1,0 +1,9 @@
+#import <React/RCTBridgeModule.h>
+
+@interface RCT_EXTERN_MODULE(InternxtAuthCredentialsModule, NSObject)
+RCT_EXTERN_METHOD(setCredentials:(NSDictionary *)creds
+                  resolver:(RCTPromiseResolveBlock)resolver
+                  rejecter:(RCTPromiseRejectBlock)rejecter)
+RCT_EXTERN_METHOD(clearCredentials:(RCTPromiseResolveBlock)resolver
+                  rejecter:(RCTPromiseRejectBlock)rejecter)
+@end

--- a/ios/Internxt/InternxtAuthCredentialsModule.swift
+++ b/ios/Internxt/InternxtAuthCredentialsModule.swift
@@ -1,0 +1,65 @@
+import Foundation
+import React
+
+/// Bridges the RN auth lifecycle to iOS. On login the host app writes the auth
+/// credentials into the shared Keychain (read by the File Provider extension) and
+/// registers the File Provider domain; on logout it clears them and removes the
+/// domain. iOS counterpart of the Android `InternxtAuthCredentialsModule`
+/// (`setCredentials` + `notifyChange(roots)` / `clearCredentials` + `notifyChange(roots)`).
+@objc(InternxtAuthCredentialsModule)
+class InternxtAuthCredentialsModule: NSObject {
+
+  @objc static func requiresMainQueueSetup() -> Bool { false }
+
+  @objc func setCredentials(
+    _ creds: NSDictionary,
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    writeSharedCredentials(creds)
+    guard #available(iOS 16.0, *) else {
+      resolver(nil)
+      return
+    }
+    FileProviderDomainManager.registerDomain { error in
+      if let error = error {
+        rejecter("E_REGISTER_DOMAIN", error.localizedDescription, error as NSError)
+        return
+      }
+      resolver(nil)
+    }
+  }
+
+  @objc func clearCredentials(
+    _ resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    guard #available(iOS 16.0, *) else {
+      SharedAuthKeychain.clearAll()
+      resolver(nil)
+      return
+    }
+
+    FileProviderDomainManager.unregisterDomain { error in
+      SharedAuthKeychain.clearAll()
+      if let error = error {
+        rejecter("E_UNREGISTER_DOMAIN", error.localizedDescription, error as NSError)
+        return
+      }
+      resolver(nil)
+    }
+  }
+
+  private func writeSharedCredentials(_ creds: NSDictionary) {
+    writeIfPresent(creds["bearerToken"], to: SharedAuthKeychain.photosTokenKey)
+    writeIfPresent(creds["mnemonic"], to: SharedAuthKeychain.mnemonicKey)
+    writeIfPresent(creds["rootFolderUuid"], to: SharedAuthKeychain.rootFolderIdKey)
+    writeIfPresent(creds["bridgeUser"], to: SharedAuthKeychain.bridgeUserKey)
+    writeIfPresent(creds["userId"], to: SharedAuthKeychain.userIdKey)
+  }
+
+  private func writeIfPresent(_ value: Any?, to sharedKey: String) {
+    guard let value = value as? String, !value.isEmpty else { return }
+    SharedAuthKeychain.write(value, for: sharedKey)
+  }
+}

--- a/ios/Internxt/SharedAuthKeychain.swift
+++ b/ios/Internxt/SharedAuthKeychain.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Security
+
+/// Single source of truth for the shared Keychain access group used to hand off
+/// auth credentials from the host app to the share extension and the File
+/// Provider extension. Extracted from `AppDelegate` so the native module and the
+/// app-lifecycle sync write to the exact same items.
+enum SharedAuthKeychain {
+  static let service = "app:no-auth"
+
+  static let photosTokenKey = "shared_photosToken"
+  static let mnemonicKey = "shared_mnemonic"
+  static let rootFolderIdKey = "shared_rootFolderId"
+  static let bucketKey = "shared_bucket"
+  static let bridgeUserKey = "shared_bridgeUser"
+  static let userIdKey = "shared_userId"
+
+  static let allKeys = [
+    photosTokenKey, mnemonicKey, rootFolderIdKey, bucketKey, bridgeUserKey, userIdKey,
+  ]
+
+  static var accessGroup: String? {
+    Bundle.main.object(forInfoDictionaryKey: "SharedKeychainGroup") as? String
+  }
+
+  static func read(_ sharedKey: String) -> Data? {
+    guard let accessGroup = accessGroup else { return nil }
+    var result: AnyObject?
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrGeneric as String: Data(sharedKey.utf8),
+      kSecAttrAccount as String: Data(sharedKey.utf8),
+      kSecAttrAccessGroup as String: accessGroup,
+      kSecMatchLimit as String: kSecMatchLimitOne,
+      kSecReturnData as String: true,
+    ]
+    guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+          let data = result as? Data else { return nil }
+    return data
+  }
+
+  static func write(_ value: Data, for sharedKey: String) {
+    guard let accessGroup = accessGroup else { return }
+    delete(sharedKey)
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrGeneric as String: Data(sharedKey.utf8),
+      kSecAttrAccount as String: Data(sharedKey.utf8),
+      kSecAttrAccessGroup as String: accessGroup,
+      kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked,
+      kSecValueData as String: value,
+    ]
+    SecItemAdd(query as CFDictionary, nil)
+  }
+
+  static func write(_ value: String, for sharedKey: String) {
+    write(Data(value.utf8), for: sharedKey)
+  }
+
+  static func delete(_ sharedKey: String) {
+    guard let accessGroup = accessGroup else { return }
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrGeneric as String: Data(sharedKey.utf8),
+      kSecAttrAccount as String: Data(sharedKey.utf8),
+      kSecAttrAccessGroup as String: accessGroup,
+    ]
+    SecItemDelete(query as CFDictionary)
+  }
+
+  static func clearAll() {
+    allKeys.forEach(delete)
+  }
+
+  static func readPrivate(_ privateKey: String) -> Data? {
+    var result: AnyObject?
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrGeneric as String: Data(privateKey.utf8),
+      kSecAttrAccount as String: Data(privateKey.utf8),
+      kSecMatchLimit as String: kSecMatchLimitOne,
+      kSecReturnData as String: true,
+    ]
+    guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+          let data = result as? Data else { return nil }
+    return data
+  }
+
+  static func syncFromPrivateKeychain() {
+    guard accessGroup != nil else { return }
+
+    let isAuthenticated = readPrivate("photosToken") != nil
+    guard isAuthenticated else {
+      clearAll()
+      return
+    }
+
+    copyFromPrivate(privateKey: "photosToken", sharedKey: photosTokenKey)
+    copyFromPrivate(privateKey: "xUser_mnemonic", sharedKey: mnemonicKey)
+    copyFromPrivate(privateKey: "xUser_rootFolderId", sharedKey: rootFolderIdKey)
+    copyFromPrivate(privateKey: "xUser_bucket", sharedKey: bucketKey)
+    copyFromPrivate(privateKey: "xUser_bridgeUser", sharedKey: bridgeUserKey)
+    copyFromPrivate(privateKey: "xUser_userId", sharedKey: userIdKey)
+  }
+
+  private static func copyFromPrivate(privateKey: String, sharedKey: String) {
+    guard let data = readPrivate(privateKey) else { return }
+    write(data, for: sharedKey)
+  }
+}

--- a/ios/Internxt/SharedAuthKeychain.swift
+++ b/ios/Internxt/SharedAuthKeychain.swift
@@ -49,7 +49,13 @@ enum SharedAuthKeychain {
       kSecAttrGeneric as String: Data(sharedKey.utf8),
       kSecAttrAccount as String: Data(sharedKey.utf8),
       kSecAttrAccessGroup as String: accessGroup,
-      kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked,
+      // These credentials are read by the File Provider extension in the
+      // background with no UI, so a user-authentication gate (SecAccessControl /
+      // .userPresence) is intentionally NOT used — it would block every
+      // background read. `AfterFirstUnlock` keeps the item readable once the
+      // device has been unlocked after boot while still protecting it before
+      // first unlock at boot.
+      kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
       kSecValueData as String: value,
     ]
     SecItemAdd(query as CFDictionary, nil)
@@ -100,15 +106,28 @@ enum SharedAuthKeychain {
     }
 
     copyFromPrivate(privateKey: "photosToken", sharedKey: photosTokenKey)
-    copyFromPrivate(privateKey: "xUser_mnemonic", sharedKey: mnemonicKey)
-    copyFromPrivate(privateKey: "xUser_rootFolderId", sharedKey: rootFolderIdKey)
+    copyFromPrivate(privateKey: "xUser_mnemonic", sharedKey: mnemonicKey, isJSONEncoded: true)
+    copyFromPrivate(privateKey: "xUser_rootFolderId", sharedKey: rootFolderIdKey, isJSONEncoded: true)
     copyFromPrivate(privateKey: "xUser_bucket", sharedKey: bucketKey)
     copyFromPrivate(privateKey: "xUser_bridgeUser", sharedKey: bridgeUserKey)
     copyFromPrivate(privateKey: "xUser_userId", sharedKey: userIdKey)
   }
 
-  private static func copyFromPrivate(privateKey: String, sharedKey: String) {
+  private static func copyFromPrivate(privateKey: String, sharedKey: String, isJSONEncoded: Bool = false) {
     guard let data = readPrivate(privateKey) else { return }
-    write(data, for: sharedKey)
+    write(isJSONEncoded ? jsonDecoded(data) : data, for: sharedKey)
+  }
+
+  private static func jsonDecoded(_ data: Data) -> Data {
+    guard let object = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]) else {
+      return data
+    }
+    if let string = object as? String {
+      return Data(string.utf8)
+    }
+    if let number = object as? NSNumber {
+      return Data(number.stringValue.utf8)
+    }
+    return data
   }
 }

--- a/ios/InternxtFileProvider/FileProviderExtension.swift
+++ b/ios/InternxtFileProvider/FileProviderExtension.swift
@@ -10,26 +10,32 @@ import InternxtSwiftCore
 
 class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
     required init(domain: NSFileProviderDomain) {
-        // TODO: The containing application must create a domain using `NSFileProviderManager.add(_:, completionHandler:)`. The system will then launch the application extension process, call `FileProviderExtension.init(domain:)` to instantiate the extension for that domain, and call methods on the instance.
         super.init()
     }
-    
+
+    private func currentAuthToken() -> String? {
+        guard let data = SharedAuthKeychain.read(SharedAuthKeychain.photosTokenKey) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
     func invalidate() {
         // TODO: cleanup any resources
     }
-    
+
     func item(for identifier: NSFileProviderItemIdentifier, request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, Error?) -> Void) -> Progress {
-        // resolve the given identifier to a record in the model
-        
-        // TODO: implement the actual lookup
+        _ = currentAuthToken()
+
+        // TODO: implement the actual lookup using the auth token
 
         completionHandler(FileProviderItem(identifier: identifier), nil)
         return Progress()
     }
-    
+
     func fetchContents(for itemIdentifier: NSFileProviderItemIdentifier, version requestedVersion: NSFileProviderItemVersion?, request: NSFileProviderRequest, completionHandler: @escaping (URL?, NSFileProviderItem?, Error?) -> Void) -> Progress {
+        _ = currentAuthToken()
+
         // TODO: implement fetching of the contents for the itemIdentifier at the specified version
-        
+
         completionHandler(nil, nil, NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError, userInfo:[:]))
         return Progress()
     }

--- a/ios/InternxtFileProvider/Info.plist
+++ b/ios/InternxtFileProvider/Info.plist
@@ -15,5 +15,7 @@
 	</dict>
 	<key>RCTNewArchEnabled</key>
 	<true/>
+	<key>SharedKeychainGroup</key>
+	<string>$(AppIdentifierPrefix)group.com.internxt.snacks</string>
 </dict>
 </plist>

--- a/src/services/native/InternxtAuthCredentialsModule.spec.ts
+++ b/src/services/native/InternxtAuthCredentialsModule.spec.ts
@@ -1,0 +1,75 @@
+type Wrapper = typeof import('./InternxtAuthCredentialsModule');
+type Credentials = import('./InternxtAuthCredentialsModule').InternxtAuthCredentials;
+
+const credentials: Credentials = {
+  bearerToken: 'token-abc',
+  userId: 'user-1',
+  bridgeUser: 'bridge@internxt.com',
+  mnemonic: 'pretty cloud secret words',
+  rootFolderUuid: 'root-uuid-123',
+  email: 'user@internxt.com',
+  driveBaseUrl: 'https://drive.example',
+  bridgeBaseUrl: 'https://bridge.example',
+  desktopToken: 'desktop-token',
+};
+
+const loadWrapper = (platformOS: 'android' | 'ios', nativeModule: unknown): Wrapper => {
+  let wrapper!: Wrapper;
+  jest.isolateModules(() => {
+    jest.doMock('react-native', () => ({
+      Platform: { OS: platformOS },
+      NativeModules: nativeModule === undefined ? {} : { InternxtAuthCredentialsModule: nativeModule },
+    }));
+    wrapper = require('./InternxtAuthCredentialsModule');
+  });
+  return wrapper;
+};
+
+const arrangePresentNative = (platformOS: 'android' | 'ios') => {
+  const setCredentials = jest.fn().mockResolvedValue(undefined);
+  const clearCredentials = jest.fn().mockResolvedValue(undefined);
+  const wrapper = loadWrapper(platformOS, { setCredentials, clearCredentials });
+  return { wrapper, setCredentials, clearCredentials };
+};
+
+describe('InternxtAuthCredentialsModule wrapper', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('when on iOS with the module present, then setCredentials delegates with the credentials', async () => {
+    const { wrapper, setCredentials } = arrangePresentNative('ios');
+
+    await wrapper.setCredentials(credentials);
+
+    expect(setCredentials).toHaveBeenCalledWith(credentials);
+  });
+
+  it('when on iOS with the module present, then clearCredentials delegates to the native module', async () => {
+    const { wrapper, clearCredentials } = arrangePresentNative('ios');
+
+    await wrapper.clearCredentials();
+
+    expect(clearCredentials).toHaveBeenCalledTimes(1);
+  });
+
+  it('when on Android with the module present, then setCredentials delegates with the credentials', async () => {
+    const { wrapper, setCredentials } = arrangePresentNative('android');
+
+    await wrapper.setCredentials(credentials);
+
+    expect(setCredentials).toHaveBeenCalledWith(credentials);
+  });
+
+  it('when the native module is absent, then setCredentials resolves without throwing', async () => {
+    const wrapper = loadWrapper('ios', undefined);
+
+    await expect(wrapper.setCredentials(credentials)).resolves.toBeUndefined();
+  });
+
+  it('when the native module is absent, then clearCredentials resolves without throwing', async () => {
+    const wrapper = loadWrapper('ios', undefined);
+
+    await expect(wrapper.clearCredentials()).resolves.toBeUndefined();
+  });
+});

--- a/src/services/native/InternxtAuthCredentialsModule.ts
+++ b/src/services/native/InternxtAuthCredentialsModule.ts
@@ -18,7 +18,7 @@ interface NativeBridge {
 }
 
 const bridge: NativeBridge | undefined =
-  Platform.OS === 'android' ? NativeModules.InternxtAuthCredentialsModule : undefined;
+  Platform.OS === 'android' || Platform.OS === 'ios' ? NativeModules.InternxtAuthCredentialsModule : undefined;
 
 export async function setCredentials(creds: InternxtAuthCredentials): Promise<void> {
   if (!bridge) return;

--- a/src/store/slices/auth/auth.syncNativeCredentials.spec.ts
+++ b/src/store/slices/auth/auth.syncNativeCredentials.spec.ts
@@ -1,0 +1,109 @@
+jest.mock('../../../services/native/InternxtAuthCredentialsModule', () => ({
+  setCredentials: jest.fn().mockResolvedValue(undefined),
+  clearCredentials: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@internxt-mobile/services/common', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+  imageService: {},
+  PROFILE_PICTURE_CACHE_KEY: 'profile-picture',
+  SdkManager: { init: jest.fn(), setApiSecurity: jest.fn(), getInstance: jest.fn() },
+}));
+
+jest.mock('../drive', () => ({ driveActions: { resetState: jest.fn(() => ({ type: 'drive/resetState' })) } }));
+jest.mock('../ui', () => ({ uiActions: { resetState: jest.fn(() => ({ type: 'ui/resetState' })) } }));
+
+jest.mock('@internxt-mobile/services/drive', () => ({
+  __esModule: true,
+  default: { clear: jest.fn().mockResolvedValue(undefined) },
+}));
+
+jest.mock('src/services/ErrorService', () => ({ __esModule: true, default: { reportError: jest.fn() } }));
+
+jest.mock('../../../services/AppService', () => {
+  const appConstants = {
+    DRIVE_NEW_API_URL: 'https://drive',
+    BRIDGE_URL: 'https://bridge',
+    CLOUDFLARE_TOKEN: 'cf',
+    CRYPTO_SECRET: 'crypto-secret',
+    CRYPTO_SECRET2: 'crypto-secret-2',
+  };
+  return { __esModule: true, default: { constants: appConstants }, constants: appConstants };
+});
+
+jest.mock('../../../services/AsyncStorageService', () => ({
+  __esModule: true,
+  default: {
+    saveItem: jest.fn().mockResolvedValue(undefined),
+    getItem: jest.fn().mockResolvedValue('current-photos-token'),
+    deleteItem: jest.fn().mockResolvedValue(undefined),
+    clearStorage: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock('../../../services/AuthService', () => ({
+  __esModule: true,
+  default: {
+    emitLoginEvent: jest.fn(),
+    emitLogoutEvent: jest.fn(),
+    signout: jest.fn().mockResolvedValue(undefined),
+    refreshAuthToken: jest.fn(),
+    getAuthCredentials: jest.fn(),
+  },
+}));
+
+jest.mock('../../../services/NotificationsService', () => ({ __esModule: true, default: {} }));
+jest.mock('../../../services/UserService', () => ({ __esModule: true, default: {} }));
+
+import authService from '../../../services/AuthService';
+import { clearCredentials, setCredentials } from '../../../services/native/InternxtAuthCredentialsModule';
+import { refreshTokensThunk, signInThunk, signOutThunk } from './index';
+
+const setCredentialsMock = setCredentials as jest.Mock;
+const clearCredentialsMock = clearCredentials as jest.Mock;
+const refreshAuthTokenMock = authService.refreshAuthToken as jest.Mock;
+const getAuthCredentialsMock = authService.getAuthCredentials as jest.Mock;
+
+const user = {
+  userId: 'user-1',
+  bridgeUser: 'bridge@internxt.com',
+  mnemonic: 'pretty cloud secret words',
+  rootFolderUuid: 'root-uuid-123',
+  email: 'user@internxt.com',
+} as never;
+
+type DispatchableThunk = (dispatch: jest.Mock, getState: jest.Mock, extra: undefined) => Promise<unknown>;
+
+const runThunk = (action: unknown) =>
+  (action as DispatchableThunk)(jest.fn(), jest.fn(), undefined);
+
+describe('auth thunks native credentials handoff', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('when the login completes, then the wrapper receives the new token', async () => {
+    await runThunk(signInThunk({ user, token: 'access-token', newToken: 'login-new-token' }));
+
+    expect(setCredentialsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ bearerToken: 'login-new-token', rootFolderUuid: 'root-uuid-123' }),
+    );
+  });
+
+  it('when the token is refreshed in the foreground, then the wrapper receives the refreshed token', async () => {
+    refreshAuthTokenMock.mockResolvedValue({ token: 'access-2', newToken: 'refreshed-new-token' });
+    getAuthCredentialsMock.mockResolvedValue({
+      credentials: { accessToken: 'access-2', photosToken: 'refreshed-new-token', user },
+    });
+
+    await runThunk(refreshTokensThunk());
+
+    expect(setCredentialsMock).toHaveBeenCalledWith(expect.objectContaining({ bearerToken: 'refreshed-new-token' }));
+  });
+
+  it('when the logout completes, then clearCredentials is invoked', async () => {
+    await runThunk(signOutThunk({ reason: 'manual' }));
+
+    expect(clearCredentialsMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Sync auth credentials to a shared App Group Keychain so the File Provider extension can read them; register the com.internxt.drive domain on login and call removeAllDomains on logout so the provider appears/disappears in Files.app. Bump InternxtFileProvider MARKETING_VERSION 1.0 -> 1.9.0 (Debug+Release) so the extension version matches the host or iOS won't load it. Device-verified on a real iPhone.