### PR TITLE
[PB-6484] feature/Live photo support in Photos

### DIFF
--- a/ios/Internxt.xcodeproj/project.pbxproj
+++ b/ios/Internxt.xcodeproj/project.pbxproj
@@ -7,19 +7,21 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		066A8CB3AE8BF936041F2166 /* libPods-InternxtShareExtension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C81B53BFDD9C51F9D6B5D12 /* libPods-InternxtShareExtension.a */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		1818AB341F31CC033FFF750B /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD55E1E535AECF7719BDD772 /* ExpoModulesProvider.swift */; };
 		18D7DE9587FA2B2314575ED6 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4921399A370F5CE6EE7EA0F /* ExpoModulesProvider.swift */; };
 		2F8E878CDCAC7D5C07B5C670 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 37A2C3A4643426D3F429F041 /* PrivacyInfo.xcprivacy */; };
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
+		796CE562F25C5F16D80F868D /* libPods-Internxt.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 039F6E1EA42E3A932EA23F11 /* libPods-Internxt.a */; };
 		7D373856C83A43879BFBE604 /* InternxtShareExtension.appex in Copy Files */ = {isa = PBXBuildFile; fileRef = 7F5486528A7D46DD91A7910F /* InternxtShareExtension.appex */; };
+		8CEE07D2C59F6E3DA678015B /* libPods-InternxtShareExtension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E7039B379DC01F054767587 /* libPods-InternxtShareExtension.a */; };
 		8F8148045BC14A539BD1917D /* ShareExtensionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6F72E1B98D469883DAFB30 /* ShareExtensionViewController.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
 		DEBEAEBF2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBEAEBE2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift */; };
 		DEBEAEC02F72E65B00A6E6D5 /* AppGroupPendingShareModule.m in Sources */ = {isa = PBXBuildFile; fileRef = DEBEAEBD2F72E65B00A6E6D5 /* AppGroupPendingShareModule.m */; };
+		1A3E7803EDA342F39787DC8F /* PHAssetExportModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9949B2A33B5D4CA2BD828B67 /* PHAssetExportModule.swift */; };
+		9DB4D633CA40422A956585FD /* PHAssetExportModule.m in Sources */ = {isa = PBXBuildFile; fileRef = D330686328BD4286AB778B88 /* PHAssetExportModule.m */; };
 		F11748422D0307B40044C1D9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11748412D0307B40044C1D9 /* AppDelegate.swift */; };
-		F303DA465EEA64DA9533A772 /* libPods-Internxt.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A89847209F6CFC3FD92AC16 /* libPods-Internxt.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,26 +59,28 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		039F6E1EA42E3A932EA23F11 /* libPods-Internxt.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Internxt.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		0A112D9227DD6AEC70ABC994 /* Pods-InternxtShareExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtShareExtension.release.xcconfig"; path = "Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension.release.xcconfig"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* Internxt.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Internxt.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Internxt/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Internxt/Info.plist; sourceTree = "<group>"; };
 		30C3C55FF8AE435F8A82A9BC /* InternxtShareExtension.entitlements */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; path = InternxtShareExtension.entitlements; sourceTree = "<group>"; };
-		3137C2C6F76AB6AD60EA1295 /* Pods-InternxtShareExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtShareExtension.release.xcconfig"; path = "Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension.release.xcconfig"; sourceTree = "<group>"; };
 		37A2C3A4643426D3F429F041 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = Internxt/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		3A6F72E1B98D469883DAFB30 /* ShareExtensionViewController.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; path = ShareExtensionViewController.swift; sourceTree = "<group>"; };
-		4A89847209F6CFC3FD92AC16 /* libPods-Internxt.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Internxt.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		4C81B53BFDD9C51F9D6B5D12 /* libPods-InternxtShareExtension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-InternxtShareExtension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		577249B2C1B116E6254E7F3B /* Pods-InternxtShareExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtShareExtension.debug.xcconfig"; path = "Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension.debug.xcconfig"; sourceTree = "<group>"; };
+		67F1D584B9E997834D9494CC /* Pods-Internxt.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.debug.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.debug.xcconfig"; sourceTree = "<group>"; };
+		6E7039B379DC01F054767587 /* libPods-InternxtShareExtension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-InternxtShareExtension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7F5486528A7D46DD91A7910F /* InternxtShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; fileEncoding = 9; includeInIndex = 0; path = InternxtShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
-		9100F1A71A8CDC836FBE3334 /* Pods-Internxt.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.debug.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.debug.xcconfig"; sourceTree = "<group>"; };
-		A45129F6CEC8A3D7CDF1EEB8 /* Pods-InternxtShareExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtShareExtension.debug.xcconfig"; path = "Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		A4921399A370F5CE6EE7EA0F /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-InternxtShareExtension/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = Internxt/SplashScreen.storyboard; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
 		BD55E1E535AECF7719BDD772 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-Internxt/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
-		CBA2FB657C9ED0ADE12E1B7E /* Pods-Internxt.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.release.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.release.xcconfig"; sourceTree = "<group>"; };
 		DAE15E8DB4DF4E048E04B0E0 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DEBEAEBD2F72E65B00A6E6D5 /* AppGroupPendingShareModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = AppGroupPendingShareModule.m; path = Internxt/AppGroupPendingShareModule.m; sourceTree = "<group>"; };
 		DEBEAEBE2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppGroupPendingShareModule.swift; path = Internxt/AppGroupPendingShareModule.swift; sourceTree = "<group>"; };
+		D330686328BD4286AB778B88 /* PHAssetExportModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PHAssetExportModule.m; path = Internxt/PHAssetExportModule.m; sourceTree = "<group>"; };
+		9949B2A33B5D4CA2BD828B67 /* PHAssetExportModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PHAssetExportModule.swift; path = Internxt/PHAssetExportModule.swift; sourceTree = "<group>"; };
+		E40DA9D6F8373E195B0B45C1 /* Pods-Internxt.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.release.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.release.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		F11748412D0307B40044C1D9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = Internxt/AppDelegate.swift; sourceTree = "<group>"; };
 		F11748442D0722820044C1D9 /* Internxt-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "Internxt-Bridging-Header.h"; path = "Internxt/Internxt-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -87,7 +91,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F303DA465EEA64DA9533A772 /* libPods-Internxt.a in Frameworks */,
+				796CE562F25C5F16D80F868D /* libPods-Internxt.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -95,7 +99,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				066A8CB3AE8BF936041F2166 /* libPods-InternxtShareExtension.a in Frameworks */,
+				8CEE07D2C59F6E3DA678015B /* libPods-InternxtShareExtension.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -107,6 +111,8 @@
 			children = (
 				DEBEAEBD2F72E65B00A6E6D5 /* AppGroupPendingShareModule.m */,
 				DEBEAEBE2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift */,
+				D330686328BD4286AB778B88 /* PHAssetExportModule.m */,
+				9949B2A33B5D4CA2BD828B67 /* PHAssetExportModule.swift */,
 				F11748412D0307B40044C1D9 /* AppDelegate.swift */,
 				F11748442D0722820044C1D9 /* Internxt-Bridging-Header.h */,
 				BB2F792B24A3F905000567C9 /* Supporting */,
@@ -122,8 +128,8 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				4A89847209F6CFC3FD92AC16 /* libPods-Internxt.a */,
-				4C81B53BFDD9C51F9D6B5D12 /* libPods-InternxtShareExtension.a */,
+				039F6E1EA42E3A932EA23F11 /* libPods-Internxt.a */,
+				6E7039B379DC01F054767587 /* libPods-InternxtShareExtension.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -149,10 +155,10 @@
 		808723478BA906DED7CCCEE0 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				9100F1A71A8CDC836FBE3334 /* Pods-Internxt.debug.xcconfig */,
-				CBA2FB657C9ED0ADE12E1B7E /* Pods-Internxt.release.xcconfig */,
-				A45129F6CEC8A3D7CDF1EEB8 /* Pods-InternxtShareExtension.debug.xcconfig */,
-				3137C2C6F76AB6AD60EA1295 /* Pods-InternxtShareExtension.release.xcconfig */,
+				67F1D584B9E997834D9494CC /* Pods-Internxt.debug.xcconfig */,
+				E40DA9D6F8373E195B0B45C1 /* Pods-Internxt.release.xcconfig */,
+				577249B2C1B116E6254E7F3B /* Pods-InternxtShareExtension.debug.xcconfig */,
+				0A112D9227DD6AEC70ABC994 /* Pods-InternxtShareExtension.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -222,7 +228,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "Internxt" */;
 			buildPhases = (
-				988615585F28C567C6D3916F /* [CP] Check Pods Manifest.lock */,
+				86F524C72CB9354A141BC65B /* [CP] Check Pods Manifest.lock */,
 				C23BF8EF9D9B379F6EADAAE0 /* [Expo] Configure project */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
@@ -230,8 +236,8 @@
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				DDE0311FCC774124B044B69C /* Embed Foundation Extensions */,
 				EF531C08E8F54B18956A8C0E /* Copy Files */,
-				8D6DC14076A7D1C549474F30 /* [CP] Embed Pods Frameworks */,
-				58AC62CE3700043536F38AFC /* [CP] Copy Pods Resources */,
+				793E832705612D06758FCFD3 /* [CP] Embed Pods Frameworks */,
+				117E35238C1E08B0CA4EA36A /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -247,14 +253,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DDB0A9F040BE45D9929C1B2D /* Build configuration list for PBXNativeTarget "InternxtShareExtension" */;
 			buildPhases = (
-				AE91FC931C5D3B6A9DF116B1 /* [CP] Check Pods Manifest.lock */,
+				1C4D7191F4CCE20A90B8A052 /* [CP] Check Pods Manifest.lock */,
 				90134DAC718F4FE0B3AB7B91 /* Start Packager */,
 				BEAE0DA94817B237B864F997 /* [Expo] Configure project */,
 				3495BDAE4F75461EBD6FFF8F /* Sources */,
 				3ABC9B4F4B9D448B9797EBD7 /* Frameworks */,
 				2F5766E756C84914803E7082 /* Resources */,
 				AA9E71431FBB401A8272B8C4 /* Bundle React Native code and images */,
-				65392C932B0AAFBA1254B923 /* [CP] Copy Pods Resources */,
+				2DCE1C1C5631927FFC0F82BC /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -343,7 +349,7 @@
 			shellPath = /bin/sh;
 			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n# The project root by default is one level up from the ios directory\nexport PROJECT_ROOT=\"$PROJECT_DIR\"/..\n\nif [[ \"$CONFIGURATION\" = *Debug* ]]; then\n  export SKIP_BUNDLING=1\nfi\nif [[ -z \"$ENTRY_FILE\" ]]; then\n  # Set the entry JS file using the bundler's entry resolution.\n  export ENTRY_FILE=\"$(\"$NODE_BINARY\" -e \"require('expo/scripts/resolveAppEntry')\" \"$PROJECT_ROOT\" ios absolute | tail -n 1)\"\nfi\n\nif [[ -z \"$CLI_PATH\" ]]; then\n  # Use Expo CLI\n  export CLI_PATH=\"$(\"$NODE_BINARY\" --print \"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\")\"\nfi\nif [[ -z \"$BUNDLE_COMMAND\" ]]; then\n  # Default Expo CLI command for bundling\n  export BUNDLE_COMMAND=\"export:embed\"\nfi\n\n# Source .xcode.env.updates if it exists to allow\n# SKIP_BUNDLING to be unset if needed\nif [[ -f \"$PODS_ROOT/../.xcode.env.updates\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.updates\"\nfi\n# Source local changes to allow overrides\n# if needed\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`\n\n";
 		};
-		58AC62CE3700043536F38AFC /* [CP] Copy Pods Resources */ = {
+		117E35238C1E08B0CA4EA36A /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -391,7 +397,29 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Internxt/Pods-Internxt-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		65392C932B0AAFBA1254B923 /* [CP] Copy Pods Resources */ = {
+		1C4D7191F4CCE20A90B8A052 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-InternxtShareExtension-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		2DCE1C1C5631927FFC0F82BC /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -435,7 +463,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		8D6DC14076A7D1C549474F30 /* [CP] Embed Pods Frameworks */ = {
+		793E832705612D06758FCFD3 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -457,21 +485,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Internxt/Pods-Internxt-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		90134DAC718F4FE0B3AB7B91 /* Start Packager */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Start Packager";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "export RCT_METRO_PORT=\"${RCT_METRO_PORT:=8081}\"\necho \"export RCT_METRO_PORT=${RCT_METRO_PORT}\" > \"${SRCROOT}/../node_modules/react-native/scripts/.packager.env\"\nif [ -z \"${RCT_NO_LAUNCH_PACKAGER+xxx}\" ] ; then\n  if nc -w 5 -z localhost ${RCT_METRO_PORT} ; then\n    if ! curl -s \"http://localhost:${RCT_METRO_PORT}/status\" | grep -q \"packager-status:running\" ; then\n      echo \"Port ${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\"\n      exit 2\n    fi\n  else\n    open \"$SRCROOT/../node_modules/react-native/scripts/launchPackager.command\" || echo \"Can't start packager automatically\"\n  fi\nfi\n";
-		};
-		988615585F28C567C6D3916F /* [CP] Check Pods Manifest.lock */ = {
+		86F524C72CB9354A141BC65B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -493,6 +507,20 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		90134DAC718F4FE0B3AB7B91 /* Start Packager */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Start Packager";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export RCT_METRO_PORT=\"${RCT_METRO_PORT:=8081}\"\necho \"export RCT_METRO_PORT=${RCT_METRO_PORT}\" > \"${SRCROOT}/../node_modules/react-native/scripts/.packager.env\"\nif [ -z \"${RCT_NO_LAUNCH_PACKAGER+xxx}\" ] ; then\n  if nc -w 5 -z localhost ${RCT_METRO_PORT} ; then\n    if ! curl -s \"http://localhost:${RCT_METRO_PORT}/status\" | grep -q \"packager-status:running\" ; then\n      echo \"Port ${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\"\n      exit 2\n    fi\n  else\n    open \"$SRCROOT/../node_modules/react-native/scripts/launchPackager.command\" || echo \"Can't start packager automatically\"\n  fi\nfi\n";
+		};
 		AA9E71431FBB401A8272B8C4 /* Bundle React Native code and images */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -506,28 +534,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -e\n  NODE_BINARY=${NODE_BINARY:-node}\n  \n  # Source environment files\n  if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n    source \"$PODS_ROOT/../.xcode.env\"\n  fi\n  if [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n    source \"$PODS_ROOT/../.xcode.env.local\"\n  fi\n  \n  # Set project root\n  export PROJECT_ROOT=\"$PROJECT_DIR\"/..\n  \n  # Set entry file\n  export ENTRY_FILE=\"$PROJECT_ROOT/index.share.js\"\n  \n  # Set up Expo CLI\n  if [[ -z \"$CLI_PATH\" ]]; then\n    export CLI_PATH=\"$(\"$NODE_BINARY\" --print \"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\")\"\n  fi\n  \n  if [[ -z \"$BUNDLE_COMMAND\" ]]; then\n    export BUNDLE_COMMAND=\"export:embed\"\n  fi\n  \n  REACT_NATIVE_SCRIPTS_PATH=$(\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts'\")\n  WITH_ENVIRONMENT=\"$REACT_NATIVE_SCRIPTS_PATH/xcode/with-environment.sh\"\n  REACT_NATIVE_XCODE=\"$REACT_NATIVE_SCRIPTS_PATH/react-native-xcode.sh\"\n  \n  /bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"";
-		};
-		AE91FC931C5D3B6A9DF116B1 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-InternxtShareExtension-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
 		};
 		BEAE0DA94817B237B864F997 /* [Expo] Configure project */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -588,6 +594,8 @@
 				1818AB341F31CC033FFF750B /* ExpoModulesProvider.swift in Sources */,
 				DEBEAEBF2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift in Sources */,
 				DEBEAEC02F72E65B00A6E6D5 /* AppGroupPendingShareModule.m in Sources */,
+				1A3E7803EDA342F39787DC8F /* PHAssetExportModule.swift in Sources */,
+				9DB4D633CA40422A956585FD /* PHAssetExportModule.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -613,7 +621,7 @@
 /* Begin XCBuildConfiguration section */
 		00BF7E5F54544AE9B1CDE9D5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A45129F6CEC8A3D7CDF1EEB8 /* Pods-InternxtShareExtension.debug.xcconfig */;
+			baseConfigurationReference = 577249B2C1B116E6254E7F3B /* Pods-InternxtShareExtension.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = InternxtShareExtension/InternxtShareExtension.entitlements;
@@ -642,7 +650,7 @@
 		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9100F1A71A8CDC836FBE3334 /* Pods-Internxt.debug.xcconfig */;
+			baseConfigurationReference = 67F1D584B9E997834D9494CC /* Pods-Internxt.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -681,7 +689,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CBA2FB657C9ED0ADE12E1B7E /* Pods-Internxt.release.xcconfig */;
+			baseConfigurationReference = E40DA9D6F8373E195B0B45C1 /* Pods-Internxt.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -832,7 +840,7 @@
 		};
 		B247FB85ACF44D11B7509F34 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3137C2C6F76AB6AD60EA1295 /* Pods-InternxtShareExtension.release.xcconfig */;
+			baseConfigurationReference = 0A112D9227DD6AEC70ABC994 /* Pods-InternxtShareExtension.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = InternxtShareExtension/InternxtShareExtension.entitlements;

--- a/ios/Internxt/PHAssetExportModule.m
+++ b/ios/Internxt/PHAssetExportModule.m
@@ -8,4 +8,17 @@ RCT_EXTERN_METHOD(
   rejecter:(RCTPromiseRejectBlock)rejecter
 )
 
+RCT_EXTERN_METHOD(
+  exportLivePhotoComponents:(NSString *)localIdentifier
+  resolver:(RCTPromiseResolveBlock)resolver
+  rejecter:(RCTPromiseRejectBlock)rejecter
+)
+
+RCT_EXTERN_METHOD(
+  saveLivePhoto:(NSString *)photoPath
+  videoPath:(NSString *)videoPath
+  resolver:(RCTPromiseResolveBlock)resolver
+  rejecter:(RCTPromiseRejectBlock)rejecter
+)
+
 @end

--- a/ios/Internxt/PHAssetExportModule.swift
+++ b/ios/Internxt/PHAssetExportModule.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Photos
+import React
 
 @objc(PHAssetExport)
 class PHAssetExportModule: NSObject {
@@ -43,6 +44,110 @@ class PHAssetExportModule: NSObject {
         "size": size,
         "fileName": resource.originalFilename,
       ])
+    }
+  }
+
+  // Exports both components of a Live Photo (photo + paired video) as raw resource bytes.
+  // Using PHAssetResourceManager ensures original byte content (including Apple asset-identifier
+  // metadata) is preserved, which is required to reconstruct the Live Photo pair on save.
+  @objc func exportLivePhotoComponents(
+    _ localIdentifier: String,
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    let assets = PHAsset.fetchAssets(withLocalIdentifiers: [localIdentifier], options: nil)
+    guard let asset = assets.firstObject else {
+      rejecter("NOT_FOUND", "PHAsset not found: \(localIdentifier)", nil)
+      return
+    }
+
+    guard asset.mediaSubtypes.contains(.photoLive) else {
+      rejecter("NOT_LIVE_PHOTO", "PHAsset \(localIdentifier) is not a Live Photo", nil)
+      return
+    }
+
+    let resources = PHAssetResource.assetResources(for: asset)
+
+    // Prefer the primary resource type; edited Live Photos may only expose fullSize variants.
+    guard let photoResource = resources.first(where: { $0.type == .photo })
+            ?? resources.first(where: { $0.type == .fullSizePhoto }) else {
+      rejecter("NO_PHOTO_RESOURCE", "No photo resource found for \(localIdentifier)", nil)
+      return
+    }
+
+    guard let videoResource = resources.first(where: { $0.type == .pairedVideo })
+            ?? resources.first(where: { $0.type == .fullSizePairedVideo }) else {
+      rejecter("NO_VIDEO_RESOURCE", "No paired video resource found for \(localIdentifier)", nil)
+      return
+    }
+
+    let options = PHAssetResourceRequestOptions()
+    options.isNetworkAccessAllowed = true
+
+    let photoExt = (photoResource.originalFilename as NSString).pathExtension.lowercased()
+    let photoDest = FileManager.default.temporaryDirectory
+      .appendingPathComponent("\(UUID().uuidString).\(photoExt)")
+
+    PHAssetResourceManager.default().writeData(for: photoResource, toFile: photoDest, options: options) { [weak self] photoError in
+      guard self != nil else { return }
+      if let photoError = photoError {
+        rejecter("PHOTO_EXPORT_FAILED", photoError.localizedDescription, photoError as NSError)
+        return
+      }
+
+      let videoExt = (videoResource.originalFilename as NSString).pathExtension.lowercased()
+      let videoDest = FileManager.default.temporaryDirectory
+        .appendingPathComponent("\(UUID().uuidString).\(videoExt)")
+
+      PHAssetResourceManager.default().writeData(for: videoResource, toFile: videoDest, options: options) { videoError in
+        if let videoError = videoError {
+          // Clean up the already-written photo before rejecting
+          try? FileManager.default.removeItem(at: photoDest)
+          rejecter("VIDEO_EXPORT_FAILED", videoError.localizedDescription, videoError as NSError)
+          return
+        }
+
+        let photoSize = (try? (FileManager.default.attributesOfItem(atPath: photoDest.path)[.size] as? NSNumber)?.int64Value) ?? 0
+        let videoSize = (try? (FileManager.default.attributesOfItem(atPath: videoDest.path)[.size] as? NSNumber)?.int64Value) ?? 0
+
+        resolver([
+          "photo": [
+            "uri": photoDest.absoluteString,
+            "size": photoSize,
+            "fileName": photoResource.originalFilename,
+          ],
+          "video": [
+            "uri": videoDest.absoluteString,
+            "size": videoSize,
+            "fileName": videoResource.originalFilename,
+          ],
+        ])
+      }
+    }
+  }
+
+  // Saves a photo + paired video as a real Live Photo in the camera roll.
+  // Both files must carry the original Apple asset-identifier metadata (preserved by exportLivePhotoComponents).
+  @objc func saveLivePhoto(
+    _ photoPath: String,
+    videoPath: String,
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    let photoURL = URL(fileURLWithPath: photoPath)
+    let videoURL = URL(fileURLWithPath: videoPath)
+
+    PHPhotoLibrary.shared().performChanges({
+      let request = PHAssetCreationRequest.forAsset()
+      request.addResource(with: .photo, fileURL: photoURL, options: nil)
+      request.addResource(with: .pairedVideo, fileURL: videoURL, options: nil)
+    }) { success, error in
+      if success {
+        resolver(nil)
+      } else {
+        let msg = error?.localizedDescription ?? "Unknown error saving Live Photo"
+        rejecter("SAVE_FAILED", msg, error as NSError?)
+      }
     }
   }
 }

--- a/ios/Internxt/PHAssetExportModule.swift
+++ b/ios/Internxt/PHAssetExportModule.swift
@@ -88,9 +88,9 @@ class PHAssetExportModule: NSObject {
     let photoDest = FileManager.default.temporaryDirectory
       .appendingPathComponent("\(UUID().uuidString).\(photoExt)")
 
-    PHAssetResourceManager.default().writeData(for: photoResource, toFile: photoDest, options: options) { [weak self] photoError in
-      guard self != nil else { return }
+    PHAssetResourceManager.default().writeData(for: photoResource, toFile: photoDest, options: options) { photoError in
       if let photoError = photoError {
+        try? FileManager.default.removeItem(at: photoDest)
         rejecter("PHOTO_EXPORT_FAILED", photoError.localizedDescription, photoError as NSError)
         return
       }

--- a/ios/Internxt/PrivacyInfo.xcprivacy
+++ b/ios/Internxt/PrivacyInfo.xcprivacy
@@ -6,6 +6,16 @@
 	<array>
 		<dict>
 			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+				<string>0A2A.1</string>
+				<string>3B52.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
 			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
@@ -18,16 +28,6 @@
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
 				<string>35F9.1</string>
-			</array>
-		</dict>
-		<dict>
-			<key>NSPrivacyAccessedAPIType</key>
-			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
-			<key>NSPrivacyAccessedAPITypeReasons</key>
-			<array>
-				<string>0A2A.1</string>
-				<string>3B52.1</string>
-				<string>C617.1</string>
 			</array>
 		</dict>
 		<dict>

--- a/src/screens/PhotosScreen/components/GroupHeader/GroupHeaderStatus.tsx
+++ b/src/screens/PhotosScreen/components/GroupHeader/GroupHeaderStatus.tsx
@@ -77,7 +77,7 @@ export const GroupHeaderUploading = ({
   return (
     <>
       <ActivityIndicator size="small" color={primaryColor} />
-      <AppText medium style={[tailwind('text-base'), { color: labelColor, lineHeight: 24 }]}>
+      <AppText medium numberOfLines={1} style={[tailwind('text-base'), { color: labelColor, lineHeight: 24, flexShrink: 1 }]}>
         {strings.screens.photos.groupHeader.backingUp}
       </AppText>
       {count != null && (
@@ -122,7 +122,7 @@ export const GroupHeaderPaused = ({
   const tailwind = useTailwind();
   return (
     <>
-      <AppText medium style={[tailwind('text-base'), { color: labelColor, lineHeight: 24 }]}>
+      <AppText medium numberOfLines={1} style={[tailwind('text-base'), { color: labelColor, lineHeight: 24, flexShrink: 1 }]}>
         {strings.screens.photos.groupHeader.backupPaused}
       </AppText>
       <AppText style={[tailwind('text-sm'), { color: statusColor, lineHeight: 24 }]}>

--- a/src/screens/PhotosScreen/components/PhotoItem.tsx
+++ b/src/screens/PhotosScreen/components/PhotoItem.tsx
@@ -96,6 +96,26 @@ const VideoBadge = ({ duration }: { duration?: string }): JSX.Element => {
   );
 };
 
+const LiveBadge = (): JSX.Element => {
+  const tailwind = useTailwind();
+  const getColor = useGetColor();
+
+  return (
+    <View style={[tailwind('absolute justify-center items-start'), { top: 8, left: 8 }]} pointerEvents="none">
+      <LinearGradient
+        colors={['rgba(0,0,0,0.6)', 'rgba(0,0,0,0.32)', 'rgba(0,0,0,0.08)', 'transparent']}
+        locations={[0, 0.3, 0.6, 1]}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={styles.liveBadgeShadow}
+      />
+      <AppText medium style={[tailwind('text-xs'), { color: getColor('text-white'), letterSpacing: 0.5 }]}>
+        LIVE
+      </AppText>
+    </View>
+  );
+};
+
 const localPhotoCellAreEqual = (prev: CellProps & { item: PhotoItemType }, next: CellProps & { item: PhotoItemType }) =>
   prev.item.id === next.item.id &&
   prev.item.backupState === next.item.backupState &&
@@ -103,6 +123,7 @@ const localPhotoCellAreEqual = (prev: CellProps & { item: PhotoItemType }, next:
   prev.item.uploadProgress === next.item.uploadProgress &&
   prev.item.mediaType === next.item.mediaType &&
   prev.item.duration === next.item.duration &&
+  prev.item.isLivePhoto === next.item.isLivePhoto &&
   prev.isSelectMode === next.isSelectMode &&
   prev.isSelected === next.isSelected &&
   prev.onPress === next.onPress &&
@@ -147,6 +168,7 @@ const LocalPhotoCell = memo(
         )}
 
         {item.mediaType === 'video' && <VideoBadge duration={item.duration} />}
+        {item.isLivePhoto && <LiveBadge />}
 
         <SelectOverlay isSelectMode={isSelectMode} isSelected={isSelected} />
       </TouchableOpacity>
@@ -188,6 +210,7 @@ const CloudPhotoCell = memo(
         </View>
 
         {item.mediaType === 'video' && <VideoBadge />}
+        {item.isLivePhoto && <LiveBadge />}
 
         <SelectOverlay isSelectMode={isSelectMode} isSelected={isSelected} />
       </TouchableOpacity>
@@ -220,6 +243,14 @@ const styles = StyleSheet.create({
     width: 80,
     height: 40,
     borderTopRightRadius: 100,
+  },
+  liveBadgeShadow: {
+    position: 'absolute',
+    top: -20,
+    left: -20,
+    width: 80,
+    height: 40,
+    borderBottomRightRadius: 100,
   },
   durationShadow: {
     position: 'absolute',

--- a/src/screens/PhotosScreen/hooks/useCloudAssets.ts
+++ b/src/screens/PhotosScreen/hooks/useCloudAssets.ts
@@ -20,7 +20,9 @@ export const useCloudAssets = (): CloudAssetsResult => {
       photosLocalDB.getAllCloudAssets(),
       photosLocalDB.getSyncedRemoteFileIds(),
     ]);
-    const deduplicated = allCloud.filter((cloudEntry) => !syncedRemoteIds.has(cloudEntry.remoteFileId));
+    const deduplicated = allCloud.filter(
+      (cloudEntry) => !syncedRemoteIds.has(cloudEntry.remoteFileId) && cloudEntry.livePhotoRole !== 'paired_video',
+    );
     setCloudItems(deduplicated.map(cloudEntryToPhotoItem));
   }, []);
 

--- a/src/screens/PhotosScreen/types.ts
+++ b/src/screens/PhotosScreen/types.ts
@@ -10,6 +10,7 @@ export interface PhotoItem {
   mediaType: PhotoMediaType;
   duration?: string;
   uploadProgress?: number;
+  isLivePhoto?: boolean;
 }
 
 export interface CloudPhotoItem {
@@ -23,6 +24,9 @@ export interface CloudPhotoItem {
   deviceId: string;
   createdAt: number;
   fileName: string;
+  isLivePhoto?: boolean;
+  // uuid of the paired .mov cloud asset (only present when isLivePhoto = true and on cloud-only items)
+  pairedVideoRemoteFileId?: string;
 }
 
 export type TimelinePhotoItem = PhotoItem | CloudPhotoItem;

--- a/src/screens/PhotosScreen/utils/photoTimelineGroups.ts
+++ b/src/screens/PhotosScreen/utils/photoTimelineGroups.ts
@@ -1,6 +1,7 @@
 import * as MediaLibrary from 'expo-media-library';
 import { isVideoExtension } from 'src/services/drive/file/utils/exifHelpers';
 import { CloudAssetEntry } from 'src/services/photos/database/photosLocalDB';
+import { isLivePhotoAsset } from 'src/services/photos/livePhoto.constants';
 import { PhotosDisabledReason, PhotoSyncStatus } from 'src/store/slices/photos';
 import { GroupSyncStatus } from '../components/GroupHeader/PhotosGroupHeader';
 import { TimelineDateGroup } from '../components/PhotosTimeline';
@@ -51,6 +52,7 @@ export const assetToPhotoItem = (
     backupState,
     mediaType: isVideo ? 'video' : 'photo',
     duration: isVideo ? formatVideoDuration(asset.duration) : undefined,
+    isLivePhoto: isLivePhotoAsset(asset),
   };
 };
 
@@ -143,6 +145,8 @@ export const cloudEntryToPhotoItem = (entry: CloudAssetEntry): CloudPhotoItem =>
   deviceId: entry.deviceId,
   createdAt: entry.createdAt,
   fileName: entry.fileName,
+  isLivePhoto: entry.isLivePhoto,
+  pairedVideoRemoteFileId: entry.pairedRemoteFileId ?? undefined,
 });
 
 export const mergeCloudIntoGroups = (localGroups: PhotoDateGroup[], cloudItems: CloudPhotoItem[]): PhotoDateGroup[] => {

--- a/src/services/photos/LivePhotoNativeModule.ts
+++ b/src/services/photos/LivePhotoNativeModule.ts
@@ -1,0 +1,44 @@
+import { NativeModules, Platform } from 'react-native';
+
+interface LivePhotoComponents {
+  photo: { uri: string; size: number; fileName: string };
+  video: { uri: string; size: number; fileName: string };
+}
+
+interface PHAssetExportNative {
+  exportLivePhotoComponents(localIdentifier: string): Promise<LivePhotoComponents>;
+  saveLivePhoto(photoPath: string, videoPath: string): Promise<void>;
+}
+
+const nativeModule: PHAssetExportNative | null =
+  Platform.OS === 'ios' ? (NativeModules.PHAssetExport as PHAssetExportNative) : null;
+
+/**
+ * Exports both components of an iOS Live Photo (photo + paired .mov) as raw resource bytes.
+ *
+ * @param localIdentifier - The `PHAsset.localIdentifier` of the Live Photo to export.
+ * @returns Resolves with URIs, sizes, and filenames for both the photo and paired video components.
+ * @throws If called on Android or if the asset cannot be exported.
+ */
+export const exportLivePhotoComponents = async (localIdentifier: string): Promise<LivePhotoComponents> => {
+  if (!nativeModule) {
+    throw new Error('exportLivePhotoComponents is only available on iOS');
+  }
+  return nativeModule.exportLivePhotoComponents(localIdentifier);
+};
+
+/**
+ * Saves a photo + paired video as a real Live Photo in the iOS camera roll using
+ * `PHAssetCreationRequest`. Both files must preserve their original Apple asset-identifier
+ * metadata — this is guaranteed when they come from {@link exportLivePhotoComponents}.
+ *
+ * @param photoPath - Absolute path to the photo file (HEIC/JPEG).
+ * @param videoPath - Absolute path to the paired video file (.mov).
+ * @throws If called on Android or if the save operation fails.
+ */
+export const saveLivePhotoToLibrary = async (photoPath: string, videoPath: string): Promise<void> => {
+  if (!nativeModule) {
+    throw new Error('saveLivePhotoToLibrary is only available on iOS');
+  }
+  return nativeModule.saveLivePhoto(photoPath, videoPath);
+};

--- a/src/services/photos/PhotoActionsService.ts
+++ b/src/services/photos/PhotoActionsService.ts
@@ -1,13 +1,15 @@
 import * as RNFS from '@dr.pogodin/react-native-fs';
 import * as Clipboard from 'expo-clipboard';
 import * as MediaLibrary from 'expo-media-library';
-import { TimelinePhotoItem } from 'src/screens/PhotosScreen/types';
+import { Platform } from 'react-native';
+import { CloudPhotoItem, TimelinePhotoItem } from 'src/screens/PhotosScreen/types';
 import { logger } from 'src/services/common';
 import { stripFileUri, toFileUri } from 'src/services/common/uri/uriHelpers';
 import { driveTrashService } from 'src/services/drive/trash/driveTrash.service';
 import fileSystemService from 'src/services/FileSystemService';
 import { photosLocalDB } from './database/photosLocalDB';
 import { SavePermissionDeniedError } from './errors';
+import { saveLivePhotoToLibrary } from './LivePhotoNativeModule';
 import { PhotoAssetFetchService } from './PhotoAssetFetchService';
 
 type CleanupItem = { type: 'cloud'; assetId: string } | { type: 'local-backed'; assetId: string; remoteFileId: string };
@@ -47,6 +49,11 @@ class PhotoActionsService {
       throw new SavePermissionDeniedError();
     }
 
+    if (Platform.OS === 'ios' && item.type === 'cloud-only' && item.isLivePhoto && item.pairedVideoRemoteFileId) {
+      await this.saveLivePhotoToDevice(item, signal);
+      return;
+    }
+
     const uri = await PhotoAssetFetchService.fetchUri(item, signal);
     if (!uri) {
       logger.warn(`[PhotoActionsService] saveToDevice — no URI resolved for ${item.id}`);
@@ -62,6 +69,26 @@ class PhotoActionsService {
     } catch (error) {
       logger.error(`[PhotoActionsService] saveToDevice failed for ${item.id}: ${error}`);
       throw error;
+    }
+  }
+
+  private async saveLivePhotoToDevice(item: CloudPhotoItem, signal: AbortSignal): Promise<void> {
+    const livePhotoComponents = await PhotoAssetFetchService.fetchLivePhotoComponents(item, signal);
+    if (!livePhotoComponents || signal.aborted) {
+      logger.warn(`[PhotoActionsService] saveLivePhotoToDevice — could not fetch components for ${item.id}`);
+      return;
+    }
+
+    try {
+      await saveLivePhotoToLibrary(livePhotoComponents.photoPath, livePhotoComponents.videoPath);
+      logger.info(`[PhotoActionsService] saveLivePhotoToDevice — Live Photo saved for ${item.id}`);
+    } catch (err) {
+      logger.error(`[PhotoActionsService] saveLivePhotoToDevice — native save failed for ${item.id}: ${err}`);
+      logger.warn(`[PhotoActionsService] saveLivePhotoToDevice — falling back to photo-only save for ${item.id}`);
+      const uri = await PhotoAssetFetchService.fetchUri(item, signal);
+      if (uri) {
+        await MediaLibrary.saveToLibraryAsync(toFileUri(uri));
+      }
     }
   }
 
@@ -83,6 +110,11 @@ class PhotoActionsService {
       if (item.type === 'cloud-only') {
         trashPayload.push({ id: item.id, type: 'file', uuid: item.id });
         cleanupItems.push({ type: 'cloud', assetId: item.id });
+
+        if (item.pairedVideoRemoteFileId) {
+          trashPayload.push({ id: item.pairedVideoRemoteFileId, type: 'file', uuid: item.pairedVideoRemoteFileId });
+          cleanupItems.push({ type: 'cloud', assetId: item.pairedVideoRemoteFileId });
+        }
       } else if (item.type === 'local' && item.backupState === 'backed') {
         const itemDbEntry = await photosLocalDB.getStatus(item.id);
 
@@ -90,6 +122,14 @@ class PhotoActionsService {
           const { remoteFileId } = itemDbEntry;
           trashPayload.push({ id: remoteFileId, type: 'file', uuid: remoteFileId });
           cleanupItems.push({ type: 'local-backed', assetId: item.id, remoteFileId });
+          if (itemDbEntry.pairedVideoRemoteFileId) {
+            trashPayload.push({
+              id: itemDbEntry.pairedVideoRemoteFileId,
+              type: 'file',
+              uuid: itemDbEntry.pairedVideoRemoteFileId,
+            });
+            cleanupItems.push({ type: 'cloud', assetId: itemDbEntry.pairedVideoRemoteFileId });
+          }
         } else {
           logger.info(`[PhotoActionsService] trash — local-backed ${item.id} has no remoteFileId, skipping`);
         }

--- a/src/services/photos/PhotoAssetFetchService.ts
+++ b/src/services/photos/PhotoAssetFetchService.ts
@@ -7,6 +7,7 @@ import { copyAsync } from 'expo-file-system/legacy';
 import { Platform } from 'react-native';
 import { CloudPhotoItem, PhotoItem } from 'src/screens/PhotosScreen/types';
 import { photosLocalDB } from './database/photosLocalDB';
+import { LIVE_PHOTO_VIDEO_TYPE } from './livePhoto.constants';
 import { photoMediaLibraryService } from './PhotoMediaLibraryService';
 import { splitFileNameAndExtension } from './PhotoUploadService.utils';
 
@@ -96,6 +97,50 @@ const copyPhAssetToSandbox = async (item: PhotoItem): Promise<string> => {
   return destPath;
 };
 
+const downloadPairedVideo = async (pairedVideoRemoteFileId: string, signal: AbortSignal): Promise<string | null> => {
+  const asset = await photosLocalDB.getCloudAssetById(pairedVideoRemoteFileId);
+  if (!asset?.fileId || !asset.bucket) {
+    logger.warn(`[PhotoAssetFetchService] No fileId/bucket for paired video ${pairedVideoRemoteFileId}`);
+    return null;
+  }
+  const cachePath = cachePathFor(pairedVideoRemoteFileId, asset.extension ?? LIVE_PHOTO_VIDEO_TYPE);
+  const alreadyCached = await fileSystemService.exists(cachePath);
+  if (alreadyCached) {
+    return cachePath;
+  }
+
+  const user = await asyncStorageService.getUser();
+  await fileSystemService.ensureDir(getCacheDir());
+
+  try {
+    await driveFileService.downloadFile(
+      user,
+      asset.bucket,
+      asset.fileId,
+      {
+        downloadPath: cachePath,
+        downloadProgressCallback: () => undefined,
+        decryptionProgressCallback: () => undefined,
+        signal,
+      },
+      asset.fileSize ?? 0,
+    );
+
+    if (signal.aborted) {
+      await fileSystemService.unlinkIfExists(cachePath);
+      return null;
+    }
+
+    return cachePath;
+  } catch (error) {
+    if (!signal.aborted) {
+      logger.error(`[PhotoAssetFetchService] Paired video download failed for ${pairedVideoRemoteFileId}: ${error}`);
+    }
+    await fileSystemService.unlinkIfExists(cachePath);
+    return null;
+  }
+};
+
 export type ExportUri = { uri: string; cleanup?: () => void };
 
 export const PhotoAssetFetchService = {
@@ -104,6 +149,29 @@ export const PhotoAssetFetchService = {
       return resolveLocalUri(item);
     }
     return downloadCloudAsset(item, signal);
+  },
+
+  fetchLivePhotoComponents: async (
+    item: CloudPhotoItem,
+    signal: AbortSignal,
+  ): Promise<{ photoPath: string; videoPath: string } | null> => {
+    if (!item.pairedVideoRemoteFileId) {
+      logger.warn('[PhotoAssetFetchService] fetchLivePhotoComponents called on item without pairedVideoRemoteFileId');
+      return null;
+    }
+
+    const [photoUri, videoPath] = await Promise.all([
+      downloadCloudAsset(item, signal),
+      downloadPairedVideo(item.pairedVideoRemoteFileId, signal),
+    ]);
+
+    if (!photoUri || !videoPath || signal.aborted) {
+      return null;
+    }
+
+    // downloadCloudAsset returns a file:// URI; strip it for the native module (saveLivePhotoToLibrary function)
+    const photoPath = photoUri.startsWith('file://') ? photoUri.slice('file://'.length) : photoUri;
+    return { photoPath, videoPath };
   },
 
   resolveExportUri: async (item: PhotoItem | CloudPhotoItem, signal: AbortSignal): Promise<ExportUri | null> => {

--- a/src/services/photos/PhotoCloudBrowser.ts
+++ b/src/services/photos/PhotoCloudBrowser.ts
@@ -317,7 +317,6 @@ class PhotoCloudBrowserService {
       let pairedRemoteFileId: string | null = null;
 
       if (isPairedVideoPlainName(baseName, type)) {
-        // *.livephoto.mov — look for its photo sibling; if missing, treat as an orphan normal file.
         const photoPlainName = getPhotoPlainNameFromPairedVideo(baseName).toLowerCase();
         const photoUuid = plainNameIndex.get(photoPlainName);
         if (photoUuid) {
@@ -325,7 +324,6 @@ class PhotoCloudBrowserService {
           pairedRemoteFileId = photoUuid;
         }
       } else {
-        // Regular photo — check whether a paired video exists in the same folder.
         const pairedVideoPlainName = `${baseName}.livephoto`.toLowerCase();
         const pairedVideoUuid = plainNameIndex.get(pairedVideoPlainName);
         if (pairedVideoUuid) {

--- a/src/services/photos/PhotoCloudBrowser.ts
+++ b/src/services/photos/PhotoCloudBrowser.ts
@@ -2,7 +2,8 @@ import { DriveFileData } from '@internxt-mobile/types/drive/file';
 import { FetchPaginatedFolder } from '@internxt/sdk/dist/drive/storage/types';
 import { logger } from 'src/services/common';
 import { driveFolderService } from 'src/services/drive/folder/driveFolder.service';
-import { photosLocalDB } from './database/photosLocalDB';
+import { CloudAssetEntry, LivePhotoRole, photosLocalDB } from './database/photosLocalDB';
+import { getPhotoPlainNameFromPairedVideo, isPairedVideoPlainName } from './livePhoto.constants';
 import { photosDeviceService } from './photosDeviceService';
 
 const HOUR_MS = 60 * 60 * 1000;
@@ -138,37 +139,15 @@ class PhotoCloudBrowserService {
       const folderDate = new Date(year, month - 1, Number.isNaN(day) ? 1 : day).getTime();
 
       const files = await this.listFilesWithThumbnails(dayFolder.uuid);
-      for (const file of files) {
-        if (file.status && file.status.toLowerCase() !== 'exists') continue;
-        const baseName = file.plainName ?? file.name;
-        const fileName = file.type ? `${baseName}.${file.type}` : baseName;
-        const createdAt = folderDate;
-        const thumb = file.thumbnails?.[0] ?? null;
+      const existingFiles = files.filter((f) => !f.status || f.status.toLowerCase() === 'exists');
 
-        await this.localDB.upsertCloudAsset({
-          remoteFileId: file.uuid,
-          deviceId,
-          createdAt,
-          fileName,
-          fileSize: file.size ? Number(file.size) : null,
-          fileId: file.fileId ?? null,
-          thumbnailPath: null,
-          thumbnailBucketId: thumb?.bucket_id ?? null,
-          thumbnailBucketFile: thumb?.bucket_file ?? null,
-          thumbnailType: thumb?.type ?? null,
-          discoveredAt: now,
-          plainName: file.plainName ?? null,
-          extension: file.type ?? null,
-          bucket: file.bucket ?? null,
-          folderUuid: file.folderUuid ?? null,
-          creationTimeApi: file.creationTime ? new Date(file.creationTime).getTime() : null,
-          modificationTime: file.modificationTime ? new Date(file.modificationTime).getTime() : null,
-          updatedAt: file.updatedAt ? new Date(file.updatedAt).getTime() : null,
-          status: file.status ?? null,
-          encryptVersion: file.encrypt_version ?? null,
-        });
-        foundIds.add(file.uuid);
+      const plainNameIndex = this.buildPlainNameIndex(existingFiles);
+      const entries = this.buildCloudAssetEntries({ files: existingFiles, plainNameIndex, deviceId, folderDate, now });
+
+      for (const entry of entries) {
+        foundIds.add(entry.remoteFileId);
         count++;
+        await this.localDB.upsertCloudAsset(entry);
       }
     }
 
@@ -301,6 +280,89 @@ class PhotoCloudBrowserService {
     const allMonths = monthsPerDevice.flat();
     allMonths.sort((a, b) => b.year - a.year || b.month - a.month);
     return allMonths;
+  }
+
+  private buildPlainNameIndex(files: DriveFileData[]): Map<string, string> {
+    const index = new Map<string, string>();
+    for (const file of files) {
+      const baseName = file.plainName ?? file.name;
+      index.set(baseName.toLowerCase(), file.uuid);
+    }
+    return index;
+  }
+
+  private buildCloudAssetEntries({
+    files,
+    plainNameIndex,
+    deviceId,
+    folderDate,
+    now,
+  }: {
+    files: DriveFileData[];
+    plainNameIndex: Map<string, string>;
+    deviceId: string;
+    folderDate: number;
+    now: number;
+  }): CloudAssetEntry[] {
+    const entries: CloudAssetEntry[] = [];
+
+    for (const file of files) {
+      const baseName = file.plainName ?? file.name;
+      const type = file.type ?? '';
+      const fileName = type ? `${baseName}.${type}` : baseName;
+      const thumb = file.thumbnails?.[0] ?? null;
+
+      let livePhotoRole: LivePhotoRole | null = null;
+      let isLivePhoto = false;
+      let pairedRemoteFileId: string | null = null;
+
+      if (isPairedVideoPlainName(baseName, type)) {
+        // *.livephoto.mov — look for its photo sibling; if missing, treat as an orphan normal file.
+        const photoPlainName = getPhotoPlainNameFromPairedVideo(baseName).toLowerCase();
+        const photoUuid = plainNameIndex.get(photoPlainName);
+        if (photoUuid) {
+          livePhotoRole = 'paired_video';
+          pairedRemoteFileId = photoUuid;
+        }
+      } else {
+        // Regular photo — check whether a paired video exists in the same folder.
+        const pairedVideoPlainName = `${baseName}.livephoto`.toLowerCase();
+        const pairedVideoUuid = plainNameIndex.get(pairedVideoPlainName);
+        if (pairedVideoUuid) {
+          isLivePhoto = true;
+          livePhotoRole = 'photo';
+          pairedRemoteFileId = pairedVideoUuid;
+        }
+      }
+
+      entries.push({
+        remoteFileId: file.uuid,
+        deviceId,
+        createdAt: folderDate,
+        fileName,
+        fileSize: file.size ? Number(file.size) : null,
+        fileId: file.fileId ?? null,
+        thumbnailPath: null,
+        thumbnailBucketId: thumb?.bucket_id ?? null,
+        thumbnailBucketFile: thumb?.bucket_file ?? null,
+        thumbnailType: thumb?.type ?? null,
+        discoveredAt: now,
+        plainName: file.plainName ?? null,
+        extension: type || null,
+        bucket: file.bucket ?? null,
+        folderUuid: file.folderUuid ?? null,
+        creationTimeApi: file.creationTime ? new Date(file.creationTime).getTime() : null,
+        modificationTime: file.modificationTime ? new Date(file.modificationTime).getTime() : null,
+        updatedAt: file.updatedAt ? new Date(file.updatedAt).getTime() : null,
+        status: file.status ?? null,
+        encryptVersion: file.encrypt_version ?? null,
+        isLivePhoto,
+        livePhotoRole,
+        pairedRemoteFileId,
+      });
+    }
+
+    return entries;
   }
 
   private async findChildFolder(parentUuid: string, name: string): Promise<FetchPaginatedFolder | null> {

--- a/src/services/photos/PhotoUploadQueue.ts
+++ b/src/services/photos/PhotoUploadQueue.ts
@@ -1,6 +1,6 @@
 import * as MediaLibrary from 'expo-media-library';
 import pLimit from 'p-limit';
-import { PhotoUploadService } from './PhotoUploadService';
+import { PhotoUploadResult, PhotoUploadService } from './PhotoUploadService';
 
 const UPLOAD_CONCURRENCY = 3;
 
@@ -12,7 +12,7 @@ export interface AssetUploadJob {
 interface UploadQueueCallbacks {
   onAssetStart?: (assetId: string) => void;
   onAssetProgress?: (assetId: string, ratio: number) => void;
-  onAssetDone?: (assetId: string, remoteFileId: string, modificationTime: number) => Promise<void> | void;
+  onAssetDone?: (assetId: string, result: PhotoUploadResult, modificationTime: number) => Promise<void> | void;
   onAssetError?: (assetId: string, error: Error) => Promise<void> | void;
 }
 
@@ -42,7 +42,7 @@ export const PhotoUploadQueue = {
             callbacks.onAssetStart?.(asset.id);
 
             try {
-              const remoteFileId = existingRemoteFileId
+              const photoUploadResult = existingRemoteFileId
                 ? await PhotoUploadService.replace(
                     asset,
                     existingRemoteFileId,
@@ -58,7 +58,7 @@ export const PhotoUploadQueue = {
                     (ratio) => callbacks.onAssetProgress?.(asset.id, ratio),
                     signal,
                   );
-              await callbacks.onAssetDone?.(asset.id, remoteFileId, asset.modificationTime);
+              await callbacks.onAssetDone?.(asset.id, photoUploadResult, asset.modificationTime);
             } catch (uploadError) {
               await callbacks.onAssetError?.(asset.id, uploadError as Error);
             }

--- a/src/services/photos/PhotoUploadService.spec.ts
+++ b/src/services/photos/PhotoUploadService.spec.ts
@@ -147,7 +147,7 @@ describe('PhotoUploadService.upload', () => {
 
   test('when uploading a supported image, then the drive file uuid is returned', async () => {
     const result = await PhotoUploadService.upload(makeAsset(), DEVICE_ID, PHOTOS_BUCKET);
-    expect(result).toBe('drive-file-uuid');
+    expect(result.photoUuid).toBe('drive-file-uuid');
   });
 
   test('when the photo already exists in Drive, then its existing uuid is returned without uploading again', async () => {
@@ -155,7 +155,7 @@ describe('PhotoUploadService.upload', () => {
 
     const result = await PhotoUploadService.upload(makeAsset(), DEVICE_ID, PHOTOS_BUCKET);
 
-    expect(result).toBe('existing-uuid');
+    expect(result.photoUuid).toBe('existing-uuid');
     expect(mockUploadFile).not.toHaveBeenCalled();
     expect(mockCreateFileEntry).not.toHaveBeenCalled();
   });
@@ -185,7 +185,7 @@ describe('PhotoUploadService.upload', () => {
 
     expect(mockGenerateThumbnail).not.toHaveBeenCalled();
     expect(mockCreateThumbnailEntry).not.toHaveBeenCalled();
-    expect(result).toBe('drive-file-uuid');
+    expect(result.photoUuid).toBe('drive-file-uuid');
   });
 
   test('when thumbnail generation throws, then the upload still returns the drive file uuid', async () => {
@@ -195,7 +195,7 @@ describe('PhotoUploadService.upload', () => {
 
     const result = await PhotoUploadService.upload(makeAsset(), DEVICE_ID, PHOTOS_BUCKET);
 
-    expect(result).toBe('drive-file-uuid');
+    expect(result.photoUuid).toBe('drive-file-uuid');
     expect(mockCreateThumbnailEntry).not.toHaveBeenCalled();
   });
 
@@ -207,7 +207,7 @@ describe('PhotoUploadService.upload', () => {
 
     const result = await PhotoUploadService.upload(makeAsset(), DEVICE_ID, PHOTOS_BUCKET);
 
-    expect(result).toBe('drive-file-uuid');
+    expect(result.photoUuid).toBe('drive-file-uuid');
     expect(mockCreateThumbnailEntry).not.toHaveBeenCalled();
   });
 
@@ -231,7 +231,7 @@ describe('PhotoUploadService.upload', () => {
 
     const result = await PhotoUploadService.upload(makeAsset(), DEVICE_ID, PHOTOS_BUCKET);
 
-    expect(result).toBe('recovered-uuid');
+    expect(result.photoUuid).toBe('recovered-uuid');
   });
 
   test('when createFileEntry returns a 409 conflict and checkFileExistence finds nothing, then the original error is rethrown', async () => {
@@ -272,7 +272,7 @@ describe('PhotoUploadService.replace', () => {
 
   test('when replacing an asset, then the existing remote file id is returned', async () => {
     const result = await PhotoUploadService.replace(makeAsset(), 'existing-remote-id', DEVICE_ID, PHOTOS_BUCKET);
-    expect(result).toBe('existing-remote-id');
+    expect(result.photoUuid).toBe('existing-remote-id');
   });
 
   test('when thumbnail generation fails during a replace, then the replace still returns the existing remote file id', async () => {
@@ -281,7 +281,7 @@ describe('PhotoUploadService.replace', () => {
 
     const result = await PhotoUploadService.replace(makeAsset(), 'existing-remote-id', DEVICE_ID, PHOTOS_BUCKET);
 
-    expect(result).toBe('existing-remote-id');
+    expect(result.photoUuid).toBe('existing-remote-id');
   });
 
   test('when the server rejects the replace with a 400, then a new drive entry is created and its uuid is returned', async () => {
@@ -291,7 +291,7 @@ describe('PhotoUploadService.replace', () => {
     const result = await PhotoUploadService.replace(makeAsset(), 'deleted-remote-id', DEVICE_ID, PHOTOS_BUCKET);
 
     expect(mockCreateFileEntry).toHaveBeenCalledTimes(1);
-    expect(result).toBe('new-drive-uuid');
+    expect(result.photoUuid).toBe('new-drive-uuid');
   });
 
   test('when the server rejects the replace with a 400 and a new entry is created, then the thumbnail is registered against the new file uuid', async () => {

--- a/src/services/photos/PhotoUploadService.ts
+++ b/src/services/photos/PhotoUploadService.ts
@@ -335,8 +335,6 @@ export const PhotoUploadService = {
       try {
         components = await exportLivePhotoComponents(asset.id);
       } catch (livePhotoErr) {
-        // Native module not available (not yet rebuilt, or older binary) — fall back to standard
-        // photo-only upload so the photo is not lost and the asset does not loop forever.
         logger.warn(
           `[PhotoUploadService] exportLivePhotoComponents failed, falling back to photo-only upload: ${livePhotoErr}`,
         );
@@ -392,7 +390,6 @@ export const PhotoUploadService = {
           await cleanupTempFile(videoLocalPath);
         }
       }
-      // components === null: fall through to standard upload path below
     }
 
     let fileUploadResult: FileUploadResult;
@@ -533,7 +530,6 @@ export const PhotoUploadService = {
           await cleanupTempFile(videoLocalPath);
         }
       }
-      // components === null: fall through to standard replace path below
     }
 
     const {

--- a/src/services/photos/PhotoUploadService.ts
+++ b/src/services/photos/PhotoUploadService.ts
@@ -12,6 +12,8 @@ import { uploadService } from 'src/services/common/network/upload/upload.service
 import fileSystemService from 'src/services/FileSystemService';
 import { logger } from '../common';
 import { FileAlreadyExistsError } from './errors';
+import { getPairedVideoPlainNameFromPhoto, isLivePhotoAsset } from './livePhoto.constants';
+import { exportLivePhotoComponents } from './LivePhotoNativeModule';
 import { photoBackupFolders } from './PhotoBackupFolders';
 import { photoMediaLibraryService } from './PhotoMediaLibraryService';
 import {
@@ -47,6 +49,11 @@ interface FileUploadResult {
   credentials: UploadCredentials;
 }
 
+export interface PhotoUploadResult {
+  photoUuid: string;
+  pairedVideoUuid?: string;
+}
+
 const resolveLocalPath = async (
   asset: MediaLibrary.Asset,
 ): Promise<{ localPath: string; tempPath?: string; thumbnailUri?: string }> => {
@@ -71,6 +78,65 @@ const resolveLocalPath = async (
     return { localPath: tempPath, tempPath };
   }
   return { localPath: stripFileScheme(uri) };
+};
+
+const uploadSingleFile = async (params: {
+  localFilePath: string;
+  folderUuid: string;
+  plainName: string;
+  fileExtension: string;
+  creationIso: string;
+  modificationIso: string;
+  credentials: UploadCredentials;
+  onProgress?: (ratio: number) => void;
+  signal?: AbortSignal;
+}): Promise<string> => {
+  const {
+    localFilePath,
+    folderUuid,
+    plainName,
+    fileExtension,
+    creationIso,
+    modificationIso,
+    credentials,
+    onProgress,
+    signal,
+  } = params;
+  const { bucketId, encryptionKey, bridgeUser, bridgePass } = credentials;
+
+  const fileStat = await fileSystemService.stat(localFilePath);
+
+  const { existentFiles } = await uploadService.checkFileExistence(folderUuid, [{ plainName, type: fileExtension }]);
+  if (existentFiles.length > 0) {
+    return existentFiles[0].uuid;
+  }
+
+  let fileId: string;
+  try {
+    fileId = await uploadFile(
+      localFilePath,
+      bucketId,
+      encryptionKey,
+      constants.BRIDGE_URL,
+      { user: bridgeUser, pass: bridgePass },
+      { notifyProgress: onProgress, signal },
+    );
+  } catch (uploadError) {
+    if (uploadError instanceof Error && uploadError.name !== 'Error') throw uploadError;
+    const message = uploadError instanceof Error ? uploadError.message : String(uploadError);
+    throw new Error(`Bucket upload failed for ${plainName}.${fileExtension}: ${message}`);
+  }
+
+  return createFileEntryOrFetchExisting({
+    fileId,
+    type: fileExtension,
+    size: fileStat.size,
+    plainName,
+    bucket: bucketId,
+    folderUuid,
+    modificationTime: modificationIso,
+    creationTime: creationIso,
+  });
 };
 
 const uploadAssetToBucket = async (
@@ -215,6 +281,45 @@ const createFileEntryOrFetchExisting = async (params: {
   }
 };
 
+const uploadPairedVideo = async (params: {
+  videoLocalPath: string;
+  videoFileName: string;
+  photoPlainName: string;
+  folderUuid: string;
+  creationIso: string;
+  modificationIso: string;
+  credentials: UploadCredentials;
+  signal?: AbortSignal;
+}): Promise<string | null> => {
+  const {
+    videoLocalPath,
+    videoFileName,
+    photoPlainName,
+    folderUuid,
+    creationIso,
+    modificationIso,
+    credentials,
+    signal,
+  } = params;
+  const { fileExtension } = splitFileNameAndExtension(videoFileName);
+  const pairedVideoPlainName = getPairedVideoPlainNameFromPhoto(photoPlainName);
+  try {
+    return await uploadSingleFile({
+      localFilePath: videoLocalPath,
+      folderUuid,
+      plainName: pairedVideoPlainName,
+      fileExtension,
+      creationIso,
+      modificationIso,
+      credentials,
+      signal,
+    });
+  } catch (err) {
+    logger.error(`[PhotoUploadService] Failed to upload Live Photo paired video for photo "${photoPlainName}":`, err);
+    return null;
+  }
+};
+
 export const PhotoUploadService = {
   async upload(
     asset: MediaLibrary.Asset,
@@ -222,13 +327,80 @@ export const PhotoUploadService = {
     photosBucket: string,
     onProgress?: (ratio: number) => void,
     signal?: AbortSignal,
-  ): Promise<string> {
+  ): Promise<PhotoUploadResult> {
+    const livePhoto = Platform.OS === 'ios' && isLivePhotoAsset(asset);
+
+    if (livePhoto) {
+      let components;
+      try {
+        components = await exportLivePhotoComponents(asset.id);
+      } catch (livePhotoErr) {
+        // Native module not available (not yet rebuilt, or older binary) — fall back to standard
+        // photo-only upload so the photo is not lost and the asset does not loop forever.
+        logger.warn(
+          `[PhotoUploadService] exportLivePhotoComponents failed, falling back to photo-only upload: ${livePhotoErr}`,
+        );
+        components = null;
+      }
+
+      if (components) {
+        const photoLocalPath = stripFileSchemeAndFragment(components.photo.uri);
+        const videoLocalPath = stripFileSchemeAndFragment(components.video.uri);
+
+        try {
+          const createdDate = new Date(asset.creationTime);
+          const creationIso = createdDate.toISOString();
+          const modificationIso = new Date(asset.modificationTime).toISOString();
+          const fileName = components.photo.fileName;
+          const { plainName, fileExtension } = splitFileNameAndExtension(fileName);
+
+          const [user, folderUuid] = await Promise.all([
+            asyncStorageService.getUser(),
+            photoBackupFolders.getOrCreateFolderForDate(deviceId, createdDate),
+          ]);
+          const { encryptionKey, bridgeUser, bridgePass } = getEnvironmentConfigFromUser(user);
+          const credentials: UploadCredentials = { bucketId: photosBucket, encryptionKey, bridgeUser, bridgePass };
+
+          const photoUuid = await uploadSingleFile({
+            localFilePath: photoLocalPath,
+            folderUuid,
+            plainName,
+            fileExtension,
+            creationIso,
+            modificationIso,
+            credentials,
+            onProgress,
+            signal,
+          });
+
+          await uploadThumbnailForAsset(asset.uri, fileExtension, photoUuid, credentials);
+
+          const pairedVideoUuid = await uploadPairedVideo({
+            videoLocalPath,
+            videoFileName: components.video.fileName,
+            photoPlainName: plainName,
+            folderUuid,
+            creationIso,
+            modificationIso,
+            credentials,
+            signal,
+          });
+
+          return { photoUuid, pairedVideoUuid: pairedVideoUuid ?? undefined };
+        } finally {
+          await cleanupTempFile(photoLocalPath);
+          await cleanupTempFile(videoLocalPath);
+        }
+      }
+      // components === null: fall through to standard upload path below
+    }
+
     let fileUploadResult: FileUploadResult;
     try {
       fileUploadResult = await uploadAssetToBucket(asset, deviceId, photosBucket, onProgress, signal);
     } catch (err) {
       if (err instanceof FileAlreadyExistsError) {
-        return err.existingUuid;
+        return { photoUuid: err.existingUuid };
       }
       throw err;
     }
@@ -242,14 +414,13 @@ export const PhotoUploadService = {
       modificationIso,
       creationIso,
       folderUuid,
-      localFilePath,
       thumbnailSource,
       tempPath,
       credentials,
     } = fileUploadResult;
 
     try {
-      const fileUuid = await createFileEntryOrFetchExisting({
+      const photoUuid = await createFileEntryOrFetchExisting({
         fileId,
         type: fileExtension,
         size: fileSize,
@@ -260,9 +431,9 @@ export const PhotoUploadService = {
         creationTime: creationIso,
       });
 
-      await uploadThumbnailForAsset(thumbnailSource, fileExtension, fileUuid, credentials);
+      await uploadThumbnailForAsset(thumbnailSource, fileExtension, photoUuid, credentials);
 
-      return fileUuid;
+      return { photoUuid };
     } finally {
       await cleanupTempFile(tempPath);
     }
@@ -275,11 +446,99 @@ export const PhotoUploadService = {
     photosBucket: string,
     onProgress?: (ratio: number) => void,
     signal?: AbortSignal,
-  ): Promise<string> {
+  ): Promise<PhotoUploadResult> {
+    const livePhoto = Platform.OS === 'ios' && isLivePhotoAsset(asset);
+
+    if (livePhoto) {
+      let components;
+      try {
+        components = await exportLivePhotoComponents(asset.id);
+      } catch (livePhotoErr) {
+        logger.warn(
+          `[PhotoUploadService] exportLivePhotoComponents failed during replace, falling back to photo-only: ${livePhotoErr}`,
+        );
+        components = null;
+      }
+
+      if (components) {
+        const photoLocalPath = stripFileSchemeAndFragment(components.photo.uri);
+        const videoLocalPath = stripFileSchemeAndFragment(components.video.uri);
+
+        try {
+          const createdDate = new Date(asset.creationTime);
+          const creationIso = createdDate.toISOString();
+          const modificationIso = new Date(asset.modificationTime).toISOString();
+          const { plainName, fileExtension } = splitFileNameAndExtension(components.photo.fileName);
+
+          const photoFileStat = await fileSystemService.stat(photoLocalPath);
+          const user = await asyncStorageService.getUser();
+          const { encryptionKey, bridgeUser, bridgePass } = getEnvironmentConfigFromUser(user);
+          const credentials: UploadCredentials = {
+            bucketId: photosBucket,
+            encryptionKey,
+            bridgeUser,
+            bridgePass,
+          };
+
+          let photoUuid = existingRemoteFileId;
+          const photoFileId = await uploadFile(
+            photoLocalPath,
+            photosBucket,
+            encryptionKey,
+            constants.BRIDGE_URL,
+            { user: bridgeUser, pass: bridgePass },
+            { notifyProgress: onProgress, signal },
+          );
+
+          try {
+            await uploadService.replaceFileEntry(existingRemoteFileId, {
+              fileId: photoFileId,
+              size: photoFileStat.size,
+            });
+            await uploadThumbnailForAsset(asset.uri, fileExtension, existingRemoteFileId, credentials);
+          } catch (replaceError) {
+            if (!isDeletedOrTrashedError(replaceError)) throw replaceError;
+            const folderUuid = await photoBackupFolders.getOrCreateFolderForDate(deviceId, createdDate);
+            const driveFile = await uploadService.createFileEntry({
+              fileId: photoFileId,
+              type: fileExtension,
+              size: photoFileStat.size,
+              plainName,
+              bucket: photosBucket,
+              folderUuid,
+              encryptVersion: EncryptionVersion.Aes03,
+              modificationTime: modificationIso,
+              creationTime: creationIso,
+            });
+            await uploadThumbnailForAsset(asset.uri, fileExtension, driveFile.uuid, credentials);
+            photoUuid = driveFile.uuid;
+          }
+
+          // Retrieve folderUuid for the paired video (may differ from original if photo was re-created)
+          const folderUuid = await photoBackupFolders.getOrCreateFolderForDate(deviceId, createdDate);
+          const pairedVideoUuid = await uploadPairedVideo({
+            videoLocalPath,
+            videoFileName: components.video.fileName,
+            photoPlainName: plainName,
+            folderUuid,
+            creationIso,
+            modificationIso,
+            credentials,
+            signal,
+          });
+
+          return { photoUuid, pairedVideoUuid: pairedVideoUuid ?? undefined };
+        } finally {
+          await cleanupTempFile(photoLocalPath);
+          await cleanupTempFile(videoLocalPath);
+        }
+      }
+      // components === null: fall through to standard replace path below
+    }
+
     const {
       fileId,
       fileSize,
-      localFilePath,
       thumbnailSource,
       fileExtension,
       tempPath,
@@ -292,10 +551,10 @@ export const PhotoUploadService = {
     } = await uploadAssetToBucket(asset, deviceId, photosBucket, onProgress, signal);
 
     try {
+      let photoUuid = existingRemoteFileId;
       try {
         await uploadService.replaceFileEntry(existingRemoteFileId, { fileId, size: fileSize });
         await uploadThumbnailForAsset(thumbnailSource, fileExtension, existingRemoteFileId, credentials);
-        return existingRemoteFileId;
       } catch (replaceError) {
         if (!isDeletedOrTrashedError(replaceError)) {
           logger.error(`Failed to replace file entry for ${existingRemoteFileId}:`, replaceError);
@@ -313,8 +572,9 @@ export const PhotoUploadService = {
           creationTime: creationIso,
         });
         await uploadThumbnailForAsset(thumbnailSource, fileExtension, driveFile.uuid, credentials);
-        return driveFile.uuid;
+        photoUuid = driveFile.uuid;
       }
+      return { photoUuid };
     } finally {
       await cleanupTempFile(tempPath);
     }

--- a/src/services/photos/PhotoUploadService.utils.spec.ts
+++ b/src/services/photos/PhotoUploadService.utils.spec.ts
@@ -23,6 +23,26 @@ describe('stripFileSchemeAndFragment', () => {
       '/var/mobile/My Photos/photo.jpg',
     );
   });
+
+  test('when the URI is a Live Photo photo component written to the app temp directory, then it returns the raw path', () => {
+    expect(
+      stripFileSchemeAndFragment(
+        'file:///private/var/mobile/Containers/Data/Application/1B1254D9-CBD8-4CA4-AF75-2BB779DA86D5/tmp/597F1AAF-B2A5-418F-8FCB-5D82CBC92C2E.heic',
+      ),
+    ).toBe(
+      '/private/var/mobile/Containers/Data/Application/1B1254D9-CBD8-4CA4-AF75-2BB779DA86D5/tmp/597F1AAF-B2A5-418F-8FCB-5D82CBC92C2E.heic',
+    );
+  });
+
+  test('when the URI is a Live Photo paired video component with a time fragment, then it strips the fragment', () => {
+    expect(
+      stripFileSchemeAndFragment(
+        'file:///private/var/mobile/Containers/Data/Application/1B1254D9-CBD8-4CA4-AF75-2BB779DA86D5/tmp/4E8A1155-3CCF-4D92-83FF-4F7B58770A79.mov#t=0.0',
+      ),
+    ).toBe(
+      '/private/var/mobile/Containers/Data/Application/1B1254D9-CBD8-4CA4-AF75-2BB779DA86D5/tmp/4E8A1155-3CCF-4D92-83FF-4F7B58770A79.mov',
+    );
+  });
 });
 
 describe('stripFileScheme', () => {
@@ -79,5 +99,27 @@ describe('splitFileNameAndExtension', () => {
 
   test('when a filename starts with a dot and has no other dots, then it returns the full name and an empty extension', () => {
     expect(splitFileNameAndExtension('.hidden')).toEqual({ plainName: '', fileExtension: 'hidden' });
+  });
+
+  test('when the Live Photo photo component filename has an uppercase extension, then it splits correctly', () => {
+    expect(splitFileNameAndExtension('IMG_4747.HEIC')).toEqual({ plainName: 'IMG_4747', fileExtension: 'HEIC' });
+  });
+
+  test('when the Live Photo paired video filename has an uppercase extension, then it splits correctly', () => {
+    expect(splitFileNameAndExtension('IMG_4747.MOV')).toEqual({ plainName: 'IMG_4747', fileExtension: 'MOV' });
+  });
+
+  test('when the paired video drive filename includes the livephoto suffix and an uppercase extension, then it splits at the last dot', () => {
+    expect(splitFileNameAndExtension('IMG_4747.livephoto.MOV')).toEqual({
+      plainName: 'IMG_4747.livephoto',
+      fileExtension: 'MOV',
+    });
+  });
+
+  test('when the photo filename contains a UUID as Apple writes to the temp directory, then it splits correctly', () => {
+    expect(splitFileNameAndExtension('597F1AAF-B2A5-418F-8FCB-5D82CBC92C2E.heic')).toEqual({
+      plainName: '597F1AAF-B2A5-418F-8FCB-5D82CBC92C2E',
+      fileExtension: 'heic',
+    });
   });
 });

--- a/src/services/photos/database/photosLocalDB.spec.ts
+++ b/src/services/photos/database/photosLocalDB.spec.ts
@@ -24,7 +24,7 @@ describe('photosLocalDB', () => {
     await photosLocalDB.init();
 
     expect(mockSqlite.open).toHaveBeenCalledWith('photos_sync.db');
-    expect(mockSqlite.executeSql).toHaveBeenCalledTimes(6);
+    expect(mockSqlite.executeSql).toHaveBeenCalledTimes(7);
     const statements = mockSqlite.executeSql.mock.calls.map(([, stmt]) => stmt as string);
     expect(statements.some((s) => s.includes('CREATE TABLE IF NOT EXISTS asset_sync'))).toBe(true);
     expect(statements.some((s) => s.includes('CREATE TABLE IF NOT EXISTS cloud_asset'))).toBe(true);
@@ -47,7 +47,7 @@ describe('photosLocalDB', () => {
     expect(stmt).toContain('\'pending\'');
     expect(stmt).toContain('ON CONFLICT');
     expect(stmt).toContain('status != \'synced\'');
-    expect(params).toEqual(['asset-1', null, null, null, null, null, null]);
+    expect(params).toEqual(['asset-1', null, null, null, null, null, null, 0]);
   });
 
   test('when a photo is marked as pending with media info, then all media info fields are passed to the database', async () => {
@@ -61,7 +61,7 @@ describe('photosLocalDB', () => {
     });
 
     const [, , params] = mockSqlite.executeSql.mock.calls[0];
-    expect(params).toEqual(['asset-1', 'photo.jpg', 1714000000000, 3024, 4032, 0, 'photo']);
+    expect(params).toEqual(['asset-1', 'photo.jpg', 1714000000000, 3024, 4032, 0, 'photo', 0]);
   });
 
   test('when a photo is marked as pending for edit, then the status is pending_edit and it never overwrites a non-synced photo', async () => {
@@ -71,7 +71,7 @@ describe('photosLocalDB', () => {
     const [, stmt, params] = mockSqlite.executeSql.mock.calls[0];
     expect(stmt).toContain('\'pending_edit\'');
     expect(stmt).toContain('status = \'synced\'');
-    expect(params).toEqual(['asset-1', null, null, null, null, null, null]);
+    expect(params).toEqual(['asset-1', null, null, null, null, null, null, 0]);
   });
 
   test('when a photo is marked as pending for edit with media info, then all media info fields are passed to the database', async () => {
@@ -85,7 +85,7 @@ describe('photosLocalDB', () => {
     });
 
     const [, , params] = mockSqlite.executeSql.mock.calls[0];
-    expect(params).toEqual(['asset-2', 'video.mp4', 1714000000000, 1920, 1080, 30, 'video']);
+    expect(params).toEqual(['asset-2', 'video.mp4', 1714000000000, 1920, 1080, 30, 'video', 0]);
   });
 
   test('when a file size is cached for an asset, then the file size and asset id are passed to the database', async () => {
@@ -219,6 +219,7 @@ describe('photosLocalDB', () => {
       status: 'pending',
       remote_file_id: null,
       synced_at: null,
+      deleted_at: null,
       error_message: null,
       attempt_count: 0,
       created_at: 1713900000000,
@@ -231,6 +232,9 @@ describe('photosLocalDB', () => {
       height: null,
       duration: null,
       media_type: null,
+      is_live_photo: 0,
+      paired_video_remote_file_id: null,
+      paired_video_status: null,
     });
 
     const result = await photosLocalDB.getStatus('asset-3');
@@ -240,6 +244,7 @@ describe('photosLocalDB', () => {
       status: 'pending',
       remoteFileId: null,
       syncedAt: null,
+      deletedAt: null,
       errorMessage: null,
       attemptCount: 0,
       createdAt: 1713900000000,
@@ -252,6 +257,9 @@ describe('photosLocalDB', () => {
       height: null,
       duration: null,
       mediaType: null,
+      isLivePhoto: false,
+      pairedVideoRemoteFileId: null,
+      pairedVideoStatus: null,
     });
   });
 
@@ -300,11 +308,22 @@ describe('photosLocalDB', () => {
       status: 'synced',
       remote_file_id: 'remote-id',
       synced_at: 1714000000000,
+      deleted_at: null,
       error_message: null,
       attempt_count: 0,
       created_at: 1713900000000,
       last_attempt_at: 1714000000000,
       modification_time: 1714000000,
+      file_name: null,
+      file_size: null,
+      creation_time: null,
+      width: null,
+      height: null,
+      duration: null,
+      media_type: null,
+      is_live_photo: 0,
+      paired_video_remote_file_id: null,
+      paired_video_status: null,
     });
 
     const result = await photosLocalDB.getStatus('asset-1');
@@ -314,11 +333,22 @@ describe('photosLocalDB', () => {
       status: 'synced',
       remoteFileId: 'remote-id',
       syncedAt: 1714000000000,
+      deletedAt: null,
       errorMessage: null,
       attemptCount: 0,
       createdAt: 1713900000000,
       lastAttemptAt: 1714000000000,
       modificationTime: 1714000000,
+      fileName: null,
+      fileSize: null,
+      creationTime: null,
+      width: null,
+      height: null,
+      duration: null,
+      mediaType: null,
+      isLivePhoto: false,
+      pairedVideoRemoteFileId: null,
+      pairedVideoStatus: null,
     });
   });
 
@@ -328,11 +358,22 @@ describe('photosLocalDB', () => {
       status: 'error',
       remote_file_id: null,
       synced_at: null,
+      deleted_at: null,
       error_message: 'Network timeout',
       attempt_count: 3,
       created_at: 1713900000000,
       last_attempt_at: 1714000000000,
       modification_time: null,
+      file_name: null,
+      file_size: null,
+      creation_time: null,
+      width: null,
+      height: null,
+      duration: null,
+      media_type: null,
+      is_live_photo: 0,
+      paired_video_remote_file_id: null,
+      paired_video_status: null,
     });
 
     const result = await photosLocalDB.getStatus('asset-2');
@@ -342,11 +383,22 @@ describe('photosLocalDB', () => {
       status: 'error',
       remoteFileId: null,
       syncedAt: null,
+      deletedAt: null,
       errorMessage: 'Network timeout',
       attemptCount: 3,
       createdAt: 1713900000000,
       lastAttemptAt: 1714000000000,
       modificationTime: null,
+      fileName: null,
+      fileSize: null,
+      creationTime: null,
+      width: null,
+      height: null,
+      duration: null,
+      mediaType: null,
+      isLivePhoto: false,
+      pairedVideoRemoteFileId: null,
+      pairedVideoStatus: null,
     });
   });
 
@@ -363,7 +415,7 @@ describe('photosLocalDB', () => {
     const createTableCalls = statements.filter((s) => s.includes('CREATE TABLE'));
     const createIndexCalls = statements.filter((s) => s.includes('CREATE INDEX'));
     expect(createTableCalls).toHaveLength(2);
-    expect(createIndexCalls).toHaveLength(4);
+    expect(createIndexCalls).toHaveLength(5);
   });
 });
 
@@ -458,6 +510,9 @@ describe('photosLocalDB cloud asset methods', () => {
       null, // updatedAt
       null, // status
       null, // encryptVersion
+      0,    // is_live_photo
+      null, // live_photo_role
+      null, // paired_remote_file_id
     ]);
   });
 
@@ -507,6 +562,9 @@ describe('photosLocalDB cloud asset methods', () => {
       1718060000000, // updatedAt
       'EXISTS', // status
       'aes-2', // encryptVersion
+      0,       // is_live_photo
+      null,    // live_photo_role
+      null,    // paired_remote_file_id
     ]);
   });
 
@@ -524,6 +582,18 @@ describe('photosLocalDB cloud asset methods', () => {
         thumbnail_bucket_file: 'f1',
         thumbnail_type: 'jpg',
         discovered_at: 1718100000,
+        plain_name: null,
+        extension: null,
+        bucket: null,
+        folder_uuid: null,
+        creation_time_api: null,
+        modification_time: null,
+        updated_at: null,
+        status: null,
+        encrypt_version: null,
+        is_live_photo: 0,
+        live_photo_role: null,
+        paired_remote_file_id: null,
       },
     ]);
 
@@ -542,6 +612,18 @@ describe('photosLocalDB cloud asset methods', () => {
       thumbnailBucketFile: 'f1',
       thumbnailType: 'jpg',
       discoveredAt: 1718100000,
+      plainName: null,
+      extension: null,
+      bucket: null,
+      folderUuid: null,
+      creationTimeApi: null,
+      modificationTime: null,
+      updatedAt: null,
+      status: null,
+      encryptVersion: null,
+      isLivePhoto: false,
+      livePhotoRole: null,
+      pairedRemoteFileId: null,
     });
   });
 

--- a/src/services/photos/database/photosLocalDB.ts
+++ b/src/services/photos/database/photosLocalDB.ts
@@ -4,6 +4,8 @@ import cloudAssetTable from './tables/cloud_asset';
 
 const DB_NAME = 'photos_sync.db';
 
+export type LivePhotoRole = 'photo' | 'paired_video';
+
 export interface CloudAssetEntry {
   remoteFileId: string;
   deviceId: string;
@@ -25,6 +27,9 @@ export interface CloudAssetEntry {
   updatedAt?: number | null;
   status?: string | null;
   encryptVersion?: string | null;
+  isLivePhoto?: boolean;
+  livePhotoRole?: LivePhotoRole | null;
+  pairedRemoteFileId?: string | null;
 }
 
 interface CloudAssetRow {
@@ -48,9 +53,13 @@ interface CloudAssetRow {
   updated_at: number | null;
   status: string | null;
   encrypt_version: string | null;
+  is_live_photo: number;
+  live_photo_role: LivePhotoRole | null;
+  paired_remote_file_id: string | null;
 }
 
 export type AssetSyncStatus = 'pending' | 'pending_edit' | 'synced' | 'error' | 'deleted' | 'cloud_deleted';
+export type PairedVideoStatus = 'synced' | 'error';
 
 export interface AssetSyncEntry {
   assetId: string;
@@ -70,6 +79,9 @@ export interface AssetSyncEntry {
   height: number | null;
   duration: number | null;
   mediaType: string | null;
+  isLivePhoto: boolean;
+  pairedVideoRemoteFileId: string | null;
+  pairedVideoStatus: PairedVideoStatus | null;
 }
 
 interface AssetSyncRow {
@@ -90,6 +102,9 @@ interface AssetSyncRow {
   height: number | null;
   duration: number | null;
   media_type: string | null;
+  is_live_photo: number;
+  paired_video_remote_file_id: string | null;
+  paired_video_status: PairedVideoStatus | null;
 }
 
 export interface SyncedAssetInfo {
@@ -104,6 +119,7 @@ export interface AssetMediaInfo {
   height: number;
   duration: number;
   mediaType: string;
+  isLivePhoto?: boolean;
 }
 
 const CHUNK_SIZE = 300;
@@ -130,6 +146,9 @@ const rowToCloudAssetEntry = (row: CloudAssetRow): CloudAssetEntry => {
     updatedAt: row.updated_at,
     status: row.status,
     encryptVersion: row.encrypt_version,
+    isLivePhoto: row.is_live_photo === 1,
+    livePhotoRole: row.live_photo_role,
+    pairedRemoteFileId: row.paired_remote_file_id,
   };
 };
 
@@ -151,6 +170,9 @@ const rowToAssetSyncEntry = (row: AssetSyncRow): AssetSyncEntry => ({
   height: row.height,
   duration: row.duration,
   mediaType: row.media_type,
+  isLivePhoto: row.is_live_photo === 1,
+  pairedVideoRemoteFileId: row.paired_video_remote_file_id,
+  pairedVideoStatus: row.paired_video_status,
 });
 
 class PhotosLocalDB {
@@ -165,6 +187,7 @@ class PhotosLocalDB {
       await sqliteService.executeSql(DB_NAME, cloudAssetTable.statements.createIndexCreated);
       await sqliteService.executeSql(DB_NAME, cloudAssetTable.statements.createIndexDevice);
       await sqliteService.executeSql(DB_NAME, cloudAssetTable.statements.createIndexMonth);
+      await sqliteService.executeSql(DB_NAME, cloudAssetTable.statements.createIndexRole);
     })();
     return this.initPromise;
   }
@@ -178,6 +201,7 @@ class PhotosLocalDB {
       mediaInfo?.height ?? null,
       mediaInfo?.duration ?? null,
       mediaInfo?.mediaType ?? null,
+      mediaInfo?.isLivePhoto ? 1 : 0,
     ]);
   }
 
@@ -190,6 +214,7 @@ class PhotosLocalDB {
       mediaInfo?.height ?? null,
       mediaInfo?.duration ?? null,
       mediaInfo?.mediaType ?? null,
+      mediaInfo?.isLivePhoto ? 1 : 0,
     ]);
   }
 
@@ -198,6 +223,22 @@ class PhotosLocalDB {
       assetId,
       remoteFileId,
       modificationTime,
+    ]);
+  }
+
+  async markSyncedLivePhoto(
+    assetId: string,
+    remoteFileId: string,
+    modificationTime: number | null,
+    pairedVideoRemoteFileId: string | null,
+    pairedVideoStatus: PairedVideoStatus,
+  ): Promise<void> {
+    await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.markSyncedLivePhoto, [
+      assetId,
+      remoteFileId,
+      modificationTime,
+      pairedVideoRemoteFileId,
+      pairedVideoStatus,
     ]);
   }
 
@@ -362,6 +403,9 @@ class PhotosLocalDB {
       entry.updatedAt ?? null,
       entry.status ?? null,
       entry.encryptVersion ?? null,
+      entry.isLivePhoto ? 1 : 0,
+      entry.livePhotoRole ?? null,
+      entry.pairedRemoteFileId ?? null,
     ]);
   }
 

--- a/src/services/photos/database/tables/asset_sync.ts
+++ b/src/services/photos/database/tables/asset_sync.ts
@@ -3,53 +3,58 @@ const TABLE_NAME = 'asset_sync';
 const statements = {
   createTable: `
     CREATE TABLE IF NOT EXISTS ${TABLE_NAME} (
-      asset_id          TEXT    PRIMARY KEY NOT NULL,
-      status            TEXT    NOT NULL CHECK (status IN ('pending', 'pending_edit', 'synced', 'error', 'deleted', 'cloud_deleted')),
-      remote_file_id    TEXT,
-      error_message     TEXT,
-      attempt_count     INTEGER NOT NULL DEFAULT 0,
-      created_at        INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
-      last_attempt_at   INTEGER,
-      synced_at         INTEGER,
-      deleted_at        INTEGER,
-      modification_time INTEGER,
-      file_name         TEXT,
-      file_size         INTEGER,
-      creation_time     INTEGER,
-      width             INTEGER,
-      height            INTEGER,
-      duration          INTEGER,
-      media_type        TEXT
+      asset_id                    TEXT    PRIMARY KEY NOT NULL,
+      status                      TEXT    NOT NULL CHECK (status IN ('pending', 'pending_edit', 'synced', 'error', 'deleted', 'cloud_deleted')),
+      remote_file_id              TEXT,
+      error_message               TEXT,
+      attempt_count               INTEGER NOT NULL DEFAULT 0,
+      created_at                  INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+      last_attempt_at             INTEGER,
+      synced_at                   INTEGER,
+      deleted_at                  INTEGER,
+      modification_time           INTEGER,
+      file_name                   TEXT,
+      file_size                   INTEGER,
+      creation_time               INTEGER,
+      width                       INTEGER,
+      height                      INTEGER,
+      duration                    INTEGER,
+      media_type                  TEXT,
+      is_live_photo               INTEGER NOT NULL DEFAULT 0,
+      paired_video_remote_file_id TEXT,
+      paired_video_status         TEXT
     );
   `,
   createIndex: `CREATE INDEX IF NOT EXISTS idx_asset_sync_status ON ${TABLE_NAME}(status);`,
   dropTable: `DROP TABLE IF EXISTS ${TABLE_NAME};`,
 
   markPending: `
-    INSERT INTO ${TABLE_NAME} (asset_id, status, file_name, creation_time, width, height, duration, media_type)
-    VALUES (?, 'pending', ?, ?, ?, ?, ?, ?)
+    INSERT INTO ${TABLE_NAME} (asset_id, status, file_name, creation_time, width, height, duration, media_type, is_live_photo)
+    VALUES (?, 'pending', ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(asset_id) DO UPDATE SET
-      status       = 'pending',
-      file_name    = COALESCE(excluded.file_name, ${TABLE_NAME}.file_name),
+      status        = 'pending',
+      file_name     = COALESCE(excluded.file_name, ${TABLE_NAME}.file_name),
       creation_time = COALESCE(excluded.creation_time, ${TABLE_NAME}.creation_time),
-      width        = COALESCE(excluded.width, ${TABLE_NAME}.width),
-      height       = COALESCE(excluded.height, ${TABLE_NAME}.height),
-      duration     = COALESCE(excluded.duration, ${TABLE_NAME}.duration),
-      media_type   = COALESCE(excluded.media_type, ${TABLE_NAME}.media_type)
+      width         = COALESCE(excluded.width, ${TABLE_NAME}.width),
+      height        = COALESCE(excluded.height, ${TABLE_NAME}.height),
+      duration      = COALESCE(excluded.duration, ${TABLE_NAME}.duration),
+      media_type    = COALESCE(excluded.media_type, ${TABLE_NAME}.media_type),
+      is_live_photo = excluded.is_live_photo
     WHERE ${TABLE_NAME}.status != 'synced';
   `,
 
   markPendingEdit: `
-    INSERT INTO ${TABLE_NAME} (asset_id, status, file_name, creation_time, width, height, duration, media_type)
-    VALUES (?, 'pending_edit', ?, ?, ?, ?, ?, ?)
+    INSERT INTO ${TABLE_NAME} (asset_id, status, file_name, creation_time, width, height, duration, media_type, is_live_photo)
+    VALUES (?, 'pending_edit', ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(asset_id) DO UPDATE SET
-      status       = 'pending_edit',
-      file_name    = COALESCE(excluded.file_name, ${TABLE_NAME}.file_name),
+      status        = 'pending_edit',
+      file_name     = COALESCE(excluded.file_name, ${TABLE_NAME}.file_name),
       creation_time = COALESCE(excluded.creation_time, ${TABLE_NAME}.creation_time),
-      width        = COALESCE(excluded.width, ${TABLE_NAME}.width),
-      height       = COALESCE(excluded.height, ${TABLE_NAME}.height),
-      duration     = COALESCE(excluded.duration, ${TABLE_NAME}.duration),
-      media_type   = COALESCE(excluded.media_type, ${TABLE_NAME}.media_type)
+      width         = COALESCE(excluded.width, ${TABLE_NAME}.width),
+      height        = COALESCE(excluded.height, ${TABLE_NAME}.height),
+      duration      = COALESCE(excluded.duration, ${TABLE_NAME}.duration),
+      media_type    = COALESCE(excluded.media_type, ${TABLE_NAME}.media_type),
+      is_live_photo = excluded.is_live_photo
     WHERE ${TABLE_NAME}.status = 'synced';
   `,
 
@@ -62,6 +67,21 @@ const statements = {
       synced_at         = excluded.synced_at,
       last_attempt_at   = excluded.last_attempt_at,
       modification_time = excluded.modification_time;
+  `,
+
+  markSyncedLivePhoto: `
+    INSERT INTO ${TABLE_NAME} (asset_id, status, remote_file_id, synced_at, last_attempt_at, modification_time,
+                               is_live_photo, paired_video_remote_file_id, paired_video_status)
+    VALUES (?, 'synced', ?, (unixepoch() * 1000), (unixepoch() * 1000), ?, 1, ?, ?)
+    ON CONFLICT(asset_id) DO UPDATE SET
+      status                      = 'synced',
+      remote_file_id              = excluded.remote_file_id,
+      synced_at                   = excluded.synced_at,
+      last_attempt_at             = excluded.last_attempt_at,
+      modification_time           = excluded.modification_time,
+      is_live_photo               = 1,
+      paired_video_remote_file_id = excluded.paired_video_remote_file_id,
+      paired_video_status         = excluded.paired_video_status;
   `,
 
   markError: `
@@ -82,7 +102,8 @@ const statements = {
   getStatus: `
     SELECT asset_id, status, remote_file_id, synced_at, error_message, attempt_count,
            created_at, last_attempt_at, modification_time,
-           file_name, file_size, creation_time, width, height, duration, media_type
+           file_name, file_size, creation_time, width, height, duration, media_type,
+           is_live_photo, paired_video_remote_file_id, paired_video_status
     FROM ${TABLE_NAME} WHERE asset_id = ?;
   `,
   getSyncedInList: (placeholders: string) =>

--- a/src/services/photos/database/tables/cloud_asset.ts
+++ b/src/services/photos/database/tables/cloud_asset.ts
@@ -4,7 +4,8 @@ const COLUMNS = `
   remote_file_id, device_id, created_at, file_name, file_size, file_id,
   thumbnail_path, thumbnail_bucket_id, thumbnail_bucket_file, thumbnail_type, discovered_at,
   plain_name, extension, bucket, folder_uuid,
-  creation_time_api, modification_time, updated_at, status, encrypt_version
+  creation_time_api, modification_time, updated_at, status, encrypt_version,
+  is_live_photo, live_photo_role, paired_remote_file_id
 `;
 
 const statements = {
@@ -29,16 +30,20 @@ const statements = {
       modification_time      INTEGER,
       updated_at             INTEGER,
       status                 TEXT,
-      encrypt_version        TEXT
+      encrypt_version        TEXT,
+      is_live_photo          INTEGER NOT NULL DEFAULT 0,
+      live_photo_role        TEXT,
+      paired_remote_file_id  TEXT
     );
   `,
   createIndexCreated: `CREATE INDEX IF NOT EXISTS idx_cloud_asset_created ON ${TABLE_NAME}(created_at DESC);`,
   createIndexDevice: `CREATE INDEX IF NOT EXISTS idx_cloud_asset_device ON ${TABLE_NAME}(device_id);`,
   createIndexMonth: `CREATE INDEX IF NOT EXISTS idx_cloud_asset_month ON ${TABLE_NAME}(device_id, created_at);`,
+  createIndexRole: `CREATE INDEX IF NOT EXISTS idx_cloud_asset_role ON ${TABLE_NAME}(live_photo_role);`,
 
   upsert: `
     INSERT INTO ${TABLE_NAME} (${COLUMNS})
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(remote_file_id) DO UPDATE SET
       device_id              = excluded.device_id,
       created_at             = excluded.created_at,
@@ -58,10 +63,20 @@ const statements = {
       modification_time      = excluded.modification_time,
       updated_at             = excluded.updated_at,
       status                 = excluded.status,
-      encrypt_version        = excluded.encrypt_version;
+      encrypt_version        = excluded.encrypt_version,
+      is_live_photo          = excluded.is_live_photo,
+      live_photo_role        = excluded.live_photo_role,
+      paired_remote_file_id  = excluded.paired_remote_file_id;
   `,
 
   getAll: `
+    SELECT ${COLUMNS}
+    FROM ${TABLE_NAME}
+    WHERE live_photo_role IS NULL OR live_photo_role != 'paired_video'
+    ORDER BY created_at DESC;
+  `,
+
+  getAllIncludingPaired: `
     SELECT ${COLUMNS}
     FROM ${TABLE_NAME}
     ORDER BY created_at DESC;
@@ -70,7 +85,8 @@ const statements = {
   getByRange: `
     SELECT ${COLUMNS}
     FROM ${TABLE_NAME}
-    WHERE created_at >= ? AND created_at <= ?
+    WHERE (created_at >= ? AND created_at <= ?)
+      AND (live_photo_role IS NULL OR live_photo_role != 'paired_video')
     ORDER BY created_at DESC;
   `,
 

--- a/src/services/photos/livePhoto.constants.spec.ts
+++ b/src/services/photos/livePhoto.constants.spec.ts
@@ -1,0 +1,117 @@
+import * as MediaLibrary from 'expo-media-library';
+import {
+  getPairedVideoPlainNameFromPhoto,
+  getPhotoPlainNameFromPairedVideo,
+  isLivePhotoAsset,
+  isPairedVideoPlainName,
+  LIVE_PHOTO_PLAIN_NAME_SUFFIX,
+} from './livePhoto.constants';
+
+describe('when checking whether a file is a Live Photo paired video', () => {
+  test('when the type is mov and the plain name ends with the live photo suffix, then it is a paired video', () => {
+    expect(isPairedVideoPlainName('IMG_1234.livephoto', 'mov')).toBe(true);
+  });
+
+  test('when the suffix and type are uppercase, then case is ignored', () => {
+    expect(isPairedVideoPlainName('IMG_1234.LIVEPHOTO', 'MOV')).toBe(true);
+  });
+
+  test('when the type is mov but the plain name has no suffix, then it is not a paired video', () => {
+    expect(isPairedVideoPlainName('IMG_1234', 'mov')).toBe(false);
+  });
+
+  test('when the type is mp4 with the suffix, then it is not a paired video', () => {
+    expect(isPairedVideoPlainName('clip.livephoto', 'mp4')).toBe(false);
+  });
+
+  test('when the type is heic and the plain name has the suffix, then it is not a paired video', () => {
+    expect(isPairedVideoPlainName('IMG_1234.livephoto', 'heic')).toBe(false);
+  });
+
+  test('when a user file happens to be named with the suffix but has a different type, then it is not a paired video', () => {
+    expect(isPairedVideoPlainName('myvideo.livephoto', 'avi')).toBe(false);
+  });
+
+  test('when the plain name only contains the suffix itself, then it is still identified as a paired video', () => {
+    // Edge: someone named the file exactly ".livephoto"
+    expect(isPairedVideoPlainName(LIVE_PHOTO_PLAIN_NAME_SUFFIX, 'mov')).toBe(true);
+  });
+});
+
+describe('when converting between photo and paired-video plain names', () => {
+  test('when given a photo plain name, then adding and removing the suffix produces the original name', () => {
+    const photoName = 'IMG_1234';
+    expect(getPhotoPlainNameFromPairedVideo(getPairedVideoPlainNameFromPhoto(photoName))).toBe(photoName);
+  });
+
+  test('when given a paired video plain name, then removing and re-adding the suffix produces the original name', () => {
+    const videoName = 'IMG_5678.livephoto';
+    expect(getPairedVideoPlainNameFromPhoto(getPhotoPlainNameFromPairedVideo(videoName))).toBe(videoName);
+  });
+
+  test('when converting a typical photo name to a paired video name, then the suffix is appended correctly', () => {
+    expect(getPairedVideoPlainNameFromPhoto('IMG_9999')).toBe('IMG_9999.livephoto');
+  });
+
+  test('when recovering the photo name from a paired video plain name, then the suffix is stripped correctly', () => {
+    expect(getPhotoPlainNameFromPairedVideo('IMG_9999.livephoto')).toBe('IMG_9999');
+  });
+
+  test('when the photo name already contains dots, then only the suffix is affected', () => {
+    const photoName = 'my.album.photo';
+    const videoName = getPairedVideoPlainNameFromPhoto(photoName);
+    expect(videoName).toBe('my.album.photo.livephoto');
+    expect(getPhotoPlainNameFromPairedVideo(videoName)).toBe(photoName);
+  });
+});
+
+const makeAsset = (overrides: Partial<MediaLibrary.Asset> = {}): MediaLibrary.Asset =>
+  ({
+    id: 'asset-1',
+    uri: 'ph://asset-1',
+    mediaType: MediaLibrary.MediaType.photo,
+    mediaSubtypes: [],
+    filename: 'IMG_0001.heic',
+    width: 3024,
+    height: 4032,
+    fileSize: 4_000_000,
+    creationTime: Date.now(),
+    modificationTime: Date.now(),
+    duration: 0,
+    albumId: undefined,
+    ...overrides,
+  }) as MediaLibrary.Asset;
+
+describe('when determining whether a device asset is a Live Photo', () => {
+  test('when the asset is a photo with the livePhoto subtype, then it is a Live Photo', () => {
+    const asset = makeAsset({ mediaSubtypes: ['livePhoto'] });
+    expect(isLivePhotoAsset(asset)).toBe(true);
+  });
+
+  test('when the asset is a photo with multiple subtypes including livePhoto, then it is a Live Photo', () => {
+    const asset = makeAsset({ mediaSubtypes: ['hdr', 'livePhoto'] });
+    expect(isLivePhotoAsset(asset)).toBe(true);
+  });
+
+  test('when the asset is a photo with no subtypes, then it is not a Live Photo', () => {
+    const asset = makeAsset({ mediaSubtypes: [] });
+    expect(isLivePhotoAsset(asset)).toBe(false);
+  });
+
+  test('when the asset has a livePhoto subtype but is a video, then it is not a Live Photo', () => {
+    // Use string literal: in Jest the native module is mocked and MediaType.video can be undefined.
+    const asset = makeAsset({ mediaType: 'video' as MediaLibrary.MediaTypeValue, mediaSubtypes: ['livePhoto'] });
+    expect(isLivePhotoAsset(asset)).toBe(false);
+  });
+
+  test('when the asset mediaSubtypes field is undefined, then it is not a Live Photo', () => {
+    const asset = makeAsset({ mediaSubtypes: undefined });
+    expect(isLivePhotoAsset(asset)).toBe(false);
+  });
+
+  test('when the asset is an audio file with the livePhoto subtype, then it is not a Live Photo', () => {
+    // Use string literal: in Jest the native module is mocked and MediaType.audio can be undefined.
+    const asset = makeAsset({ mediaType: 'audio' as MediaLibrary.MediaTypeValue, mediaSubtypes: ['livePhoto'] });
+    expect(isLivePhotoAsset(asset)).toBe(false);
+  });
+});

--- a/src/services/photos/livePhoto.constants.ts
+++ b/src/services/photos/livePhoto.constants.ts
@@ -1,0 +1,24 @@
+import * as MediaLibrary from 'expo-media-library';
+
+// The suffix appended to the photo's plainName when uploading the paired Live Photo video.
+// Example: photo "IMG_1234.heic" → video "IMG_1234.livephoto.mov" in the same day folder.
+// Self-correcting: a *.livephoto.mov with no matching photo sibling is treated as a regular video.
+export const LIVE_PHOTO_PLAIN_NAME_SUFFIX = '.livephoto';
+export const LIVE_PHOTO_VIDEO_TYPE = 'mov';
+
+// Returns true when a file (identified by plainName + type) is a Live Photo paired video.
+export const isPairedVideoPlainName = (plainName: string, type: string): boolean =>
+  type.toLowerCase() === LIVE_PHOTO_VIDEO_TYPE && plainName.toLowerCase().endsWith(LIVE_PHOTO_PLAIN_NAME_SUFFIX);
+
+// Given the plainName of the paired video (e.g. "IMG_1234.livephoto"), returns the photo's plainName ("IMG_1234").
+export const getPhotoPlainNameFromPairedVideo = (videoPlainName: string): string =>
+  videoPlainName.slice(0, -LIVE_PHOTO_PLAIN_NAME_SUFFIX.length);
+
+// Given the photo's plainName (e.g. "IMG_1234"), returns the paired video's plainName ("IMG_1234.livephoto").
+export const getPairedVideoPlainNameFromPhoto = (photoPlainName: string): string =>
+  `${photoPlainName}${LIVE_PHOTO_PLAIN_NAME_SUFFIX}`;
+
+// Returns true when a MediaLibrary asset is an iOS Live Photo.
+// getAssetsAsync populates mediaSubtypes, so this is cheap (no extra getAssetInfoAsync call needed).
+export const isLivePhotoAsset = (asset: MediaLibrary.Asset): boolean =>
+  asset.mediaType === MediaLibrary.MediaType.photo && (asset.mediaSubtypes?.includes('livePhoto') ?? false);

--- a/src/services/photos/livePhoto.constants.ts
+++ b/src/services/photos/livePhoto.constants.ts
@@ -1,24 +1,16 @@
 import * as MediaLibrary from 'expo-media-library';
 
-// The suffix appended to the photo's plainName when uploading the paired Live Photo video.
-// Example: photo "IMG_1234.heic" → video "IMG_1234.livephoto.mov" in the same day folder.
-// Self-correcting: a *.livephoto.mov with no matching photo sibling is treated as a regular video.
 export const LIVE_PHOTO_PLAIN_NAME_SUFFIX = '.livephoto';
 export const LIVE_PHOTO_VIDEO_TYPE = 'mov';
 
-// Returns true when a file (identified by plainName + type) is a Live Photo paired video.
 export const isPairedVideoPlainName = (plainName: string, type: string): boolean =>
   type.toLowerCase() === LIVE_PHOTO_VIDEO_TYPE && plainName.toLowerCase().endsWith(LIVE_PHOTO_PLAIN_NAME_SUFFIX);
 
-// Given the plainName of the paired video (e.g. "IMG_1234.livephoto"), returns the photo's plainName ("IMG_1234").
 export const getPhotoPlainNameFromPairedVideo = (videoPlainName: string): string =>
   videoPlainName.slice(0, -LIVE_PHOTO_PLAIN_NAME_SUFFIX.length);
 
-// Given the photo's plainName (e.g. "IMG_1234"), returns the paired video's plainName ("IMG_1234.livephoto").
 export const getPairedVideoPlainNameFromPhoto = (photoPlainName: string): string =>
   `${photoPlainName}${LIVE_PHOTO_PLAIN_NAME_SUFFIX}`;
 
-// Returns true when a MediaLibrary asset is an iOS Live Photo.
-// getAssetsAsync populates mediaSubtypes, so this is cheap (no extra getAssetInfoAsync call needed).
 export const isLivePhotoAsset = (asset: MediaLibrary.Asset): boolean =>
   asset.mediaType === MediaLibrary.MediaType.photo && (asset.mediaSubtypes?.includes('livePhoto') ?? false);

--- a/src/store/slices/photos/index.spec.ts
+++ b/src/store/slices/photos/index.spec.ts
@@ -92,7 +92,9 @@ jest.mock('src/services/photos/database/photosLocalDB', () => ({
     markPending: jest.fn().mockResolvedValue(undefined),
     markPendingEdit: jest.fn().mockResolvedValue(undefined),
     markSynced: jest.fn().mockResolvedValue(undefined),
+    markSyncedLivePhoto: jest.fn().mockResolvedValue(undefined),
     markError: jest.fn().mockResolvedValue(undefined),
+    getStatus: jest.fn().mockResolvedValue(null),
   },
 }));
 
@@ -143,7 +145,11 @@ describe('photos slice', () => {
     mockCloudBrowser.syncAllHistory.mockResolvedValue(undefined);
     // Prevent checkPermissionRevocationThunk from overwriting permissionStatus with undefined
     mockPermissionService.getStatus.mockResolvedValue('granted');
-    (Network.getNetworkStateAsync as jest.Mock).mockResolvedValue({ type: Network.NetworkStateType.WIFI, isConnected: true, isInternetReachable: true });
+    (Network.getNetworkStateAsync as jest.Mock).mockResolvedValue({
+      type: Network.NetworkStateType.WIFI,
+      isConnected: true,
+      isInternetReachable: true,
+    });
     (Network.addNetworkStateListener as jest.Mock).mockReturnValue({ remove: jest.fn() });
   });
 
@@ -768,7 +774,7 @@ describe('photos slice', () => {
       mockUploadQueue.start.mockImplementationOnce(async (_jobs, _deviceId, _photosBucket, callbacks) => {
         // Simulate pause being set mid-upload
         store.dispatch(photosSlice.actions.setIsPaused(true));
-        await callbacks.onAssetDone?.('a1', 'remote-1', Date.now());
+        await callbacks.onAssetDone?.('a1', { photoUuid: 'remote-1' }, Date.now());
       });
 
       const store = makeStore();

--- a/src/store/slices/photos/index.ts
+++ b/src/store/slices/photos/index.ts
@@ -222,6 +222,7 @@ export const runDiscoveryThunk = createAsyncThunk<void, void, { state: RootState
             height: asset.height,
             duration: asset.duration,
             mediaType: asset.mediaType,
+            isLivePhoto: asset.mediaSubtypes?.includes('livePhoto') ?? false,
           }),
         ),
         ...editedAssets.map((asset) =>
@@ -232,6 +233,7 @@ export const runDiscoveryThunk = createAsyncThunk<void, void, { state: RootState
             height: asset.height,
             duration: asset.duration,
             mediaType: asset.mediaType,
+            isLivePhoto: asset.mediaSubtypes?.includes('livePhoto') ?? false,
           }),
         ),
       ]);
@@ -341,8 +343,20 @@ export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean }
         onAssetProgress: (_, ratio) => {
           dispatch(photosSlice.actions.setCurrentUploadProgress(ratio));
         },
-        onAssetDone: async (assetId, remoteFileId, modificationTime) => {
-          await photosLocalDB.markSynced(assetId, remoteFileId, modificationTime);
+        onAssetDone: async (assetId, result, modificationTime) => {
+          if (result.pairedVideoUuid !== undefined) {
+            await photosLocalDB.markSyncedLivePhoto(
+              assetId,
+              result.photoUuid,
+              modificationTime,
+              result.pairedVideoUuid,
+              'synced',
+            );
+          } else if (result.pairedVideoUuid === undefined && (await photosLocalDB.getStatus(assetId))?.isLivePhoto) {
+            await photosLocalDB.markSyncedLivePhoto(assetId, result.photoUuid, modificationTime, null, 'error');
+          } else {
+            await photosLocalDB.markSynced(assetId, result.photoUuid, modificationTime);
+          }
           dispatch(photosSlice.actions.removeUploadingAssetId(assetId));
           dispatch(photosSlice.actions.incrementTotalAssetsUploaded());
           dispatch(photosSlice.actions.incrementSessionUploadedAssets());


### PR DESCRIPTION
Add Live Photo support: upload both components (photo and video), pair them by naming convention, and reconstruct a real Live Photo on save to gallery.

## Summary

  - **`PHAssetExportModule.swift` + `.m`**: two new native methods. `exportLivePhotoComponents` extracts the photo  and paired video  as raw resource bytes via`PHAssetResourceManager.writeData`. `saveLivePhoto` reconstructs a real Live Photo in the camera roll using `PHAssetCreationRequest.addResource`.

  - **`LivePhotoNativeModule.ts`**: typed TS wrapper for both native methods.

  - **`PhotoUploadService`**: Live Photo assets upload both components. The photo component is uploaded first from the native temp export. The paired video follows. Both temps are cleaned up in `finally`. Return shape changed from `Promise<string>` to `Promise<{ photoUuid: string; pairedVideoUuid?: string }>`. If the video upload fails, the photo is still marked synced and the video is retried in the next cycle.

  - **`PhotoCloudBrowser`**: `fetchMonthFromFolder` now runs two passes per day folder, `buildPlainNameIndex` indexes all plain names first, then `buildCloudAssetEntries` resolves Live Photo pairing without ordering dependency. Orphan `.livephoto.mov` files are treated as normal videos.

  - **`cloud_asset` schema**: new columns `is_live_photo`, `live_photo_role`,  `paired_remote_file_id`. Paired video rows are stored but filtered out of the timeline .

  - **`PhotoActionsService`**: `saveToDevice` branches on `isLivePhoto`, downloads both components via `PhotoAssetFetchService.fetchLivePhotoComponents` and calls `saveLivePhotoToLibrary`. Falls back to photo-only save if the video download or native call fails.

  - **`PhotoItem`**: LIVE badge in the top-left corner, mirroring the `VideoBadge` pattern.

  - Android unaffected: `isLivePhotoAsset` always returns false, no native code runs.