### PR TITLE
[PB-5921]: File Provider folder browsing (read-only enumeration)

### DIFF
--- a/ios/Internxt.xcodeproj/project.pbxproj
+++ b/ios/Internxt.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		AA0100052F87A94000E14783 /* InternxtAuthCredentialsModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100042F87A94000E14783 /* InternxtAuthCredentialsModule.swift */; };
 		AA0100072F87A94000E14783 /* InternxtAuthCredentialsModule.m in Sources */ = {isa = PBXBuildFile; fileRef = AA0100062F87A94000E14783 /* InternxtAuthCredentialsModule.m */; };
 		AA0100082F87A94000E14783 /* SharedAuthKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100002F87A94000E14783 /* SharedAuthKeychain.swift */; };
+		AB1D47702F87A94000E14783 /* FileProviderItemIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47722F87A94000E14783 /* FileProviderItemIdentifier.swift */; };
+		AB1D47712F87A94000E14783 /* DriveAPIFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47732F87A94000E14783 /* DriveAPIFactory.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
 		DE1D47432F87A94000E14783 /* UniformTypeIdentifiers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE1D47422F87A94000E14783 /* UniformTypeIdentifiers.framework */; };
 		DE1D474F2F87A94000E14783 /* InternxtFileProvider.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = DE1D47412F87A94000E14783 /* InternxtFileProvider.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -95,6 +97,8 @@
 		AA0100042F87A94000E14783 /* InternxtAuthCredentialsModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = InternxtAuthCredentialsModule.swift; path = Internxt/InternxtAuthCredentialsModule.swift; sourceTree = "<group>"; };
 		AA0100062F87A94000E14783 /* InternxtAuthCredentialsModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = InternxtAuthCredentialsModule.m; path = Internxt/InternxtAuthCredentialsModule.m; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = Internxt/SplashScreen.storyboard; sourceTree = "<group>"; };
+		AB1D47722F87A94000E14783 /* FileProviderItemIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderItemIdentifier.swift; sourceTree = "<group>"; };
+		AB1D47732F87A94000E14783 /* DriveAPIFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DriveAPIFactory.swift; sourceTree = "<group>"; };
 		AC8B28CC3C9A8FDF21A8C1E7 /* Pods-InternxtFileProvider.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtFileProvider.debug.xcconfig"; path = "Target Support Files/Pods-InternxtFileProvider/Pods-InternxtFileProvider.debug.xcconfig"; sourceTree = "<group>"; };
 		B8AF05FC3A0730CCBD5A3D8F /* Pods-InternxtShareExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtShareExtension.release.xcconfig"; path = "Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension.release.xcconfig"; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
@@ -276,6 +280,8 @@
 				DE1D47632F87A94000E14783 /* FileProviderExtension.swift */,
 				DE1D47642F87A94000E14783 /* FileProviderEnumerator.swift */,
 				DE1D47652F87A94000E14783 /* FileProviderItem.swift */,
+				AB1D47722F87A94000E14783 /* FileProviderItemIdentifier.swift */,
+				AB1D47732F87A94000E14783 /* DriveAPIFactory.swift */,
 				DE1D47662F87A94000E14783 /* Info.plist */,
 				DE1D47672F87A94000E14783 /* InternxtFileProvider.entitlements */,
 				DE1D47682F87A94000E14783 /* InternxtFileProvider.plist */,
@@ -733,6 +739,8 @@
 				DE1D47602F87A94000E14783 /* FileProviderExtension.swift in Sources */,
 				DE1D47612F87A94000E14783 /* FileProviderEnumerator.swift in Sources */,
 				DE1D47622F87A94000E14783 /* FileProviderItem.swift in Sources */,
+				AB1D47702F87A94000E14783 /* FileProviderItemIdentifier.swift in Sources */,
+				AB1D47712F87A94000E14783 /* DriveAPIFactory.swift in Sources */,
 				AA0100082F87A94000E14783 /* SharedAuthKeychain.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/Internxt/SharedAuthKeychain.swift
+++ b/ios/Internxt/SharedAuthKeychain.swift
@@ -14,9 +14,11 @@ enum SharedAuthKeychain {
   static let bucketKey = "shared_bucket"
   static let bridgeUserKey = "shared_bridgeUser"
   static let userIdKey = "shared_userId"
+  static let driveBaseUrlKey = "shared_driveBaseUrl"
 
   static let allKeys = [
     photosTokenKey, mnemonicKey, rootFolderIdKey, bucketKey, bridgeUserKey, userIdKey,
+    driveBaseUrlKey,
   ]
 
   static var accessGroup: String? {

--- a/ios/InternxtFileProvider/DriveAPIFactory.swift
+++ b/ios/InternxtFileProvider/DriveAPIFactory.swift
@@ -1,0 +1,36 @@
+import Foundation
+import InternxtSwiftCore
+
+enum DriveAPIFactory {
+  static func make() -> DriveAPI? {
+    guard let authToken = sharedString(SharedAuthKeychain.photosTokenKey),
+          let baseUrl = sharedString(SharedAuthKeychain.driveBaseUrlKey) else {
+      return nil
+    }
+
+    return DriveAPI(
+      baseUrl: baseUrl,
+      authToken: authToken,
+      clientName: clientName,
+      clientVersion: clientVersion
+    )
+  }
+
+  private static func sharedString(_ key: String) -> String? {
+    guard let data = SharedAuthKeychain.read(key) else { return nil }
+    let value = String(decoding: data, as: UTF8.self)
+    return value.isEmpty ? nil : value
+  }
+
+  private static var clientName: String {
+    bundleString("CFBundleName") ?? "drive-mobile"
+  }
+
+  private static var clientVersion: String {
+    bundleString("CFBundleShortVersionString") ?? "0.0.0"
+  }
+
+  private static func bundleString(_ key: String) -> String? {
+    Bundle(for: FileProviderExtension.self).object(forInfoDictionaryKey: key) as? String
+  }
+}

--- a/ios/InternxtFileProvider/FileProviderEnumerator.swift
+++ b/ios/InternxtFileProvider/FileProviderEnumerator.swift
@@ -6,52 +6,136 @@
 //
 
 import FileProvider
+import InternxtSwiftCore
 
 class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
-    
-    private let enumeratedItemIdentifier: NSFileProviderItemIdentifier
-    private let anchor = NSFileProviderSyncAnchor("an anchor".data(using: .utf8)!)
-    
-    init(enumeratedItemIdentifier: NSFileProviderItemIdentifier) {
-        self.enumeratedItemIdentifier = enumeratedItemIdentifier
-        super.init()
+
+  private static let pageSize = 50
+  private static let order = "ASC"
+
+  private enum Phase: String {
+    case folders
+    case files
+  }
+
+  private struct Cursor {
+    let phase: Phase
+    let offset: Int
+
+    static let initial = Cursor(phase: .folders, offset: 0)
+
+    func encoded() -> NSFileProviderPage {
+      NSFileProviderPage("\(phase.rawValue):\(offset)".data(using: .utf8)!)
     }
 
-    func invalidate() {
-        // TODO: perform invalidation of server connection if necessary
+    static func decode(_ page: NSFileProviderPage) -> Cursor {
+      guard let raw = String(data: page.rawValue, encoding: .utf8),
+            let separatorIndex = raw.firstIndex(of: ":"),
+            let phase = Phase(rawValue: String(raw[raw.startIndex..<separatorIndex])),
+            let offset = Int(raw[raw.index(after: separatorIndex)...]) else {
+        return .initial
+      }
+      return Cursor(phase: phase, offset: offset)
+    }
+  }
+
+  private let enumeratedItemIdentifier: NSFileProviderItemIdentifier
+  private let anchor = NSFileProviderSyncAnchor("an anchor".data(using: .utf8)!)
+
+  init(enumeratedItemIdentifier: NSFileProviderItemIdentifier) {
+    self.enumeratedItemIdentifier = enumeratedItemIdentifier
+    super.init()
+  }
+
+  func invalidate() {}
+
+  func enumerateItems(for observer: NSFileProviderEnumerationObserver, startingAt page: NSFileProviderPage) {
+    let cursor = Cursor.decode(page)
+
+    guard FileProviderItemID.isDriveFolderContainer(enumeratedItemIdentifier) else {
+      observer.didEnumerate([])
+      observer.finishEnumerating(upTo: nil)
+      return
     }
 
-    func enumerateItems(for observer: NSFileProviderEnumerationObserver, startingAt page: NSFileProviderPage) {
-        /* TODO:
-         - inspect the page to determine whether this is an initial or a follow-up request
-         
-         If this is an enumerator for a directory, the root container or all directories:
-         - perform a server request to fetch directory contents
-         If this is an enumerator for the active set:
-         - perform a server request to update your local database
-         - fetch the active set from your local database
-         
-         - inform the observer about the items returned by the server (possibly multiple times)
-         - inform the observer that you are finished with this page
-         */
-        observer.didEnumerate([FileProviderItem(identifier: NSFileProviderItemIdentifier("a file"))])
-        observer.finishEnumerating(upTo: nil)
-    }
-    
-    func enumerateChanges(for observer: NSFileProviderChangeObserver, from anchor: NSFileProviderSyncAnchor) {
-        /* TODO:
-         - query the server for updates since the passed-in sync anchor
-         
-         If this is an enumerator for the active set:
-         - note the changes in your local database
-         
-         - inform the observer about item deletions and updates (modifications + insertions)
-         - inform the observer when you have finished enumerating up to a subsequent sync anchor
-         */
-        observer.finishEnumeratingChanges(upTo: anchor, moreComing: false)
+    guard let folderUuid = FileProviderItemID.folderUuid(for: enumeratedItemIdentifier),
+          let driveAPI = DriveAPIFactory.make() else {
+      observer.finishEnumeratingWithError(notAuthenticatedError())
+      return
     }
 
-    func currentSyncAnchor(completionHandler: @escaping (NSFileProviderSyncAnchor?) -> Void) {
-        completionHandler(anchor)
+    Task {
+      do {
+        switch cursor.phase {
+        case .folders:
+          try await enumerateFolders(driveAPI, folderUuid: folderUuid, offset: cursor.offset, observer: observer)
+        case .files:
+          try await enumerateFiles(driveAPI, folderUuid: folderUuid, offset: cursor.offset, observer: observer)
+        }
+      } catch {
+        observer.finishEnumeratingWithError(enumerationError(from: error))
+      }
     }
+  }
+
+  private func enumerateFolders(
+    _ driveAPI: DriveAPI,
+    folderUuid: String,
+    offset: Int,
+    observer: NSFileProviderEnumerationObserver
+  ) async throws {
+    let response = try await driveAPI.getFolderFolders(
+      folderUuid: folderUuid, offset: offset, limit: Self.pageSize, order: Self.order
+    )
+    let items = response.folders.map {
+      FileProviderItem(folder: $0, parent: enumeratedItemIdentifier)
+    }
+    observer.didEnumerate(items)
+
+    if response.folders.count == Self.pageSize {
+      observer.finishEnumerating(upTo: Cursor(phase: .folders, offset: offset + Self.pageSize).encoded())
+    } else {
+      observer.finishEnumerating(upTo: Cursor(phase: .files, offset: 0).encoded())
+    }
+  }
+
+  private func enumerateFiles(
+    _ driveAPI: DriveAPI,
+    folderUuid: String,
+    offset: Int,
+    observer: NSFileProviderEnumerationObserver
+  ) async throws {
+    let response = try await driveAPI.getFolderFilesV2(
+      folderUuid: folderUuid, offset: offset, limit: Self.pageSize, order: Self.order
+    )
+    let items = response.files.map {
+      FileProviderItem(file: $0, parent: enumeratedItemIdentifier)
+    }
+    observer.didEnumerate(items)
+
+    if response.files.count == Self.pageSize {
+      observer.finishEnumerating(upTo: Cursor(phase: .files, offset: offset + Self.pageSize).encoded())
+    } else {
+      observer.finishEnumerating(upTo: nil)
+    }
+  }
+
+  private func notAuthenticatedError() -> Error {
+    NSFileProviderError(.notAuthenticated)
+  }
+
+  private func enumerationError(from error: Error) -> Error {
+    if let apiError = error as? APIClientError, apiError.statusCode == 401 {
+      return notAuthenticatedError()
+    }
+    return error
+  }
+
+  func enumerateChanges(for observer: NSFileProviderChangeObserver, from anchor: NSFileProviderSyncAnchor) {
+    observer.finishEnumeratingChanges(upTo: anchor, moreComing: false)
+  }
+
+  func currentSyncAnchor(completionHandler: @escaping (NSFileProviderSyncAnchor?) -> Void) {
+    completionHandler(anchor)
+  }
 }

--- a/ios/InternxtFileProvider/FileProviderItem.swift
+++ b/ios/InternxtFileProvider/FileProviderItem.swift
@@ -6,40 +6,188 @@
 //
 
 import FileProvider
+import InternxtSwiftCore
 import UniformTypeIdentifiers
 
 class FileProviderItem: NSObject, NSFileProviderItem {
 
-    // TODO: implement an initializer to create an item from your extension's backing model
-    // TODO: implement the accessors to return the values from your extension's backing model
-    
-    private let identifier: NSFileProviderItemIdentifier
-    
-    init(identifier: NSFileProviderItemIdentifier) {
-        self.identifier = identifier
+  private let identifier: NSFileProviderItemIdentifier
+  private let parent: NSFileProviderItemIdentifier
+  private let name: String
+  private let kind: DriveItemKind
+  private let fileExtension: String?
+  private let updatedAt: String?
+  private let createdAt: String?
+  private let sizeInBytes: String?
+
+  private init(
+    identifier: NSFileProviderItemIdentifier,
+    parent: NSFileProviderItemIdentifier,
+    name: String,
+    kind: DriveItemKind,
+    fileExtension: String?,
+    createdAt: String?,
+    updatedAt: String?,
+    sizeInBytes: String?
+  ) {
+    self.identifier = identifier
+    self.parent = parent
+    self.name = name
+    self.kind = kind
+    self.fileExtension = fileExtension
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
+    self.sizeInBytes = sizeInBytes
+  }
+
+  convenience init(folder: GetFolderFoldersResult, parent: NSFileProviderItemIdentifier) {
+    self.init(
+      identifier: FileProviderItemID.encode(.folder, uuid: folder.uuid ?? ""),
+      parent: parent,
+      name: folder.plainName ?? folder.name,
+      kind: .folder,
+      fileExtension: nil,
+      createdAt: folder.createdAt,
+      updatedAt: folder.updatedAt,
+      sizeInBytes: nil
+    )
+  }
+
+  convenience init(file: GetFolderFilesResultV2, parent: NSFileProviderItemIdentifier) {
+    self.init(
+      identifier: FileProviderItemID.encode(.file, uuid: file.uuid),
+      parent: parent,
+      name: file.plainName ?? file.name ?? file.uuid,
+      kind: .file,
+      fileExtension: file.type,
+      createdAt: file.createdAt,
+      updatedAt: file.updatedAt,
+      sizeInBytes: file.size
+    )
+  }
+
+  static func root(displayName: String) -> FileProviderItem {
+    FileProviderItem(
+      identifier: .rootContainer,
+      parent: .rootContainer,
+      name: displayName,
+      kind: .folder,
+      fileExtension: nil,
+      createdAt: nil,
+      updatedAt: nil,
+      sizeInBytes: nil
+    )
+  }
+
+  convenience init(folderMeta: GetFolderMetaByIdResponse, identifier: NSFileProviderItemIdentifier) {
+    self.init(
+      identifier: identifier,
+      parent: FileProviderItemID.parentIdentifier(folderUuid: folderMeta.parentUuid),
+      name: folderMeta.plainName ?? folderMeta.name ?? identifier.rawValue,
+      kind: .folder,
+      fileExtension: nil,
+      createdAt: folderMeta.createdAt,
+      updatedAt: folderMeta.updatedAt,
+      sizeInBytes: nil
+    )
+  }
+
+  convenience init(fileMeta: GetFileMetaByIdResponse, identifier: NSFileProviderItemIdentifier) {
+    self.init(
+      identifier: identifier,
+      parent: FileProviderItemID.parentIdentifier(folderUuid: fileMeta.folderUuid),
+      name: fileMeta.plainName ?? fileMeta.name,
+      kind: .file,
+      fileExtension: fileMeta.type,
+      createdAt: fileMeta.createdAt,
+      updatedAt: fileMeta.updatedAt,
+      sizeInBytes: fileMeta.size
+    )
+  }
+
+  var itemIdentifier: NSFileProviderItemIdentifier {
+    identifier
+  }
+
+  var parentItemIdentifier: NSFileProviderItemIdentifier {
+    parent
+  }
+
+  var capabilities: NSFileProviderItemCapabilities {
+    switch kind {
+    case .folder:
+      return [.allowsReading, .allowsContentEnumerating]
+    case .file:
+      return [.allowsReading]
     }
-    
-    var itemIdentifier: NSFileProviderItemIdentifier {
-        return identifier
+  }
+
+  var itemVersion: NSFileProviderItemVersion {
+    let version = Data((updatedAt ?? identifier.rawValue).utf8)
+    return NSFileProviderItemVersion(contentVersion: version, metadataVersion: version)
+  }
+
+  var filename: String {
+    guard kind == .file, let fileExtension = fileExtension, !fileExtension.isEmpty else {
+      return name
     }
-    
-    var parentItemIdentifier: NSFileProviderItemIdentifier {
-        return .rootContainer
+    return "\(name).\(fileExtension)"
+  }
+
+  var contentType: UTType {
+    guard kind == .file else { return .folder }
+    if let fileExtension = fileExtension, !fileExtension.isEmpty,
+       let type = UTType(filenameExtension: fileExtension) {
+      return type
     }
-    
-    var capabilities: NSFileProviderItemCapabilities {
-        return [.allowsReading, .allowsWriting, .allowsRenaming, .allowsReparenting, .allowsTrashing, .allowsDeleting]
+    return .data
+  }
+
+  var documentSize: NSNumber? {
+    guard kind == .file, let sizeInBytes = sizeInBytes,
+          let bytes = Int64(sizeInBytes) else {
+      return nil
     }
-    
-    var itemVersion: NSFileProviderItemVersion {
-        NSFileProviderItemVersion(contentVersion: "a content version".data(using: .utf8)!, metadataVersion: "a metadata version".data(using: .utf8)!)
+    return NSNumber(value: bytes)
+  }
+
+  private var isFolder: Bool {
+    kind == .folder
+  }
+
+  var isUploaded: Bool {
+    true
+  }
+
+  var isDownloaded: Bool {
+    isFolder
+  }
+
+  var isMostRecentVersionDownloaded: Bool {
+    isFolder
+  }
+
+  var creationDate: Date? {
+    Self.parseISO8601(createdAt)
+  }
+
+  var contentModificationDate: Date? {
+    Self.parseISO8601(updatedAt)
+  }
+
+  private static let iso8601Formatter: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter
+  }()
+
+  private static func parseISO8601(_ value: String?) -> Date? {
+    guard let value = value, !value.isEmpty else { return nil }
+    if let date = iso8601Formatter.date(from: value) {
+      return date
     }
-    
-    var filename: String {
-        return identifier.rawValue
-    }
-    
-    var contentType: UTType {
-        return identifier == NSFileProviderItemIdentifier.rootContainer ? .folder : .plainText
-    }
+    let fallback = ISO8601DateFormatter()
+    fallback.formatOptions = [.withInternetDateTime]
+    return fallback.date(from: value)
+  }
 }

--- a/ios/InternxtFileProvider/FileProviderItem.swift
+++ b/ios/InternxtFileProvider/FileProviderItem.swift
@@ -168,11 +168,11 @@ class FileProviderItem: NSObject, NSFileProviderItem {
   }
 
   var creationDate: Date? {
-    Self.parseISO8601(createdAt)
+    Self.parseDate(createdAt)
   }
 
   var contentModificationDate: Date? {
-    Self.parseISO8601(updatedAt)
+    Self.parseDate(updatedAt)
   }
 
   private static let iso8601Formatter: ISO8601DateFormatter = {
@@ -181,13 +181,17 @@ class FileProviderItem: NSObject, NSFileProviderItem {
     return formatter
   }()
 
-  private static func parseISO8601(_ value: String?) -> Date? {
+  private static let iso8601FormatterNoFractionalSeconds: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    return formatter
+  }()
+
+  private static func parseDate(_ value: String?) -> Date? {
     guard let value = value, !value.isEmpty else { return nil }
     if let date = iso8601Formatter.date(from: value) {
       return date
     }
-    let fallback = ISO8601DateFormatter()
-    fallback.formatOptions = [.withInternetDateTime]
-    return fallback.date(from: value)
+    return iso8601FormatterNoFractionalSeconds.date(from: value)
   }
 }

--- a/ios/InternxtFileProvider/FileProviderItemIdentifier.swift
+++ b/ios/InternxtFileProvider/FileProviderItemIdentifier.swift
@@ -1,0 +1,49 @@
+import FileProvider
+
+enum DriveItemKind: String {
+  case folder = "f"
+  case file = "d"
+}
+
+enum FileProviderItemID {
+  private static let separator: Character = ":"
+
+  static func encode(_ kind: DriveItemKind, uuid: String) -> NSFileProviderItemIdentifier {
+    NSFileProviderItemIdentifier("\(kind.rawValue)\(separator)\(uuid)")
+  }
+
+  static func decode(_ identifier: NSFileProviderItemIdentifier) -> (kind: DriveItemKind, uuid: String)? {
+    let raw = identifier.rawValue
+    guard let separatorIndex = raw.firstIndex(of: separator) else { return nil }
+    let prefix = String(raw[raw.startIndex..<separatorIndex])
+    let uuid = String(raw[raw.index(after: separatorIndex)...])
+    guard let kind = DriveItemKind(rawValue: prefix), !uuid.isEmpty else { return nil }
+    return (kind, uuid)
+  }
+
+  static func isDriveFolderContainer(_ container: NSFileProviderItemIdentifier) -> Bool {
+    if container == .rootContainer { return true }
+    guard let decoded = decode(container) else { return false }
+    return decoded.kind == .folder
+  }
+
+  static func folderUuid(for container: NSFileProviderItemIdentifier) -> String? {
+    if container == .rootContainer {
+      return rootFolderUuid()
+    }
+    guard let decoded = decode(container), decoded.kind == .folder else { return nil }
+    return decoded.uuid
+  }
+
+  static func rootFolderUuid() -> String? {
+    guard let data = SharedAuthKeychain.read(SharedAuthKeychain.rootFolderIdKey) else { return nil }
+    let uuid = String(decoding: data, as: UTF8.self)
+    return uuid.isEmpty ? nil : uuid
+  }
+
+  static func parentIdentifier(folderUuid: String?) -> NSFileProviderItemIdentifier {
+    guard let folderUuid = folderUuid, !folderUuid.isEmpty else { return .rootContainer }
+    if folderUuid == rootFolderUuid() { return .rootContainer }
+    return encode(.folder, uuid: folderUuid)
+  }
+}


### PR DESCRIPTION
  Implements read-only browsing of Drive in the iOS Files.app via the `InternxtFileProvider` extension.
  
### What this delivers
  - **Root + subfolder enumeration** — lists folders and files from the Drive API
    and navigates into subfolders.
  - **Correct names** — `plainName` + extension.
  - **Pagination** — 50 items/page via `NSFileProviderPage` as the cursor
    (folders first, then files, `plainName ASC`), so large folders show all items.
  - **Item metadata** — size, creation/modification dates, and per-kind
    materialization flags so items render as normal cloud items (folders
    materialized; files cloud-downloadable) instead of greyed/locked placeholders.
  - **Auth/offline states** — missing credentials → `notAuthenticated`
    (drives the system "Sign in to Internxt Drive" prompt); network errors
    surface as errors without crashing.
  - **Drive API wiring** — `DriveAPIFactory` builds an authenticated client from
    the shared App Group keychain; adds a shared `driveBaseUrl` key.
  - **Type-prefixed item identifiers** (`f:`/`d:`) so a container identifier
    round-tripped by Files.app resolves back to a Drive folder uuid.