### PR TITLE
[PB-6489] feature/Added support to burst photos in Photos

### DIFF
--- a/ios/Internxt.xcodeproj/project.pbxproj
+++ b/ios/Internxt.xcodeproj/project.pbxproj
@@ -10,17 +10,19 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		1818AB341F31CC033FFF750B /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD55E1E535AECF7719BDD772 /* ExpoModulesProvider.swift */; };
 		18D7DE9587FA2B2314575ED6 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4921399A370F5CE6EE7EA0F /* ExpoModulesProvider.swift */; };
+		1A3E7803EDA342F39787DC8F /* PHAssetExportModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9949B2A33B5D4CA2BD828B67 /* PHAssetExportModule.swift */; };
+		223B28DBAE304C1A3EEA3C09 /* libPods-Internxt.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AA9432502B9F4CF8AD631009 /* libPods-Internxt.a */; };
 		2F8E878CDCAC7D5C07B5C670 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 37A2C3A4643426D3F429F041 /* PrivacyInfo.xcprivacy */; };
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
-		796CE562F25C5F16D80F868D /* libPods-Internxt.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 039F6E1EA42E3A932EA23F11 /* libPods-Internxt.a */; };
 		7D373856C83A43879BFBE604 /* InternxtShareExtension.appex in Copy Files */ = {isa = PBXBuildFile; fileRef = 7F5486528A7D46DD91A7910F /* InternxtShareExtension.appex */; };
-		8CEE07D2C59F6E3DA678015B /* libPods-InternxtShareExtension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E7039B379DC01F054767587 /* libPods-InternxtShareExtension.a */; };
+		815DB2CE452C262F36B98B31 /* libPods-InternxtShareExtension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A6973A5C0BD8C46ED94EDBDD /* libPods-InternxtShareExtension.a */; };
 		8F8148045BC14A539BD1917D /* ShareExtensionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6F72E1B98D469883DAFB30 /* ShareExtensionViewController.swift */; };
+		9DB4D633CA40422A956585FD /* PHAssetExportModule.m in Sources */ = {isa = PBXBuildFile; fileRef = D330686328BD4286AB778B88 /* PHAssetExportModule.m */; };
+		A1B2C3D4E5F601234567890A /* PHBurstExportModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6012345678901 /* PHBurstExportModule.swift */; };
+		A1B2C3D4E5F601234567890B /* PHBurstExportModule.m in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6012345678902 /* PHBurstExportModule.m */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
 		DEBEAEBF2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBEAEBE2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift */; };
 		DEBEAEC02F72E65B00A6E6D5 /* AppGroupPendingShareModule.m in Sources */ = {isa = PBXBuildFile; fileRef = DEBEAEBD2F72E65B00A6E6D5 /* AppGroupPendingShareModule.m */; };
-		1A3E7803EDA342F39787DC8F /* PHAssetExportModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9949B2A33B5D4CA2BD828B67 /* PHAssetExportModule.swift */; };
-		9DB4D633CA40422A956585FD /* PHAssetExportModule.m in Sources */ = {isa = PBXBuildFile; fileRef = D330686328BD4286AB778B88 /* PHAssetExportModule.m */; };
 		F11748422D0307B40044C1D9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11748412D0307B40044C1D9 /* AppDelegate.swift */; };
 /* End PBXBuildFile section */
 
@@ -59,28 +61,30 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		039F6E1EA42E3A932EA23F11 /* libPods-Internxt.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Internxt.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		0A112D9227DD6AEC70ABC994 /* Pods-InternxtShareExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtShareExtension.release.xcconfig"; path = "Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension.release.xcconfig"; sourceTree = "<group>"; };
+		05A755ADB481DBEDED0768E3 /* Pods-Internxt.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.debug.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.debug.xcconfig"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* Internxt.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Internxt.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Internxt/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Internxt/Info.plist; sourceTree = "<group>"; };
+		1CAA71E6949ECBC2300FA01C /* Pods-Internxt.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.release.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.release.xcconfig"; sourceTree = "<group>"; };
 		30C3C55FF8AE435F8A82A9BC /* InternxtShareExtension.entitlements */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; path = InternxtShareExtension.entitlements; sourceTree = "<group>"; };
 		37A2C3A4643426D3F429F041 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = Internxt/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		386ABCE8EE029E7AF8AA3468 /* Pods-InternxtShareExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtShareExtension.release.xcconfig"; path = "Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension.release.xcconfig"; sourceTree = "<group>"; };
 		3A6F72E1B98D469883DAFB30 /* ShareExtensionViewController.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; path = ShareExtensionViewController.swift; sourceTree = "<group>"; };
-		577249B2C1B116E6254E7F3B /* Pods-InternxtShareExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtShareExtension.debug.xcconfig"; path = "Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension.debug.xcconfig"; sourceTree = "<group>"; };
-		67F1D584B9E997834D9494CC /* Pods-Internxt.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.debug.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.debug.xcconfig"; sourceTree = "<group>"; };
-		6E7039B379DC01F054767587 /* libPods-InternxtShareExtension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-InternxtShareExtension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		73C04D69B69DDEE21B515E90 /* Pods-InternxtShareExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtShareExtension.debug.xcconfig"; path = "Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		7F5486528A7D46DD91A7910F /* InternxtShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; fileEncoding = 9; includeInIndex = 0; path = InternxtShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		9949B2A33B5D4CA2BD828B67 /* PHAssetExportModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PHAssetExportModule.swift; path = Internxt/PHAssetExportModule.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F6012345678901 /* PHBurstExportModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PHBurstExportModule.swift; path = Internxt/PHBurstExportModule.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F6012345678902 /* PHBurstExportModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PHBurstExportModule.m; path = Internxt/PHBurstExportModule.m; sourceTree = "<group>"; };
 		A4921399A370F5CE6EE7EA0F /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-InternxtShareExtension/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
+		A6973A5C0BD8C46ED94EDBDD /* libPods-InternxtShareExtension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-InternxtShareExtension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = Internxt/SplashScreen.storyboard; sourceTree = "<group>"; };
+		AA9432502B9F4CF8AD631009 /* libPods-Internxt.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Internxt.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
 		BD55E1E535AECF7719BDD772 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-Internxt/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
+		D330686328BD4286AB778B88 /* PHAssetExportModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PHAssetExportModule.m; path = Internxt/PHAssetExportModule.m; sourceTree = "<group>"; };
 		DAE15E8DB4DF4E048E04B0E0 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DEBEAEBD2F72E65B00A6E6D5 /* AppGroupPendingShareModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = AppGroupPendingShareModule.m; path = Internxt/AppGroupPendingShareModule.m; sourceTree = "<group>"; };
 		DEBEAEBE2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppGroupPendingShareModule.swift; path = Internxt/AppGroupPendingShareModule.swift; sourceTree = "<group>"; };
-		D330686328BD4286AB778B88 /* PHAssetExportModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PHAssetExportModule.m; path = Internxt/PHAssetExportModule.m; sourceTree = "<group>"; };
-		9949B2A33B5D4CA2BD828B67 /* PHAssetExportModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PHAssetExportModule.swift; path = Internxt/PHAssetExportModule.swift; sourceTree = "<group>"; };
-		E40DA9D6F8373E195B0B45C1 /* Pods-Internxt.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.release.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.release.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		F11748412D0307B40044C1D9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = Internxt/AppDelegate.swift; sourceTree = "<group>"; };
 		F11748442D0722820044C1D9 /* Internxt-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "Internxt-Bridging-Header.h"; path = "Internxt/Internxt-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -91,7 +95,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				796CE562F25C5F16D80F868D /* libPods-Internxt.a in Frameworks */,
+				223B28DBAE304C1A3EEA3C09 /* libPods-Internxt.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -99,7 +103,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8CEE07D2C59F6E3DA678015B /* libPods-InternxtShareExtension.a in Frameworks */,
+				815DB2CE452C262F36B98B31 /* libPods-InternxtShareExtension.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -113,6 +117,8 @@
 				DEBEAEBE2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift */,
 				D330686328BD4286AB778B88 /* PHAssetExportModule.m */,
 				9949B2A33B5D4CA2BD828B67 /* PHAssetExportModule.swift */,
+				A1B2C3D4E5F6012345678902 /* PHBurstExportModule.m */,
+				A1B2C3D4E5F6012345678901 /* PHBurstExportModule.swift */,
 				F11748412D0307B40044C1D9 /* AppDelegate.swift */,
 				F11748442D0722820044C1D9 /* Internxt-Bridging-Header.h */,
 				BB2F792B24A3F905000567C9 /* Supporting */,
@@ -128,8 +134,8 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				039F6E1EA42E3A932EA23F11 /* libPods-Internxt.a */,
-				6E7039B379DC01F054767587 /* libPods-InternxtShareExtension.a */,
+				AA9432502B9F4CF8AD631009 /* libPods-Internxt.a */,
+				A6973A5C0BD8C46ED94EDBDD /* libPods-InternxtShareExtension.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -155,10 +161,10 @@
 		808723478BA906DED7CCCEE0 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				67F1D584B9E997834D9494CC /* Pods-Internxt.debug.xcconfig */,
-				E40DA9D6F8373E195B0B45C1 /* Pods-Internxt.release.xcconfig */,
-				577249B2C1B116E6254E7F3B /* Pods-InternxtShareExtension.debug.xcconfig */,
-				0A112D9227DD6AEC70ABC994 /* Pods-InternxtShareExtension.release.xcconfig */,
+				05A755ADB481DBEDED0768E3 /* Pods-Internxt.debug.xcconfig */,
+				1CAA71E6949ECBC2300FA01C /* Pods-Internxt.release.xcconfig */,
+				73C04D69B69DDEE21B515E90 /* Pods-InternxtShareExtension.debug.xcconfig */,
+				386ABCE8EE029E7AF8AA3468 /* Pods-InternxtShareExtension.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -228,7 +234,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "Internxt" */;
 			buildPhases = (
-				86F524C72CB9354A141BC65B /* [CP] Check Pods Manifest.lock */,
+				5D7CA88D692EF469F8776EF5 /* [CP] Check Pods Manifest.lock */,
 				C23BF8EF9D9B379F6EADAAE0 /* [Expo] Configure project */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
@@ -236,8 +242,8 @@
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				DDE0311FCC774124B044B69C /* Embed Foundation Extensions */,
 				EF531C08E8F54B18956A8C0E /* Copy Files */,
-				793E832705612D06758FCFD3 /* [CP] Embed Pods Frameworks */,
-				117E35238C1E08B0CA4EA36A /* [CP] Copy Pods Resources */,
+				8133E76871B1204A50DC2349 /* [CP] Embed Pods Frameworks */,
+				7CBE9110FE7157B1C1836713 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -253,14 +259,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DDB0A9F040BE45D9929C1B2D /* Build configuration list for PBXNativeTarget "InternxtShareExtension" */;
 			buildPhases = (
-				1C4D7191F4CCE20A90B8A052 /* [CP] Check Pods Manifest.lock */,
+				76D3DE76D5B06FCFF198E96C /* [CP] Check Pods Manifest.lock */,
 				90134DAC718F4FE0B3AB7B91 /* Start Packager */,
 				BEAE0DA94817B237B864F997 /* [Expo] Configure project */,
 				3495BDAE4F75461EBD6FFF8F /* Sources */,
 				3ABC9B4F4B9D448B9797EBD7 /* Frameworks */,
 				2F5766E756C84914803E7082 /* Resources */,
 				AA9E71431FBB401A8272B8C4 /* Bundle React Native code and images */,
-				2DCE1C1C5631927FFC0F82BC /* [CP] Copy Pods Resources */,
+				18EDB06E33352827BF78A1B1 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -349,7 +355,95 @@
 			shellPath = /bin/sh;
 			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n# The project root by default is one level up from the ios directory\nexport PROJECT_ROOT=\"$PROJECT_DIR\"/..\n\nif [[ \"$CONFIGURATION\" = *Debug* ]]; then\n  export SKIP_BUNDLING=1\nfi\nif [[ -z \"$ENTRY_FILE\" ]]; then\n  # Set the entry JS file using the bundler's entry resolution.\n  export ENTRY_FILE=\"$(\"$NODE_BINARY\" -e \"require('expo/scripts/resolveAppEntry')\" \"$PROJECT_ROOT\" ios absolute | tail -n 1)\"\nfi\n\nif [[ -z \"$CLI_PATH\" ]]; then\n  # Use Expo CLI\n  export CLI_PATH=\"$(\"$NODE_BINARY\" --print \"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\")\"\nfi\nif [[ -z \"$BUNDLE_COMMAND\" ]]; then\n  # Default Expo CLI command for bundling\n  export BUNDLE_COMMAND=\"export:embed\"\nfi\n\n# Source .xcode.env.updates if it exists to allow\n# SKIP_BUNDLING to be unset if needed\nif [[ -f \"$PODS_ROOT/../.xcode.env.updates\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.updates\"\nfi\n# Source local changes to allow overrides\n# if needed\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`\n\n";
 		};
-		117E35238C1E08B0CA4EA36A /* [CP] Copy Pods Resources */ = {
+		18EDB06E33352827BF78A1B1 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/EXApplication/ExpoApplication_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/ExpoConstants_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoDevice/ExpoDevice_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoFileSystem/ExpoFileSystem_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoLocalization/ExpoLocalization_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoMediaLibrary/ExpoMediaLibrary_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoSystemUI/ExpoSystemUI_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/RNCAsyncStorage/RNCAsyncStorage_resources.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/RNSVG/RNSVGFilters.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/React-Core_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/React-cxxreact/React-cxxreact_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/ReactNativeFs/RNFS_PrivacyInfo.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/react-native-blob-util/ReactNativeBlobUtilPrivacyInfo.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoApplication_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoConstants_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoDevice_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoFileSystem_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoLocalization_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoMediaLibrary_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoSystemUI_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNCAsyncStorage_resources.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNSVGFilters.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-Core_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-cxxreact_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNFS_PrivacyInfo.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ReactNativeBlobUtilPrivacyInfo.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		5D7CA88D692EF469F8776EF5 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Internxt-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		76D3DE76D5B06FCFF198E96C /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-InternxtShareExtension-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		7CBE9110FE7157B1C1836713 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -397,73 +491,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Internxt/Pods-Internxt-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		1C4D7191F4CCE20A90B8A052 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-InternxtShareExtension-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		2DCE1C1C5631927FFC0F82BC /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension-resources.sh",
-				"${PODS_CONFIGURATION_BUILD_DIR}/EXApplication/ExpoApplication_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/ExpoConstants_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoDevice/ExpoDevice_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoFileSystem/ExpoFileSystem_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoLocalization/ExpoLocalization_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoMediaLibrary/ExpoMediaLibrary_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoSystemUI/ExpoSystemUI_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/RNCAsyncStorage/RNCAsyncStorage_resources.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/RNSVG/RNSVGFilters.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/React-Core_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/React-cxxreact/React-cxxreact_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/ReactNativeFs/RNFS_PrivacyInfo.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/react-native-blob-util/ReactNativeBlobUtilPrivacyInfo.bundle",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoApplication_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoConstants_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoDevice_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoFileSystem_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoLocalization_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoMediaLibrary_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoSystemUI_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNCAsyncStorage_resources.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNSVGFilters.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-Core_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-cxxreact_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNFS_PrivacyInfo.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ReactNativeBlobUtilPrivacyInfo.bundle",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		793E832705612D06758FCFD3 /* [CP] Embed Pods Frameworks */ = {
+		8133E76871B1204A50DC2349 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -483,28 +511,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Internxt/Pods-Internxt-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		86F524C72CB9354A141BC65B /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Internxt-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		90134DAC718F4FE0B3AB7B91 /* Start Packager */ = {
@@ -596,6 +602,8 @@
 				DEBEAEC02F72E65B00A6E6D5 /* AppGroupPendingShareModule.m in Sources */,
 				1A3E7803EDA342F39787DC8F /* PHAssetExportModule.swift in Sources */,
 				9DB4D633CA40422A956585FD /* PHAssetExportModule.m in Sources */,
+				A1B2C3D4E5F601234567890A /* PHBurstExportModule.swift in Sources */,
+				A1B2C3D4E5F601234567890B /* PHBurstExportModule.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -621,7 +629,7 @@
 /* Begin XCBuildConfiguration section */
 		00BF7E5F54544AE9B1CDE9D5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 577249B2C1B116E6254E7F3B /* Pods-InternxtShareExtension.debug.xcconfig */;
+			baseConfigurationReference = 73C04D69B69DDEE21B515E90 /* Pods-InternxtShareExtension.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = InternxtShareExtension/InternxtShareExtension.entitlements;
@@ -650,7 +658,7 @@
 		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 67F1D584B9E997834D9494CC /* Pods-Internxt.debug.xcconfig */;
+			baseConfigurationReference = 05A755ADB481DBEDED0768E3 /* Pods-Internxt.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -689,7 +697,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E40DA9D6F8373E195B0B45C1 /* Pods-Internxt.release.xcconfig */;
+			baseConfigurationReference = 1CAA71E6949ECBC2300FA01C /* Pods-Internxt.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -840,7 +848,7 @@
 		};
 		B247FB85ACF44D11B7509F34 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0A112D9227DD6AEC70ABC994 /* Pods-InternxtShareExtension.release.xcconfig */;
+			baseConfigurationReference = 386ABCE8EE029E7AF8AA3468 /* Pods-InternxtShareExtension.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = InternxtShareExtension/InternxtShareExtension.entitlements;

--- a/ios/Internxt/PHBurstExportModule.m
+++ b/ios/Internxt/PHBurstExportModule.m
@@ -1,0 +1,23 @@
+#import <React/RCTBridgeModule.h>
+
+@interface RCT_EXTERN_MODULE(PHBurstExport, NSObject)
+
+RCT_EXTERN_METHOD(
+  getBurstRepresentativeIds:(NSArray<NSString *> *)localIds
+  resolver:(RCTPromiseResolveBlock)resolver
+  rejecter:(RCTPromiseRejectBlock)rejecter
+)
+
+RCT_EXTERN_METHOD(
+  exportBurstMembers:(NSString *)representativeId
+  resolver:(RCTPromiseResolveBlock)resolver
+  rejecter:(RCTPromiseRejectBlock)rejecter
+)
+
+RCT_EXTERN_METHOD(
+  saveBurst:(NSArray<NSString *> *)memberPaths
+  resolver:(RCTPromiseResolveBlock)resolver
+  rejecter:(RCTPromiseRejectBlock)rejecter
+)
+
+@end

--- a/ios/Internxt/PHBurstExportModule.swift
+++ b/ios/Internxt/PHBurstExportModule.swift
@@ -1,0 +1,179 @@
+import Foundation
+import Photos
+import React
+
+@objc(PHBurstExport)
+class PHBurstExportModule: NSObject {
+
+  @objc static func requiresMainQueueSetup() -> Bool { false }
+
+  /// Returns which localIdentifiers from the given batch are burst representatives.
+  /// Called once per scanner page so the burst detection costs one native call per batch.
+  @objc func getBurstRepresentativeIds(
+    _ localIds: [String],
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    let options = PHFetchOptions()
+    options.includeAllBurstAssets = true
+    options.includeHiddenAssets = true
+    let result = PHAsset.fetchAssets(withLocalIdentifiers: localIds, options: options)
+
+    var representativeIds: [String] = []
+    result.enumerateObjects { asset, _, _ in
+      NSLog("[PHBurstExport] getBurstRepresentativeIds — asset=%@ representsBurst=%@", asset.localIdentifier, asset.representsBurst ? "true" : "false")
+      if asset.representsBurst {
+        representativeIds.append(asset.localIdentifier)
+      }
+    }
+    NSLog("[PHBurstExport] getBurstRepresentativeIds — found %lu representatives out of %lu input ids", representativeIds.count, localIds.count)
+    resolver(representativeIds)
+  }
+
+  /// Exports all non-representative members of a burst as raw resource bytes.
+  /// Uses `PHAssetResourceManager` to preserve the original MakerApple maker-note (BurstUUID key 11)
+  /// so that `saveBurst(_:)` can reconstruct the burst group in the photo library.
+  @objc func exportBurstMembers(
+    _ representativeId: String,
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    let fetchOptions = PHFetchOptions()
+    fetchOptions.includeAllBurstAssets = true
+    fetchOptions.includeHiddenAssets = true
+
+    let representativeFetch = PHAsset.fetchAssets(
+      withLocalIdentifiers: [representativeId],
+      options: fetchOptions
+    )
+    guard let representative = representativeFetch.firstObject else {
+      rejecter("NOT_FOUND", "PHAsset not found: \(representativeId)", nil)
+      return
+    }
+
+    NSLog("[PHBurstExport] representsBurst=%@ burstId=%@ subtypes=%lu",
+          representative.representsBurst ? "true" : "false",
+          representative.burstIdentifier ?? "nil",
+          representative.mediaSubtypes.rawValue)
+
+    guard let burstId = representative.burstIdentifier else {
+      NSLog("[PHBurstExport] burstIdentifier is nil — not a burst")
+      resolver(["members": []])
+      return
+    }
+
+    // fetchAssets(withBurstIdentifier:) ignores includeAllBurstAssets on some iOS versions —
+    // use a general predicate fetch instead so all hidden members are included.
+    let burstOptions = PHFetchOptions()
+    burstOptions.includeAllBurstAssets = true
+    burstOptions.includeHiddenAssets = true
+    burstOptions.predicate = NSPredicate(format: "burstIdentifier == %@", burstId)
+
+    let burstAssets = PHAsset.fetchAssets(with: .image, options: burstOptions)
+    NSLog("[PHBurstExport] predicate fetch for burstId=%@ returned %lu assets", burstId, burstAssets.count)
+
+    var members: [PHAsset] = []
+    burstAssets.enumerateObjects { asset, _, _ in
+      NSLog("[PHBurstExport]   asset=%@ representsBurst=%@", asset.localIdentifier, asset.representsBurst ? "true" : "false")
+      if asset.localIdentifier != representativeId {
+        members.append(asset)
+      }
+    }
+
+    NSLog("[PHBurstExport] members after excluding representative: %lu", members.count)
+
+    if members.isEmpty {
+      resolver(["members": []])
+      return
+    }
+
+    let resourceRequestOptions = PHAssetResourceRequestOptions()
+    resourceRequestOptions.isNetworkAccessAllowed = true
+
+    var exportedMembers: [[String: Any]] = []
+    var exportErrors: [Error] = []
+    let group = DispatchGroup()
+
+    for member in members {
+      let resources = PHAssetResource.assetResources(for: member)
+      guard let resource = resources.first(where: { $0.type == .photo })
+              ?? resources.first(where: { $0.type == .fullSizePhoto })
+              ?? resources.first else {
+        continue
+      }
+
+      let ext = (resource.originalFilename as NSString).pathExtension.lowercased().isEmpty
+        ? "jpg"
+        : (resource.originalFilename as NSString).pathExtension.lowercased()
+      let dest = FileManager.default.temporaryDirectory
+        .appendingPathComponent("\(UUID().uuidString).\(ext)")
+
+      group.enter()
+      PHAssetResourceManager.default().writeData(for: resource, toFile: dest, options: resourceRequestOptions) { error in
+        defer { group.leave() }
+        if let error = error {
+          try? FileManager.default.removeItem(at: dest)
+          exportErrors.append(error)
+          return
+        }
+        let size = (try? (FileManager.default.attributesOfItem(atPath: dest.path)[.size] as? NSNumber)?.int64Value) ?? 0
+        exportedMembers.append([
+          "uri": dest.absoluteString,
+          "size": size,
+          "fileName": resource.originalFilename,
+        ])
+      }
+    }
+
+    group.notify(queue: .global()) {
+      if exportedMembers.isEmpty && !exportErrors.isEmpty {
+        rejecter("EXPORT_FAILED", exportErrors.first?.localizedDescription ?? "All member exports failed", exportErrors.first as NSError?)
+        return
+      }
+      resolver(["members": exportedMembers])
+    }
+  }
+
+  /// Saves all burst members (representative first, then non-representatives) to the photo library.
+  /// Each file is saved as a raw resource via `PHAssetCreationRequest` so that the original
+  /// MakerApple maker-note (BurstUUID key 11) is preserved — iOS uses it to regroup the
+  /// members into a burst automatically.
+  @objc func saveBurst(
+    _ memberPaths: [String],
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    guard !memberPaths.isEmpty else {
+      resolver(nil)
+      return
+    }
+
+    var saveErrors: [Error] = []
+    let group = DispatchGroup()
+
+    for path in memberPaths {
+      let fileURL = URL(fileURLWithPath: path)
+      group.enter()
+      PHPhotoLibrary.shared().performChanges({
+        let request = PHAssetCreationRequest.forAsset()
+        let options = PHAssetResourceCreationOptions()
+        options.shouldMoveFile = false
+        request.addResource(with: .photo, fileURL: fileURL, options: options)
+      }) { _, error in
+        defer { group.leave() }
+        if let error = error {
+          saveErrors.append(error)
+        }
+      }
+    }
+
+    group.notify(queue: .global()) {
+      if saveErrors.isEmpty {
+        resolver(nil)
+      } else {
+        let msg = saveErrors.map { $0.localizedDescription }.joined(separator: "; ")
+        rejecter("SAVE_FAILED", msg, saveErrors.first as NSError?)
+      }
+    }
+  }
+}

--- a/src/services/photos/PhotoUploadService.spec.ts
+++ b/src/services/photos/PhotoUploadService.spec.ts
@@ -68,6 +68,12 @@ jest.mock('./PhotoBackupFolders', () => ({
   },
 }));
 
+jest.mock('./database/photosLocalDB', () => ({
+  photosLocalDB: {
+    getStatus: jest.fn().mockResolvedValue(null),
+  },
+}));
+
 const mockGetAssetInfoAsync = MediaLibrary.getAssetInfoAsync as jest.Mock;
 const mockRnfsStat = RNFS.stat as jest.Mock;
 const mockRnfsUnlink = RNFS.unlink as jest.Mock;

--- a/src/services/photos/PhotoUploadService.ts
+++ b/src/services/photos/PhotoUploadService.ts
@@ -11,6 +11,7 @@ import { generateThumbnail } from 'src/services/common/media/thumbnail.generatio
 import { uploadService } from 'src/services/common/network/upload/upload.service';
 import fileSystemService from 'src/services/FileSystemService';
 import { logger } from '../common';
+import { uploadBurstMembersForExistingRepresentative, uploadBurstMembersIfBurst } from './burst/BurstUploadHandler';
 import { FileAlreadyExistsError } from './errors';
 import { getPairedVideoPlainNameFromPhoto, isLivePhotoAsset } from './livePhoto.constants';
 import { exportLivePhotoComponents } from './LivePhotoNativeModule';
@@ -27,7 +28,7 @@ import {
 
 const TEMP_FILE_PREFIX = 'photo_upload_';
 
-interface UploadCredentials {
+export interface UploadCredentials {
   bucketId: string;
   encryptionKey: string;
   bridgeUser: string;
@@ -52,6 +53,7 @@ interface FileUploadResult {
 export interface PhotoUploadResult {
   photoUuid: string;
   pairedVideoUuid?: string;
+  burst?: { burstId: string; memberUuids: string[] };
 }
 
 const resolveLocalPath = async (
@@ -80,7 +82,7 @@ const resolveLocalPath = async (
   return { localPath: stripFileScheme(uri) };
 };
 
-const uploadSingleFile = async (params: {
+export const uploadSingleFile = async (params: {
   localFilePath: string;
   folderUuid: string;
   plainName: string;
@@ -398,7 +400,17 @@ export const PhotoUploadService = {
       fileUploadResult = await uploadAssetToBucket(asset, deviceId, photosBucket, onProgress, signal);
     } catch (err) {
       if (err instanceof FileAlreadyExistsError) {
-        return { photoUuid: err.existingUuid };
+        logger.info(
+          `[PhotoUploadService] FileAlreadyExists path — assetId=${asset.id} existingUuid=${err.existingUuid}`,
+        );
+        const burst = await uploadBurstMembersForExistingRepresentative({
+          asset,
+          deviceId,
+          photosBucket,
+          signal,
+          uploadMember: uploadSingleFile,
+        });
+        return { photoUuid: err.existingUuid, ...(burst ? { burst } : {}) };
       }
       throw err;
     }
@@ -431,7 +443,19 @@ export const PhotoUploadService = {
 
       await uploadThumbnailForAsset(thumbnailSource, fileExtension, photoUuid, credentials);
 
-      return { photoUuid };
+      logger.info(`[PhotoUploadService] BURST block reached — assetId=${asset.id} plainName=${plainName}`);
+      const burst = await uploadBurstMembersIfBurst({
+        assetId: asset.id,
+        representativePlainName: plainName,
+        folderUuid,
+        creationIso,
+        modificationIso,
+        credentials,
+        signal,
+        uploadMember: uploadSingleFile,
+      });
+
+      return { photoUuid, ...(burst ? { burst } : {}) };
     } finally {
       await cleanupTempFile(tempPath);
     }
@@ -572,7 +596,19 @@ export const PhotoUploadService = {
         await uploadThumbnailForAsset(thumbnailSource, fileExtension, driveFile.uuid, credentials);
         photoUuid = driveFile.uuid;
       }
-      return { photoUuid };
+
+      const burst = await uploadBurstMembersIfBurst({
+        assetId: asset.id,
+        representativePlainName: plainName,
+        folderUuid,
+        creationIso,
+        modificationIso,
+        credentials,
+        signal,
+        uploadMember: uploadSingleFile,
+      });
+
+      return { photoUuid, ...(burst ? { burst } : {}) };
     } finally {
       await cleanupTempFile(tempPath);
     }

--- a/src/services/photos/burst/BurstCloudLinker.spec.ts
+++ b/src/services/photos/burst/BurstCloudLinker.spec.ts
@@ -1,0 +1,61 @@
+import { buildBurstBaseSet, linkBurst } from './BurstCloudLinker';
+
+describe('burst cloud linker', () => {
+  describe('when building the burst base set from a list of plain names', () => {
+    test('when the list contains member names, then their base names are included in the set', () => {
+      const set = buildBurstBaseSet(['IMG_1234', 'IMG_1234.burst.0', 'IMG_1234.burst.1', 'Other']);
+      expect(set.has('IMG_1234')).toBe(true);
+      expect(set.has('Other')).toBe(false);
+    });
+
+    test('when the list has no member names, then the set is empty', () => {
+      const set = buildBurstBaseSet(['IMG_1234', 'Another']);
+      expect(set.size).toBe(0);
+    });
+
+    test('when the list contains null or undefined entries, then they are ignored', () => {
+      const set = buildBurstBaseSet([null, undefined, 'IMG.burst.0']);
+      expect(set.has('IMG')).toBe(true);
+    });
+  });
+
+  describe('when linking a cloud asset to a burst group', () => {
+    const plainNameIndex = new Map<string, string>([
+      ['img_1234', 'uuid-representative'],
+      ['img_1234.burst.0', 'uuid-member-0'],
+    ]);
+    const burstBaseSet = new Set(['img_1234']);
+
+    test('when the plain name belongs to a burst member and the representative exists, then it returns the member role and the representative uuid as group id', () => {
+      const result = linkBurst('img_1234.burst.0', 'uuid-member-0', plainNameIndex, burstBaseSet);
+      expect(result).toEqual({ burstRole: 'member', burstGroupId: 'uuid-representative' });
+    });
+
+    test('when the plain name is a burst member with uppercase letters and the index has lowercase keys, then it still resolves the representative', () => {
+      const upperIndex = new Map<string, string>([['img_1234', 'uuid-representative']]);
+      const result = linkBurst('IMG_1234.burst.0', 'uuid-member-0', upperIndex, burstBaseSet);
+      expect(result).toEqual({ burstRole: 'member', burstGroupId: 'uuid-representative' });
+    });
+
+    test('when the plain name is a representative with known members, then it returns the representative role and its own uuid as group id', () => {
+      const result = linkBurst('img_1234', 'uuid-representative', plainNameIndex, burstBaseSet);
+      expect(result).toEqual({ burstRole: 'representative', burstGroupId: 'uuid-representative' });
+    });
+
+    test('when the plain name is a member but the representative is not in the index, then it returns null', () => {
+      const emptyIndex = new Map<string, string>();
+      const result = linkBurst('img_9999.burst.0', 'uuid-orphan', emptyIndex, burstBaseSet);
+      expect(result).toBeNull();
+    });
+
+    test('when the plain name is neither a member nor a representative in the base set, then it returns null', () => {
+      const result = linkBurst('regular_photo', 'uuid-regular', plainNameIndex, burstBaseSet);
+      expect(result).toBeNull();
+    });
+
+    test('when the plain name is null, then it returns null', () => {
+      const result = linkBurst(null, 'uuid-null', plainNameIndex, burstBaseSet);
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/services/photos/burst/BurstCloudLinker.ts
+++ b/src/services/photos/burst/BurstCloudLinker.ts
@@ -1,0 +1,59 @@
+import { BurstRole } from '../database/photosLocalDB';
+import { getRepresentativePlainNameFromMember, isBurstMemberPlainName } from './burst.constants';
+
+interface BurstLinkResult {
+  burstRole: BurstRole;
+  burstGroupId: string;
+}
+
+/**
+ * Resolves the burst role and group ID for a single cloud asset entry during cloud history sync.
+ *
+ *
+ * @param plainName - Plain name of the cloud asset (e.g. `"IMG_0042"` or `"IMG_0042.burst.3"`).
+ * @param remoteFileId - Remote file ID of this asset, used as `burstGroupId` when it is the representative.
+ * @param plainNameIndex - Map of `plainName -> remoteFileId` for the current discovery batch; used to look up the representative's ID from a member.
+ * @param burstBaseSet - Pre-computed set of base plain names that have at least one `.burst.N` child in the batch. Build it once with {@link buildBurstBaseSet} before iterating entries.
+ * @returns A `BurstLinkResult` with role and group ID, or `null` if the asset is not part of any burst group.
+ */
+export const linkBurst = (
+  plainName: string | null | undefined,
+  remoteFileId: string,
+  plainNameIndex: Map<string, string>,
+  burstBaseSet: Set<string>,
+): BurstLinkResult | null => {
+  if (!plainName) return null;
+
+  if (isBurstMemberPlainName(plainName)) {
+    const baseName = getRepresentativePlainNameFromMember(plainName);
+    const repRemoteFileId = plainNameIndex.get(baseName.toLowerCase());
+    if (!repRemoteFileId) {
+      return null;
+    }
+    return { burstRole: 'member', burstGroupId: repRemoteFileId };
+  }
+
+  if (burstBaseSet.has(plainName)) {
+    return { burstRole: 'representative', burstGroupId: remoteFileId };
+  }
+
+  return null;
+};
+
+/**
+ * Builds the set of base plain names that have at least one `.burst.N` child in the batch.
+ *
+ * Call this once per discovery batch before iterating entries, then pass the result to {@link linkBurst}.
+ *
+ * @param plainNames - All decrypted plain names in the current discovery batch (nulls/undefineds are skipped).
+ * @returns A `Set` of base plain names (e.g. `"IMG_0042"`) for which at least one burst member exists.
+ */
+export const buildBurstBaseSet = (plainNames: (string | null | undefined)[]): Set<string> => {
+  const set = new Set<string>();
+  for (const name of plainNames) {
+    if (name && isBurstMemberPlainName(name)) {
+      set.add(getRepresentativePlainNameFromMember(name));
+    }
+  }
+  return set;
+};

--- a/src/services/photos/burst/BurstFetchService.spec.ts
+++ b/src/services/photos/burst/BurstFetchService.spec.ts
@@ -1,0 +1,136 @@
+import { CloudPhotoItem } from 'src/screens/PhotosScreen/types';
+import { photosLocalDB } from '../database/photosLocalDB';
+import { PhotoAssetFetchService } from '../PhotoAssetFetchService';
+import { BurstFetchService } from './BurstFetchService';
+import { BurstNativeModule } from './BurstNativeModule';
+
+jest.mock('./BurstNativeModule', () => ({
+  BurstNativeModule: {
+    getBurstRepresentativeIds: jest.fn(),
+    exportBurstMembers: jest.fn(),
+    saveBurst: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock('src/services/photos/database/photosLocalDB', () => ({
+  photosLocalDB: {
+    getBurstMembers: jest.fn().mockResolvedValue([]),
+  },
+}));
+
+jest.mock('src/services/photos/PhotoAssetFetchService', () => ({
+  PhotoAssetFetchService: {
+    fetchUri: jest.fn(),
+  },
+}));
+
+const mockSaveBurst = BurstNativeModule.saveBurst as jest.MockedFunction<typeof BurstNativeModule.saveBurst>;
+const mockGetBurstMembers = photosLocalDB.getBurstMembers as jest.MockedFunction<typeof photosLocalDB.getBurstMembers>;
+const mockFetchUri = PhotoAssetFetchService.fetchUri as jest.MockedFunction<typeof PhotoAssetFetchService.fetchUri>;
+
+const makeCloudItem = (overrides: Partial<CloudPhotoItem> = {}): CloudPhotoItem => ({
+  id: 'rep-uuid',
+  type: 'cloud-only',
+  mediaType: 'photo',
+  thumbnailPath: null,
+  thumbnailBucketId: null,
+  thumbnailBucketFile: null,
+  thumbnailType: null,
+  deviceId: 'device-1',
+  createdAt: 1714000000000,
+  fileName: 'IMG_1234.heic',
+  burstGroupId: 'burst-group-1',
+  isBurst: true,
+  ...overrides,
+});
+
+describe('burst fetch service', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('when the item has no burstGroupId, then it returns false without fetching anything', async () => {
+    const item = makeCloudItem({ burstGroupId: undefined });
+    const controller = new AbortController();
+
+    const result = await BurstFetchService.saveBurstToDevice(item, controller.signal);
+
+    expect(result).toBe(false);
+    expect(mockFetchUri).not.toHaveBeenCalled();
+  });
+
+  test('when the representative and its members download successfully, then saveBurst receives raw paths without the file:// prefix', async () => {
+    mockGetBurstMembers.mockResolvedValue([
+      {
+        remoteFileId: 'member-uuid-0',
+        deviceId: 'device-1',
+        createdAt: 1714000000000,
+        fileName: 'IMG_1234.burst.0.heic',
+        fileSize: null,
+        fileId: null,
+        thumbnailPath: null,
+        thumbnailBucketId: null,
+        thumbnailBucketFile: null,
+        thumbnailType: null,
+        discoveredAt: 1714000000000,
+      },
+    ]);
+    mockFetchUri
+      .mockResolvedValueOnce('file:///var/mobile/burst/rep.heic')
+      .mockResolvedValueOnce('file:///var/mobile/burst/member0.heic');
+
+    const controller = new AbortController();
+    const result = await BurstFetchService.saveBurstToDevice(makeCloudItem(), controller.signal);
+
+    expect(result).toBe(true);
+    expect(mockSaveBurst).toHaveBeenCalledWith(['/var/mobile/burst/rep.heic', '/var/mobile/burst/member0.heic']);
+  });
+
+  test('when one of the fetched URIs is null, then it returns false without calling saveBurst', async () => {
+    mockFetchUri.mockResolvedValueOnce('file:///var/mobile/burst/rep.heic').mockResolvedValueOnce(null);
+    mockGetBurstMembers.mockResolvedValue([
+      {
+        remoteFileId: 'member-uuid-0',
+        deviceId: 'device-1',
+        createdAt: 1714000000000,
+        fileName: 'IMG_1234.burst.0.heic',
+        fileSize: null,
+        fileId: null,
+        thumbnailPath: null,
+        thumbnailBucketId: null,
+        thumbnailBucketFile: null,
+        thumbnailType: null,
+        discoveredAt: 1714000000000,
+      },
+    ]);
+
+    const controller = new AbortController();
+    const result = await BurstFetchService.saveBurstToDevice(makeCloudItem(), controller.signal);
+
+    expect(result).toBe(false);
+    expect(mockSaveBurst).not.toHaveBeenCalled();
+  });
+
+  test('when the signal is aborted after fetching URIs, then it returns false without calling saveBurst', async () => {
+    const controller = new AbortController();
+    mockFetchUri.mockImplementation(async () => {
+      controller.abort();
+      return 'file:///var/mobile/burst/rep.heic';
+    });
+
+    const result = await BurstFetchService.saveBurstToDevice(makeCloudItem(), controller.signal);
+
+    expect(result).toBe(false);
+    expect(mockSaveBurst).not.toHaveBeenCalled();
+  });
+
+  test('when no burst members exist in the database, then only the representative is saved', async () => {
+    mockGetBurstMembers.mockResolvedValue([]);
+    mockFetchUri.mockResolvedValue('file:///var/mobile/burst/rep.heic');
+
+    const controller = new AbortController();
+    const result = await BurstFetchService.saveBurstToDevice(makeCloudItem(), controller.signal);
+
+    expect(result).toBe(true);
+    expect(mockFetchUri).toHaveBeenCalledTimes(1);
+    expect(mockSaveBurst).toHaveBeenCalledWith(['/var/mobile/burst/rep.heic']);
+  });
+});

--- a/src/services/photos/burst/BurstFetchService.ts
+++ b/src/services/photos/burst/BurstFetchService.ts
@@ -1,0 +1,73 @@
+import { CloudPhotoItem } from 'src/screens/PhotosScreen/types';
+import { logger } from 'src/services/common';
+import { stripFileUri } from 'src/services/common/uri/uriHelpers';
+import { photosLocalDB } from '../database/photosLocalDB';
+import { PhotoAssetFetchService } from '../PhotoAssetFetchService';
+import { BurstNativeModule } from './BurstNativeModule';
+
+const entryToCloudPhotoItem = (entry: {
+  remoteFileId: string;
+  fileName: string;
+  thumbnailPath: string | null;
+  thumbnailBucketId: string | null;
+  thumbnailBucketFile: string | null;
+  thumbnailType: string | null;
+  deviceId: string;
+  createdAt: number;
+}): CloudPhotoItem => ({
+  id: entry.remoteFileId,
+  type: 'cloud-only',
+  mediaType: 'photo',
+  thumbnailPath: entry.thumbnailPath,
+  thumbnailBucketId: entry.thumbnailBucketId,
+  thumbnailBucketFile: entry.thumbnailBucketFile,
+  thumbnailType: entry.thumbnailType,
+  deviceId: entry.deviceId,
+  createdAt: entry.createdAt,
+  fileName: entry.fileName,
+});
+
+/**
+ * Handles downloading and restoring burst photo groups from the cloud to the device photo library.
+ */
+export const BurstFetchService = {
+  /**
+   * Downloads the burst representative and all its members, then calls the native
+   * `saveBurst` to reconstruct the burst group in the device photo library.
+   *
+   * If no member entries are found in the local DB (e.g. cloud sync hasn't linked them yet),
+   * only the representative is restored and a warning is logged — the call still succeeds.
+   *
+   * @param item - The representative `CloudPhotoItem` for the burst group. Must have `burstGroupId` set.
+   * @param signal - `AbortSignal` used to cancel in-flight downloads; returns `false` immediately if aborted.
+   * @returns `true` on success, `false` if aborted, if `burstGroupId` is missing, or if any member URI could not be resolved.
+   */
+  saveBurstToDevice: async (item: CloudPhotoItem, signal: AbortSignal): Promise<boolean> => {
+    if (!item.burstGroupId) return false;
+
+    const memberEntries = await photosLocalDB.getBurstMembers(item.burstGroupId);
+    if (memberEntries.length === 0) {
+      logger.warn(`[BurstFetch] No members found for burst group ${item.burstGroupId} — restoring representative only`);
+    }
+
+    const allItems: CloudPhotoItem[] = [item, ...memberEntries.map(entryToCloudPhotoItem)];
+
+    const uriResults = await Promise.all(allItems.map((i) => PhotoAssetFetchService.fetchUri(i, signal)));
+
+    if (signal.aborted) {
+      return false;
+    }
+
+    const paths: string[] = [];
+    for (const uri of uriResults) {
+      if (!uri) {
+        return false;
+      }
+      // saveBurst needs raw paths (no file:// prefix), same as saveLivePhoto pattern.
+      paths.push(stripFileUri(uri));
+    }
+
+    await BurstNativeModule.saveBurst(paths);
+    return true;
+  },
+};

--- a/src/services/photos/burst/BurstNativeModule.ts
+++ b/src/services/photos/burst/BurstNativeModule.ts
@@ -1,0 +1,42 @@
+import { NativeModules, Platform } from 'react-native';
+
+interface BurstMember {
+  uri: string;
+  size: number;
+  fileName: string;
+}
+
+interface PHBurstExportNative {
+  getBurstRepresentativeIds(localIds: string[]): Promise<string[]>;
+  exportBurstMembers(representativeId: string): Promise<{ members: BurstMember[] }>;
+  saveBurst(memberPaths: string[]): Promise<void>;
+}
+
+const nativeModule: PHBurstExportNative | null =
+  Platform.OS === 'ios' ? (NativeModules.PHBurstExport as PHBurstExportNative) : null;
+
+export const BurstNativeModule = {
+  getBurstRepresentativeIds: async (localIds: string[]): Promise<string[]> => {
+    if (!nativeModule || localIds.length === 0) {
+      return [];
+    }
+    return nativeModule.getBurstRepresentativeIds(localIds);
+  },
+
+  exportBurstMembers: async (representativeId: string): Promise<BurstMember[]> => {
+    if (!nativeModule) {
+      return [];
+    }
+    const result = await nativeModule.exportBurstMembers(representativeId);
+    return result.members;
+  },
+
+  saveBurst: async (memberPaths: string[]): Promise<void> => {
+    if (!nativeModule || memberPaths.length === 0) {
+      return;
+    }
+    return nativeModule.saveBurst(memberPaths);
+  },
+};
+
+export type { BurstMember };

--- a/src/services/photos/burst/BurstUploadHandler.spec.ts
+++ b/src/services/photos/burst/BurstUploadHandler.spec.ts
@@ -1,0 +1,281 @@
+import { AbortError } from 'src/network/errors';
+import { photosLocalDB } from '../database/photosLocalDB';
+import { BurstNativeModule } from './BurstNativeModule';
+import { retryIncompleteBursts, uploadBurstMembers } from './BurstUploadHandler';
+
+jest.mock('./BurstNativeModule', () => ({
+  BurstNativeModule: {
+    getBurstRepresentativeIds: jest.fn(),
+    exportBurstMembers: jest.fn(),
+    saveBurst: jest.fn(),
+  },
+}));
+
+jest.mock('src/services/FileSystemService', () => ({
+  __esModule: true,
+  default: {
+    unlinkIfExists: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock('src/services/photos/database/photosLocalDB', () => ({
+  photosLocalDB: {
+    getIncompleteBurstAssets: jest.fn().mockResolvedValue([]),
+    markSyncedBurst: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock('src/services/AsyncStorageService', () => ({
+  __esModule: true,
+  default: {
+    getUser: jest.fn().mockResolvedValue({
+      userId: 'user-1',
+      email: 'test@internxt.com',
+      mnemonic: 'word '.repeat(12).trim(),
+      bridgeUser: 'bridge-user',
+      bridgePass: 'bridge-pass',
+    }),
+  },
+}));
+
+jest.mock('src/services/photos/PhotoBackupFolders', () => ({
+  photoBackupFolders: {
+    getOrCreateFolderForDate: jest.fn().mockResolvedValue('folder-uuid-abc'),
+  },
+}));
+
+jest.mock('src/lib/network', () => ({
+  getEnvironmentConfigFromUser: jest.fn().mockReturnValue({
+    encryptionKey: 'enc-key',
+    bridgeUser: 'bridge-user',
+    bridgePass: 'bridge-pass',
+  }),
+}));
+
+const mockExportBurstMembers = BurstNativeModule.exportBurstMembers as jest.MockedFunction<
+  typeof BurstNativeModule.exportBurstMembers
+>;
+const mockPhotosLocalDB = photosLocalDB as jest.Mocked<typeof photosLocalDB>;
+
+const baseParams = {
+  assetId: 'local-id-123',
+  representativePlainName: 'IMG_1234',
+  folderUuid: 'folder-uuid-abc',
+  creationIso: '2024-01-01T00:00:00.000Z',
+  modificationIso: '2024-01-01T00:00:00.000Z',
+  credentials: { bucketId: 'bucket', encryptionKey: 'key', bridgeUser: 'user', bridgePass: 'pass' },
+};
+
+describe('burst upload handler — maybeUploadBurstMembers', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('when the asset has no burst members, then it returns null without calling the upload function', async () => {
+    mockExportBurstMembers.mockResolvedValue([]);
+    const uploadMember = jest.fn();
+
+    const result = await uploadBurstMembers({ ...baseParams, uploadMember });
+
+    expect(result).toBeNull();
+    expect(uploadMember).not.toHaveBeenCalled();
+  });
+
+  test('when the asset has two burst members, then it uploads each one with a numbered plain name and returns their uuids', async () => {
+    mockExportBurstMembers.mockResolvedValue([
+      { uri: 'file:///tmp/member0.heic', size: 1000, fileName: 'member0.heic' },
+      { uri: 'file:///tmp/member1.heic', size: 1200, fileName: 'member1.heic' },
+    ]);
+    const uploadMember = jest.fn().mockResolvedValueOnce('uuid-0').mockResolvedValueOnce('uuid-1');
+
+    const result = await uploadBurstMembers({ ...baseParams, uploadMember });
+
+    expect(result).toEqual({ burstId: 'local-id-123', memberUuids: ['uuid-0', 'uuid-1'] });
+    expect(uploadMember).toHaveBeenCalledTimes(2);
+    expect(uploadMember).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plainName: 'IMG_1234.burst.0',
+        fileExtension: 'heic',
+        localFilePath: '/tmp/member0.heic',
+      }),
+    );
+    expect(uploadMember).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plainName: 'IMG_1234.burst.1',
+        fileExtension: 'heic',
+        localFilePath: '/tmp/member1.heic',
+      }),
+    );
+  });
+
+  test('when the member uri starts with file://, then the prefix is stripped before upload', async () => {
+    mockExportBurstMembers.mockResolvedValue([
+      { uri: 'file:///var/mobile/tmp/burst0.jpg', size: 800, fileName: 'burst0.jpg' },
+    ]);
+    const uploadMember = jest.fn().mockResolvedValue('uuid-strip');
+
+    await uploadBurstMembers({ ...baseParams, uploadMember });
+
+    expect(uploadMember).toHaveBeenCalledWith(expect.objectContaining({ localFilePath: '/var/mobile/tmp/burst0.jpg' }));
+  });
+
+  test('when a member has no file extension, then that member is skipped and does not reach the upload function', async () => {
+    mockExportBurstMembers.mockResolvedValue([
+      { uri: 'file:///tmp/noext', size: 500, fileName: 'noext' },
+      { uri: 'file:///tmp/member1.heic', size: 900, fileName: 'member1.heic' },
+    ]);
+    const uploadMember = jest.fn().mockResolvedValue('uuid-1');
+
+    const result = await uploadBurstMembers({ ...baseParams, uploadMember });
+
+    expect(uploadMember).toHaveBeenCalledTimes(1);
+    expect(uploadMember).toHaveBeenCalledWith(expect.objectContaining({ localFilePath: '/tmp/member1.heic' }));
+    expect(result?.memberUuids).toEqual(['uuid-1']);
+  });
+
+  test('when the abort signal fires between members, then processing stops and an AbortError is thrown', async () => {
+    const controller = new AbortController();
+    mockExportBurstMembers.mockResolvedValue([
+      { uri: 'file:///tmp/member0.heic', size: 1000, fileName: 'member0.heic' },
+      { uri: 'file:///tmp/member1.heic', size: 1000, fileName: 'member1.heic' },
+    ]);
+    const uploadMember = jest.fn().mockImplementation(async () => {
+      controller.abort();
+      return 'uuid-0';
+    });
+
+    await expect(uploadBurstMembers({ ...baseParams, signal: controller.signal, uploadMember })).rejects.toBeInstanceOf(
+      AbortError,
+    );
+
+    expect(uploadMember).toHaveBeenCalledTimes(1);
+  });
+
+  test('when exportBurstMembers throws, then it returns null without propagating the error', async () => {
+    mockExportBurstMembers.mockRejectedValue(new Error('PHKit error'));
+    const uploadMember = jest.fn();
+
+    const result = await uploadBurstMembers({ ...baseParams, uploadMember });
+
+    expect(result).toBeNull();
+    expect(uploadMember).not.toHaveBeenCalled();
+  });
+});
+
+describe('burst upload handler — retryIncompleteBursts', () => {
+  const uploadMember = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    uploadMember.mockResolvedValue('uuid-member');
+  });
+
+  test('when there are no incomplete bursts, then the upload function is never called', async () => {
+    mockPhotosLocalDB.getIncompleteBurstAssets.mockResolvedValue([]);
+
+    await retryIncompleteBursts({ deviceId: 'dev-1', photosBucket: 'bucket-1', uploadMember });
+
+    expect(uploadMember).not.toHaveBeenCalled();
+  });
+
+  test('when a burst still has no members after retry, then it stays incomplete and markSyncedBurst is not called', async () => {
+    mockPhotosLocalDB.getIncompleteBurstAssets.mockResolvedValue([
+      {
+        assetId: 'burst-1',
+        remoteFileId: 'remote-1',
+        fileName: 'IMG_0001.heic',
+        creationTime: 1000,
+        modificationTime: 1000,
+      },
+    ]);
+    mockExportBurstMembers.mockResolvedValue([]);
+
+    await retryIncompleteBursts({ deviceId: 'dev-1', photosBucket: 'bucket-1', uploadMember });
+
+    expect(mockPhotosLocalDB.markSyncedBurst).not.toHaveBeenCalled();
+  });
+
+  test('when a burst gains members on retry, then it is marked complete with the member count', async () => {
+    mockPhotosLocalDB.getIncompleteBurstAssets.mockResolvedValue([
+      {
+        assetId: 'burst-1',
+        remoteFileId: 'remote-1',
+        fileName: 'IMG_0001.heic',
+        creationTime: 1714000000000,
+        modificationTime: 1714000000000,
+      },
+    ]);
+    mockExportBurstMembers.mockResolvedValue([
+      { uri: 'file:///tmp/f0.heic', size: 1000, fileName: 'f0.heic' },
+      { uri: 'file:///tmp/f1.heic', size: 1000, fileName: 'f1.heic' },
+    ]);
+    uploadMember.mockResolvedValueOnce('member-uuid-0').mockResolvedValueOnce('member-uuid-1');
+
+    await retryIncompleteBursts({ deviceId: 'dev-1', photosBucket: 'bucket-1', uploadMember });
+
+    expect(mockPhotosLocalDB.markSyncedBurst).toHaveBeenCalledWith(
+      'burst-1',
+      'remote-1',
+      1714000000000,
+      'burst-1',
+      ['member-uuid-0', 'member-uuid-1'],
+      2,
+    );
+  });
+
+  test('when the signal is aborted before processing starts, then no burst is processed', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    mockPhotosLocalDB.getIncompleteBurstAssets.mockResolvedValue([
+      {
+        assetId: 'burst-1',
+        remoteFileId: 'remote-1',
+        fileName: 'IMG_0001.heic',
+        creationTime: 1000,
+        modificationTime: 1000,
+      },
+    ]);
+
+    await retryIncompleteBursts({
+      deviceId: 'dev-1',
+      photosBucket: 'bucket-1',
+      signal: controller.signal,
+      uploadMember,
+    });
+
+    expect(uploadMember).not.toHaveBeenCalled();
+    expect(mockPhotosLocalDB.markSyncedBurst).not.toHaveBeenCalled();
+  });
+
+  test('when one burst fails, then it logs the error and continues with the next burst', async () => {
+    mockPhotosLocalDB.getIncompleteBurstAssets.mockResolvedValue([
+      {
+        assetId: 'burst-fail',
+        remoteFileId: 'remote-fail',
+        fileName: 'IMG_FAIL.heic',
+        creationTime: 1000,
+        modificationTime: 1000,
+      },
+      {
+        assetId: 'burst-ok',
+        remoteFileId: 'remote-ok',
+        fileName: 'IMG_OK.heic',
+        creationTime: 1714000000000,
+        modificationTime: 1714000000000,
+      },
+    ]);
+    mockExportBurstMembers
+      .mockRejectedValueOnce(new Error('export error'))
+      .mockResolvedValueOnce([{ uri: 'file:///tmp/f0.heic', size: 1000, fileName: 'f0.heic' }]);
+
+    await retryIncompleteBursts({ deviceId: 'dev-1', photosBucket: 'bucket-1', uploadMember });
+
+    expect(mockPhotosLocalDB.markSyncedBurst).toHaveBeenCalledTimes(1);
+    expect(mockPhotosLocalDB.markSyncedBurst).toHaveBeenCalledWith(
+      'burst-ok',
+      'remote-ok',
+      1714000000000,
+      'burst-ok',
+      ['uuid-member'],
+      1,
+    );
+  });
+});

--- a/src/services/photos/burst/BurstUploadHandler.ts
+++ b/src/services/photos/burst/BurstUploadHandler.ts
@@ -1,0 +1,260 @@
+import * as MediaLibrary from 'expo-media-library';
+import { Platform } from 'react-native';
+import { getEnvironmentConfigFromUser } from 'src/lib/network';
+import { AbortError } from 'src/network/errors';
+import asyncStorageService from 'src/services/AsyncStorageService';
+import { logger } from 'src/services/common';
+import { stripFileUri } from 'src/services/common/uri/uriHelpers';
+import fileSystemService from 'src/services/FileSystemService';
+import { photosLocalDB } from '../database/photosLocalDB';
+import { photoBackupFolders } from '../PhotoBackupFolders';
+import { UploadCredentials } from '../PhotoUploadService';
+import { splitFileNameAndExtension } from '../PhotoUploadService.utils';
+import { getBurstMemberPlainName } from './burst.constants';
+import { BurstMember, BurstNativeModule } from './BurstNativeModule';
+
+interface UploadMemberParams {
+  localFilePath: string;
+  folderUuid: string;
+  plainName: string;
+  fileExtension: string;
+  creationIso: string;
+  modificationIso: string;
+  credentials: UploadCredentials;
+  onProgress?: (ratio: number) => void;
+  signal?: AbortSignal;
+}
+
+export interface BurstUploadResult {
+  burstId: string;
+  memberUuids: string[];
+}
+
+interface MaybeUploadMembersParams {
+  assetId: string;
+  representativePlainName: string;
+  folderUuid: string;
+  creationIso: string;
+  modificationIso: string;
+  credentials: UploadCredentials;
+  signal?: AbortSignal;
+  uploadMember: (params: UploadMemberParams) => Promise<string>;
+}
+
+/**
+ * Exports and uploads all non-representative members of a burst group (iOS only).
+ *
+ * @returns The burst ID and uploaded member UUIDs on success, or `null` if there are no members
+ *   to upload — either because the asset is not a burst, or because limited photo access
+ *   prevented the native export. The caller can distinguish the limited-access case by checking
+ *   `isBurst` in the DB and calling `markSyncedBurst` with `memberCount = null` to schedule a retry.
+ */
+export const uploadBurstMembers = async (params: MaybeUploadMembersParams): Promise<BurstUploadResult | null> => {
+  const {
+    assetId,
+    representativePlainName,
+    folderUuid,
+    creationIso,
+    modificationIso,
+    credentials,
+    signal,
+    uploadMember,
+  } = params;
+
+  logger.info(`[BurstUpload] exportBurstMembers start — assetId=${assetId}`);
+  let members: BurstMember[];
+  try {
+    members = await BurstNativeModule.exportBurstMembers(assetId);
+  } catch (err) {
+    logger.error(`[BurstUpload] exportBurstMembers threw — assetId=${assetId}: ${err}`);
+    return null;
+  }
+  logger.info(`[BurstUpload] exportBurstMembers done — members=${members.length}`);
+  if (members.length === 0) {
+    return null;
+  }
+
+  const memberUuids: string[] = [];
+  const tempPaths: string[] = [];
+
+  try {
+    for (let i = 0; i < members.length; i++) {
+      if (signal?.aborted) {
+        throw new AbortError();
+      }
+
+      const member = members[i];
+      const localFilePath = stripFileUri(member.uri);
+      tempPaths.push(localFilePath);
+
+      const { fileExtension: rawExt } = splitFileNameAndExtension(member.fileName);
+      if (!rawExt) {
+        logger.warn(`[BurstUpload] Member ${i} has no extension in fileName="${member.fileName}" — skipping`);
+        continue;
+      }
+      const ext = rawExt.toLowerCase();
+      const plainName = getBurstMemberPlainName(representativePlainName, i);
+
+      const uuid = await uploadMember({
+        localFilePath,
+        folderUuid,
+        plainName,
+        fileExtension: ext,
+        creationIso,
+        modificationIso,
+        credentials,
+        signal,
+      });
+
+      memberUuids.push(uuid);
+    }
+  } finally {
+    for (const path of tempPaths) {
+      await fileSystemService.unlinkIfExists(path);
+    }
+  }
+
+  // burstId is the assetId of the representative
+  return { burstId: assetId, memberUuids };
+};
+
+/**
+ * Retries member uploads for burst representatives that were previously marked synced but incomplete,
+ * typically because limited photo access prevented the native export.
+ *
+ * Called on every upload cycle before the main queue. If access is still limited the representative
+ * stays incomplete and will be retried again next cycle. The representative is never re-uploaded.
+ *
+ * Idempotent: if a previous cycle uploaded some members before a network failure, those `.burst.N`
+ * files already exist in Drive and `uploadSingleFile`'s existence check skips them.
+ *
+ * @returns The number of burst groups fully completed in this cycle.
+ */
+export const retryIncompleteBursts = async (params: {
+  deviceId: string;
+  photosBucket: string;
+  signal?: AbortSignal;
+  uploadMember: (params: UploadMemberParams) => Promise<string>;
+}): Promise<number> => {
+  const { deviceId, photosBucket, signal, uploadMember } = params;
+
+  const incompleteBursts = await photosLocalDB.getIncompleteBurstAssets();
+  if (incompleteBursts.length === 0) {
+    return 0;
+  }
+
+  const user = await asyncStorageService.getUser();
+  const { encryptionKey, bridgeUser, bridgePass } = getEnvironmentConfigFromUser(user);
+  const credentials: UploadCredentials = { bucketId: photosBucket, encryptionKey, bridgeUser, bridgePass };
+
+  let completed = 0;
+  for (const burst of incompleteBursts) {
+    if (signal?.aborted) break;
+    try {
+      const createdDate = new Date(burst.creationTime ?? 0);
+      const folderUuid = await photoBackupFolders.getOrCreateFolderForDate(deviceId, createdDate);
+      const { plainName: representativePlainName } = splitFileNameAndExtension(burst.fileName ?? '');
+
+      const result = await uploadBurstMembers({
+        assetId: burst.assetId,
+        representativePlainName,
+        folderUuid,
+        creationIso: createdDate.toISOString(),
+        modificationIso: new Date(burst.modificationTime ?? burst.creationTime ?? 0).toISOString(),
+        credentials,
+        signal,
+        uploadMember,
+      });
+
+      if (result) {
+        await photosLocalDB.markSyncedBurst(
+          burst.assetId,
+          burst.remoteFileId ?? result.burstId,
+          burst.modificationTime,
+          result.burstId,
+          result.memberUuids,
+          result.memberUuids.length,
+        );
+        logger.info(`[BurstUpload] Retry complete — assetId=${burst.assetId} members=${result.memberUuids.length}`);
+        completed++;
+      }
+    } catch (err) {
+      if (err instanceof AbortError) break;
+      logger.error(`[BurstUpload] Member retry failed for ${burst.assetId}: ${String(err)}`);
+    }
+  }
+  return completed;
+};
+
+/**
+ * Uploads burst members for an asset that is a burst representative on iOS.
+ * No-op on Android or when the asset is not flagged as burst in the local DB.
+ *
+ * @returns Uploaded member UUIDs on success, `undefined` if the asset is not a burst or not on iOS.
+ */
+export const uploadBurstMembersIfBurst = async (params: {
+  assetId: string;
+  representativePlainName: string;
+  folderUuid: string;
+  creationIso: string;
+  modificationIso: string;
+  credentials: UploadCredentials;
+  signal?: AbortSignal;
+  uploadMember: (params: UploadMemberParams) => Promise<string>;
+}): Promise<BurstUploadResult | undefined> => {
+  if (Platform.OS !== 'ios') {
+    return undefined;
+  }
+
+  const status = await photosLocalDB.getStatus(params.assetId);
+  if (!status?.isBurst) {
+    return undefined;
+  }
+
+  const result = await uploadBurstMembers(params);
+  return result ?? undefined;
+};
+
+/**
+ * Resolves credentials and folder uuid, then uploads burst members for a representative
+ * No-op on Android or when the asset is not flagged as burst in the local DB.
+ *
+ * @returns Uploaded member UUIDs on success, `undefined` if the asset is not a burst or not on iOS.
+ */
+export const uploadBurstMembersForExistingRepresentative = async (params: {
+  asset: MediaLibrary.Asset;
+  deviceId: string;
+  photosBucket: string;
+  signal?: AbortSignal;
+  uploadMember: (params: UploadMemberParams) => Promise<string>;
+}): Promise<BurstUploadResult | undefined> => {
+  const { asset, deviceId, photosBucket, signal, uploadMember } = params;
+
+  if (Platform.OS !== 'ios') {
+    return undefined;
+  }
+  const status = await photosLocalDB.getStatus(asset.id);
+  if (!status?.isBurst) {
+    return undefined;
+  }
+
+  const createdDate = new Date(asset.creationTime);
+  const { plainName } = splitFileNameAndExtension(asset.filename);
+  const [user, folderUuid] = await Promise.all([
+    asyncStorageService.getUser(),
+    photoBackupFolders.getOrCreateFolderForDate(deviceId, createdDate),
+  ]);
+  const { encryptionKey, bridgeUser, bridgePass } = getEnvironmentConfigFromUser(user);
+  const credentials: UploadCredentials = { bucketId: photosBucket, encryptionKey, bridgeUser, bridgePass };
+  const result = await uploadBurstMembers({
+    assetId: asset.id,
+    representativePlainName: plainName,
+    folderUuid,
+    creationIso: createdDate.toISOString(),
+    modificationIso: new Date(asset.modificationTime).toISOString(),
+    credentials,
+    signal,
+    uploadMember,
+  });
+  return result ?? undefined;
+};

--- a/src/services/photos/burst/burst.constants.spec.ts
+++ b/src/services/photos/burst/burst.constants.spec.ts
@@ -1,0 +1,47 @@
+import {
+  getBurstMemberPlainName,
+  getRepresentativePlainNameFromMember,
+  isBurstMemberPlainName,
+} from './burst.constants';
+
+describe('burst member plain name helpers', () => {
+  describe('when building a member plain name', () => {
+    test('when given a base name and index, then it returns the expected dot-separated member name', () => {
+      expect(getBurstMemberPlainName('IMG_1234', 0)).toBe('IMG_1234.burst.0');
+      expect(getBurstMemberPlainName('IMG_1234', 5)).toBe('IMG_1234.burst.5');
+    });
+
+    test('when given a name with mixed casing, then the base is preserved unchanged', () => {
+      expect(getBurstMemberPlainName('MyPhoto', 2)).toBe('MyPhoto.burst.2');
+    });
+  });
+
+  describe('when detecting whether a plain name belongs to a burst member', () => {
+    test('when the name ends with the burst infix and an index, then it is detected as a member', () => {
+      expect(isBurstMemberPlainName('IMG_1234.burst.0')).toBe(true);
+      expect(isBurstMemberPlainName('IMG_1234.burst.99')).toBe(true);
+    });
+
+    test('when the name is the representative or an unrelated name, then it is not detected as a member', () => {
+      expect(isBurstMemberPlainName('IMG_1234')).toBe(false);
+      expect(isBurstMemberPlainName('IMG_1234.livephoto')).toBe(false);
+      expect(isBurstMemberPlainName('IMG_1234.burst')).toBe(false);
+      expect(isBurstMemberPlainName('')).toBe(false);
+    });
+
+    test('when the burst infix appears in the middle but not at the end, then it is not detected as a member', () => {
+      expect(isBurstMemberPlainName('IMG.burst.0.extra')).toBe(false);
+    });
+  });
+
+  describe('when recovering the representative plain name from a member name', () => {
+    test('when given a valid member name, then it returns the base without the burst suffix', () => {
+      expect(getRepresentativePlainNameFromMember('IMG_1234.burst.0')).toBe('IMG_1234');
+      expect(getRepresentativePlainNameFromMember('IMG_1234.burst.99')).toBe('IMG_1234');
+    });
+
+    test('when given a multi-word base name, then the full base is preserved', () => {
+      expect(getRepresentativePlainNameFromMember('My Photo 2024.burst.3')).toBe('My Photo 2024');
+    });
+  });
+});

--- a/src/services/photos/burst/burst.constants.ts
+++ b/src/services/photos/burst/burst.constants.ts
@@ -1,0 +1,11 @@
+export const BURST_MEMBER_INFIX = '.burst.';
+
+export const getBurstMemberPlainName = (repPlainName: string, index: number): string =>
+  `${repPlainName}${BURST_MEMBER_INFIX}${index}`;
+
+const BURST_MEMBER_PATTERN = /\.burst\.\d+$/;
+
+export const isBurstMemberPlainName = (plainName: string): boolean => BURST_MEMBER_PATTERN.test(plainName);
+
+export const getRepresentativePlainNameFromMember = (memberPlainName: string): string =>
+  memberPlainName.replace(BURST_MEMBER_PATTERN, '');

--- a/src/services/photos/burst/index.ts
+++ b/src/services/photos/burst/index.ts
@@ -1,0 +1,5 @@
+export * from './burst.constants';
+export * from './BurstNativeModule';
+export * from './BurstUploadHandler';
+export * from './BurstCloudLinker';
+export * from './BurstFetchService';

--- a/src/services/photos/database/photosLocalDB.spec.ts
+++ b/src/services/photos/database/photosLocalDB.spec.ts
@@ -24,7 +24,7 @@ describe('photosLocalDB', () => {
     await photosLocalDB.init();
 
     expect(mockSqlite.open).toHaveBeenCalledWith('photos_sync.db');
-    expect(mockSqlite.executeSql).toHaveBeenCalledTimes(7);
+    expect(mockSqlite.executeSql).toHaveBeenCalledTimes(8);
     const statements = mockSqlite.executeSql.mock.calls.map(([, stmt]) => stmt as string);
     expect(statements.some((s) => s.includes('CREATE TABLE IF NOT EXISTS asset_sync'))).toBe(true);
     expect(statements.some((s) => s.includes('CREATE TABLE IF NOT EXISTS cloud_asset'))).toBe(true);
@@ -44,10 +44,10 @@ describe('photosLocalDB', () => {
 
     expect(mockSqlite.executeSql).toHaveBeenCalledTimes(1);
     const [, stmt, params] = mockSqlite.executeSql.mock.calls[0];
-    expect(stmt).toContain('\'pending\'');
+    expect(stmt).toContain("'pending'");
     expect(stmt).toContain('ON CONFLICT');
-    expect(stmt).toContain('status != \'synced\'');
-    expect(params).toEqual(['asset-1', null, null, null, null, null, null, 0]);
+    expect(stmt).toContain("status != 'synced'");
+    expect(params).toEqual(['asset-1', null, null, null, null, null, null, 0, 0]);
   });
 
   test('when a photo is marked as pending with media info, then all media info fields are passed to the database', async () => {
@@ -61,7 +61,7 @@ describe('photosLocalDB', () => {
     });
 
     const [, , params] = mockSqlite.executeSql.mock.calls[0];
-    expect(params).toEqual(['asset-1', 'photo.jpg', 1714000000000, 3024, 4032, 0, 'photo', 0]);
+    expect(params).toEqual(['asset-1', 'photo.jpg', 1714000000000, 3024, 4032, 0, 'photo', 0, 0]);
   });
 
   test('when a photo is marked as pending for edit, then the status is pending_edit and it never overwrites a non-synced photo', async () => {
@@ -69,9 +69,9 @@ describe('photosLocalDB', () => {
 
     expect(mockSqlite.executeSql).toHaveBeenCalledTimes(1);
     const [, stmt, params] = mockSqlite.executeSql.mock.calls[0];
-    expect(stmt).toContain('\'pending_edit\'');
-    expect(stmt).toContain('status = \'synced\'');
-    expect(params).toEqual(['asset-1', null, null, null, null, null, null, 0]);
+    expect(stmt).toContain("'pending_edit'");
+    expect(stmt).toContain("status = 'synced'");
+    expect(params).toEqual(['asset-1', null, null, null, null, null, null, 0, 0]);
   });
 
   test('when a photo is marked as pending for edit with media info, then all media info fields are passed to the database', async () => {
@@ -85,7 +85,7 @@ describe('photosLocalDB', () => {
     });
 
     const [, , params] = mockSqlite.executeSql.mock.calls[0];
-    expect(params).toEqual(['asset-2', 'video.mp4', 1714000000000, 1920, 1080, 30, 'video', 0]);
+    expect(params).toEqual(['asset-2', 'video.mp4', 1714000000000, 1920, 1080, 30, 'video', 0, 0]);
   });
 
   test('when a file size is cached for an asset, then the file size and asset id are passed to the database', async () => {
@@ -102,7 +102,7 @@ describe('photosLocalDB', () => {
 
     expect(mockSqlite.executeSql).toHaveBeenCalledTimes(1);
     const [, stmt, params] = mockSqlite.executeSql.mock.calls[0];
-    expect(stmt).toContain('\'synced\'');
+    expect(stmt).toContain("'synced'");
     expect(stmt).toContain('unixepoch()');
     expect(params).toEqual(['asset-1', 'remote-file-id', 1714000000]);
   });
@@ -119,7 +119,7 @@ describe('photosLocalDB', () => {
 
     expect(mockSqlite.executeSql).toHaveBeenCalledTimes(1);
     const [, stmt, params] = mockSqlite.executeSql.mock.calls[0];
-    expect(stmt).toContain('\'error\'');
+    expect(stmt).toContain("'error'");
     expect(params).toEqual(['asset-2', null]);
   });
 
@@ -136,7 +136,7 @@ describe('photosLocalDB', () => {
     const [, stmt] = mockSqlite.executeSql.mock.calls[0];
     expect(stmt).toContain('attempt_count + 1');
     expect(stmt).toContain('ON CONFLICT');
-    expect(stmt).toContain('status != \'synced\'');
+    expect(stmt).toContain("status != 'synced'");
   });
 
   test('when looking up synced photos, then both synced and cloud_deleted statuses are queried', async () => {
@@ -145,7 +145,7 @@ describe('photosLocalDB', () => {
     await photosLocalDB.getSyncedEntries(['asset-1']);
 
     const [, stmt] = mockSqlite.getAllAsync.mock.calls[0];
-    expect(stmt).toContain('status IN (\'synced\', \'cloud_deleted\')');
+    expect(stmt).toContain("status IN ('synced', 'cloud_deleted')");
   });
 
   test('when looking up 300 photos at once, then a single database query is made with all ids', async () => {
@@ -235,6 +235,10 @@ describe('photosLocalDB', () => {
       is_live_photo: 0,
       paired_video_remote_file_id: null,
       paired_video_status: null,
+      is_burst: 0,
+      burst_id: null,
+      burst_member_remote_file_ids: null,
+      burst_member_count: null,
     });
 
     const result = await photosLocalDB.getStatus('asset-3');
@@ -260,6 +264,10 @@ describe('photosLocalDB', () => {
       isLivePhoto: false,
       pairedVideoRemoteFileId: null,
       pairedVideoStatus: null,
+      isBurst: false,
+      burstId: null,
+      burstMemberRemoteFileIds: null,
+      burstMemberCount: null,
     });
   });
 
@@ -324,6 +332,10 @@ describe('photosLocalDB', () => {
       is_live_photo: 0,
       paired_video_remote_file_id: null,
       paired_video_status: null,
+      is_burst: 0,
+      burst_id: null,
+      burst_member_remote_file_ids: null,
+      burst_member_count: null,
     });
 
     const result = await photosLocalDB.getStatus('asset-1');
@@ -349,6 +361,10 @@ describe('photosLocalDB', () => {
       isLivePhoto: false,
       pairedVideoRemoteFileId: null,
       pairedVideoStatus: null,
+      isBurst: false,
+      burstId: null,
+      burstMemberRemoteFileIds: null,
+      burstMemberCount: null,
     });
   });
 
@@ -374,6 +390,10 @@ describe('photosLocalDB', () => {
       is_live_photo: 0,
       paired_video_remote_file_id: null,
       paired_video_status: null,
+      is_burst: 0,
+      burst_id: null,
+      burst_member_remote_file_ids: null,
+      burst_member_count: null,
     });
 
     const result = await photosLocalDB.getStatus('asset-2');
@@ -399,6 +419,10 @@ describe('photosLocalDB', () => {
       isLivePhoto: false,
       pairedVideoRemoteFileId: null,
       pairedVideoStatus: null,
+      isBurst: false,
+      burstId: null,
+      burstMemberRemoteFileIds: null,
+      burstMemberCount: null,
     });
   });
 
@@ -415,7 +439,7 @@ describe('photosLocalDB', () => {
     const createTableCalls = statements.filter((s) => s.includes('CREATE TABLE'));
     const createIndexCalls = statements.filter((s) => s.includes('CREATE INDEX'));
     expect(createTableCalls).toHaveLength(2);
-    expect(createIndexCalls).toHaveLength(5);
+    expect(createIndexCalls).toHaveLength(6);
   });
 });
 
@@ -510,9 +534,11 @@ describe('photosLocalDB cloud asset methods', () => {
       null, // updatedAt
       null, // status
       null, // encryptVersion
-      0,    // is_live_photo
+      0, // is_live_photo
       null, // live_photo_role
       null, // paired_remote_file_id
+      null, // burst_role
+      null, // burst_group_id
     ]);
   });
 
@@ -562,9 +588,11 @@ describe('photosLocalDB cloud asset methods', () => {
       1718060000000, // updatedAt
       'EXISTS', // status
       'aes-2', // encryptVersion
-      0,       // is_live_photo
-      null,    // live_photo_role
-      null,    // paired_remote_file_id
+      0, // is_live_photo
+      null, // live_photo_role
+      null, // paired_remote_file_id
+      null, // burst_role
+      null, // burst_group_id
     ]);
   });
 

--- a/src/services/photos/database/photosLocalDB.ts
+++ b/src/services/photos/database/photosLocalDB.ts
@@ -5,6 +5,8 @@ import cloudAssetTable from './tables/cloud_asset';
 const DB_NAME = 'photos_sync.db';
 
 export type LivePhotoRole = 'photo' | 'paired_video';
+// BURST:
+export type BurstRole = 'representative' | 'member';
 
 export interface CloudAssetEntry {
   remoteFileId: string;
@@ -30,6 +32,8 @@ export interface CloudAssetEntry {
   isLivePhoto?: boolean;
   livePhotoRole?: LivePhotoRole | null;
   pairedRemoteFileId?: string | null;
+  burstRole?: BurstRole | null;
+  burstGroupId?: string | null;
 }
 
 interface CloudAssetRow {
@@ -56,6 +60,8 @@ interface CloudAssetRow {
   is_live_photo: number;
   live_photo_role: LivePhotoRole | null;
   paired_remote_file_id: string | null;
+  burst_role: BurstRole | null;
+  burst_group_id: string | null;
 }
 
 export type AssetSyncStatus = 'pending' | 'pending_edit' | 'synced' | 'error' | 'deleted' | 'cloud_deleted';
@@ -82,6 +88,10 @@ export interface AssetSyncEntry {
   isLivePhoto: boolean;
   pairedVideoRemoteFileId: string | null;
   pairedVideoStatus: PairedVideoStatus | null;
+  isBurst: boolean;
+  burstId: string | null;
+  burstMemberRemoteFileIds: string[] | null;
+  burstMemberCount: number | null;
 }
 
 interface AssetSyncRow {
@@ -105,11 +115,23 @@ interface AssetSyncRow {
   is_live_photo: number;
   paired_video_remote_file_id: string | null;
   paired_video_status: PairedVideoStatus | null;
+  is_burst: number;
+  burst_id: string | null;
+  burst_member_remote_file_ids: string | null;
+  burst_member_count: number | null;
 }
 
 export interface SyncedAssetInfo {
   modificationTime: number | null;
   status: 'synced' | 'cloud_deleted';
+}
+
+export interface IncompleteBurstAsset {
+  assetId: string;
+  remoteFileId: string | null;
+  fileName: string | null;
+  creationTime: number | null;
+  modificationTime: number | null;
 }
 
 export interface AssetMediaInfo {
@@ -120,6 +142,8 @@ export interface AssetMediaInfo {
   duration: number;
   mediaType: string;
   isLivePhoto?: boolean;
+  isBurst?: boolean;
+  burstId?: string | null;
 }
 
 const CHUNK_SIZE = 300;
@@ -149,6 +173,8 @@ const rowToCloudAssetEntry = (row: CloudAssetRow): CloudAssetEntry => {
     isLivePhoto: row.is_live_photo === 1,
     livePhotoRole: row.live_photo_role,
     pairedRemoteFileId: row.paired_remote_file_id,
+    burstRole: row.burst_role,
+    burstGroupId: row.burst_group_id,
   };
 };
 
@@ -173,6 +199,10 @@ const rowToAssetSyncEntry = (row: AssetSyncRow): AssetSyncEntry => ({
   isLivePhoto: row.is_live_photo === 1,
   pairedVideoRemoteFileId: row.paired_video_remote_file_id,
   pairedVideoStatus: row.paired_video_status,
+  isBurst: row.is_burst === 1,
+  burstId: row.burst_id,
+  burstMemberRemoteFileIds: row.burst_member_remote_file_ids ? JSON.parse(row.burst_member_remote_file_ids) : null,
+  burstMemberCount: row.burst_member_count,
 });
 
 class PhotosLocalDB {
@@ -188,6 +218,7 @@ class PhotosLocalDB {
       await sqliteService.executeSql(DB_NAME, cloudAssetTable.statements.createIndexDevice);
       await sqliteService.executeSql(DB_NAME, cloudAssetTable.statements.createIndexMonth);
       await sqliteService.executeSql(DB_NAME, cloudAssetTable.statements.createIndexRole);
+      await sqliteService.executeSql(DB_NAME, cloudAssetTable.statements.createIndexBurstGroup);
     })();
     return this.initPromise;
   }
@@ -202,6 +233,7 @@ class PhotosLocalDB {
       mediaInfo?.duration ?? null,
       mediaInfo?.mediaType ?? null,
       mediaInfo?.isLivePhoto ? 1 : 0,
+      mediaInfo?.isBurst ? 1 : 0,
     ]);
   }
 
@@ -215,6 +247,7 @@ class PhotosLocalDB {
       mediaInfo?.duration ?? null,
       mediaInfo?.mediaType ?? null,
       mediaInfo?.isLivePhoto ? 1 : 0,
+      mediaInfo?.isBurst ? 1 : 0,
     ]);
   }
 
@@ -406,6 +439,9 @@ class PhotosLocalDB {
       entry.isLivePhoto ? 1 : 0,
       entry.livePhotoRole ?? null,
       entry.pairedRemoteFileId ?? null,
+      // BURST:
+      entry.burstRole ?? null,
+      entry.burstGroupId ?? null,
     ]);
   }
 
@@ -439,6 +475,71 @@ class PhotosLocalDB {
 
   async resetCloudAssets(): Promise<void> {
     await sqliteService.executeSql(DB_NAME, cloudAssetTable.statements.reset);
+  }
+
+  /**
+   * Marks a burst representative as synced, storing the uploaded member UUIDs as JSON.
+   *
+   * @param assetId - Local device asset ID of the representative.
+   * @param remoteFileId - Remote file ID assigned after upload.
+   * @param modificationTime - Last modification timestamp of the asset, or `null` if unavailable.
+   * @param burstId - Native burst identifier used to group member photos on device.
+   * @param memberUuids - Remote file IDs of the member photos uploaded in this cycle.
+   * @param memberCount - Total number of member photos in the burst group, or `null` if the group
+   *   is incomplete (e.g. limited photo access prevented uploading all members). A `null` value
+   *   signals the retry pass in `runUploadThunk` to re-attempt member upload on a later cycle.
+   */
+  async markSyncedBurst(
+    assetId: string,
+    remoteFileId: string,
+    modificationTime: number | null,
+    burstId: string,
+    memberUuids: string[],
+    memberCount: number | null,
+  ): Promise<void> {
+    await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.markSyncedBurst, [
+      assetId,
+      remoteFileId,
+      modificationTime,
+      burstId,
+      JSON.stringify(memberUuids),
+      memberCount,
+    ]);
+  }
+
+  /**
+   * Returns all member photos for a burst group (used for download and cascade delete).
+   *
+   * @param burstGroupId - The native burst identifier used to group members on device.
+   * @returns A promise resolving to an array of cloud asset entries for the burst members.
+   */
+  async getBurstMembers(burstGroupId: string): Promise<CloudAssetEntry[]> {
+    const rows = await sqliteService.getAllAsync<CloudAssetRow>(DB_NAME, cloudAssetTable.statements.getBurstMembers, [
+      burstGroupId,
+    ]);
+    return rows.map(rowToCloudAssetEntry);
+  }
+
+  /**
+   * Returns burst representatives whose members haven't been uploaded yet.
+   *
+   * @returns A promise resolving to an array of incomplete burst assets.
+   */
+  async getIncompleteBurstAssets(): Promise<IncompleteBurstAsset[]> {
+    const rows = await sqliteService.getAllAsync<{
+      asset_id: string;
+      remote_file_id: string | null;
+      file_name: string | null;
+      creation_time: number | null;
+      modification_time: number | null;
+    }>(DB_NAME, assetSyncTable.statements.getIncompleteBurstAssets);
+    return rows.map((r) => ({
+      assetId: r.asset_id,
+      remoteFileId: r.remote_file_id,
+      fileName: r.file_name,
+      creationTime: r.creation_time,
+      modificationTime: r.modification_time,
+    }));
   }
 
   async getCloudFetchCacheAge(deviceId: string, year: number, month: number): Promise<number | null> {

--- a/src/services/photos/database/tables/asset_sync.ts
+++ b/src/services/photos/database/tables/asset_sync.ts
@@ -22,15 +22,20 @@ const statements = {
       media_type                  TEXT,
       is_live_photo               INTEGER NOT NULL DEFAULT 0,
       paired_video_remote_file_id TEXT,
-      paired_video_status         TEXT
+      paired_video_status         TEXT,
+      -- BURST: burst photo columns (iOS only). Clean install required when adding these.
+      is_burst                    INTEGER NOT NULL DEFAULT 0,
+      burst_id                    TEXT,
+      burst_member_remote_file_ids TEXT,
+      burst_member_count          INTEGER
     );
   `,
   createIndex: `CREATE INDEX IF NOT EXISTS idx_asset_sync_status ON ${TABLE_NAME}(status);`,
   dropTable: `DROP TABLE IF EXISTS ${TABLE_NAME};`,
 
   markPending: `
-    INSERT INTO ${TABLE_NAME} (asset_id, status, file_name, creation_time, width, height, duration, media_type, is_live_photo)
-    VALUES (?, 'pending', ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO ${TABLE_NAME} (asset_id, status, file_name, creation_time, width, height, duration, media_type, is_live_photo, is_burst)
+    VALUES (?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(asset_id) DO UPDATE SET
       status        = 'pending',
       file_name     = COALESCE(excluded.file_name, ${TABLE_NAME}.file_name),
@@ -39,13 +44,15 @@ const statements = {
       height        = COALESCE(excluded.height, ${TABLE_NAME}.height),
       duration      = COALESCE(excluded.duration, ${TABLE_NAME}.duration),
       media_type    = COALESCE(excluded.media_type, ${TABLE_NAME}.media_type),
-      is_live_photo = excluded.is_live_photo
+      is_live_photo = excluded.is_live_photo,
+      -- BURST: persist burst flag from discovery so the upload pass can detect incomplete bursts.
+      is_burst      = excluded.is_burst
     WHERE ${TABLE_NAME}.status != 'synced';
   `,
 
   markPendingEdit: `
-    INSERT INTO ${TABLE_NAME} (asset_id, status, file_name, creation_time, width, height, duration, media_type, is_live_photo)
-    VALUES (?, 'pending_edit', ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO ${TABLE_NAME} (asset_id, status, file_name, creation_time, width, height, duration, media_type, is_live_photo, is_burst)
+    VALUES (?, 'pending_edit', ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(asset_id) DO UPDATE SET
       status        = 'pending_edit',
       file_name     = COALESCE(excluded.file_name, ${TABLE_NAME}.file_name),
@@ -54,7 +61,9 @@ const statements = {
       height        = COALESCE(excluded.height, ${TABLE_NAME}.height),
       duration      = COALESCE(excluded.duration, ${TABLE_NAME}.duration),
       media_type    = COALESCE(excluded.media_type, ${TABLE_NAME}.media_type),
-      is_live_photo = excluded.is_live_photo
+      is_live_photo = excluded.is_live_photo,
+      -- BURST:
+      is_burst      = excluded.is_burst
     WHERE ${TABLE_NAME}.status = 'synced';
   `,
 
@@ -84,6 +93,23 @@ const statements = {
       paired_video_status         = excluded.paired_video_status;
   `,
 
+  // BURST: marks a burst representative as synced with its member uuids (iOS only).
+  markSyncedBurst: `
+    INSERT INTO ${TABLE_NAME} (asset_id, status, remote_file_id, synced_at, last_attempt_at, modification_time,
+                               is_burst, burst_id, burst_member_remote_file_ids, burst_member_count)
+    VALUES (?, 'synced', ?, (unixepoch() * 1000), (unixepoch() * 1000), ?, 1, ?, ?, ?)
+    ON CONFLICT(asset_id) DO UPDATE SET
+      status                       = 'synced',
+      remote_file_id               = excluded.remote_file_id,
+      synced_at                    = excluded.synced_at,
+      last_attempt_at              = excluded.last_attempt_at,
+      modification_time            = excluded.modification_time,
+      is_burst                     = 1,
+      burst_id                     = excluded.burst_id,
+      burst_member_remote_file_ids = excluded.burst_member_remote_file_ids,
+      burst_member_count           = excluded.burst_member_count;
+  `,
+
   markError: `
     INSERT INTO ${TABLE_NAME} (asset_id, status, error_message, attempt_count, last_attempt_at)
     VALUES (?, 'error', ?, 1, (unixepoch() * 1000))
@@ -103,7 +129,8 @@ const statements = {
     SELECT asset_id, status, remote_file_id, synced_at, error_message, attempt_count,
            created_at, last_attempt_at, modification_time,
            file_name, file_size, creation_time, width, height, duration, media_type,
-           is_live_photo, paired_video_remote_file_id, paired_video_status
+           is_live_photo, paired_video_remote_file_id, paired_video_status,
+           is_burst, burst_id, burst_member_remote_file_ids, burst_member_count
     FROM ${TABLE_NAME} WHERE asset_id = ?;
   `,
   getSyncedInList: (placeholders: string) =>
@@ -137,6 +164,14 @@ const statements = {
     WHERE status = 'synced'
       AND creation_time IS NOT NULL
       AND remote_file_id IS NOT NULL;
+  `,
+
+  getIncompleteBurstAssets: `
+    SELECT asset_id, remote_file_id, file_name, creation_time, modification_time
+    FROM ${TABLE_NAME}
+    WHERE status = 'synced'
+      AND is_burst = 1
+      AND burst_member_count IS NULL;
   `,
 };
 

--- a/src/services/photos/database/tables/cloud_asset.ts
+++ b/src/services/photos/database/tables/cloud_asset.ts
@@ -5,7 +5,8 @@ const COLUMNS = `
   thumbnail_path, thumbnail_bucket_id, thumbnail_bucket_file, thumbnail_type, discovered_at,
   plain_name, extension, bucket, folder_uuid,
   creation_time_api, modification_time, updated_at, status, encrypt_version,
-  is_live_photo, live_photo_role, paired_remote_file_id
+  is_live_photo, live_photo_role, paired_remote_file_id,
+  burst_role, burst_group_id
 `;
 
 const statements = {
@@ -33,17 +34,21 @@ const statements = {
       encrypt_version        TEXT,
       is_live_photo          INTEGER NOT NULL DEFAULT 0,
       live_photo_role        TEXT,
-      paired_remote_file_id  TEXT
+      paired_remote_file_id  TEXT,
+      -- BURST: burst photo columns (iOS only). Clean install required when adding these.
+      burst_role             TEXT,
+      burst_group_id         TEXT
     );
   `,
   createIndexCreated: `CREATE INDEX IF NOT EXISTS idx_cloud_asset_created ON ${TABLE_NAME}(created_at DESC);`,
   createIndexDevice: `CREATE INDEX IF NOT EXISTS idx_cloud_asset_device ON ${TABLE_NAME}(device_id);`,
   createIndexMonth: `CREATE INDEX IF NOT EXISTS idx_cloud_asset_month ON ${TABLE_NAME}(device_id, created_at);`,
   createIndexRole: `CREATE INDEX IF NOT EXISTS idx_cloud_asset_role ON ${TABLE_NAME}(live_photo_role);`,
+  createIndexBurstGroup: `CREATE INDEX IF NOT EXISTS idx_cloud_asset_burst_group ON ${TABLE_NAME}(burst_group_id);`,
 
   upsert: `
     INSERT INTO ${TABLE_NAME} (${COLUMNS})
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(remote_file_id) DO UPDATE SET
       device_id              = excluded.device_id,
       created_at             = excluded.created_at,
@@ -66,13 +71,16 @@ const statements = {
       encrypt_version        = excluded.encrypt_version,
       is_live_photo          = excluded.is_live_photo,
       live_photo_role        = excluded.live_photo_role,
-      paired_remote_file_id  = excluded.paired_remote_file_id;
+      paired_remote_file_id  = excluded.paired_remote_file_id,
+      burst_role             = COALESCE(excluded.burst_role, ${TABLE_NAME}.burst_role),
+      burst_group_id         = COALESCE(excluded.burst_group_id, ${TABLE_NAME}.burst_group_id);
   `,
 
   getAll: `
     SELECT ${COLUMNS}
     FROM ${TABLE_NAME}
-    WHERE live_photo_role IS NULL OR live_photo_role != 'paired_video'
+    WHERE (live_photo_role IS NULL OR live_photo_role != 'paired_video')
+      AND (burst_role IS NULL OR burst_role != 'member')
     ORDER BY created_at DESC;
   `,
 
@@ -87,7 +95,14 @@ const statements = {
     FROM ${TABLE_NAME}
     WHERE (created_at >= ? AND created_at <= ?)
       AND (live_photo_role IS NULL OR live_photo_role != 'paired_video')
+      AND (burst_role IS NULL OR burst_role != 'member')
     ORDER BY created_at DESC;
+  `,
+
+  getBurstMembers: `
+    SELECT ${COLUMNS}
+    FROM ${TABLE_NAME}
+    WHERE burst_group_id = ? AND burst_role = 'member';
   `,
 
   getById: `


### PR DESCRIPTION
Add burst photos service layer: native module, upload handler and DB schema

  ## Summary
  
  - **`PHBurstExportModule.swift/.m`**: iOS native module that exports non-representative burst members as temp files via
  `PHAssetResource`, bridged to JS as `BurstNativeModule`
  - **`BurstUploadHandler.ts`**: uploads burst members after the representative is synced; `retryIncompleteBursts`
  re-attempts member export on the next cycle when limited photo access prevented export.
  - **`BurstFetchService.ts`**: fetches burst member entries from the cloud for a given representative.
  - **`BurstCloudLinker.ts`**: links uploaded burst members to their representative in the cloud DB.
  - **`burst.constants.ts`**: naming convention for burst member files.
  - **`database/tables/asset_sync.ts`**: adds `is_burst` column to track burst representatives in the local sync table.
  - **`database/tables/cloud_asset.ts`**: adds `burst_role` and `burst_group_id` columns to the cloud asset table.
  - **`database/photosLocalDB.ts`**: adds `markSyncedBurst`, `getIncompleteBurstAssets`, and related burst queries.
  - **`PhotoUploadService.ts`**: calls `uploadBurstMembersIfBurst` after a representative is uploaded.