### PR TITLE
[PB-6489] feature/Added support to burst photos in Photos

### DIFF
--- a/assets/lang/strings.ts
+++ b/assets/lang/strings.ts
@@ -221,6 +221,8 @@ const translations = {
           back: 'Back',
           waitingToUpload: 'Waiting to upload',
           uploading: 'Uploading',
+          burstBadge: 'Burst',
+          burstIncomplete: 'Burst not fully backed up. Grant full Photos access to back up all burst photos.',
           metadata: {
             info: 'Name',
             uploaded: 'Uploaded',
@@ -1215,6 +1217,9 @@ const translations = {
           back: 'Volver',
           waitingToUpload: 'Pendiente de subir',
           uploading: 'Subiendo',
+          burstBadge: 'Ráfaga',
+          burstIncomplete:
+            'Ráfaga incompleta. Para respaldar todas las fotos de la ráfaga, concede acceso completo a Fotos.',
           metadata: {
             info: 'Nombre',
             uploaded: 'Subido',

--- a/src/screens/PhotoPreviewScreen/components/BurstIncompleteBanner.tsx
+++ b/src/screens/PhotoPreviewScreen/components/BurstIncompleteBanner.tsx
@@ -1,0 +1,41 @@
+import strings from 'assets/lang/strings';
+import { WarningIcon } from 'phosphor-react-native';
+import { View } from 'react-native';
+import Animated, { Easing, useAnimatedStyle, withTiming } from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import AppText from 'src/components/AppText';
+import { useTailwind } from 'tailwind-rn';
+
+interface Props {
+  visible: boolean;
+}
+
+export const BurstIncompleteBanner = ({ visible }: Props): JSX.Element => {
+  const tailwind = useTailwind();
+  const insets = useSafeAreaInsets();
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: withTiming(visible ? 1 : 0, { duration: 150, easing: Easing.out(Easing.quad) }),
+  }));
+
+  const bottomOffset = 160 + insets.bottom;
+
+  return (
+    <Animated.View
+      pointerEvents="none"
+      style={[animatedStyle, { position: 'absolute', bottom: bottomOffset, left: 16, right: 16 }]}
+    >
+      <View
+        style={[
+          tailwind('flex-row items-center rounded-xl px-3 py-2'),
+          { backgroundColor: 'rgba(0,0,0,0.65)', gap: 8 },
+        ]}
+      >
+        <WarningIcon size={18} color="#F59E0B" weight="fill" />
+        <AppText style={tailwind('text-white text-supporting-2 flex-1')}>
+          {strings.screens.photos.photoPreview.burstIncomplete}
+        </AppText>
+      </View>
+    </Animated.View>
+  );
+};

--- a/src/screens/PhotoPreviewScreen/index.tsx
+++ b/src/screens/PhotoPreviewScreen/index.tsx
@@ -11,6 +11,7 @@ import { useTailwind } from 'tailwind-rn';
 import MoreActionsBottomSheet from '../PhotosScreen/components/MoreActionsBottomSheet';
 import { usePhotoActionHandlers } from '../PhotosScreen/hooks/usePhotoActionHandlers';
 import { isItemBacked } from '../PhotosScreen/utils/photoUtils';
+import { BurstIncompleteBanner } from './components/BurstIncompleteBanner';
 import { MetadataPanel } from './components/MetadataPanel';
 import { PreviewCarousel } from './components/PreviewCarousel';
 import { PreviewHeader } from './components/PreviewHeader';
@@ -120,6 +121,7 @@ export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
 
   const showCarousel = isUiVisible && !zoomActive && !hasVideoStarted;
   const isSynced = currentItem ? isItemBacked(currentItem) : false;
+  const isBurstIncomplete = currentItem?.type === 'local' && currentItem?.isBurstUploadIncomplete === true;
 
   return (
     <View style={tailwind('flex-1 bg-black')}>
@@ -160,6 +162,7 @@ export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
           isSynced={isSynced}
         />
       )}
+      <BurstIncompleteBanner visible={isUiVisible && isBurstIncomplete} />
       {metadataOpen && currentItem && <MetadataPanel item={currentItem} onClose={() => setMetadataOpen(false)} />}
       <MoreActionsBottomSheet
         isOpen={isMoreActionsOpen}

--- a/src/screens/PhotosScreen/components/PhotoItem.tsx
+++ b/src/screens/PhotosScreen/components/PhotoItem.tsx
@@ -1,5 +1,14 @@
+import strings from 'assets/lang/strings';
 import { LinearGradient } from 'expo-linear-gradient';
-import { ArrowUpIcon, CheckIcon, CloudIcon, CloudSlashIcon, ImageIcon, PlayIcon } from 'phosphor-react-native';
+import {
+  ArrowUpIcon,
+  CheckIcon,
+  CloudIcon,
+  CloudSlashIcon,
+  ImageIcon,
+  PlayIcon,
+  WarningIcon,
+} from 'phosphor-react-native';
 import { memo, useCallback, useEffect, useRef } from 'react';
 import { Animated, Easing, Image, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { Circle } from 'react-native-progress';
@@ -116,6 +125,29 @@ const LiveBadge = (): JSX.Element => {
   );
 };
 
+const BurstBadge = ({ isBurstIncomplete }: { isBurstIncomplete?: boolean }): JSX.Element => {
+  const tailwind = useTailwind();
+  const getColor = useGetColor();
+
+  return (
+    <View style={[tailwind('absolute justify-center items-start'), { top: 8, left: 8 }]} pointerEvents="none">
+      <LinearGradient
+        colors={['rgba(0,0,0,0.6)', 'rgba(0,0,0,0.32)', 'rgba(0,0,0,0.08)', 'transparent']}
+        locations={[0, 0.3, 0.6, 1]}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={styles.liveBadgeShadow}
+      />
+      <View style={tailwind('flex-row items-center')}>
+        <AppText medium style={[tailwind('text-xs'), { color: getColor('text-white'), letterSpacing: 0.5 }]}>
+          {strings.screens.photos.photoPreview.burstBadge}
+        </AppText>
+        {isBurstIncomplete && <WarningIcon size={10} weight="fill" color="#F59E0B" style={{ marginLeft: 2 }} />}
+      </View>
+    </View>
+  );
+};
+
 const localPhotoCellAreEqual = (prev: CellProps & { item: PhotoItemType }, next: CellProps & { item: PhotoItemType }) =>
   prev.item.id === next.item.id &&
   prev.item.backupState === next.item.backupState &&
@@ -124,6 +156,8 @@ const localPhotoCellAreEqual = (prev: CellProps & { item: PhotoItemType }, next:
   prev.item.mediaType === next.item.mediaType &&
   prev.item.duration === next.item.duration &&
   prev.item.isLivePhoto === next.item.isLivePhoto &&
+  prev.item.isBurst === next.item.isBurst &&
+  prev.item.isBurstUploadIncomplete === next.item.isBurstUploadIncomplete &&
   prev.isSelectMode === next.isSelectMode &&
   prev.isSelected === next.isSelected &&
   prev.onPress === next.onPress &&
@@ -169,6 +203,7 @@ const LocalPhotoCell = memo(
 
         {item.mediaType === 'video' && <VideoBadge duration={item.duration} />}
         {item.isLivePhoto && <LiveBadge />}
+        {item.isBurst && <BurstBadge isBurstIncomplete={item.isBurstUploadIncomplete} />}
 
         <SelectOverlay isSelectMode={isSelectMode} isSelected={isSelected} />
       </TouchableOpacity>
@@ -211,7 +246,7 @@ const CloudPhotoCell = memo(
 
         {item.mediaType === 'video' && <VideoBadge />}
         {item.isLivePhoto && <LiveBadge />}
-
+        {item.isBurst && <BurstBadge />}
         <SelectOverlay isSelectMode={isSelectMode} isSelected={isSelected} />
       </TouchableOpacity>
     );

--- a/src/screens/PhotosScreen/hooks/useLocalAssets.spec.ts
+++ b/src/screens/PhotosScreen/hooks/useLocalAssets.spec.ts
@@ -15,6 +15,7 @@ jest.mock('src/services/photos/database/photosLocalDB', () => ({
   photosLocalDB: {
     init: jest.fn().mockResolvedValue(undefined),
     getSyncedEntries: jest.fn(),
+    getIncompleteBurstAssets: jest.fn().mockResolvedValue([]),
   },
 }));
 

--- a/src/screens/PhotosScreen/hooks/useLocalAssets.ts
+++ b/src/screens/PhotosScreen/hooks/useLocalAssets.ts
@@ -2,6 +2,7 @@ import * as MediaLibrary from 'expo-media-library';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AppState } from 'react-native';
 import { logger } from 'src/services/common';
+import { BurstNativeModule } from 'src/services/photos/burst/BurstNativeModule';
 import { photosLocalDB } from 'src/services/photos/database/photosLocalDB';
 import { useAppSelector } from 'src/store/hooks';
 
@@ -14,6 +15,8 @@ export interface LocalAssetsResult {
   syncedIds: Set<string>;
   cloudDeletedIds: Set<string>;
   uploadingIdSet: Set<string>;
+  burstRepresentativeIdSet: Set<string>;
+  incompleteUploadBurstIdSet: Set<string>;
   loadNextPage: () => void;
   reload: () => Promise<void>;
 }
@@ -24,6 +27,8 @@ export const useLocalAssets = (): LocalAssetsResult => {
   const [syncedIds, setSyncedIds] = useState<Set<string>>(new Set());
   // TODO: Reserved for show a distinct icon for cloud-deleted vs never-backed assets. Remove if finally will be the same.
   const [cloudDeletedIds, setCloudDeletedIds] = useState<Set<string>>(new Set());
+  const [burstRepresentativeIdSet, setBurstRepresentativeIdSet] = useState<Set<string>>(new Set());
+  const [incompleteUploadBurstIdSet, setIncompleteUploadBurstIdSet] = useState<Set<string>>(new Set());
 
   const cursorRef = useRef<string | undefined>(undefined);
   const hasMoreRef = useRef(true);
@@ -104,7 +109,20 @@ export const useLocalAssets = (): LocalAssetsResult => {
     }
     setSyncedIds(synced);
     setCloudDeletedIds(cloudDeleted);
+
+    const incompleteBursts = await photosLocalDB.getIncompleteBurstAssets();
+    setIncompleteUploadBurstIdSet(new Set(incompleteBursts.map((burst) => burst.assetId)));
   }, [assets]);
+
+  const assetIds = useMemo(() => assets.map((asset) => asset.id), [assets]);
+  useEffect(() => {
+    if (assetIds.length === 0) {
+      return;
+    }
+    BurstNativeModule.getBurstRepresentativeIds(assetIds)
+      .then((ids) => setBurstRepresentativeIdSet(new Set(ids)))
+      .catch((err) => logger.error(`[LocalAssets] getBurstRepresentativeIds failed: ${err}`));
+  }, [assetIds]);
 
   const reloadFromStart = useCallback(async () => {
     cursorRef.current = undefined;
@@ -146,5 +164,15 @@ export const useLocalAssets = (): LocalAssetsResult => {
     refreshSyncStatusFromDB();
   }, [refreshSyncStatusFromDB, syncStatus, sessionUploadedAssets, isFetchingCloudHistory]);
 
-  return { assets, isLoading, syncedIds, cloudDeletedIds, uploadingIdSet, loadNextPage, reload: reloadFromStart };
+  return {
+    assets,
+    isLoading,
+    syncedIds,
+    cloudDeletedIds,
+    uploadingIdSet,
+    burstRepresentativeIdSet,
+    incompleteUploadBurstIdSet: incompleteUploadBurstIdSet,
+    loadNextPage,
+    reload: reloadFromStart,
+  };
 };

--- a/src/screens/PhotosScreen/hooks/usePhotosTimeline.ts
+++ b/src/screens/PhotosScreen/hooks/usePhotosTimeline.ts
@@ -14,7 +14,16 @@ export interface PhotosTimelineResult {
 }
 
 export const usePhotosTimeline = (): PhotosTimelineResult => {
-  const { assets, isLoading, syncedIds, uploadingIdSet, loadNextPage, reload: reloadLocal } = useLocalAssets();
+  const {
+    assets,
+    isLoading,
+    syncedIds,
+    uploadingIdSet,
+    burstRepresentativeIdSet,
+    incompleteUploadBurstIdSet: incompleteBurstIdSet,
+    loadNextPage,
+    reload: reloadLocal,
+  } = useLocalAssets();
   const { cloudItems, reloadCloud } = useCloudAssets();
 
   const {
@@ -28,8 +37,8 @@ export const usePhotosTimeline = (): PhotosTimelineResult => {
   } = useAppSelector((state) => state.photos);
 
   const localGroups = useMemo(
-    () => groupAssetsByDate(assets, syncedIds, uploadingIdSet),
-    [assets, syncedIds, uploadingIdSet],
+    () => groupAssetsByDate(assets, syncedIds, uploadingIdSet, burstRepresentativeIdSet, incompleteBurstIdSet),
+    [assets, syncedIds, uploadingIdSet, burstRepresentativeIdSet, incompleteBurstIdSet],
   );
 
   const mergedGroups = useMemo(() => mergeCloudIntoGroups(localGroups, cloudItems), [localGroups, cloudItems]);

--- a/src/screens/PhotosScreen/types.ts
+++ b/src/screens/PhotosScreen/types.ts
@@ -11,6 +11,8 @@ export interface PhotoItem {
   duration?: string;
   uploadProgress?: number;
   isLivePhoto?: boolean;
+  isBurst?: boolean;
+  isBurstUploadIncomplete?: boolean;
 }
 
 export interface CloudPhotoItem {
@@ -27,6 +29,8 @@ export interface CloudPhotoItem {
   isLivePhoto?: boolean;
   // uuid of the paired .mov cloud asset (only present when isLivePhoto = true and on cloud-only items)
   pairedVideoRemoteFileId?: string;
+  isBurst?: boolean;
+  burstGroupId?: string;
 }
 
 export type TimelinePhotoItem = PhotoItem | CloudPhotoItem;

--- a/src/screens/PhotosScreen/utils/photoTimelineGroups.ts
+++ b/src/screens/PhotosScreen/utils/photoTimelineGroups.ts
@@ -33,6 +33,8 @@ export const assetToPhotoItem = (
   asset: MediaLibrary.Asset,
   syncedIds: Set<string>,
   uploadingIdSet: Set<string>,
+  burstRepresentativeIdSet?: Set<string>,
+  incompleteBurstIdSet?: Set<string>,
 ): PhotoItem => {
   let backupState: PhotoBackupState;
   if (uploadingIdSet.has(asset.id)) {
@@ -53,6 +55,8 @@ export const assetToPhotoItem = (
     mediaType: isVideo ? 'video' : 'photo',
     duration: isVideo ? formatVideoDuration(asset.duration) : undefined,
     isLivePhoto: isLivePhotoAsset(asset),
+    isBurst: burstRepresentativeIdSet?.has(asset.id) ?? false,
+    isBurstUploadIncomplete: incompleteBurstIdSet?.has(asset.id) ?? false,
   };
 };
 
@@ -60,6 +64,8 @@ export const groupAssetsByDate = (
   assets: MediaLibrary.Asset[],
   syncedIds: Set<string>,
   uploadingIdSet: Set<string>,
+  burstRepresentativeIdSet?: Set<string>,
+  incompleteBurstIdSet?: Set<string>,
 ): PhotoDateGroup[] => {
   const now = new Date();
   const groupMap = new Map<string, { label: string; photos: PhotoItem[] }>();
@@ -73,7 +79,9 @@ export const groupAssetsByDate = (
       group = { label: getDateLabel(date, now), photos: [] };
       groupMap.set(groupKey, group);
     }
-    group.photos.push(assetToPhotoItem(asset, syncedIds, uploadingIdSet));
+    group.photos.push(
+      assetToPhotoItem(asset, syncedIds, uploadingIdSet, burstRepresentativeIdSet, incompleteBurstIdSet),
+    );
   }
 
   return Array.from(groupMap.entries()).map(([key, { label, photos }]) => ({
@@ -147,6 +155,8 @@ export const cloudEntryToPhotoItem = (entry: CloudAssetEntry): CloudPhotoItem =>
   fileName: entry.fileName,
   isLivePhoto: entry.isLivePhoto,
   pairedVideoRemoteFileId: entry.pairedRemoteFileId ?? undefined,
+  isBurst: entry.burstRole === 'representative',
+  burstGroupId: entry.burstGroupId ?? undefined,
 });
 
 export const mergeCloudIntoGroups = (localGroups: PhotoDateGroup[], cloudItems: CloudPhotoItem[]): PhotoDateGroup[] => {

--- a/src/services/photos/PhotoActionsService.ts
+++ b/src/services/photos/PhotoActionsService.ts
@@ -7,6 +7,7 @@ import { logger } from 'src/services/common';
 import { stripFileUri, toFileUri } from 'src/services/common/uri/uriHelpers';
 import { driveTrashService } from 'src/services/drive/trash/driveTrash.service';
 import fileSystemService from 'src/services/FileSystemService';
+import { BurstFetchService } from './burst/BurstFetchService';
 import { photosLocalDB } from './database/photosLocalDB';
 import { SavePermissionDeniedError } from './errors';
 import { saveLivePhotoToLibrary } from './LivePhotoNativeModule';
@@ -52,6 +53,17 @@ class PhotoActionsService {
     if (Platform.OS === 'ios' && item.type === 'cloud-only' && item.isLivePhoto && item.pairedVideoRemoteFileId) {
       await this.saveLivePhotoToDevice(item, signal);
       return;
+    }
+
+    if (Platform.OS === 'ios' && item.type === 'cloud-only' && item.isBurst && item.burstGroupId) {
+      const saved = await BurstFetchService.saveBurstToDevice(item, signal);
+      if (saved) {
+        logger.info(`[PhotoActionsService] saveToDevice — burst saved for ${item.id}`);
+        return;
+      }
+      logger.warn(
+        `[PhotoActionsService] saveToDevice — burst save incomplete for ${item.id}, falling through to single save`,
+      );
     }
 
     const uri = await PhotoAssetFetchService.fetchUri(item, signal);
@@ -114,6 +126,14 @@ class PhotoActionsService {
         if (item.pairedVideoRemoteFileId) {
           trashPayload.push({ id: item.pairedVideoRemoteFileId, type: 'file', uuid: item.pairedVideoRemoteFileId });
           cleanupItems.push({ type: 'cloud', assetId: item.pairedVideoRemoteFileId });
+        }
+
+        if (item.isBurst && item.burstGroupId) {
+          const members = await photosLocalDB.getBurstMembers(item.burstGroupId);
+          for (const member of members) {
+            trashPayload.push({ id: member.remoteFileId, type: 'file', uuid: member.remoteFileId });
+            cleanupItems.push({ type: 'cloud', assetId: member.remoteFileId });
+          }
         }
       } else if (item.type === 'local' && item.backupState === 'backed') {
         const itemDbEntry = await photosLocalDB.getStatus(item.id);

--- a/src/services/photos/PhotoCloudBrowser.ts
+++ b/src/services/photos/PhotoCloudBrowser.ts
@@ -2,8 +2,14 @@ import { DriveFileData } from '@internxt-mobile/types/drive/file';
 import { FetchPaginatedFolder } from '@internxt/sdk/dist/drive/storage/types';
 import { logger } from 'src/services/common';
 import { driveFolderService } from 'src/services/drive/folder/driveFolder.service';
-import { CloudAssetEntry, LivePhotoRole, photosLocalDB } from './database/photosLocalDB';
-import { getPhotoPlainNameFromPairedVideo, isPairedVideoPlainName } from './livePhoto.constants';
+import { buildBurstBaseSet, linkBurst } from './burst/BurstCloudLinker';
+import { isBurstMemberPlainName } from './burst/burst.constants';
+import { BurstRole, CloudAssetEntry, LivePhotoRole, photosLocalDB } from './database/photosLocalDB';
+import {
+  getPairedVideoPlainNameFromPhoto,
+  getPhotoPlainNameFromPairedVideo,
+  isPairedVideoPlainName,
+} from './livePhoto.constants';
 import { photosDeviceService } from './photosDeviceService';
 
 const HOUR_MS = 60 * 60 * 1000;
@@ -11,6 +17,21 @@ const CACHE_TTL_MS = 24 * HOUR_MS;
 const PAGE_SIZE = 50;
 const MIN_MONTH_NUMBER = 1;
 const MAX_MONTH_NUMBER = 12;
+
+const resolveBurstFields = (
+  baseName: string | null,
+  fileUuid: string,
+  plainNameIndex: Map<string, string>,
+  burstBaseSet: Set<string>,
+): { burstRole?: BurstRole; burstGroupId?: string } => {
+  const burstLink = linkBurst(baseName, fileUuid, plainNameIndex, burstBaseSet);
+  if (!burstLink && baseName && isBurstMemberPlainName(baseName)) {
+    logger.warn(
+      `[CloudBrowser] .burst member ${baseName} has no representative in the same day-folder — cross-day burst detected`,
+    );
+  }
+  return burstLink ? { burstRole: burstLink.burstRole, burstGroupId: burstLink.burstGroupId } : {};
+};
 
 const fetchAllPages = async <T>(fetcher: (offset: number) => Promise<T[]>): Promise<T[]> => {
   const all: T[] = [];
@@ -305,6 +326,7 @@ class PhotoCloudBrowserService {
     now: number;
   }): CloudAssetEntry[] {
     const entries: CloudAssetEntry[] = [];
+    const burstBaseSet = buildBurstBaseSet(files.map((f) => f.plainName ?? f.name ?? null));
 
     for (const file of files) {
       const baseName = file.plainName ?? file.name;
@@ -324,7 +346,7 @@ class PhotoCloudBrowserService {
           pairedRemoteFileId = photoUuid;
         }
       } else {
-        const pairedVideoPlainName = `${baseName}.livephoto`.toLowerCase();
+        const pairedVideoPlainName = getPairedVideoPlainNameFromPhoto(baseName).toLowerCase();
         const pairedVideoUuid = plainNameIndex.get(pairedVideoPlainName);
         if (pairedVideoUuid) {
           isLivePhoto = true;
@@ -357,6 +379,7 @@ class PhotoCloudBrowserService {
         isLivePhoto,
         livePhotoRole,
         pairedRemoteFileId,
+        ...resolveBurstFields(baseName, file.uuid, plainNameIndex, burstBaseSet),
       });
     }
 

--- a/src/services/photos/database/photosLocalDB.spec.ts
+++ b/src/services/photos/database/photosLocalDB.spec.ts
@@ -44,9 +44,9 @@ describe('photosLocalDB', () => {
 
     expect(mockSqlite.executeSql).toHaveBeenCalledTimes(1);
     const [, stmt, params] = mockSqlite.executeSql.mock.calls[0];
-    expect(stmt).toContain("'pending'");
+    expect(stmt).toContain('\'pending\'');
     expect(stmt).toContain('ON CONFLICT');
-    expect(stmt).toContain("status != 'synced'");
+    expect(stmt).toContain('status != \'synced\'');
     expect(params).toEqual(['asset-1', null, null, null, null, null, null, 0, 0]);
   });
 
@@ -69,8 +69,8 @@ describe('photosLocalDB', () => {
 
     expect(mockSqlite.executeSql).toHaveBeenCalledTimes(1);
     const [, stmt, params] = mockSqlite.executeSql.mock.calls[0];
-    expect(stmt).toContain("'pending_edit'");
-    expect(stmt).toContain("status = 'synced'");
+    expect(stmt).toContain('\'pending_edit\'');
+    expect(stmt).toContain('status = \'synced\'');
     expect(params).toEqual(['asset-1', null, null, null, null, null, null, 0, 0]);
   });
 
@@ -102,7 +102,7 @@ describe('photosLocalDB', () => {
 
     expect(mockSqlite.executeSql).toHaveBeenCalledTimes(1);
     const [, stmt, params] = mockSqlite.executeSql.mock.calls[0];
-    expect(stmt).toContain("'synced'");
+    expect(stmt).toContain('\'synced\'');
     expect(stmt).toContain('unixepoch()');
     expect(params).toEqual(['asset-1', 'remote-file-id', 1714000000]);
   });
@@ -119,7 +119,7 @@ describe('photosLocalDB', () => {
 
     expect(mockSqlite.executeSql).toHaveBeenCalledTimes(1);
     const [, stmt, params] = mockSqlite.executeSql.mock.calls[0];
-    expect(stmt).toContain("'error'");
+    expect(stmt).toContain('\'error\'');
     expect(params).toEqual(['asset-2', null]);
   });
 
@@ -136,7 +136,7 @@ describe('photosLocalDB', () => {
     const [, stmt] = mockSqlite.executeSql.mock.calls[0];
     expect(stmt).toContain('attempt_count + 1');
     expect(stmt).toContain('ON CONFLICT');
-    expect(stmt).toContain("status != 'synced'");
+    expect(stmt).toContain('status != \'synced\'');
   });
 
   test('when looking up synced photos, then both synced and cloud_deleted statuses are queried', async () => {
@@ -145,7 +145,7 @@ describe('photosLocalDB', () => {
     await photosLocalDB.getSyncedEntries(['asset-1']);
 
     const [, stmt] = mockSqlite.getAllAsync.mock.calls[0];
-    expect(stmt).toContain("status IN ('synced', 'cloud_deleted')");
+    expect(stmt).toContain('status IN (\'synced\', \'cloud_deleted\')');
   });
 
   test('when looking up 300 photos at once, then a single database query is made with all ids', async () => {


### PR DESCRIPTION
Added burst UI: incomplete badge, photo item indicator and timeline grouping

  ## Summary

  - **`BurstIncompleteBanner.tsx`**: banner shown in photo preview when a burst representative was synced but members are still pending.
  - **`PhotoItem.tsx`**: adds a burst indicator badge on the timeline grid for representatives with incomplete member uploads.
  - **`useLocalAssets.ts`**: tracks `incompleteUploadBurstIdSet` from the local DB to drive the badge and banner visibility.
  - **`usePhotosTimeline.ts`**: groups burst members under their representative in the timeline so they don't appear as
  separate items.
  - **`photoTimelineGroups.ts`** / **`types.ts`**: burst grouping logic and associated types.
  - **`PhotoActionsService.ts`**: adds burstexport and share actions.
  - **`PhotoCloudBrowser.ts`**: fetches burst member metadata from the cloud for preview.