### PR TITLE
[PB-5922]: download and decrypt File Provider files for open in Files

### DIFF
--- a/ios/Internxt.xcodeproj/project.pbxproj
+++ b/ios/Internxt.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		AA0100082F87A94000E14783 /* SharedAuthKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100002F87A94000E14783 /* SharedAuthKeychain.swift */; };
 		AB1D47702F87A94000E14783 /* FileProviderItemIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47722F87A94000E14783 /* FileProviderItemIdentifier.swift */; };
 		AB1D47712F87A94000E14783 /* DriveAPIFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47732F87A94000E14783 /* DriveAPIFactory.swift */; };
+		AB1D47802F87A94000E14783 /* NetworkFacadeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47822F87A94000E14783 /* NetworkFacadeFactory.swift */; };
+		AB1D47812F87A94000E14783 /* SharedKeychainCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47832F87A94000E14783 /* SharedKeychainCredentials.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
 		DE1D47432F87A94000E14783 /* UniformTypeIdentifiers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE1D47422F87A94000E14783 /* UniformTypeIdentifiers.framework */; };
 		DE1D474F2F87A94000E14783 /* InternxtFileProvider.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = DE1D47412F87A94000E14783 /* InternxtFileProvider.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -99,6 +101,8 @@
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = Internxt/SplashScreen.storyboard; sourceTree = "<group>"; };
 		AB1D47722F87A94000E14783 /* FileProviderItemIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderItemIdentifier.swift; sourceTree = "<group>"; };
 		AB1D47732F87A94000E14783 /* DriveAPIFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DriveAPIFactory.swift; sourceTree = "<group>"; };
+		AB1D47822F87A94000E14783 /* NetworkFacadeFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkFacadeFactory.swift; sourceTree = "<group>"; };
+		AB1D47832F87A94000E14783 /* SharedKeychainCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedKeychainCredentials.swift; sourceTree = "<group>"; };
 		AC8B28CC3C9A8FDF21A8C1E7 /* Pods-InternxtFileProvider.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtFileProvider.debug.xcconfig"; path = "Target Support Files/Pods-InternxtFileProvider/Pods-InternxtFileProvider.debug.xcconfig"; sourceTree = "<group>"; };
 		B8AF05FC3A0730CCBD5A3D8F /* Pods-InternxtShareExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtShareExtension.release.xcconfig"; path = "Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension.release.xcconfig"; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
@@ -282,6 +286,8 @@
 				DE1D47652F87A94000E14783 /* FileProviderItem.swift */,
 				AB1D47722F87A94000E14783 /* FileProviderItemIdentifier.swift */,
 				AB1D47732F87A94000E14783 /* DriveAPIFactory.swift */,
+				AB1D47822F87A94000E14783 /* NetworkFacadeFactory.swift */,
+				AB1D47832F87A94000E14783 /* SharedKeychainCredentials.swift */,
 				DE1D47662F87A94000E14783 /* Info.plist */,
 				DE1D47672F87A94000E14783 /* InternxtFileProvider.entitlements */,
 				DE1D47682F87A94000E14783 /* InternxtFileProvider.plist */,
@@ -741,6 +747,8 @@
 				DE1D47622F87A94000E14783 /* FileProviderItem.swift in Sources */,
 				AB1D47702F87A94000E14783 /* FileProviderItemIdentifier.swift in Sources */,
 				AB1D47712F87A94000E14783 /* DriveAPIFactory.swift in Sources */,
+				AB1D47802F87A94000E14783 /* NetworkFacadeFactory.swift in Sources */,
+				AB1D47812F87A94000E14783 /* SharedKeychainCredentials.swift in Sources */,
 				AA0100082F87A94000E14783 /* SharedAuthKeychain.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/Internxt/InternxtAuthCredentialsModule.swift
+++ b/ios/Internxt/InternxtAuthCredentialsModule.swift
@@ -62,6 +62,7 @@ class InternxtAuthCredentialsModule: NSObject {
     writeIfPresent(creds["bridgeUser"], to: SharedAuthKeychain.bridgeUserKey)
     writeIfPresent(creds["userId"], to: SharedAuthKeychain.userIdKey)
     writeIfPresent(creds["driveBaseUrl"], to: SharedAuthKeychain.driveBaseUrlKey)
+    writeIfPresent(creds["bridgeBaseUrl"], to: SharedAuthKeychain.bridgeBaseUrlKey)
   }
 
   private func writeIfPresent(_ value: Any?, to sharedKey: String) {

--- a/ios/Internxt/SharedAuthKeychain.swift
+++ b/ios/Internxt/SharedAuthKeychain.swift
@@ -15,10 +15,11 @@ enum SharedAuthKeychain {
   static let bridgeUserKey = "shared_bridgeUser"
   static let userIdKey = "shared_userId"
   static let driveBaseUrlKey = "shared_driveBaseUrl"
+  static let bridgeBaseUrlKey = "shared_bridgeBaseUrl"
 
   static let allKeys = [
     photosTokenKey, mnemonicKey, rootFolderIdKey, bucketKey, bridgeUserKey, userIdKey,
-    driveBaseUrlKey,
+    driveBaseUrlKey, bridgeBaseUrlKey,
   ]
 
   static var accessGroup: String? {
@@ -111,8 +112,8 @@ enum SharedAuthKeychain {
     copyFromPrivate(privateKey: "xUser_mnemonic", sharedKey: mnemonicKey, isJSONEncoded: true)
     copyFromPrivate(privateKey: "xUser_rootFolderId", sharedKey: rootFolderIdKey, isJSONEncoded: true)
     copyFromPrivate(privateKey: "xUser_bucket", sharedKey: bucketKey)
-    copyFromPrivate(privateKey: "xUser_bridgeUser", sharedKey: bridgeUserKey)
-    copyFromPrivate(privateKey: "xUser_userId", sharedKey: userIdKey)
+    copyFromPrivate(privateKey: "xUser_bridgeUser", sharedKey: bridgeUserKey, isJSONEncoded: true)
+    copyFromPrivate(privateKey: "xUser_userId", sharedKey: userIdKey, isJSONEncoded: true)
   }
 
   private static func copyFromPrivate(privateKey: String, sharedKey: String, isJSONEncoded: Bool = false) {

--- a/ios/InternxtFileProvider/DriveAPIFactory.swift
+++ b/ios/InternxtFileProvider/DriveAPIFactory.swift
@@ -3,34 +3,16 @@ import InternxtSwiftCore
 
 enum DriveAPIFactory {
   static func make() -> DriveAPI? {
-    guard let authToken = sharedString(SharedAuthKeychain.photosTokenKey),
-          let baseUrl = sharedString(SharedAuthKeychain.driveBaseUrlKey) else {
+    guard let authToken = SharedKeychainCredentials.string(SharedAuthKeychain.photosTokenKey),
+          let baseUrl = SharedKeychainCredentials.string(SharedAuthKeychain.driveBaseUrlKey) else {
       return nil
     }
 
     return DriveAPI(
       baseUrl: baseUrl,
       authToken: authToken,
-      clientName: clientName,
-      clientVersion: clientVersion
+      clientName: SharedKeychainCredentials.clientName,
+      clientVersion: SharedKeychainCredentials.clientVersion
     )
-  }
-
-  private static func sharedString(_ key: String) -> String? {
-    guard let data = SharedAuthKeychain.read(key) else { return nil }
-    let value = String(decoding: data, as: UTF8.self)
-    return value.isEmpty ? nil : value
-  }
-
-  private static var clientName: String {
-    bundleString("CFBundleName") ?? "drive-mobile"
-  }
-
-  private static var clientVersion: String {
-    bundleString("CFBundleShortVersionString") ?? "0.0.0"
-  }
-
-  private static func bundleString(_ key: String) -> String? {
-    Bundle(for: FileProviderExtension.self).object(forInfoDictionaryKey: key) as? String
   }
 }

--- a/ios/InternxtFileProvider/FileProviderExtension.swift
+++ b/ios/InternxtFileProvider/FileProviderExtension.swift
@@ -65,18 +65,106 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         }
     }
 
+    private static let offlineURLErrorCodes: Set<URLError.Code> = [
+        .notConnectedToInternet,
+        .networkConnectionLost,
+        .timedOut,
+        .cannotConnectToHost,
+        .dataNotAllowed,
+        .cannotFindHost
+    ]
+
+    private static let offlineErrorCodes: Set<ErrorCode> = [
+        .networkNoConnection,
+        .networkConnectionLost,
+        .networkTimeout,
+        .networkCannotConnect
+    ]
+
     private func lookupError(from error: Error) -> Error {
-        if let apiError = error as? APIClientError, apiError.statusCode == 401 {
+        if isUnauthorized(error) {
             return NSFileProviderError(.notAuthenticated)
+        }
+        if isOffline(error) {
+            return NSFileProviderError(.serverUnreachable)
         }
         return error
     }
 
-    func fetchContents(for itemIdentifier: NSFileProviderItemIdentifier, version requestedVersion: NSFileProviderItemVersion?, request: NSFileProviderRequest, completionHandler: @escaping (URL?, NSFileProviderItem?, Error?) -> Void) -> Progress {
-        // TODO: implement fetching of the contents for the itemIdentifier at the specified version
+    private func isUnauthorized(_ error: Error) -> Bool {
+        if let enriched = error as? EnrichedError {
+            if enriched.code == .apiUnauthorized {
+                return true
+            }
+            if let cause = enriched.cause {
+                return isUnauthorized(cause)
+            }
+            return false
+        }
+        if let apiError = error as? APIClientError {
+            return apiError.statusCode == 401
+        }
+        return false
+    }
 
-        completionHandler(nil, nil, NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError, userInfo:[:]))
-        return Progress()
+    private func isOffline(_ error: Error) -> Bool {
+        if let enriched = error as? EnrichedError {
+            if Self.offlineErrorCodes.contains(enriched.code) {
+                return true
+            }
+            if let cause = enriched.cause {
+                return isOffline(cause)
+            }
+            return false
+        }
+        if let urlError = error as? URLError {
+            return Self.offlineURLErrorCodes.contains(urlError.code)
+        }
+        if let apiError = error as? APIClientError {
+            return apiError.statusCode <= 0
+        }
+        return false
+    }
+
+    func fetchContents(for itemIdentifier: NSFileProviderItemIdentifier, version requestedVersion: NSFileProviderItemVersion?, request: NSFileProviderRequest, completionHandler: @escaping (URL?, NSFileProviderItem?, Error?) -> Void) -> Progress {
+        guard let decoded = FileProviderItemID.decode(itemIdentifier), decoded.kind == .file else {
+            completionHandler(nil, nil, NSFileProviderError(.noSuchItem))
+            return Progress()
+        }
+
+        guard let driveAPI = DriveAPIFactory.make(), let networkFacade = NetworkFacadeFactory.make() else {
+            completionHandler(nil, nil, NSFileProviderError(.notAuthenticated))
+            return Progress()
+        }
+
+        let progress = Progress(totalUnitCount: 100)
+        Task {
+            let encryptedTmp = Self.temporaryFileURL()
+            let plainTmp = Self.temporaryFileURL()
+            defer { try? FileManager.default.removeItem(at: encryptedTmp) }
+
+            do {
+                let meta = try await driveAPI.getFileMetaByUuid(uuid: decoded.uuid)
+                _ = try await networkFacade.downloadFile(
+                    bucketId: meta.bucket,
+                    fileId: meta.fileId,
+                    encryptedFileDestination: encryptedTmp,
+                    destinationURL: plainTmp,
+                    progressHandler: { fraction in
+                        progress.completedUnitCount = Int64(fraction * 100)
+                    }
+                )
+                let item = FileProviderItem(fileMeta: meta, identifier: itemIdentifier)
+                completionHandler(plainTmp, item, nil)
+            } catch {
+                completionHandler(nil, nil, lookupError(from: error))
+            }
+        }
+        return progress
+    }
+
+    private static func temporaryFileURL() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
     }
     
     func createItem(basedOn itemTemplate: NSFileProviderItem, fields: NSFileProviderItemFields, contents url: URL?, options: NSFileProviderCreateItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) -> Progress {

--- a/ios/InternxtFileProvider/NetworkFacadeFactory.swift
+++ b/ios/InternxtFileProvider/NetworkFacadeFactory.swift
@@ -1,0 +1,35 @@
+import Foundation
+import CryptoKit
+import InternxtSwiftCore
+
+enum NetworkFacadeFactory {
+  static func make() -> NetworkFacade? {
+    guard let mnemonic = SharedKeychainCredentials.string(SharedAuthKeychain.mnemonicKey) else {
+      return nil
+    }
+    guard let bridgeBaseUrl = SharedKeychainCredentials.string(SharedAuthKeychain.bridgeBaseUrlKey) else {
+      return nil
+    }
+    guard let bridgeUser = SharedKeychainCredentials.string(SharedAuthKeychain.bridgeUserKey) else {
+      return nil
+    }
+    guard let userId = SharedKeychainCredentials.string(SharedAuthKeychain.userIdKey) else {
+      return nil
+    }
+
+    let bridgePass = deriveBridgePass(userId: userId)
+    let basicAuthToken = Data("\(bridgeUser):\(bridgePass)".utf8).base64EncodedString()
+    let networkAPI = NetworkAPI(
+      baseUrl: bridgeBaseUrl,
+      basicAuthToken: basicAuthToken,
+      clientName: SharedKeychainCredentials.clientName,
+      clientVersion: SharedKeychainCredentials.clientVersion
+    )
+    return NetworkFacade(mnemonic: mnemonic, networkAPI: networkAPI)
+  }
+
+  private static func deriveBridgePass(userId: String) -> String {
+    let digest = SHA256.hash(data: Data(userId.utf8))
+    return digest.map { String(format: "%02x", $0) }.joined()
+  }
+}

--- a/ios/InternxtFileProvider/SharedKeychainCredentials.swift
+++ b/ios/InternxtFileProvider/SharedKeychainCredentials.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum SharedKeychainCredentials {
+  static func string(_ key: String) -> String? {
+    guard let data = SharedAuthKeychain.read(key) else { return nil }
+    let value = String(decoding: data, as: UTF8.self)
+    return value.isEmpty ? nil : value
+  }
+
+  static var clientName: String {
+    bundleString("CFBundleName") ?? "drive-mobile"
+  }
+
+  static var clientVersion: String {
+    bundleString("CFBundleShortVersionString") ?? "0.0.0"
+  }
+
+  private static func bundleString(_ key: String) -> String? {
+    Bundle(for: FileProviderExtension.self).object(forInfoDictionaryKey: key) as? String
+  }
+}

--- a/src/services/native/InternxtAuthCredentialsModule.spec.ts
+++ b/src/services/native/InternxtAuthCredentialsModule.spec.ts
@@ -37,7 +37,7 @@ describe('InternxtAuthCredentialsModule wrapper', () => {
     jest.resetModules();
   });
 
-  it('when on iOS with the module present, then setCredentials delegates with the credentials', async () => {
+  test('when on iOS with the module present, then setCredentials delegates with the credentials', async () => {
     const { wrapper, setCredentials } = arrangePresentNative('ios');
 
     await wrapper.setCredentials(credentials);
@@ -45,7 +45,7 @@ describe('InternxtAuthCredentialsModule wrapper', () => {
     expect(setCredentials).toHaveBeenCalledWith(credentials);
   });
 
-  it('when on iOS with the module present, then setCredentials forwards driveBaseUrl to the native module', async () => {
+  test('when on iOS with the module present, then setCredentials forwards driveBaseUrl to the native module', async () => {
     const { wrapper, setCredentials } = arrangePresentNative('ios');
 
     await wrapper.setCredentials(credentials);
@@ -53,7 +53,15 @@ describe('InternxtAuthCredentialsModule wrapper', () => {
     expect(setCredentials.mock.calls[0][0]).toMatchObject({ driveBaseUrl: 'https://drive.example' });
   });
 
-  it('when on iOS with the module present, then clearCredentials delegates to the native module', async () => {
+  test('when on iOS with the module present, then setCredentials forwards bridgeBaseUrl to the native module', async () => {
+    const { wrapper, setCredentials } = arrangePresentNative('ios');
+
+    await wrapper.setCredentials(credentials);
+
+    expect(setCredentials.mock.calls[0][0]).toMatchObject({ bridgeBaseUrl: 'https://bridge.example' });
+  });
+
+  test('when on iOS with the module present, then clearCredentials delegates to the native module', async () => {
     const { wrapper, clearCredentials } = arrangePresentNative('ios');
 
     await wrapper.clearCredentials();
@@ -61,7 +69,7 @@ describe('InternxtAuthCredentialsModule wrapper', () => {
     expect(clearCredentials).toHaveBeenCalledTimes(1);
   });
 
-  it('when on Android with the module present, then setCredentials delegates with the credentials', async () => {
+  test('when on Android with the module present, then setCredentials delegates with the credentials', async () => {
     const { wrapper, setCredentials } = arrangePresentNative('android');
 
     await wrapper.setCredentials(credentials);
@@ -69,13 +77,13 @@ describe('InternxtAuthCredentialsModule wrapper', () => {
     expect(setCredentials).toHaveBeenCalledWith(credentials);
   });
 
-  it('when the native module is absent, then setCredentials resolves without throwing', async () => {
+  test('when the native module is absent, then setCredentials resolves without throwing', async () => {
     const wrapper = loadWrapper('ios', undefined);
 
     await expect(wrapper.setCredentials(credentials)).resolves.toBeUndefined();
   });
 
-  it('when the native module is absent, then clearCredentials resolves without throwing', async () => {
+  test('when the native module is absent, then clearCredentials resolves without throwing', async () => {
     const wrapper = loadWrapper('ios', undefined);
 
     await expect(wrapper.clearCredentials()).resolves.toBeUndefined();


### PR DESCRIPTION
Adds NetworkFacadeFactory and SharedKeychainCredentials to the File Provider extension so items can be downloaded from the network and decrypted on demand. Persists bridgeBaseUrl to the shared keychain and JSON-decodes bridgeUser/userId so the extension reads matching credentials.