### PR TITLE
[PB-5923]: create folders and upload encrypted files via File Provider

### DIFF
--- a/ios/Internxt.xcodeproj/project.pbxproj
+++ b/ios/Internxt.xcodeproj/project.pbxproj
@@ -24,6 +24,10 @@
 		AB1D47712F87A94000E14783 /* DriveAPIFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47732F87A94000E14783 /* DriveAPIFactory.swift */; };
 		AB1D47802F87A94000E14783 /* NetworkFacadeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47822F87A94000E14783 /* NetworkFacadeFactory.swift */; };
 		AB1D47812F87A94000E14783 /* SharedKeychainCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47832F87A94000E14783 /* SharedKeychainCredentials.swift */; };
+		AB1D47902F87A94000E14783 /* FileProviderErrorMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47912F87A94000E14783 /* FileProviderErrorMapper.swift */; };
+		AB1D47922F87A94000E14783 /* FileProviderUploadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47932F87A94000E14783 /* FileProviderUploadService.swift */; };
+		AB1D47942F87A94000E14783 /* FileProviderDownloadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47952F87A94000E14783 /* FileProviderDownloadService.swift */; };
+		AB1D47962F87A94000E14783 /* FileProviderMutationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47972F87A94000E14783 /* FileProviderMutationService.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
 		DE1D47432F87A94000E14783 /* UniformTypeIdentifiers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE1D47422F87A94000E14783 /* UniformTypeIdentifiers.framework */; };
 		DE1D474F2F87A94000E14783 /* InternxtFileProvider.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = DE1D47412F87A94000E14783 /* InternxtFileProvider.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -103,6 +107,10 @@
 		AB1D47732F87A94000E14783 /* DriveAPIFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DriveAPIFactory.swift; sourceTree = "<group>"; };
 		AB1D47822F87A94000E14783 /* NetworkFacadeFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkFacadeFactory.swift; sourceTree = "<group>"; };
 		AB1D47832F87A94000E14783 /* SharedKeychainCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedKeychainCredentials.swift; sourceTree = "<group>"; };
+		AB1D47912F87A94000E14783 /* FileProviderErrorMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderErrorMapper.swift; sourceTree = "<group>"; };
+		AB1D47932F87A94000E14783 /* FileProviderUploadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderUploadService.swift; sourceTree = "<group>"; };
+		AB1D47952F87A94000E14783 /* FileProviderDownloadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderDownloadService.swift; sourceTree = "<group>"; };
+		AB1D47972F87A94000E14783 /* FileProviderMutationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderMutationService.swift; sourceTree = "<group>"; };
 		AC8B28CC3C9A8FDF21A8C1E7 /* Pods-InternxtFileProvider.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtFileProvider.debug.xcconfig"; path = "Target Support Files/Pods-InternxtFileProvider/Pods-InternxtFileProvider.debug.xcconfig"; sourceTree = "<group>"; };
 		B8AF05FC3A0730CCBD5A3D8F /* Pods-InternxtShareExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtShareExtension.release.xcconfig"; path = "Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension.release.xcconfig"; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
@@ -284,6 +292,10 @@
 				DE1D47632F87A94000E14783 /* FileProviderExtension.swift */,
 				DE1D47642F87A94000E14783 /* FileProviderEnumerator.swift */,
 				DE1D47652F87A94000E14783 /* FileProviderItem.swift */,
+				AB1D47912F87A94000E14783 /* FileProviderErrorMapper.swift */,
+				AB1D47932F87A94000E14783 /* FileProviderUploadService.swift */,
+				AB1D47952F87A94000E14783 /* FileProviderDownloadService.swift */,
+				AB1D47972F87A94000E14783 /* FileProviderMutationService.swift */,
 				AB1D47722F87A94000E14783 /* FileProviderItemIdentifier.swift */,
 				AB1D47732F87A94000E14783 /* DriveAPIFactory.swift */,
 				AB1D47822F87A94000E14783 /* NetworkFacadeFactory.swift */,
@@ -745,6 +757,10 @@
 				DE1D47602F87A94000E14783 /* FileProviderExtension.swift in Sources */,
 				DE1D47612F87A94000E14783 /* FileProviderEnumerator.swift in Sources */,
 				DE1D47622F87A94000E14783 /* FileProviderItem.swift in Sources */,
+				AB1D47902F87A94000E14783 /* FileProviderErrorMapper.swift in Sources */,
+				AB1D47922F87A94000E14783 /* FileProviderUploadService.swift in Sources */,
+				AB1D47942F87A94000E14783 /* FileProviderDownloadService.swift in Sources */,
+				AB1D47962F87A94000E14783 /* FileProviderMutationService.swift in Sources */,
 				AB1D47702F87A94000E14783 /* FileProviderItemIdentifier.swift in Sources */,
 				AB1D47712F87A94000E14783 /* DriveAPIFactory.swift in Sources */,
 				AB1D47802F87A94000E14783 /* NetworkFacadeFactory.swift in Sources */,

--- a/ios/InternxtFileProvider/FileProviderDownloadService.swift
+++ b/ios/InternxtFileProvider/FileProviderDownloadService.swift
@@ -1,0 +1,37 @@
+//
+//  FileProviderDownloadService.swift
+//  InternxtFileProvider
+//
+//  Created by Ramon Candel on 9/4/26.
+//
+
+import FileProvider
+import InternxtSwiftCore
+
+struct FileProviderDownloadService {
+    let driveAPI: DriveAPI
+    let networkFacade: NetworkFacade
+
+    func fetchContents(
+        uuid: String,
+        progressHandler: @escaping (Double) -> Void
+    ) async throws -> (url: URL, meta: GetFileMetaByIdResponse) {
+        let encryptedTmp = Self.temporaryFileURL()
+        let plainTmp = Self.temporaryFileURL()
+        defer { try? FileManager.default.removeItem(at: encryptedTmp) }
+
+        let meta = try await driveAPI.getFileMetaByUuid(uuid: uuid)
+        _ = try await networkFacade.downloadFile(
+            bucketId: meta.bucket,
+            fileId: meta.fileId,
+            encryptedFileDestination: encryptedTmp,
+            destinationURL: plainTmp,
+            progressHandler: progressHandler
+        )
+        return (plainTmp, meta)
+    }
+
+    static func temporaryFileURL() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    }
+}

--- a/ios/InternxtFileProvider/FileProviderErrorMapper.swift
+++ b/ios/InternxtFileProvider/FileProviderErrorMapper.swift
@@ -1,0 +1,72 @@
+//
+//  FileProviderErrorMapper.swift
+//  InternxtFileProvider
+//
+//  Created by Ramon Candel on 9/4/26.
+//
+
+import FileProvider
+import InternxtSwiftCore
+
+enum FileProviderErrorMapper {
+    private static let offlineURLErrorCodes: Set<URLError.Code> = [
+        .notConnectedToInternet,
+        .networkConnectionLost,
+        .timedOut,
+        .cannotConnectToHost,
+        .dataNotAllowed,
+        .cannotFindHost
+    ]
+
+    private static let offlineErrorCodes: Set<ErrorCode> = [
+        .networkNoConnection,
+        .networkConnectionLost,
+        .networkTimeout,
+        .networkCannotConnect
+    ]
+
+    static func lookupError(from error: Error) -> Error {
+        if isUnauthorized(error) {
+            return NSFileProviderError(.notAuthenticated)
+        }
+        if isOffline(error) {
+            return NSFileProviderError(.serverUnreachable)
+        }
+        return NSFileProviderError(.noSuchItem)
+    }
+
+    static func isUnauthorized(_ error: Error) -> Bool {
+        if let enriched = error as? EnrichedError {
+            if enriched.code == .apiUnauthorized {
+                return true
+            }
+            if let cause = enriched.cause {
+                return isUnauthorized(cause)
+            }
+            return false
+        }
+        if let apiError = error as? APIClientError {
+            return apiError.statusCode == 401
+        }
+        return false
+    }
+
+    static func isOffline(_ error: Error) -> Bool {
+        if let enriched = error as? EnrichedError {
+            if offlineErrorCodes.contains(enriched.code) {
+                return true
+            }
+            if let cause = enriched.cause {
+                return isOffline(cause)
+            }
+            return false
+        }
+        if let urlError = error as? URLError {
+            return offlineURLErrorCodes.contains(urlError.code)
+        }
+        if let apiError = error as? APIClientError {
+            return apiError.statusCode <= 0
+        }
+        return false
+    }
+}

--- a/ios/InternxtFileProvider/FileProviderExtension.swift
+++ b/ios/InternxtFileProvider/FileProviderExtension.swift
@@ -7,13 +7,41 @@
 
 import FileProvider
 import InternxtSwiftCore
+import UniformTypeIdentifiers
 
 class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
     private let rootDisplayName: String
 
+    private enum FriendlyError {
+        static let offlineDescription = "No internet connection"
+        static let offlineReason = "Connect to the internet and try again to upload to Internxt Drive."
+        static let notAuthenticatedDescription = "Sign in required"
+        static let notAuthenticatedReason = "Open the Internxt app and sign in to continue."
+        static let genericDescription = "Couldn’t complete the operation"
+        static let genericReason = "Something went wrong with Internxt Drive. Please try again."
+    }
+
     required init(domain: NSFileProviderDomain) {
         self.rootDisplayName = domain.displayName
         super.init()
+    }
+
+    private static func fileProviderError(_ code: NSFileProviderError.Code, description: String, reason: String? = nil) -> NSError {
+        var userInfo: [String: Any] = [NSLocalizedDescriptionKey: description]
+        userInfo[NSLocalizedFailureReasonErrorKey] = reason ?? description
+        return NSError(domain: NSFileProviderError.errorDomain, code: code.rawValue, userInfo: userInfo)
+    }
+
+    private static var offlineError: NSError {
+        fileProviderError(.serverUnreachable, description: FriendlyError.offlineDescription, reason: FriendlyError.offlineReason)
+    }
+
+    private static var notAuthenticatedError: NSError {
+        fileProviderError(.notAuthenticated, description: FriendlyError.notAuthenticatedDescription, reason: FriendlyError.notAuthenticatedReason)
+    }
+
+    private static var noSuchItemError: NSError {
+        fileProviderError(.noSuchItem, description: FriendlyError.genericDescription, reason: FriendlyError.genericReason)
     }
 
     func invalidate() {
@@ -28,12 +56,12 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         }
 
         guard let decoded = FileProviderItemID.decode(identifier) else {
-            completionHandler(nil, NSFileProviderError(.noSuchItem))
+            completionHandler(nil, Self.noSuchItemError)
             return Progress()
         }
 
         guard let driveAPI = DriveAPIFactory.make() else {
-            completionHandler(nil, NSFileProviderError(.notAuthenticated))
+            completionHandler(nil, Self.notAuthenticatedError)
             return Progress()
         }
 
@@ -83,12 +111,12 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
 
     private func lookupError(from error: Error) -> Error {
         if isUnauthorized(error) {
-            return NSFileProviderError(.notAuthenticated)
+            return Self.notAuthenticatedError
         }
         if isOffline(error) {
-            return NSFileProviderError(.serverUnreachable)
+            return Self.offlineError
         }
-        return error
+        return Self.noSuchItemError
     }
 
     private func isUnauthorized(_ error: Error) -> Bool {
@@ -128,12 +156,12 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
 
     func fetchContents(for itemIdentifier: NSFileProviderItemIdentifier, version requestedVersion: NSFileProviderItemVersion?, request: NSFileProviderRequest, completionHandler: @escaping (URL?, NSFileProviderItem?, Error?) -> Void) -> Progress {
         guard let decoded = FileProviderItemID.decode(itemIdentifier), decoded.kind == .file else {
-            completionHandler(nil, nil, NSFileProviderError(.noSuchItem))
+            completionHandler(nil, nil, Self.noSuchItemError)
             return Progress()
         }
 
         guard let driveAPI = DriveAPIFactory.make(), let networkFacade = NetworkFacadeFactory.make() else {
-            completionHandler(nil, nil, NSFileProviderError(.notAuthenticated))
+            completionHandler(nil, nil, Self.notAuthenticatedError)
             return Progress()
         }
 
@@ -168,17 +196,198 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
     }
     
     func createItem(basedOn itemTemplate: NSFileProviderItem, fields: NSFileProviderItemFields, contents url: URL?, options: NSFileProviderCreateItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) -> Progress {
-        // TODO: a new item was created on disk, process the item's creation
-        
-        completionHandler(itemTemplate, [], false, nil)
-        return Progress()
+        guard let driveAPI = DriveAPIFactory.make(), let networkFacade = NetworkFacadeFactory.make() else {
+            completionHandler(nil, [], false, Self.notAuthenticatedError)
+            return Progress()
+        }
+
+        guard let parentUuid = FileProviderItemID.folderUuid(for: itemTemplate.parentItemIdentifier) else {
+            completionHandler(nil, [], false, Self.noSuchItemError)
+            return Progress()
+        }
+
+        let parentIdentifier = itemTemplate.parentItemIdentifier
+
+        if itemTemplate.contentType?.conforms(to: .folder) == true {
+            return createFolder(
+                name: itemTemplate.filename,
+                parentUuid: parentUuid,
+                parentIdentifier: parentIdentifier,
+                driveAPI: driveAPI,
+                completionHandler: completionHandler
+            )
+        }
+
+        guard let contentsURL = url else {
+            completionHandler(nil, [], false, Self.noSuchItemError)
+            return Progress()
+        }
+
+        return uploadFile(
+            filename: itemTemplate.filename,
+            contentsURL: contentsURL,
+            parentUuid: parentUuid,
+            parentIdentifier: parentIdentifier,
+            driveAPI: driveAPI,
+            networkFacade: networkFacade,
+            completionHandler: completionHandler
+        )
+    }
+
+    private func createFolder(
+        name: String,
+        parentUuid: String,
+        parentIdentifier: NSFileProviderItemIdentifier,
+        driveAPI: DriveAPI,
+        completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
+    ) -> Progress {
+        let progress = Progress(totalUnitCount: 1)
+        Task {
+            do {
+                let response = try await driveAPI.createFolderNew(parentFolderUuid: parentUuid, folderName: name)
+                progress.completedUnitCount = 1
+                let item = FileProviderItem(folder: response, parent: parentIdentifier)
+                completionHandler(item, [], false, nil)
+            } catch {
+                completionHandler(nil, [], false, lookupError(from: error))
+            }
+        }
+        return progress
+    }
+
+    private func uploadFile(
+        filename: String,
+        contentsURL: URL,
+        parentUuid: String,
+        parentIdentifier: NSFileProviderItemIdentifier,
+        driveAPI: DriveAPI,
+        networkFacade: NetworkFacade,
+        completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
+    ) -> Progress {
+        let progress = Progress(totalUnitCount: 100)
+        Task {
+            let encryptedTmp = Self.temporaryFileURL()
+            defer { try? FileManager.default.removeItem(at: encryptedTmp) }
+
+            do {
+                let meta = try await driveAPI.getFolderMetaByUuid(uuid: parentUuid)
+                guard let bucket = try await Self.resolveBucket(parentMeta: meta, driveAPI: driveAPI) else {
+                    completionHandler(nil, [], false, Self.notAuthenticatedError)
+                    return
+                }
+                guard let input = InputStream(url: contentsURL) else {
+                    completionHandler(nil, [], false, Self.noSuchItemError)
+                    return
+                }
+
+                let fileSize = Self.fileSize(of: contentsURL)
+                let finish = try await networkFacade.uploadFile(
+                    input: input,
+                    encryptedOutput: encryptedTmp,
+                    fileSize: fileSize,
+                    bucketId: bucket,
+                    progressHandler: { fraction in
+                        progress.completedUnitCount = Int64(fraction * 100)
+                    }
+                )
+
+                let (baseName, fileExtension) = Self.splitNameExtension(filename)
+                let created = try await driveAPI.createFileNew(createFile: CreateFileDataNew(
+                    fileId: finish.id,
+                    type: fileExtension,
+                    bucket: bucket,
+                    size: fileSize,
+                    folderId: meta.id,
+                    name: baseName,
+                    plainName: baseName,
+                    folderUuid: parentUuid
+                ))
+
+                let item = FileProviderItem(file: created, parent: parentIdentifier)
+                completionHandler(item, [], false, nil)
+            } catch {
+                completionHandler(nil, [], false, lookupError(from: error))
+            }
+        }
+        return progress
+    }
+
+    private static func resolveBucket(parentMeta: GetFolderMetaByIdResponse, driveAPI: DriveAPI) async throws -> String? {
+        if let bucket = parentMeta.bucket {
+            return bucket
+        }
+        guard let rootUuid = FileProviderItemID.rootFolderUuid() else {
+            return nil
+        }
+        let rootMeta = try await driveAPI.getFolderMetaByUuid(uuid: rootUuid)
+        return rootMeta.bucket
+    }
+
+    private static func fileSize(of url: URL) -> Int {
+        let values = try? url.resourceValues(forKeys: [.fileSizeKey])
+        return values?.fileSize ?? 0
+    }
+
+    private static func splitNameExtension(_ filename: String) -> (base: String, fileExtension: String?) {
+        FileProviderItem.splitNameExtension(filename, kind: .file)
     }
     
     func modifyItem(_ item: NSFileProviderItem, baseVersion version: NSFileProviderItemVersion, changedFields: NSFileProviderItemFields, contents newContents: URL?, options: NSFileProviderModifyItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) -> Progress {
-        // TODO: an item was modified on disk, process the item's modification
-        
-        completionHandler(nil, [], false, NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError, userInfo:[:]))
+        if changedFields.contains(.contents) || changedFields.contains(.parentItemIdentifier) {
+            completionHandler(item, [], false, nil)
+            return Progress()
+        }
+
+        if changedFields.contains(.filename) {
+            return renameItem(item, completionHandler: completionHandler)
+        }
+
+        completionHandler(item, [], false, nil)
         return Progress()
+    }
+
+    private func renameItem(
+        _ item: NSFileProviderItem,
+        completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
+    ) -> Progress {
+        guard let driveAPI = DriveAPIFactory.make() else {
+            completionHandler(nil, [], false, Self.notAuthenticatedError)
+            return Progress()
+        }
+
+        guard let decoded = FileProviderItemID.decode(item.itemIdentifier) else {
+            completionHandler(nil, [], false, Self.noSuchItemError)
+            return Progress()
+        }
+
+        let newFilename = item.filename
+        let progress = Progress(totalUnitCount: 1)
+        Task {
+            do {
+                try await rename(decoded, to: newFilename, driveAPI: driveAPI)
+                progress.completedUnitCount = 1
+                let renamed = FileProviderItem.renamed(from: item, newFilename: newFilename) ?? item
+                completionHandler(renamed, [], false, nil)
+            } catch {
+                completionHandler(nil, [], false, lookupError(from: error))
+            }
+        }
+        return progress
+    }
+
+    private func rename(
+        _ decoded: (kind: DriveItemKind, uuid: String),
+        to newFilename: String,
+        driveAPI: DriveAPI
+    ) async throws {
+        switch decoded.kind {
+        case .folder:
+            _ = try await driveAPI.updateFolderNew(folderUuid: decoded.uuid, folderName: newFilename)
+        case .file:
+            let meta = try await driveAPI.getFileMetaByUuid(uuid: decoded.uuid)
+            let (baseName, _) = Self.splitNameExtension(newFilename)
+            _ = try await driveAPI.updateFileNew(uuid: decoded.uuid, bucketId: meta.bucket, newFilename: baseName)
+        }
     }
     
     func deleteItem(identifier: NSFileProviderItemIdentifier, baseVersion version: NSFileProviderItemVersion, options: NSFileProviderDeleteItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (Error?) -> Void) -> Progress {

--- a/ios/InternxtFileProvider/FileProviderExtension.swift
+++ b/ios/InternxtFileProvider/FileProviderExtension.swift
@@ -12,36 +12,9 @@ import UniformTypeIdentifiers
 class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
     private let rootDisplayName: String
 
-    private enum FriendlyError {
-        static let offlineDescription = "No internet connection"
-        static let offlineReason = "Connect to the internet and try again to upload to Internxt Drive."
-        static let notAuthenticatedDescription = "Sign in required"
-        static let notAuthenticatedReason = "Open the Internxt app and sign in to continue."
-        static let genericDescription = "Couldn’t complete the operation"
-        static let genericReason = "Something went wrong with Internxt Drive. Please try again."
-    }
-
     required init(domain: NSFileProviderDomain) {
         self.rootDisplayName = domain.displayName
         super.init()
-    }
-
-    private static func fileProviderError(_ code: NSFileProviderError.Code, description: String, reason: String? = nil) -> NSError {
-        var userInfo: [String: Any] = [NSLocalizedDescriptionKey: description]
-        userInfo[NSLocalizedFailureReasonErrorKey] = reason ?? description
-        return NSError(domain: NSFileProviderError.errorDomain, code: code.rawValue, userInfo: userInfo)
-    }
-
-    private static var offlineError: NSError {
-        fileProviderError(.serverUnreachable, description: FriendlyError.offlineDescription, reason: FriendlyError.offlineReason)
-    }
-
-    private static var notAuthenticatedError: NSError {
-        fileProviderError(.notAuthenticated, description: FriendlyError.notAuthenticatedDescription, reason: FriendlyError.notAuthenticatedReason)
-    }
-
-    private static var noSuchItemError: NSError {
-        fileProviderError(.noSuchItem, description: FriendlyError.genericDescription, reason: FriendlyError.genericReason)
     }
 
     func invalidate() {
@@ -56,12 +29,12 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         }
 
         guard let decoded = FileProviderItemID.decode(identifier) else {
-            completionHandler(nil, Self.noSuchItemError)
+            completionHandler(nil, NSFileProviderError(.noSuchItem))
             return Progress()
         }
 
         guard let driveAPI = DriveAPIFactory.make() else {
-            completionHandler(nil, Self.notAuthenticatedError)
+            completionHandler(nil, NSFileProviderError(.notAuthenticated))
             return Progress()
         }
 
@@ -111,12 +84,12 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
 
     private func lookupError(from error: Error) -> Error {
         if isUnauthorized(error) {
-            return Self.notAuthenticatedError
+            return NSFileProviderError(.notAuthenticated)
         }
         if isOffline(error) {
-            return Self.offlineError
+            return NSFileProviderError(.serverUnreachable)
         }
-        return Self.noSuchItemError
+        return NSFileProviderError(.noSuchItem)
     }
 
     private func isUnauthorized(_ error: Error) -> Bool {
@@ -156,12 +129,12 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
 
     func fetchContents(for itemIdentifier: NSFileProviderItemIdentifier, version requestedVersion: NSFileProviderItemVersion?, request: NSFileProviderRequest, completionHandler: @escaping (URL?, NSFileProviderItem?, Error?) -> Void) -> Progress {
         guard let decoded = FileProviderItemID.decode(itemIdentifier), decoded.kind == .file else {
-            completionHandler(nil, nil, Self.noSuchItemError)
+            completionHandler(nil, nil, NSFileProviderError(.noSuchItem))
             return Progress()
         }
 
         guard let driveAPI = DriveAPIFactory.make(), let networkFacade = NetworkFacadeFactory.make() else {
-            completionHandler(nil, nil, Self.notAuthenticatedError)
+            completionHandler(nil, nil, NSFileProviderError(.notAuthenticated))
             return Progress()
         }
 
@@ -197,12 +170,12 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
     
     func createItem(basedOn itemTemplate: NSFileProviderItem, fields: NSFileProviderItemFields, contents url: URL?, options: NSFileProviderCreateItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) -> Progress {
         guard let driveAPI = DriveAPIFactory.make(), let networkFacade = NetworkFacadeFactory.make() else {
-            completionHandler(nil, [], false, Self.notAuthenticatedError)
+            completionHandler(nil, [], false, NSFileProviderError(.notAuthenticated))
             return Progress()
         }
 
         guard let parentUuid = FileProviderItemID.folderUuid(for: itemTemplate.parentItemIdentifier) else {
-            completionHandler(nil, [], false, Self.noSuchItemError)
+            completionHandler(nil, [], false, NSFileProviderError(.noSuchItem))
             return Progress()
         }
 
@@ -219,7 +192,7 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         }
 
         guard let contentsURL = url else {
-            completionHandler(nil, [], false, Self.noSuchItemError)
+            completionHandler(nil, [], false, NSFileProviderError(.noSuchItem))
             return Progress()
         }
 
@@ -272,11 +245,11 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
             do {
                 let meta = try await driveAPI.getFolderMetaByUuid(uuid: parentUuid)
                 guard let bucket = try await Self.resolveBucket(parentMeta: meta, driveAPI: driveAPI) else {
-                    completionHandler(nil, [], false, Self.notAuthenticatedError)
+                    completionHandler(nil, [], false, NSFileProviderError(.notAuthenticated))
                     return
                 }
                 guard let input = InputStream(url: contentsURL) else {
-                    completionHandler(nil, [], false, Self.noSuchItemError)
+                    completionHandler(nil, [], false, NSFileProviderError(.noSuchItem))
                     return
                 }
 
@@ -351,12 +324,12 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
     ) -> Progress {
         guard let driveAPI = DriveAPIFactory.make() else {
-            completionHandler(nil, [], false, Self.notAuthenticatedError)
+            completionHandler(nil, [], false, NSFileProviderError(.notAuthenticated))
             return Progress()
         }
 
         guard let decoded = FileProviderItemID.decode(item.itemIdentifier) else {
-            completionHandler(nil, [], false, Self.noSuchItemError)
+            completionHandler(nil, [], false, NSFileProviderError(.noSuchItem))
             return Progress()
         }
 

--- a/ios/InternxtFileProvider/FileProviderExtension.swift
+++ b/ios/InternxtFileProvider/FileProviderExtension.swift
@@ -38,93 +38,18 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
             return Progress()
         }
 
+        let mutationService = FileProviderMutationService(driveAPI: driveAPI)
         let progress = Progress(totalUnitCount: 1)
         Task {
             do {
-                let item = try await resolveItem(decoded, identifier: identifier, driveAPI: driveAPI)
+                let item = try await mutationService.resolveItem(decoded, identifier: identifier)
                 progress.completedUnitCount = 1
                 completionHandler(item, nil)
             } catch {
-                completionHandler(nil, lookupError(from: error))
+                completionHandler(nil, FileProviderErrorMapper.lookupError(from: error))
             }
         }
         return progress
-    }
-
-    private func resolveItem(
-        _ decoded: (kind: DriveItemKind, uuid: String),
-        identifier: NSFileProviderItemIdentifier,
-        driveAPI: DriveAPI
-    ) async throws -> FileProviderItem {
-        switch decoded.kind {
-        case .folder:
-            let meta = try await driveAPI.getFolderMetaByUuid(uuid: decoded.uuid)
-            return FileProviderItem(folderMeta: meta, identifier: identifier)
-        case .file:
-            let meta = try await driveAPI.getFileMetaByUuid(uuid: decoded.uuid)
-            return FileProviderItem(fileMeta: meta, identifier: identifier)
-        }
-    }
-
-    private static let offlineURLErrorCodes: Set<URLError.Code> = [
-        .notConnectedToInternet,
-        .networkConnectionLost,
-        .timedOut,
-        .cannotConnectToHost,
-        .dataNotAllowed,
-        .cannotFindHost
-    ]
-
-    private static let offlineErrorCodes: Set<ErrorCode> = [
-        .networkNoConnection,
-        .networkConnectionLost,
-        .networkTimeout,
-        .networkCannotConnect
-    ]
-
-    private func lookupError(from error: Error) -> Error {
-        if isUnauthorized(error) {
-            return NSFileProviderError(.notAuthenticated)
-        }
-        if isOffline(error) {
-            return NSFileProviderError(.serverUnreachable)
-        }
-        return NSFileProviderError(.noSuchItem)
-    }
-
-    private func isUnauthorized(_ error: Error) -> Bool {
-        if let enriched = error as? EnrichedError {
-            if enriched.code == .apiUnauthorized {
-                return true
-            }
-            if let cause = enriched.cause {
-                return isUnauthorized(cause)
-            }
-            return false
-        }
-        if let apiError = error as? APIClientError {
-            return apiError.statusCode == 401
-        }
-        return false
-    }
-
-    private func isOffline(_ error: Error) -> Bool {
-        if let enriched = error as? EnrichedError {
-            if Self.offlineErrorCodes.contains(enriched.code) {
-                return true
-            }
-            if let cause = enriched.cause {
-                return isOffline(cause)
-            }
-            return false
-        }
-        if let urlError = error as? URLError {
-            return Self.offlineURLErrorCodes.contains(urlError.code)
-        }
-        if let apiError = error as? APIClientError {
-            return apiError.statusCode <= 0
-        }
-        return false
     }
 
     func fetchContents(for itemIdentifier: NSFileProviderItemIdentifier, version requestedVersion: NSFileProviderItemVersion?, request: NSFileProviderRequest, completionHandler: @escaping (URL?, NSFileProviderItem?, Error?) -> Void) -> Progress {
@@ -138,36 +63,22 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
             return Progress()
         }
 
+        let downloadService = FileProviderDownloadService(driveAPI: driveAPI, networkFacade: networkFacade)
         let progress = Progress(totalUnitCount: 100)
         Task {
-            let encryptedTmp = Self.temporaryFileURL()
-            let plainTmp = Self.temporaryFileURL()
-            defer { try? FileManager.default.removeItem(at: encryptedTmp) }
-
             do {
-                let meta = try await driveAPI.getFileMetaByUuid(uuid: decoded.uuid)
-                _ = try await networkFacade.downloadFile(
-                    bucketId: meta.bucket,
-                    fileId: meta.fileId,
-                    encryptedFileDestination: encryptedTmp,
-                    destinationURL: plainTmp,
-                    progressHandler: { fraction in
-                        progress.completedUnitCount = Int64(fraction * 100)
-                    }
-                )
-                let item = FileProviderItem(fileMeta: meta, identifier: itemIdentifier)
-                completionHandler(plainTmp, item, nil)
+                let result = try await downloadService.fetchContents(uuid: decoded.uuid) { fraction in
+                    progress.completedUnitCount = Int64(fraction * 100)
+                }
+                let item = FileProviderItem(fileMeta: result.meta, identifier: itemIdentifier)
+                completionHandler(result.url, item, nil)
             } catch {
-                completionHandler(nil, nil, lookupError(from: error))
+                completionHandler(nil, nil, FileProviderErrorMapper.lookupError(from: error))
             }
         }
         return progress
     }
 
-    private static func temporaryFileURL() -> URL {
-        FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-    }
-    
     func createItem(basedOn itemTemplate: NSFileProviderItem, fields: NSFileProviderItemFields, contents url: URL?, options: NSFileProviderCreateItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) -> Progress {
         guard let driveAPI = DriveAPIFactory.make(), let networkFacade = NetworkFacadeFactory.make() else {
             completionHandler(nil, [], false, NSFileProviderError(.notAuthenticated))
@@ -180,13 +91,14 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         }
 
         let parentIdentifier = itemTemplate.parentItemIdentifier
+        let uploadService = FileProviderUploadService(driveAPI: driveAPI, networkFacade: networkFacade)
 
         if itemTemplate.contentType?.conforms(to: .folder) == true {
             return createFolder(
                 name: itemTemplate.filename,
                 parentUuid: parentUuid,
                 parentIdentifier: parentIdentifier,
-                driveAPI: driveAPI,
+                uploadService: uploadService,
                 completionHandler: completionHandler
             )
         }
@@ -201,8 +113,7 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
             contentsURL: contentsURL,
             parentUuid: parentUuid,
             parentIdentifier: parentIdentifier,
-            driveAPI: driveAPI,
-            networkFacade: networkFacade,
+            uploadService: uploadService,
             completionHandler: completionHandler
         )
     }
@@ -211,18 +122,18 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         name: String,
         parentUuid: String,
         parentIdentifier: NSFileProviderItemIdentifier,
-        driveAPI: DriveAPI,
+        uploadService: FileProviderUploadService,
         completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
     ) -> Progress {
         let progress = Progress(totalUnitCount: 1)
         Task {
             do {
-                let response = try await driveAPI.createFolderNew(parentFolderUuid: parentUuid, folderName: name)
+                let response = try await uploadService.createFolder(name: name, parentUuid: parentUuid)
                 progress.completedUnitCount = 1
                 let item = FileProviderItem(folder: response, parent: parentIdentifier)
                 completionHandler(item, [], false, nil)
             } catch {
-                completionHandler(nil, [], false, lookupError(from: error))
+                completionHandler(nil, [], false, FileProviderErrorMapper.lookupError(from: error))
             }
         }
         return progress
@@ -233,78 +144,41 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         contentsURL: URL,
         parentUuid: String,
         parentIdentifier: NSFileProviderItemIdentifier,
-        driveAPI: DriveAPI,
-        networkFacade: NetworkFacade,
+        uploadService: FileProviderUploadService,
         completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
     ) -> Progress {
         let progress = Progress(totalUnitCount: 100)
         Task {
-            let encryptedTmp = Self.temporaryFileURL()
+            let encryptedTmp = FileProviderDownloadService.temporaryFileURL()
             defer { try? FileManager.default.removeItem(at: encryptedTmp) }
 
             do {
-                let meta = try await driveAPI.getFolderMetaByUuid(uuid: parentUuid)
-                guard let bucket = try await Self.resolveBucket(parentMeta: meta, driveAPI: driveAPI) else {
-                    completionHandler(nil, [], false, NSFileProviderError(.notAuthenticated))
-                    return
-                }
-                guard let input = InputStream(url: contentsURL) else {
-                    completionHandler(nil, [], false, NSFileProviderError(.noSuchItem))
-                    return
-                }
-
-                let fileSize = Self.fileSize(of: contentsURL)
-                let finish = try await networkFacade.uploadFile(
-                    input: input,
+                let result = try await uploadService.uploadFile(
+                    filename: filename,
+                    contentsURL: contentsURL,
+                    parentUuid: parentUuid,
                     encryptedOutput: encryptedTmp,
-                    fileSize: fileSize,
-                    bucketId: bucket,
                     progressHandler: { fraction in
                         progress.completedUnitCount = Int64(fraction * 100)
                     }
                 )
 
-                let (baseName, fileExtension) = Self.splitNameExtension(filename)
-                let created = try await driveAPI.createFileNew(createFile: CreateFileDataNew(
-                    fileId: finish.id,
-                    type: fileExtension,
-                    bucket: bucket,
-                    size: fileSize,
-                    folderId: meta.id,
-                    name: baseName,
-                    plainName: baseName,
-                    folderUuid: parentUuid
-                ))
-
-                let item = FileProviderItem(file: created, parent: parentIdentifier)
-                completionHandler(item, [], false, nil)
+                switch result {
+                case .created(let created):
+                    let item = FileProviderItem(file: created, parent: parentIdentifier)
+                    completionHandler(item, [], false, nil)
+                case .notAuthenticated:
+                    completionHandler(nil, [], false, NSFileProviderError(.notAuthenticated))
+                case .noSuchItem:
+                    completionHandler(nil, [], false, NSFileProviderError(.noSuchItem))
+                }
             } catch {
-                completionHandler(nil, [], false, lookupError(from: error))
+                completionHandler(nil, [], false, FileProviderErrorMapper.lookupError(from: error))
             }
         }
         return progress
     }
 
-    private static func resolveBucket(parentMeta: GetFolderMetaByIdResponse, driveAPI: DriveAPI) async throws -> String? {
-        if let bucket = parentMeta.bucket {
-            return bucket
-        }
-        guard let rootUuid = FileProviderItemID.rootFolderUuid() else {
-            return nil
-        }
-        let rootMeta = try await driveAPI.getFolderMetaByUuid(uuid: rootUuid)
-        return rootMeta.bucket
-    }
-
-    private static func fileSize(of url: URL) -> Int {
-        let values = try? url.resourceValues(forKeys: [.fileSizeKey])
-        return values?.fileSize ?? 0
-    }
-
-    private static func splitNameExtension(_ filename: String) -> (base: String, fileExtension: String?) {
-        FileProviderItem.splitNameExtension(filename, kind: .file)
-    }
-    
     func modifyItem(_ item: NSFileProviderItem, baseVersion version: NSFileProviderItemVersion, changedFields: NSFileProviderItemFields, contents newContents: URL?, options: NSFileProviderModifyItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) -> Progress {
         if changedFields.contains(.contents) || changedFields.contains(.parentItemIdentifier) {
             completionHandler(item, [], false, nil)
@@ -333,43 +207,29 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
             return Progress()
         }
 
+        let mutationService = FileProviderMutationService(driveAPI: driveAPI)
         let newFilename = item.filename
         let progress = Progress(totalUnitCount: 1)
         Task {
             do {
-                try await rename(decoded, to: newFilename, driveAPI: driveAPI)
+                try await mutationService.rename(decoded, to: newFilename)
                 progress.completedUnitCount = 1
                 let renamed = FileProviderItem.renamed(from: item, newFilename: newFilename) ?? item
                 completionHandler(renamed, [], false, nil)
             } catch {
-                completionHandler(nil, [], false, lookupError(from: error))
+                completionHandler(nil, [], false, FileProviderErrorMapper.lookupError(from: error))
             }
         }
         return progress
     }
 
-    private func rename(
-        _ decoded: (kind: DriveItemKind, uuid: String),
-        to newFilename: String,
-        driveAPI: DriveAPI
-    ) async throws {
-        switch decoded.kind {
-        case .folder:
-            _ = try await driveAPI.updateFolderNew(folderUuid: decoded.uuid, folderName: newFilename)
-        case .file:
-            let meta = try await driveAPI.getFileMetaByUuid(uuid: decoded.uuid)
-            let (baseName, _) = Self.splitNameExtension(newFilename)
-            _ = try await driveAPI.updateFileNew(uuid: decoded.uuid, bucketId: meta.bucket, newFilename: baseName)
-        }
-    }
-    
     func deleteItem(identifier: NSFileProviderItemIdentifier, baseVersion version: NSFileProviderItemVersion, options: NSFileProviderDeleteItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (Error?) -> Void) -> Progress {
         // TODO: an item was deleted on disk, process the item's deletion
-        
+
         completionHandler(NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError, userInfo:[:]))
         return Progress()
     }
-    
+
     func enumerator(for containerItemIdentifier: NSFileProviderItemIdentifier, request: NSFileProviderRequest) throws -> NSFileProviderEnumerator {
         return FileProviderEnumerator(enumeratedItemIdentifier: containerItemIdentifier)
     }

--- a/ios/InternxtFileProvider/FileProviderItem.swift
+++ b/ios/InternxtFileProvider/FileProviderItem.swift
@@ -66,6 +66,63 @@ class FileProviderItem: NSObject, NSFileProviderItem {
     )
   }
 
+  convenience init(folder: CreateFolderResponseNew, parent: NSFileProviderItemIdentifier) {
+    self.init(
+      identifier: FileProviderItemID.encode(.folder, uuid: folder.uuid),
+      parent: parent,
+      name: folder.plainName ?? folder.name,
+      kind: .folder,
+      fileExtension: nil,
+      createdAt: folder.createdAt,
+      updatedAt: folder.updatedAt,
+      sizeInBytes: nil
+    )
+  }
+
+  convenience init(file: CreateFileResponseNew, parent: NSFileProviderItemIdentifier) {
+    self.init(
+      identifier: FileProviderItemID.encode(.file, uuid: file.uuid),
+      parent: parent,
+      name: file.plain_name,
+      kind: .file,
+      fileExtension: file.type,
+      createdAt: file.createdAt,
+      updatedAt: file.updatedAt,
+      sizeInBytes: file.size
+    )
+  }
+
+  static func renamed(from item: NSFileProviderItem, newFilename: String) -> FileProviderItem? {
+    guard let decoded = FileProviderItemID.decode(item.itemIdentifier) else { return nil }
+    let (baseName, newExtension) = splitNameExtension(newFilename, kind: decoded.kind)
+    return FileProviderItem(
+      identifier: item.itemIdentifier,
+      parent: item.parentItemIdentifier,
+      name: baseName,
+      kind: decoded.kind,
+      fileExtension: newExtension,
+      createdAt: iso8601String(from: item.creationDate ?? nil),
+      updatedAt: iso8601String(from: item.contentModificationDate ?? nil),
+      sizeInBytes: (item.documentSize ?? nil)?.stringValue
+    )
+  }
+
+  private static func iso8601String(from date: Date?) -> String? {
+    guard let date = date else { return nil }
+    return iso8601Formatter.string(from: date)
+  }
+
+  static func splitNameExtension(_ filename: String, kind: DriveItemKind) -> (base: String, fileExtension: String?) {
+    guard kind == .file else { return (filename, nil) }
+    let url = URL(fileURLWithPath: filename)
+    let fileExtension = url.pathExtension
+    let base = url.deletingPathExtension().lastPathComponent
+    if fileExtension.isEmpty || base.isEmpty {
+      return (filename, nil)
+    }
+    return (base, fileExtension)
+  }
+
   static func root(displayName: String) -> FileProviderItem {
     FileProviderItem(
       identifier: .rootContainer,
@@ -116,9 +173,9 @@ class FileProviderItem: NSObject, NSFileProviderItem {
   var capabilities: NSFileProviderItemCapabilities {
     switch kind {
     case .folder:
-      return [.allowsReading, .allowsContentEnumerating]
+      return [.allowsReading, .allowsContentEnumerating, .allowsAddingSubItems, .allowsRenaming]
     case .file:
-      return [.allowsReading]
+      return [.allowsReading, .allowsRenaming]
     }
   }
 

--- a/ios/InternxtFileProvider/FileProviderMutationService.swift
+++ b/ios/InternxtFileProvider/FileProviderMutationService.swift
@@ -1,0 +1,41 @@
+//
+//  FileProviderMutationService.swift
+//  InternxtFileProvider
+//
+//  Created by Ramon Candel on 9/4/26.
+//
+
+import FileProvider
+import InternxtSwiftCore
+
+struct FileProviderMutationService {
+    let driveAPI: DriveAPI
+
+    func resolveItem(
+        _ decoded: (kind: DriveItemKind, uuid: String),
+        identifier: NSFileProviderItemIdentifier
+    ) async throws -> FileProviderItem {
+        switch decoded.kind {
+        case .folder:
+            let meta = try await driveAPI.getFolderMetaByUuid(uuid: decoded.uuid)
+            return FileProviderItem(folderMeta: meta, identifier: identifier)
+        case .file:
+            let meta = try await driveAPI.getFileMetaByUuid(uuid: decoded.uuid)
+            return FileProviderItem(fileMeta: meta, identifier: identifier)
+        }
+    }
+
+    func rename(
+        _ decoded: (kind: DriveItemKind, uuid: String),
+        to newFilename: String
+    ) async throws {
+        switch decoded.kind {
+        case .folder:
+            _ = try await driveAPI.updateFolderNew(folderUuid: decoded.uuid, folderName: newFilename)
+        case .file:
+            let meta = try await driveAPI.getFileMetaByUuid(uuid: decoded.uuid)
+            let (baseName, _) = FileProviderItem.splitNameExtension(newFilename, kind: .file)
+            _ = try await driveAPI.updateFileNew(uuid: decoded.uuid, bucketId: meta.bucket, newFilename: baseName)
+        }
+    }
+}

--- a/ios/InternxtFileProvider/FileProviderUploadService.swift
+++ b/ios/InternxtFileProvider/FileProviderUploadService.swift
@@ -1,0 +1,86 @@
+//
+//  FileProviderUploadService.swift
+//  InternxtFileProvider
+//
+//  Created by Ramon Candel on 9/4/26.
+//
+
+import FileProvider
+import InternxtSwiftCore
+
+struct FileProviderUploadService {
+    let driveAPI: DriveAPI
+    let networkFacade: NetworkFacade
+
+    func createFolder(
+        name: String,
+        parentUuid: String
+    ) async throws -> CreateFolderResponseNew {
+        try await driveAPI.createFolderNew(parentFolderUuid: parentUuid, folderName: name)
+    }
+
+    func uploadFile(
+        filename: String,
+        contentsURL: URL,
+        parentUuid: String,
+        encryptedOutput: URL,
+        progressHandler: @escaping (Double) -> Void
+    ) async throws -> UploadResult {
+        let meta = try await driveAPI.getFolderMetaByUuid(uuid: parentUuid)
+        guard let bucket = try await resolveBucket(parentMeta: meta) else {
+            return .notAuthenticated
+        }
+        guard let input = InputStream(url: contentsURL) else {
+            return .noSuchItem
+        }
+
+        let fileSize = Self.fileSize(of: contentsURL)
+        let finish = try await networkFacade.uploadFile(
+            input: input,
+            encryptedOutput: encryptedOutput,
+            fileSize: fileSize,
+            bucketId: bucket,
+            progressHandler: progressHandler
+        )
+
+        let (baseName, fileExtension) = Self.splitNameExtension(filename)
+        let created = try await driveAPI.createFileNew(createFile: CreateFileDataNew(
+            fileId: finish.id,
+            type: fileExtension,
+            bucket: bucket,
+            size: fileSize,
+            folderId: meta.id,
+            name: baseName,
+            plainName: baseName,
+            folderUuid: parentUuid
+        ))
+
+        return .created(created)
+    }
+
+    private func resolveBucket(parentMeta: GetFolderMetaByIdResponse) async throws -> String? {
+        if let bucket = parentMeta.bucket {
+            return bucket
+        }
+        guard let rootUuid = FileProviderItemID.rootFolderUuid() else {
+            return nil
+        }
+        let rootMeta = try await driveAPI.getFolderMetaByUuid(uuid: rootUuid)
+        return rootMeta.bucket
+    }
+
+    private static func fileSize(of url: URL) -> Int {
+        let values = try? url.resourceValues(forKeys: [.fileSizeKey])
+        return values?.fileSize ?? 0
+    }
+
+    private static func splitNameExtension(_ filename: String) -> (base: String, fileExtension: String?) {
+        FileProviderItem.splitNameExtension(filename, kind: .file)
+    }
+
+    enum UploadResult {
+        case created(CreateFileResponseNew)
+        case notAuthenticated
+        case noSuchItem
+    }
+}


### PR DESCRIPTION
Implement the write path in the NSFileProviderReplicatedExtension so the Files.app can create folders and upload files to Drive. createItem routes folder creation to the Drive API and file uploads through InternxtSwiftCore encryption plus network upload, then registers the file and returns the created NSFileProviderItem. Adds rename support via modifyItem and friendly non-crashing errors for offline/unauthenticated/generic failures.