### PR TITLE
[PB-6495] feature/Show asset upload progress in timeline and preview screen

### DIFF
--- a/assets/lang/strings.ts
+++ b/assets/lang/strings.ts
@@ -223,6 +223,7 @@ const translations = {
           uploading: 'Uploading',
           burstBadge: 'Burst',
           burstIncomplete: 'Burst not fully backed up. Grant full Photos access to back up all burst photos.',
+          burstPhotosUnit: 'photos',
           metadata: {
             info: 'Name',
             uploaded: 'Uploaded',
@@ -1220,6 +1221,7 @@ const translations = {
           burstBadge: 'Ráfaga',
           burstIncomplete:
             'Ráfaga incompleta. Para respaldar todas las fotos de la ráfaga, concede acceso completo a Fotos.',
+          burstPhotosUnit: 'fotos',
           metadata: {
             info: 'Nombre',
             uploaded: 'Subido',

--- a/src/screens/HomeScreen/useDiscoverPhotosSheet.spec.tsx
+++ b/src/screens/HomeScreen/useDiscoverPhotosSheet.spec.tsx
@@ -36,6 +36,7 @@ const makeWrapper = (photosState?: Partial<PhotosState>) => {
         totalScannedAssets: 0,
         totalAssetsUploaded: 0,
         uploadProgressById: {},
+        burstUploadProgressById: {},
         uploadingAssetIds: [],
         deviceId: null,
         photosBucket: null,

--- a/src/screens/PhotoPreviewScreen/components/PreviewHeader.tsx
+++ b/src/screens/PhotoPreviewScreen/components/PreviewHeader.tsx
@@ -13,9 +13,33 @@ import { formatHeaderDate, formatHeaderTime } from '../utils/formatters';
 
 const photoPreviewStrings = strings.screens.photos.photoPreview;
 
+const REPRESENTATIVE_PHOTO_COUNT = 1;
+
+const getUploadingLabel = (isBurst: boolean, burstLiveProgress: { uploaded: number; total: number } | null): string => {
+  if (isBurst && burstLiveProgress) {
+    const uploaded = burstLiveProgress.uploaded + REPRESENTATIVE_PHOTO_COUNT;
+    const total = burstLiveProgress.total + REPRESENTATIVE_PHOTO_COUNT;
+    return `${photoPreviewStrings.burstBadge} · ${uploaded}/${total}`;
+  }
+  if (isBurst) {
+    return photoPreviewStrings.burstBadge;
+  }
+  return photoPreviewStrings.uploading;
+};
+
+const getBackedBurstLabel = (isBurst: boolean, isUploading: boolean, burstTotal: number | null): string | null => {
+  if (isBurst && !isUploading && burstTotal != null) {
+    return `${photoPreviewStrings.burstBadge} · ${burstTotal} ${photoPreviewStrings.burstPhotosUnit}`;
+  }
+  return null;
+};
+
 interface TimelineInfoProps {
   isWaitingToUpload: boolean;
   isUploading: boolean;
+  isBurst: boolean;
+  burstLiveProgress: { uploaded: number; total: number } | null;
+  burstTotal: number | null;
   timestamp: number | undefined;
   hasTimeAccuracy: boolean;
 }
@@ -23,12 +47,23 @@ interface TimelineInfoProps {
 const TimelineInfo = ({
   isWaitingToUpload,
   isUploading,
+  isBurst,
+  burstLiveProgress,
+  burstTotal,
   timestamp,
   hasTimeAccuracy,
 }: TimelineInfoProps): JSX.Element | null => {
   const tailwind = useTailwind();
-  if (!isWaitingToUpload && !isUploading && (!timestamp || !hasTimeAccuracy)) return null;
-  const showSeparator = (isWaitingToUpload || isUploading) && timestamp && hasTimeAccuracy;
+
+  const uploadLabel = getUploadingLabel(isBurst, burstLiveProgress);
+  const backedBurstLabel = getBackedBurstLabel(isBurst, isUploading, burstTotal);
+
+  const showUploadRow = isWaitingToUpload || isUploading;
+  if (!showUploadRow && !backedBurstLabel && (!timestamp || !hasTimeAccuracy)) {
+    return null;
+  }
+  const showSeparator = showUploadRow && timestamp && hasTimeAccuracy;
+
   return (
     <View style={[tailwind('flex-row items-center justify-center opacity-75'), { gap: 8 }]}>
       {timestamp && hasTimeAccuracy && (
@@ -44,8 +79,11 @@ const TimelineInfo = ({
       {isUploading && (
         <View style={[tailwind('flex-row items-center'), { gap: 4 }]}>
           <ArrowUpIcon size={16} color="white" />
-          <AppText style={tailwind('text-sm text-white')}>{photoPreviewStrings.uploading}</AppText>
+          <AppText style={tailwind('text-sm text-white')}>{uploadLabel}</AppText>
         </View>
+      )}
+      {backedBurstLabel && !showUploadRow && (
+        <AppText style={tailwind('text-sm text-white')}>{backedBurstLabel}</AppText>
       )}
     </View>
   );
@@ -62,7 +100,14 @@ export const PreviewHeader = ({ visible, item, onClose, onMore }: PreviewHeaderP
   const tailwind = useTailwind();
   const insets = useSafeAreaInsets();
 
-  const { isWaitingToUpload, isUploading, progress: uploadProgress } = useLiveBackupStatus(item);
+  const {
+    isWaitingToUpload,
+    isUploading,
+    progress: uploadProgress,
+    isBurst,
+    burstLiveProgress,
+    burstTotal,
+  } = useLiveBackupStatus(item);
   const timestamp = useItemTimestamp(item);
   const hasTimeAccuracy = !!timestamp;
 
@@ -99,6 +144,9 @@ export const PreviewHeader = ({ visible, item, onClose, onMore }: PreviewHeaderP
               <TimelineInfo
                 isWaitingToUpload={isWaitingToUpload}
                 isUploading={isUploading}
+                isBurst={isBurst}
+                burstLiveProgress={burstLiveProgress}
+                burstTotal={burstTotal}
                 timestamp={timestamp}
                 hasTimeAccuracy={hasTimeAccuracy}
               />

--- a/src/screens/PhotoPreviewScreen/hooks/useLiveBackupStatus.spec.ts
+++ b/src/screens/PhotoPreviewScreen/hooks/useLiveBackupStatus.spec.ts
@@ -1,4 +1,5 @@
-import { renderHook } from '@testing-library/react-native';
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { photosLocalDB } from 'src/services/photos/database/photosLocalDB';
 import { useAppSelector } from 'src/store/hooks';
 import { CloudPhotoItem, PhotoItem } from '../../PhotosScreen/types';
 import { useLiveBackupStatus } from './useLiveBackupStatus';
@@ -7,11 +8,19 @@ jest.mock('src/store/hooks', () => ({
   useAppSelector: jest.fn(),
 }));
 
+jest.mock('src/services/photos/database/photosLocalDB', () => ({
+  photosLocalDB: {
+    getStatus: jest.fn().mockResolvedValue(null),
+  },
+}));
+
 const mockUseAppSelector = useAppSelector as jest.Mock;
+const mockGetStatus = photosLocalDB.getStatus as jest.Mock;
 
 const photosState = {
   uploadingAssetIds: [] as string[],
   uploadProgressById: {} as Record<string, number>,
+  burstUploadProgressById: {} as Record<string, { uploaded: number; total: number }>,
   sessionCompletedAssetIds: [] as string[],
 };
 
@@ -40,7 +49,9 @@ beforeEach(() => {
   jest.clearAllMocks();
   photosState.uploadingAssetIds = [];
   photosState.uploadProgressById = {};
+  photosState.burstUploadProgressById = {};
   photosState.sessionCompletedAssetIds = [];
+  mockGetStatus.mockResolvedValue(null);
   mockUseAppSelector.mockImplementation((selector: (state: { photos: typeof photosState }) => unknown) =>
     selector({ photos: photosState }),
   );
@@ -130,5 +141,39 @@ describe('useLiveBackupStatus', () => {
     expect(result.current.isUploading).toBe(false);
     expect(result.current.isWaitingToUpload).toBe(false);
     expect(result.current.progress).toBe(0);
+  });
+
+  test('when a burst is uploading, then live member progress is reported', () => {
+    photosState.uploadingAssetIds = ['b1'];
+    photosState.uploadProgressById = { b1: 0.6 };
+    photosState.burstUploadProgressById = { b1: { uploaded: 3, total: 5 } };
+
+    const item: PhotoItem = { id: 'b1', type: 'local', createdAt: 1000, backupState: 'not-backed', mediaType: 'photo', isBurst: true };
+    const { result } = renderHook(() => useLiveBackupStatus(item));
+
+    expect(result.current.isBurst).toBe(true);
+    expect(result.current.isUploading).toBe(true);
+    expect(result.current.burstLiveProgress).toEqual({ uploaded: 3, total: 5 });
+    expect(result.current.burstTotal).toBe(5);
+  });
+
+  test('when a burst is backed, then the member count from the database is reported as total', async () => {
+    mockGetStatus.mockResolvedValue({ burstMemberCount: 4 });
+
+    const item: PhotoItem = { id: 'b2', type: 'local', createdAt: 1000, backupState: 'backed', mediaType: 'photo', isBurst: true };
+    const { result } = renderHook(() => useLiveBackupStatus(item));
+
+    await waitFor(() => expect(result.current.burstTotal).toBe(5)); // 4 members + 1 representative
+
+    expect(result.current.isBurst).toBe(true);
+    expect(result.current.burstLiveProgress).toBeNull();
+  });
+
+  test('when the item is not a burst, then no burst info is reported', () => {
+    const { result } = renderHook(() => useLiveBackupStatus(makeLocalItem('a1', 'backed')));
+
+    expect(result.current.isBurst).toBe(false);
+    expect(result.current.burstLiveProgress).toBeNull();
+    expect(result.current.burstTotal).toBeNull();
   });
 });

--- a/src/screens/PhotoPreviewScreen/hooks/useLiveBackupStatus.ts
+++ b/src/screens/PhotoPreviewScreen/hooks/useLiveBackupStatus.ts
@@ -1,14 +1,41 @@
+import { useEffect, useState } from 'react';
+import { photosLocalDB } from 'src/services/photos/database/photosLocalDB';
 import { useAppSelector } from 'src/store/hooks';
 import { TimelinePhotoItem } from '../../PhotosScreen/types';
+
+export interface BurstLiveProgress {
+  uploaded: number;
+  total: number;
+}
 
 export interface LiveBackupStatus {
   isWaitingToUpload: boolean;
   isUploading: boolean;
   progress: number;
+  isBurst: boolean;
+  burstLiveProgress: BurstLiveProgress | null;
+  burstTotal: number | null;
 }
 
+/**
+ * Overlays live upload state from the Redux store on top of a frozen preview snapshot.
+ *
+ * The preview receives its items as a snapshot, so `item.backupState` is frozen
+ * at navigation time. This hook tracks the asset's live state instead, so the header reacts while
+ * the preview stays open: not-backed → uploading (with progress) → backed. For burst
+ * representatives it also resolves the member count — from the live `burstUploadProgressById`
+ * while uploading, or from `asset_sync.burstMemberCount` (read once via `photosLocalDB.getStatus`)
+ * once backed.
+ *
+ * @param item The currently displayed preview item, or `undefined` while there is none yet.
+ * @returns Live backup status for the header (waiting/uploading/progress), plus burst-specific
+ *   fields (`isBurst`, `burstLiveProgress`, `burstTotal`).
+ */
 export const useLiveBackupStatus = (item: TimelinePhotoItem | undefined): LiveBackupStatus => {
+  const [dbBurstTotal, setDbBurstTotal] = useState<number | null>(null);
+
   const assetId = item?.type === 'local' ? item.id : undefined;
+  const isBurst = item?.type === 'local' ? (item.isBurst ?? false) : false;
 
   const isInUploadQueue = useAppSelector((state) =>
     assetId ? state.photos.uploadingAssetIds.includes(assetId) : false,
@@ -17,13 +44,40 @@ export const useLiveBackupStatus = (item: TimelinePhotoItem | undefined): LiveBa
   const completedDuringSession = useAppSelector((state) =>
     assetId ? state.photos.sessionCompletedAssetIds.includes(assetId) : false,
   );
+  const burstLiveProgress = useAppSelector((state) =>
+    assetId ? (state.photos.burstUploadProgressById[assetId] ?? null) : null,
+  );
 
   const snapshotState = item?.type === 'local' ? item.backupState : undefined;
   const isWaitingToUpload = snapshotState === 'not-backed' && !isInUploadQueue && !completedDuringSession;
+
+  useEffect(() => {
+    if (!isBurst || !assetId || isInUploadQueue) {
+      setDbBurstTotal(null);
+      return;
+    }
+    let isCurrent = true;
+    photosLocalDB
+      .getStatus(assetId)
+      .then((entry) => {
+        if (isCurrent && entry?.burstMemberCount != null) {
+          setDbBurstTotal(entry.burstMemberCount + 1);
+        }
+      })
+      .catch(() => undefined);
+    return () => {
+      isCurrent = false;
+    };
+  }, [assetId, isBurst, isInUploadQueue]);
+
+  const burstTotal = isInUploadQueue ? (burstLiveProgress?.total ?? null) : dbBurstTotal;
 
   return {
     isUploading: isInUploadQueue,
     isWaitingToUpload,
     progress: isInUploadQueue ? progress : 0,
+    isBurst,
+    burstLiveProgress: isInUploadQueue ? burstLiveProgress : null,
+    burstTotal,
   };
 };

--- a/src/services/photos/PhotoCloudBrowser.spec.ts
+++ b/src/services/photos/PhotoCloudBrowser.spec.ts
@@ -28,6 +28,7 @@ jest.mock('./database/photosLocalDB', () => ({
     getSyncedMonths: jest.fn(),
     getDistinctCloudAssetDeviceIds: jest.fn().mockResolvedValue([]),
     deleteCloudAssetsByDevice: jest.fn(),
+    resetSyncedToPending: jest.fn(),
   },
 }));
 
@@ -60,6 +61,8 @@ beforeEach(() => {
   mockPhotosLocalDB.deleteCloudAsset.mockResolvedValue(undefined);
   mockPhotosLocalDB.getCloudAssetMonthsByDevice.mockResolvedValue([]);
   mockPhotosLocalDB.getSyncedMonths.mockResolvedValue([]);
+  mockPhotosLocalDB.getDistinctCloudAssetDeviceIds.mockResolvedValue([]);
+  mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
 });
 
 describe('PhotoCloudBrowser.listDeviceFolders', () => {
@@ -410,22 +413,23 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     expect(mockPhotosLocalDB.deleteCloudAsset).toHaveBeenCalledWith('synced-remote-uuid');
   });
 
-  test('when synced assets from a different device are missing from that device cloud folder, then they are not looked up via asset_sync', async () => {
+  test('when the current device id does not match any device in Drive, then no folders are fetched and synced assets are reset to pending', async () => {
     mockDeviceService.listDevices.mockResolvedValueOnce([makeDevice('d1-uuid', 'Internxt iPhone')]);
-    const year = makeFolder('y-uuid', '2024');
-    const month = makeFolder('m-uuid', '06');
-    const day = makeFolder('day-uuid', '15');
-    mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
-    mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth.mockResolvedValue(new Set());
-    mockFolderService.getFolderFolders
-      .mockResolvedValueOnce({ folders: [year] } as never)
-      .mockResolvedValueOnce({ folders: [month] } as never)
-      .mockResolvedValueOnce({ folders: [day] } as never);
-    mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [] } as never);
 
-    await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'other-device-uuid' });
+    await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'unknown-device-uuid' });
 
-    expect(mockPhotosLocalDB.getSyncedRemoteIdsByCreationMonth).not.toHaveBeenCalled();
+    expect(mockFolderService.getFolderFolders).not.toHaveBeenCalled();
+    expect(mockPhotosLocalDB.markCloudDeleted).not.toHaveBeenCalled();
+    expect(mockPhotosLocalDB.resetSyncedToPending).toHaveBeenCalledTimes(1);
+  });
+
+  test('when the current device no longer exists in Drive, then synced assets are reset to pending for re-upload', async () => {
+    mockDeviceService.listDevices.mockResolvedValueOnce([]);
+
+    await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'deleted-device-uuid' });
+
+    expect(mockFolderService.getFolderFolders).not.toHaveBeenCalled();
+    expect(mockPhotosLocalDB.resetSyncedToPending).toHaveBeenCalledTimes(1);
     expect(mockPhotosLocalDB.markCloudDeleted).not.toHaveBeenCalled();
   });
 
@@ -502,6 +506,22 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'd1-uuid' });
 
     expect(mockPhotosLocalDB.markCloudDeleted).toHaveBeenCalledWith('synced-april-uuid');
+  });
+
+  test('when the current device has no cloud history at all but the local DB has synced months, then those assets are reset to pending instead of cloud_deleted', async () => {
+    // Simulates the device folder having been deleted and recreated with a new identity: the
+    // (new) device folder exists and is reachable, but cloud_asset has zero rows for it — while
+    // asset_sync (local) still has 'synced' rows left over from before the deletion.
+    mockDeviceService.listDevices.mockResolvedValueOnce([makeDevice('d1-uuid', 'Internxt iPhone')]);
+    mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
+    mockPhotosLocalDB.getCloudAssetMonthsByDevice.mockResolvedValue([]);
+    mockPhotosLocalDB.getSyncedMonths.mockResolvedValue([{ year: 2024, month: 6 }]);
+    mockFolderService.getFolderFolders.mockResolvedValueOnce({ folders: [] } as never);
+
+    await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'd1-uuid' });
+
+    expect(mockPhotosLocalDB.resetSyncedToPending).toHaveBeenCalledTimes(1);
+    expect(mockPhotosLocalDB.markCloudDeleted).not.toHaveBeenCalled();
   });
 
   test('when the cloud has no months at all and the DB has known months, then every known month is reconciled', async () => {
@@ -583,5 +603,73 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     await photoCloudBrowser.syncAllHistory({});
 
     expect(mockPhotosLocalDB.deleteCloudAssetsByDevice).not.toHaveBeenCalled();
+  });
+
+  test('when the current device id is provided and multiple devices exist, then only months from the current device are fetched', async () => {
+    mockDeviceService.listDevices.mockResolvedValueOnce([
+      makeDevice('current-uuid', 'Internxt iPhone'),
+      makeDevice('other-uuid', 'Internxt iPad'),
+    ]);
+    const year = makeFolder('y-uuid', '2024');
+    const month = makeFolder('m-uuid', '06');
+    const day = makeFolder('day-uuid', '15');
+    const file = makeFile('file-uuid', 'photo.jpg');
+    mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
+    mockFolderService.getFolderFolders
+      .mockResolvedValueOnce({ folders: [year] } as never)
+      .mockResolvedValueOnce({ folders: [month] } as never)
+      .mockResolvedValueOnce({ folders: [day] } as never);
+    mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
+
+    await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'current-uuid' });
+
+    expect(mockPhotosLocalDB.upsertCloudAsset).toHaveBeenCalledTimes(1);
+    expect(mockPhotosLocalDB.upsertCloudAsset).toHaveBeenCalledWith(
+      expect.objectContaining({ deviceId: 'current-uuid' }),
+    );
+  });
+
+  test('when the current device id is provided and the local DB has rows from another device, then those rows are purged', async () => {
+    mockDeviceService.listDevices.mockResolvedValueOnce([
+      makeDevice('current-uuid', 'Internxt iPhone'),
+      makeDevice('other-uuid', 'Internxt iPad'),
+    ]);
+    mockPhotosLocalDB.getDistinctCloudAssetDeviceIds.mockResolvedValue(['current-uuid', 'other-uuid']);
+    mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(Infinity);
+
+    await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'current-uuid' });
+
+    expect(mockPhotosLocalDB.deleteCloudAssetsByDevice).toHaveBeenCalledWith('other-uuid');
+    expect(mockPhotosLocalDB.deleteCloudAssetsByDevice).not.toHaveBeenCalledWith('current-uuid');
+  });
+
+  test('when no current device id is provided, then all devices are synced', async () => {
+    mockDeviceService.listDevices.mockResolvedValueOnce([
+      makeDevice('d1-uuid', 'Internxt iPhone'),
+      makeDevice('d2-uuid', 'Internxt iPad'),
+    ]);
+    const yearD1 = makeFolder('y1-uuid', '2024');
+    const yearD2 = makeFolder('y2-uuid', '2024');
+    const month = makeFolder('m-uuid', '06');
+    const day = makeFolder('day-uuid', '15');
+    const file = makeFile('file-uuid', 'photo.jpg');
+    mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
+    // discoverAvailableMonths runs Promise.all([discoverD1, discoverD2]) so calls happen in this order:
+    // CALL#1: getFolderFolders(d1-uuid) — year folders for d1
+    // CALL#2: getFolderFolders(d2-uuid) — year folders for d2 (concurrent, before CALL#1 resolves)
+    // CALL#3: getFolderFolders(y1-uuid) — month folders for d1's 2024 folder
+    // CALL#4: getFolderFolders(y2-uuid) — month folders for d2's 2024 folder
+    // CALL#5+: default — day folders for each month
+    mockFolderService.getFolderFolders
+      .mockResolvedValueOnce({ folders: [yearD1] } as never)
+      .mockResolvedValueOnce({ folders: [yearD2] } as never)
+      .mockResolvedValueOnce({ folders: [month] } as never)
+      .mockResolvedValueOnce({ folders: [month] } as never)
+      .mockResolvedValue({ folders: [day] } as never);
+    mockFolderService.getFolderContentByUuid.mockResolvedValue({ files: [file] } as never);
+
+    await photoCloudBrowser.syncAllHistory({});
+
+    expect(mockPhotosLocalDB.upsertCloudAsset).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/services/photos/PhotoCloudBrowser.ts
+++ b/src/services/photos/PhotoCloudBrowser.ts
@@ -93,9 +93,16 @@ class PhotoCloudBrowserService {
     logger.info(
       `[CloudBrowser] syncAllHistory — currentDeviceId=${currentDeviceId ?? 'none'}, force=${force ?? false}`,
     );
-    const devices = await this.listDeviceFolders();
+    const allDevices = await this.listDeviceFolders();
+    const devices = currentDeviceId ? allDevices.filter((device) => device.uuid === currentDeviceId) : allDevices;
     if (devices.length === 0) {
       logger.info('[CloudBrowser] No device folders found — skipping sync');
+      if (currentDeviceId) {
+        // Own device folder gone from cloud — every remote reference is stale. Reset synced
+        // assets to pending (not cloud_deleted) so the next upload cycle restores the backup.
+        await this.purgeDeletedDevices(devices, onMonthFetched);
+        await this.localDB.resetSyncedToPending();
+      }
       return;
     }
     logger.info(`[CloudBrowser] Syncing ${devices.length} device(s): ${devices.map((d) => d.uuid).join(', ')}`);
@@ -261,6 +268,14 @@ class PhotoCloudBrowserService {
 
       if (currentDeviceId && deviceId === currentDeviceId) {
         const syncedMonths = await this.localDB.getSyncedMonths();
+        const isRecreatedDeviceFolder = cloudMonths.length === 0 && syncedMonths.length > 0;
+        if (isRecreatedDeviceFolder) {
+          logger.info(
+            `[CloudBrowser] Device "${deviceId}" has no cloud history but local DB has synced months — resetting to pending for re-upload`,
+          );
+          await this.localDB.resetSyncedToPending();
+          continue;
+        }
         for (const m of syncedMonths) monthSet.add(`${m.year}:${m.month}`);
       }
 

--- a/src/services/photos/PhotoUploadQueue.spec.ts
+++ b/src/services/photos/PhotoUploadQueue.spec.ts
@@ -66,7 +66,10 @@ describe('PhotoUploadQueue.start', () => {
     const onAssetDone = jest.fn();
     const onAssetError = jest.fn();
 
-    await PhotoUploadQueue.start([{ asset: a1 }, { asset: a2 }], DEVICE_ID, PHOTOS_BUCKET, { onAssetDone, onAssetError });
+    await PhotoUploadQueue.start([{ asset: a1 }, { asset: a2 }], DEVICE_ID, PHOTOS_BUCKET, {
+      onAssetDone,
+      onAssetError,
+    });
 
     expect(onAssetError).toHaveBeenCalledWith('a1', expect.any(Error));
     expect(onAssetDone).toHaveBeenCalledWith('a2', 'remote-id', a2.modificationTime);
@@ -86,8 +89,7 @@ describe('PhotoUploadQueue.start', () => {
       'existing-remote-id',
       DEVICE_ID,
       PHOTOS_BUCKET,
-      expect.any(Function),
-      expect.any(AbortSignal),
+      expect.objectContaining({ onProgress: expect.any(Function), signal: expect.any(AbortSignal) }),
     );
     expect(mockUpload).not.toHaveBeenCalled();
     expect(onAssetDone).toHaveBeenCalledWith('a1', 'existing-remote-id', asset.modificationTime);
@@ -97,7 +99,9 @@ describe('PhotoUploadQueue.start', () => {
     const onAssetStart = jest.fn();
     const onAssetDone = jest.fn();
 
-    await expect(PhotoUploadQueue.start([], DEVICE_ID, PHOTOS_BUCKET, { onAssetStart, onAssetDone })).resolves.toBeUndefined();
+    await expect(
+      PhotoUploadQueue.start([], DEVICE_ID, PHOTOS_BUCKET, { onAssetStart, onAssetDone }),
+    ).resolves.toBeUndefined();
     expect(onAssetStart).not.toHaveBeenCalled();
     expect(onAssetDone).not.toHaveBeenCalled();
   });
@@ -119,7 +123,12 @@ describe('PhotoUploadQueue.start', () => {
 
     await PhotoUploadQueue.start([{ asset }], DEVICE_ID, PHOTOS_BUCKET, {});
 
-    expect(mockUpload).toHaveBeenCalledWith(asset, DEVICE_ID, PHOTOS_BUCKET, expect.any(Function), expect.any(AbortSignal));
+    expect(mockUpload).toHaveBeenCalledWith(
+      asset,
+      DEVICE_ID,
+      PHOTOS_BUCKET,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 });
 
@@ -165,14 +174,14 @@ describe('PhotoUploadQueue.abortAll', () => {
 
     // First run — capture the signal that gets passed
     await PhotoUploadQueue.start([{ asset }], DEVICE_ID, PHOTOS_BUCKET, {});
-    const firstSignal = (mockUpload.mock.calls[0] as [unknown, unknown, unknown, unknown, AbortSignal])[4];
+    const firstSignal = (mockUpload.mock.calls[0] as [unknown, unknown, unknown, { signal: AbortSignal }])[3].signal;
 
     // Abort and start a second run
     PhotoUploadQueue.abortAll();
     jest.clearAllMocks();
     mockUpload.mockResolvedValue('remote-id');
     await PhotoUploadQueue.start([{ asset }], DEVICE_ID, PHOTOS_BUCKET, {});
-    const secondSignal = (mockUpload.mock.calls[0] as [unknown, unknown, unknown, unknown, AbortSignal])[4];
+    const secondSignal = (mockUpload.mock.calls[0] as [unknown, unknown, unknown, { signal: AbortSignal }])[3].signal;
 
     expect(secondSignal).toBeDefined();
     expect(secondSignal.aborted).toBe(false);

--- a/src/services/photos/PhotoUploadQueue.ts
+++ b/src/services/photos/PhotoUploadQueue.ts
@@ -1,6 +1,6 @@
 import * as MediaLibrary from 'expo-media-library';
 import pLimit from 'p-limit';
-import { PhotoUploadResult, PhotoUploadService } from './PhotoUploadService';
+import { PhotoUploadEvent, PhotoUploadResult, PhotoUploadService } from './PhotoUploadService';
 
 const UPLOAD_CONCURRENCY = 3;
 
@@ -14,6 +14,7 @@ interface UploadQueueCallbacks {
   onAssetProgress?: (assetId: string, ratio: number) => void;
   onAssetDone?: (assetId: string, result: PhotoUploadResult, modificationTime: number) => Promise<void> | void;
   onAssetError?: (assetId: string, error: Error) => Promise<void> | void;
+  onAssetEvent?: (assetId: string, event: PhotoUploadEvent) => void;
 }
 
 let currentController: AbortController | null = null;
@@ -42,22 +43,14 @@ export const PhotoUploadQueue = {
             callbacks.onAssetStart?.(asset.id);
 
             try {
+              const uploadOptions = {
+                onProgress: (ratio: number) => callbacks.onAssetProgress?.(asset.id, ratio),
+                signal,
+                onEvent: (event: PhotoUploadEvent) => callbacks.onAssetEvent?.(asset.id, event),
+              };
               const photoUploadResult = existingRemoteFileId
-                ? await PhotoUploadService.replace(
-                    asset,
-                    existingRemoteFileId,
-                    deviceId,
-                    photosBucket,
-                    (ratio) => callbacks.onAssetProgress?.(asset.id, ratio),
-                    signal,
-                  )
-                : await PhotoUploadService.upload(
-                    asset,
-                    deviceId,
-                    photosBucket,
-                    (ratio) => callbacks.onAssetProgress?.(asset.id, ratio),
-                    signal,
-                  );
+                ? await PhotoUploadService.replace(asset, existingRemoteFileId, deviceId, photosBucket, uploadOptions)
+                : await PhotoUploadService.upload(asset, deviceId, photosBucket, uploadOptions);
               await callbacks.onAssetDone?.(asset.id, photoUploadResult, asset.modificationTime);
             } catch (uploadError) {
               await callbacks.onAssetError?.(asset.id, uploadError as Error);

--- a/src/services/photos/PhotoUploadService.ts
+++ b/src/services/photos/PhotoUploadService.ts
@@ -56,6 +56,19 @@ export interface PhotoUploadResult {
   burst?: { burstId: string; memberUuids: string[] };
 }
 
+/**
+ * Domain events emitted during an upload, opaque to PhotoUploadQueue. Lets sub-features (burst,
+ * paired video, ...) report progress without growing the queue/service interfaces with feature-named
+ * callbacks.
+ */
+export type PhotoUploadEvent = { type: 'burst-member-total'; total: number } | { type: 'burst-member-uploaded' };
+
+interface UploadOptions {
+  onProgress?: (ratio: number) => void;
+  signal?: AbortSignal;
+  onEvent?: (event: PhotoUploadEvent) => void;
+}
+
 const resolveLocalPath = async (
   asset: MediaLibrary.Asset,
 ): Promise<{ localPath: string; tempPath?: string; thumbnailUri?: string }> => {
@@ -327,9 +340,9 @@ export const PhotoUploadService = {
     asset: MediaLibrary.Asset,
     deviceId: string,
     photosBucket: string,
-    onProgress?: (ratio: number) => void,
-    signal?: AbortSignal,
+    options: UploadOptions = {},
   ): Promise<PhotoUploadResult> {
+    const { onProgress, signal, onEvent } = options;
     const livePhoto = Platform.OS === 'ios' && isLivePhotoAsset(asset);
 
     if (livePhoto) {
@@ -409,6 +422,7 @@ export const PhotoUploadService = {
           photosBucket,
           signal,
           uploadMember: uploadSingleFile,
+          onEvent,
         });
         return { photoUuid: err.existingUuid, ...(burst ? { burst } : {}) };
       }
@@ -453,6 +467,7 @@ export const PhotoUploadService = {
         credentials,
         signal,
         uploadMember: uploadSingleFile,
+        onEvent,
       });
 
       return { photoUuid, ...(burst ? { burst } : {}) };
@@ -466,9 +481,9 @@ export const PhotoUploadService = {
     existingRemoteFileId: string,
     deviceId: string,
     photosBucket: string,
-    onProgress?: (ratio: number) => void,
-    signal?: AbortSignal,
+    options: UploadOptions = {},
   ): Promise<PhotoUploadResult> {
+    const { onProgress, signal, onEvent } = options;
     const livePhoto = Platform.OS === 'ios' && isLivePhotoAsset(asset);
 
     if (livePhoto) {
@@ -606,6 +621,7 @@ export const PhotoUploadService = {
         credentials,
         signal,
         uploadMember: uploadSingleFile,
+        onEvent,
       });
 
       return { photoUuid, ...(burst ? { burst } : {}) };

--- a/src/services/photos/burst/BurstUploadHandler.ts
+++ b/src/services/photos/burst/BurstUploadHandler.ts
@@ -8,7 +8,7 @@ import { stripFileUri } from 'src/services/common/uri/uriHelpers';
 import fileSystemService from 'src/services/FileSystemService';
 import { photosLocalDB } from '../database/photosLocalDB';
 import { photoBackupFolders } from '../PhotoBackupFolders';
-import { UploadCredentials } from '../PhotoUploadService';
+import { PhotoUploadEvent, UploadCredentials } from '../PhotoUploadService';
 import { splitFileNameAndExtension } from '../PhotoUploadService.utils';
 import { getBurstMemberPlainName } from './burst.constants';
 import { BurstMember, BurstNativeModule } from './BurstNativeModule';
@@ -39,6 +39,7 @@ interface MaybeUploadMembersParams {
   credentials: UploadCredentials;
   signal?: AbortSignal;
   uploadMember: (params: UploadMemberParams) => Promise<string>;
+  onEvent?: (event: PhotoUploadEvent) => void;
 }
 
 /**
@@ -59,6 +60,7 @@ export const uploadBurstMembers = async (params: MaybeUploadMembersParams): Prom
     credentials,
     signal,
     uploadMember,
+    onEvent,
   } = params;
 
   logger.info(`[BurstUpload] exportBurstMembers start — assetId=${assetId}`);
@@ -73,6 +75,7 @@ export const uploadBurstMembers = async (params: MaybeUploadMembersParams): Prom
   if (members.length === 0) {
     return null;
   }
+  onEvent?.({ type: 'burst-member-total', total: members.length });
 
   const memberUuids: string[] = [];
   const tempPaths: string[] = [];
@@ -107,6 +110,7 @@ export const uploadBurstMembers = async (params: MaybeUploadMembersParams): Prom
       });
 
       memberUuids.push(uuid);
+      onEvent?.({ type: 'burst-member-uploaded' });
     }
   } finally {
     for (const path of tempPaths) {
@@ -119,22 +123,25 @@ export const uploadBurstMembers = async (params: MaybeUploadMembersParams): Prom
 };
 
 /**
- * Retries member uploads for burst representatives that were previously marked synced but incomplete,
- * typically because limited photo access prevented the native export.
+ * Reads burst representatives marked synced but incomplete (members never uploaded, typically
+ * because limited photo access prevented the native export) and retries exporting and uploading
+ * their members. On success, marks the representative as fully synced. The representative itself
+ * is never re-uploaded — only its members.
  *
- * Called on every upload cycle before the main queue. If access is still limited the representative
- * stays incomplete and will be retried again next cycle. The representative is never re-uploaded.
+ * Idempotent: if a previous attempt uploaded some members before failing (e.g. a network error),
+ * those `.burst.N` files already exist in Drive and `uploadSingleFile`'s existence check skips them.
  *
- * Idempotent: if a previous cycle uploaded some members before a network failure, those `.burst.N`
- * files already exist in Drive and `uploadSingleFile`'s existence check skips them.
- *
- * @returns The number of burst groups fully completed in this cycle.
+ * @param params.onBurstEvent Forwards the `PhotoUploadEvent`s emitted per burst group (member count,
+ *   member uploaded) to the caller, scoped to the representative's assetId — used to drive the live
+ *   `Burst · n/m` progress shown while access is still limited.
+ * @returns The number of burst groups fully completed in this call.
  */
 export const retryIncompleteBursts = async (params: {
   deviceId: string;
   photosBucket: string;
   signal?: AbortSignal;
   uploadMember: (params: UploadMemberParams) => Promise<string>;
+  onBurstEvent?: (assetId: string, event: PhotoUploadEvent) => void;
 }): Promise<number> => {
   const { deviceId, photosBucket, signal, uploadMember } = params;
 
@@ -164,6 +171,7 @@ export const retryIncompleteBursts = async (params: {
         credentials,
         signal,
         uploadMember,
+        onEvent: (event) => params.onBurstEvent?.(burst.assetId, event),
       });
 
       if (result) {
@@ -201,6 +209,7 @@ export const uploadBurstMembersIfBurst = async (params: {
   credentials: UploadCredentials;
   signal?: AbortSignal;
   uploadMember: (params: UploadMemberParams) => Promise<string>;
+  onEvent?: (event: PhotoUploadEvent) => void;
 }): Promise<BurstUploadResult | undefined> => {
   if (Platform.OS !== 'ios') {
     return undefined;
@@ -227,6 +236,7 @@ export const uploadBurstMembersForExistingRepresentative = async (params: {
   photosBucket: string;
   signal?: AbortSignal;
   uploadMember: (params: UploadMemberParams) => Promise<string>;
+  onEvent?: (event: PhotoUploadEvent) => void;
 }): Promise<BurstUploadResult | undefined> => {
   const { asset, deviceId, photosBucket, signal, uploadMember } = params;
 
@@ -255,6 +265,7 @@ export const uploadBurstMembersForExistingRepresentative = async (params: {
     credentials,
     signal,
     uploadMember,
+    onEvent: params.onEvent,
   });
   return result ?? undefined;
 };

--- a/src/services/photos/database/photosLocalDB.ts
+++ b/src/services/photos/database/photosLocalDB.ts
@@ -318,16 +318,28 @@ class PhotosLocalDB {
     return row ? rowToAssetSyncEntry(row) : null;
   }
 
-  async getPendingAssets(): Promise<Array<{ assetId: string; status: AssetSyncStatus; remoteFileId: string | null }>> {
+  async getPendingAssets(): Promise<
+    Array<{
+      assetId: string;
+      status: AssetSyncStatus;
+      remoteFileId: string | null;
+      isBurst: boolean;
+      burstMemberCount: number | null;
+    }>
+  > {
     const pendingAssets = await sqliteService.getAllAsync<{
       asset_id: string;
       status: AssetSyncStatus;
       remote_file_id: string | null;
+      is_burst: number;
+      burst_member_count: number | null;
     }>(DB_NAME, assetSyncTable.statements.getPendingAssets);
     return pendingAssets.map((asset) => ({
       assetId: asset.asset_id,
       status: asset.status,
       remoteFileId: asset.remote_file_id,
+      isBurst: asset.is_burst === 1,
+      burstMemberCount: asset.burst_member_count,
     }));
   }
 
@@ -344,6 +356,10 @@ class PhotosLocalDB {
 
   async markCloudDeleted(remoteFileId: string): Promise<void> {
     await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.markCloudDeleted, [remoteFileId]);
+  }
+
+  async resetSyncedToPending(): Promise<void> {
+    await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.resetSyncedToPending);
   }
 
   async getDistinctCloudAssetDeviceIds(): Promise<string[]> {

--- a/src/services/photos/database/tables/asset_sync.ts
+++ b/src/services/photos/database/tables/asset_sync.ts
@@ -142,7 +142,7 @@ const statements = {
       AND creation_time >= ?
       AND creation_time < ?;
   `,
-  getPendingAssets: `SELECT asset_id, status, remote_file_id FROM ${TABLE_NAME} WHERE status NOT IN ('synced', 'deleted', 'cloud_deleted') ORDER BY creation_time DESC NULLS LAST;`,
+  getPendingAssets: `SELECT asset_id, status, remote_file_id, is_burst, burst_member_count FROM ${TABLE_NAME} WHERE status NOT IN ('synced', 'deleted', 'cloud_deleted') ORDER BY creation_time DESC NULLS LAST;`,
   markDeleted: `
     INSERT INTO ${TABLE_NAME} (asset_id, status, deleted_at)
     VALUES (?, 'deleted', (unixepoch() * 1000))
@@ -152,6 +152,17 @@ const statements = {
   `,
   getDeletedIds: `SELECT asset_id FROM ${TABLE_NAME} WHERE status = 'deleted';`,
   markCloudDeleted: `UPDATE ${TABLE_NAME} SET status = 'cloud_deleted' WHERE remote_file_id = ?;`,
+  resetSyncedToPending: `
+    UPDATE ${TABLE_NAME} SET
+      status = 'pending',
+      remote_file_id = NULL,
+      synced_at = NULL,
+      burst_member_remote_file_ids = NULL,
+      burst_member_count = NULL,
+      paired_video_remote_file_id = NULL,
+      paired_video_status = NULL
+    WHERE status = 'synced';
+  `,
   deleteById: `DELETE FROM ${TABLE_NAME} WHERE asset_id = ?;`,
   reset: `DELETE FROM ${TABLE_NAME};`,
   getSyncedRemoteFileIds: `SELECT remote_file_id FROM ${TABLE_NAME} WHERE status = 'synced' AND remote_file_id IS NOT NULL;`,

--- a/src/store/slices/photos/index.spec.ts
+++ b/src/store/slices/photos/index.spec.ts
@@ -177,6 +177,7 @@ describe('photos slice', () => {
       totalScannedAssets: 0,
       totalAssetsUploaded: 0,
       uploadProgressById: {},
+      burstUploadProgressById: {},
       uploadingAssetIds: [],
       deviceId: null,
       photosBucket: null,
@@ -619,6 +620,18 @@ describe('photos slice', () => {
       expect(mockScanner.scanAll).toHaveBeenCalled();
     });
 
+    test('when the thunk runs, then the device folder is re-validated before cloud sync starts', async () => {
+      const store = makeStore();
+      store.dispatch(photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted' }));
+
+      await store.dispatch(forceRefreshThunk());
+
+      expect(mockPhotoDeviceManager.ensureDeviceFolder).toHaveBeenCalledTimes(1);
+      const ensureCallOrder = mockPhotoDeviceManager.ensureDeviceFolder.mock.invocationCallOrder[0];
+      const syncCallOrder = mockCloudBrowser.syncAllHistory.mock.invocationCallOrder[0];
+      expect(ensureCallOrder).toBeLessThan(syncCallOrder);
+    });
+
     test('when discovery finds pending assets, then upload runs', async () => {
       mockScanner.scanAll.mockResolvedValueOnce([{ id: 'a1' }] as never);
       mockDeduplicator.getAssetsToSync.mockResolvedValueOnce({
@@ -672,6 +685,31 @@ describe('photos slice', () => {
 
       expect(mockCloudBrowser.syncAllHistory).toHaveBeenCalled();
       expect(mockScanner.scanAll).toHaveBeenCalled();
+    });
+
+    test('when a backup cycle runs and a device id is already stored, then the device folder is still re-validated', async () => {
+      mockPhotoDeviceManager.ensureDeviceFolder.mockResolvedValue({
+        deviceId: 'recreated-device-id',
+        plainName: 'Device',
+        bucket: 'recreated-bucket',
+      });
+
+      const store = makeStore();
+      store.dispatch(
+        photosSlice.actions.setState({
+          enabled: true,
+          permissionStatus: 'granted',
+          deviceId: 'stale-device-id',
+          photosBucket: 'stale-bucket',
+        }),
+      );
+      mockPermissionService.getStatus.mockResolvedValue('granted');
+
+      await store.dispatch(runBackupCycleThunk());
+
+      expect(mockPhotoDeviceManager.ensureDeviceFolder).toHaveBeenCalledTimes(1);
+      expect(store.getState().photos.deviceId).toBe('recreated-device-id');
+      expect(store.getState().photos.photosBucket).toBe('recreated-bucket');
     });
 
     test('when the backup cycle runs while paused, then discovery runs but the upload is skipped and sync status is paused', async () => {

--- a/src/store/slices/photos/index.ts
+++ b/src/store/slices/photos/index.ts
@@ -44,6 +44,7 @@ export interface PhotosState {
   totalScannedAssets: number;
   totalAssetsUploaded: number;
   uploadProgressById: Record<string, number>;
+  burstUploadProgressById: Record<string, { uploaded: number; total: number }>;
   uploadingAssetIds: string[];
   sessionCompletedAssetIds: string[];
   deviceId: string | null;
@@ -65,6 +66,7 @@ const initialState: PhotosState = {
   totalScannedAssets: 0,
   totalAssetsUploaded: 0,
   uploadProgressById: {},
+  burstUploadProgressById: {},
   uploadingAssetIds: [],
   sessionCompletedAssetIds: [],
   deviceId: null,
@@ -306,6 +308,7 @@ export const forceRefreshThunk = createAsyncThunk<void, void, { state: RootState
     }
 
     logger.info('[ForceRefresh] Starting — dispatching cloud sync (force) + local discovery');
+    await dispatch(initDeviceIdThunk());
     dispatch(runFullCloudHistorySyncThunk({ force: true }));
 
     await dispatch(runDiscoveryThunk()).unwrap();
@@ -332,14 +335,11 @@ export const runBackupCycleThunk = createAsyncThunk<void, void, { state: RootSta
     }
 
     await dispatch(checkPermissionRevocationThunk());
-    const { enabled, permissionStatus, deviceId, photosBucket } = getState().photos;
+    const { enabled, permissionStatus } = getState().photos;
     if (!enabled || !isPermissionActive(permissionStatus)) {
       return;
     }
-
-    if (!deviceId || !photosBucket) {
-      await dispatch(initDeviceIdThunk());
-    }
+    await dispatch(initDeviceIdThunk());
 
     dispatch(runFullCloudHistorySyncThunk());
 
@@ -442,6 +442,7 @@ export const photosSlice = createSlice({
     removeUploadingAssetId: (state, action: PayloadAction<string>) => {
       state.uploadingAssetIds = state.uploadingAssetIds.filter((id) => id !== action.payload);
       delete state.uploadProgressById[action.payload];
+      delete state.burstUploadProgressById[action.payload];
     },
     setAssetUploadProgress: (state, action: PayloadAction<{ assetId: string; progress: number }>) => {
       state.uploadProgressById[action.payload.assetId] = action.payload.progress;
@@ -451,8 +452,18 @@ export const photosSlice = createSlice({
         state.sessionCompletedAssetIds.push(action.payload);
       }
     },
+    setBurstUploadTotal: (state, action: PayloadAction<{ assetId: string; total: number }>) => {
+      state.burstUploadProgressById[action.payload.assetId] = { uploaded: 0, total: action.payload.total };
+    },
+    incrementBurstMemberUploaded: (state, action: PayloadAction<{ assetId: string }>) => {
+      const entry = state.burstUploadProgressById[action.payload.assetId];
+      if (entry) {
+        entry.uploaded += 1;
+      }
+    },
     clearUploadProgress: (state) => {
       state.uploadProgressById = {};
+      state.burstUploadProgressById = {};
       state.sessionCompletedAssetIds = [];
     },
     incrementTotalAssetsUploaded: (state) => {

--- a/src/store/slices/photos/thunks/upload.ts
+++ b/src/store/slices/photos/thunks/upload.ts
@@ -6,7 +6,7 @@ import { AbortError } from 'src/network/errors';
 import { HTTP_QUOTA_EXCEEDED } from 'src/services/common/httpStatusCodes';
 import { PhotoAssetScanner } from 'src/services/photos/PhotoAssetScanner';
 import { AssetUploadJob, PhotoUploadQueue } from 'src/services/photos/PhotoUploadQueue';
-import { PhotoUploadResult, uploadSingleFile } from 'src/services/photos/PhotoUploadService';
+import { PhotoUploadEvent, PhotoUploadResult, uploadSingleFile } from 'src/services/photos/PhotoUploadService';
 import { retryIncompleteBursts } from 'src/services/photos/burst/BurstUploadHandler';
 import { AssetSyncStatus, photosLocalDB } from 'src/services/photos/database/photosLocalDB';
 import { isPermissionActive } from 'src/services/photos/photoPermissionService';
@@ -19,6 +19,7 @@ import { photosSlice, runBackupCycleThunk } from '../index';
 type NetworkPauseStatus = 'paused-no-connection' | 'paused-no-wifi' | null;
 
 const PROGRESS_STEP = 0.02;
+const REPRESENTATIVE_ASSET_COUNT = 1;
 
 const evaluateNetworkPause = (
   state: Network.NetworkState,
@@ -133,6 +134,14 @@ export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean }
       dispatch(photosSlice.actions.setDisabledReason(null));
 
       const localDBPendingAssets = await photosLocalDB.getPendingAssets();
+
+      // Bursts trusted enough to suppress the representative's progress below (else the bar fills
+      // to 100% then drops). Untrusted when access is 'limited' and there's no prior member count.
+      const knownBurstAssetIds = new Set(
+        localDBPendingAssets
+          .filter((asset) => asset.isBurst && (asset.burstMemberCount != null || permissionStatus !== 'limited'))
+          .map((asset) => asset.assetId),
+      );
       const incompleteBurstAssets = isIOS ? await photosLocalDB.getIncompleteBurstAssets() : [];
       logger.info(`[Upload] pending=${localDBPendingAssets.length} incompleteBursts=${incompleteBurstAssets.length}`);
       if (localDBPendingAssets.length === 0 && incompleteBurstAssets.length === 0) {
@@ -149,6 +158,32 @@ export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean }
       dispatch(photosSlice.actions.setSyncStatus('uploading'));
       dispatch(photosSlice.actions.setSessionUploadTotalAssets(uploadAssetJobs.length + incompleteBurstAssets.length));
 
+      const applyBurstEvent = (assetId: string, event: PhotoUploadEvent) => {
+        switch (event.type) {
+          case 'burst-member-total': {
+            const totalFiles = event.total + REPRESENTATIVE_ASSET_COUNT;
+            dispatch(photosSlice.actions.setBurstUploadTotal({ assetId, total: event.total }));
+            dispatch(
+              photosSlice.actions.setAssetUploadProgress({
+                assetId,
+                progress: REPRESENTATIVE_ASSET_COUNT / totalFiles,
+              }),
+            );
+            break;
+          }
+          case 'burst-member-uploaded': {
+            dispatch(photosSlice.actions.incrementBurstMemberUploaded({ assetId }));
+            const burstProgress = getState().photos.burstUploadProgressById[assetId];
+            if (burstProgress) {
+              const uploadedFiles = burstProgress.uploaded + REPRESENTATIVE_ASSET_COUNT;
+              const totalFiles = burstProgress.total + REPRESENTATIVE_ASSET_COUNT;
+              dispatch(photosSlice.actions.setAssetUploadProgress({ assetId, progress: uploadedFiles / totalFiles }));
+            }
+            break;
+          }
+        }
+      };
+
       // BURST: retry incomplete burst members before the main queue so the user sees the result
       // immediately (e.g. after granting full Photos access), without waiting for all pending assets.
       if (isIOS && !getState().photos.isPaused) {
@@ -156,6 +191,7 @@ export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean }
           deviceId,
           photosBucket,
           uploadMember: uploadSingleFile,
+          onBurstEvent: applyBurstEvent,
         });
         for (let i = 0; i < completedBursts; i++) {
           dispatch(photosSlice.actions.incrementSessionUploadedAssets());
@@ -170,6 +206,9 @@ export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean }
           dispatch(photosSlice.actions.addUploadingAssetId(assetId));
         },
         onAssetProgress: (assetId, ratio) => {
+          if (knownBurstAssetIds.has(assetId)) {
+            return;
+          }
           const progressStep = Math.floor(ratio / PROGRESS_STEP);
           if (lastDispatchedUploadProgressStep.get(assetId) === progressStep) {
             return;
@@ -185,6 +224,7 @@ export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean }
           dispatch(photosSlice.actions.incrementTotalAssetsUploaded());
           dispatch(photosSlice.actions.incrementSessionUploadedAssets());
         },
+        onAssetEvent: applyBurstEvent,
         onAssetError: async (assetId, error) => {
           lastDispatchedUploadProgressStep.delete(assetId);
           const isQuotaError = (error as { status?: number })?.status === HTTP_QUOTA_EXCEEDED;


### PR DESCRIPTION
Decouples burst progress from the generic upload pipeline, fixes the burst progress bar in preview and ring in timeline, and recovers the Photos backup automatically when a device's cloud folder gets deleted.