### PR TITLE
[PB-5923]: File Provider rename, move and trash

### DIFF
--- a/ios/Internxt.xcodeproj/project.pbxproj
+++ b/ios/Internxt.xcodeproj/project.pbxproj
@@ -41,6 +41,11 @@
 		F2C595E5ECBAD697016C9410 /* libPods-InternxtShareExtension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D0A0CA179360CA52F0B5054A /* libPods-InternxtShareExtension.a */; };
 		FB1D480012F87A94000E14783 /* FileProviderErrorMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1D480112F87A94000E14783 /* FileProviderErrorMapperTests.swift */; };
 		FB1D480212F87A94000E14783 /* FileProviderErrorMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47912F87A94000E14783 /* FileProviderErrorMapper.swift */; };
+		FB1D481012F87A94000E14783 /* FileProviderMutationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1D481112F87A94000E14783 /* FileProviderMutationTests.swift */; };
+		FB1D481212F87A94000E14783 /* FileProviderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1D47652F87A94000E14783 /* FileProviderItem.swift */; };
+		FB1D481312F87A94000E14783 /* FileProviderItemIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47722F87A94000E14783 /* FileProviderItemIdentifier.swift */; };
+		FB1D481412F87A94000E14783 /* FileProviderMutationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47972F87A94000E14783 /* FileProviderMutationService.swift */; };
+		FB1D481512F87A94000E14783 /* SharedAuthKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100002F87A94000E14783 /* SharedAuthKeychain.swift */; };
 		FB1D480312F87A94000E14783 /* InternxtSwiftCore in Frameworks */ = {isa = PBXBuildFile; productRef = FB1D480412F87A94000E14783 /* InternxtSwiftCore */; };
 		FEB260B2B281D37EEABD1ECA /* libPods-InternxtFileProvider.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 20957EE3E4797FBBC2BD3192 /* libPods-InternxtFileProvider.a */; };
 /* End PBXBuildFile section */
@@ -134,6 +139,7 @@
 		F11748412D0307B40044C1D9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = Internxt/AppDelegate.swift; sourceTree = "<group>"; };
 		F11748442D0722820044C1D9 /* Internxt-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "Internxt-Bridging-Header.h"; path = "Internxt/Internxt-Bridging-Header.h"; sourceTree = "<group>"; };
 		FB1D480112F87A94000E14783 /* FileProviderErrorMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderErrorMapperTests.swift; sourceTree = "<group>"; };
+		FB1D481112F87A94000E14783 /* FileProviderMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderMutationTests.swift; sourceTree = "<group>"; };
 		FB1D480512F87A94000E14783 /* InternxtFileProviderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = InternxtFileProviderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FDEA9EEAEC8CE666D14877B2 /* Pods-Internxt.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.debug.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -326,6 +332,7 @@
 			isa = PBXGroup;
 			children = (
 				FB1D480112F87A94000E14783 /* FileProviderErrorMapperTests.swift */,
+				FB1D481112F87A94000E14783 /* FileProviderMutationTests.swift */,
 			);
 			path = InternxtFileProviderTests;
 			sourceTree = "<group>";
@@ -821,6 +828,11 @@
 			files = (
 				FB1D480012F87A94000E14783 /* FileProviderErrorMapperTests.swift in Sources */,
 				FB1D480212F87A94000E14783 /* FileProviderErrorMapper.swift in Sources */,
+				FB1D481012F87A94000E14783 /* FileProviderMutationTests.swift in Sources */,
+				FB1D481212F87A94000E14783 /* FileProviderItem.swift in Sources */,
+				FB1D481312F87A94000E14783 /* FileProviderItemIdentifier.swift in Sources */,
+				FB1D481412F87A94000E14783 /* FileProviderMutationService.swift in Sources */,
+				FB1D481512F87A94000E14783 /* SharedAuthKeychain.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/InternxtFileProvider/DriveAPIFactory.swift
+++ b/ios/InternxtFileProvider/DriveAPIFactory.swift
@@ -15,4 +15,18 @@ enum DriveAPIFactory {
       clientVersion: SharedKeychainCredentials.clientVersion
     )
   }
+
+  static func makeTrash() -> TrashAPI? {
+    guard let authToken = SharedKeychainCredentials.string(SharedAuthKeychain.photosTokenKey),
+          let baseUrl = SharedKeychainCredentials.string(SharedAuthKeychain.driveBaseUrlKey) else {
+      return nil
+    }
+
+    return TrashAPI(
+      baseUrl: baseUrl,
+      authToken: authToken,
+      clientName: SharedKeychainCredentials.clientName,
+      clientVersion: SharedKeychainCredentials.clientVersion
+    )
+  }
 }

--- a/ios/InternxtFileProvider/FileProviderErrorMapper.swift
+++ b/ios/InternxtFileProvider/FileProviderErrorMapper.swift
@@ -26,13 +26,32 @@ enum FileProviderErrorMapper {
     ]
 
     static func lookupError(from error: Error) -> Error {
+        if let alreadyMapped = error as? NSFileProviderError {
+            return alreadyMapped
+        }
         if isUnauthorized(error) {
             return NSFileProviderError(.notAuthenticated)
         }
         if isOffline(error) {
             return NSFileProviderError(.serverUnreachable)
         }
+        if isNameCollision(error) {
+            return NSFileProviderError(.filenameCollision)
+        }
         return NSFileProviderError(.noSuchItem)
+    }
+
+    static func isNameCollision(_ error: Error) -> Bool {
+        if let enriched = error as? EnrichedError {
+            if let cause = enriched.cause {
+                return isNameCollision(cause)
+            }
+            return false
+        }
+        if let apiError = error as? APIClientError {
+            return apiError.statusCode == 409
+        }
+        return false
     }
 
     static func isUnauthorized(_ error: Error) -> Bool {

--- a/ios/InternxtFileProvider/FileProviderExtension.swift
+++ b/ios/InternxtFileProvider/FileProviderExtension.swift
@@ -93,7 +93,9 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         let parentIdentifier = itemTemplate.parentItemIdentifier
         let uploadService = FileProviderUploadService(driveAPI: driveAPI, networkFacade: networkFacade)
 
-        if itemTemplate.contentType?.conforms(to: .folder) == true {
+        let isFolder = itemTemplate.contentType?.conforms(to: .folder) == true
+
+        if isFolder {
             return createFolder(
                 name: itemTemplate.filename,
                 parentUuid: parentUuid,
@@ -180,23 +182,14 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
     }
 
     func modifyItem(_ item: NSFileProviderItem, baseVersion version: NSFileProviderItemVersion, changedFields: NSFileProviderItemFields, contents newContents: URL?, options: NSFileProviderModifyItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) -> Progress {
-        if changedFields.contains(.contents) || changedFields.contains(.parentItemIdentifier) {
+        let shouldRename = changedFields.contains(.filename)
+        let shouldMove = changedFields.contains(.parentItemIdentifier)
+
+        guard shouldRename || shouldMove else {
             completionHandler(item, [], false, nil)
             return Progress()
         }
 
-        if changedFields.contains(.filename) {
-            return renameItem(item, completionHandler: completionHandler)
-        }
-
-        completionHandler(item, [], false, nil)
-        return Progress()
-    }
-
-    private func renameItem(
-        _ item: NSFileProviderItem,
-        completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
-    ) -> Progress {
         guard let driveAPI = DriveAPIFactory.make() else {
             completionHandler(nil, [], false, NSFileProviderError(.notAuthenticated))
             return Progress()
@@ -207,15 +200,31 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
             return Progress()
         }
 
+        var destinationFolderUuid: String?
+        if shouldMove {
+            guard let resolved = FileProviderItemID.folderUuid(for: item.parentItemIdentifier) else {
+                completionHandler(nil, [], false, NSFileProviderError(.noSuchItem))
+                return Progress()
+            }
+            destinationFolderUuid = resolved
+        }
+
         let mutationService = FileProviderMutationService(driveAPI: driveAPI)
         let newFilename = item.filename
         let progress = Progress(totalUnitCount: 1)
         Task {
             do {
-                try await mutationService.rename(decoded, to: newFilename)
+                if shouldRename {
+                    try await mutationService.rename(decoded, to: newFilename)
+                }
+                if let destinationFolderUuid {
+                    try await mutationService.move(decoded, toParentUuid: destinationFolderUuid)
+                }
                 progress.completedUnitCount = 1
-                let renamed = FileProviderItem.renamed(from: item, newFilename: newFilename) ?? item
-                completionHandler(renamed, [], false, nil)
+                let modified = shouldRename
+                    ? (FileProviderItem.renamed(from: item, newFilename: newFilename) ?? item)
+                    : item
+                completionHandler(modified, [], false, nil)
             } catch {
                 completionHandler(nil, [], false, FileProviderErrorMapper.lookupError(from: error))
             }
@@ -224,10 +233,28 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
     }
 
     func deleteItem(identifier: NSFileProviderItemIdentifier, baseVersion version: NSFileProviderItemVersion, options: NSFileProviderDeleteItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (Error?) -> Void) -> Progress {
-        // TODO: an item was deleted on disk, process the item's deletion
+        guard let driveAPI = DriveAPIFactory.make(), let trashAPI = DriveAPIFactory.makeTrash() else {
+            completionHandler(NSFileProviderError(.notAuthenticated))
+            return Progress()
+        }
 
-        completionHandler(NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError, userInfo:[:]))
-        return Progress()
+        guard let decoded = FileProviderItemID.decode(identifier) else {
+            completionHandler(NSFileProviderError(.noSuchItem))
+            return Progress()
+        }
+
+        let mutationService = FileProviderMutationService(driveAPI: driveAPI, trashAPI: trashAPI)
+        let progress = Progress(totalUnitCount: 1)
+        Task {
+            do {
+                try await mutationService.trash(decoded)
+                progress.completedUnitCount = 1
+                completionHandler(nil)
+            } catch {
+                completionHandler(FileProviderErrorMapper.lookupError(from: error))
+            }
+        }
+        return progress
     }
 
     func enumerator(for containerItemIdentifier: NSFileProviderItemIdentifier, request: NSFileProviderRequest) throws -> NSFileProviderEnumerator {

--- a/ios/InternxtFileProvider/FileProviderItem.swift
+++ b/ios/InternxtFileProvider/FileProviderItem.swift
@@ -173,9 +173,9 @@ class FileProviderItem: NSObject, NSFileProviderItem {
   var capabilities: NSFileProviderItemCapabilities {
     switch kind {
     case .folder:
-      return [.allowsReading, .allowsContentEnumerating, .allowsAddingSubItems, .allowsRenaming]
+      return [.allowsReading, .allowsContentEnumerating, .allowsAddingSubItems, .allowsRenaming, .allowsReparenting, .allowsDeleting]
     case .file:
-      return [.allowsReading, .allowsRenaming]
+      return [.allowsReading, .allowsRenaming, .allowsReparenting, .allowsDeleting]
     }
   }
 

--- a/ios/InternxtFileProvider/FileProviderMutationService.swift
+++ b/ios/InternxtFileProvider/FileProviderMutationService.swift
@@ -10,6 +10,7 @@ import InternxtSwiftCore
 
 struct FileProviderMutationService {
     let driveAPI: DriveAPI
+    var trashAPI: TrashAPI? = nil
 
     func resolveItem(
         _ decoded: (kind: DriveItemKind, uuid: String),
@@ -37,5 +38,34 @@ struct FileProviderMutationService {
             let (baseName, _) = FileProviderItem.splitNameExtension(newFilename, kind: .file)
             _ = try await driveAPI.updateFileNew(uuid: decoded.uuid, bucketId: meta.bucket, newFilename: baseName)
         }
+    }
+
+    func move(
+        _ decoded: (kind: DriveItemKind, uuid: String),
+        toParentUuid destinationFolderUuid: String
+    ) async throws {
+        switch decoded.kind {
+        case .folder:
+            _ = try await driveAPI.moveFolderNew(uuid: decoded.uuid, destinationFolder: destinationFolderUuid)
+        case .file:
+            _ = try await driveAPI.moveFileNew(uuid: decoded.uuid, destinationFolder: destinationFolderUuid)
+        }
+    }
+
+    func trash(_ decoded: (kind: DriveItemKind, uuid: String)) async throws {
+        guard let trashAPI else { throw NSFileProviderError(.notAuthenticated) }
+        let didTrash = try await trashAPI.trashItemsByUuid(itemsToTrash: Self.trashItems(for: decoded))
+        try Self.validateTrashOutcome(didTrash)
+    }
+
+    static func validateTrashOutcome(_ didTrash: Bool) throws {
+        guard didTrash else { throw NSFileProviderError(.serverUnreachable) }
+    }
+
+    static func trashItems(
+        for decoded: (kind: DriveItemKind, uuid: String)
+    ) -> [ItemToTrashV2] {
+        let type: ItemToTrashType = decoded.kind == .folder ? .Folder : .File
+        return [ItemToTrashV2(uuid: decoded.uuid, type: type)]
     }
 }

--- a/ios/InternxtFileProviderTests/FileProviderMutationTests.swift
+++ b/ios/InternxtFileProviderTests/FileProviderMutationTests.swift
@@ -1,0 +1,147 @@
+//
+//  FileProviderMutationTests.swift
+//  InternxtFileProviderTests
+//
+
+import XCTest
+import FileProvider
+import InternxtSwiftCore
+
+private final class StubItem: NSObject, NSFileProviderItem {
+    let itemIdentifier: NSFileProviderItemIdentifier
+    let parentItemIdentifier: NSFileProviderItemIdentifier
+    let filename: String
+
+    init(
+        identifier: NSFileProviderItemIdentifier,
+        parent: NSFileProviderItemIdentifier,
+        filename: String
+    ) {
+        self.itemIdentifier = identifier
+        self.parentItemIdentifier = parent
+        self.filename = filename
+    }
+}
+
+final class FileProviderMutationTests: XCTestCase {
+
+    private let fileIdentifier = FileProviderItemID.encode(.file, uuid: "file-uuid")
+    private let folderIdentifier = FileProviderItemID.encode(.folder, uuid: "folder-uuid")
+    private let destinationIdentifier = FileProviderItemID.encode(.folder, uuid: "destination-uuid")
+
+    private func decodedFile() -> (kind: DriveItemKind, uuid: String) {
+        (kind: .file, uuid: "file-uuid")
+    }
+
+    private func decodedFolder() -> (kind: DriveItemKind, uuid: String) {
+        (kind: .folder, uuid: "folder-uuid")
+    }
+
+    private func apiError(statusCode: Int) -> APIClientError {
+        APIClientError(statusCode: statusCode, message: "test")
+    }
+
+    private func mappedCode(from error: Error) -> Int {
+        (FileProviderErrorMapper.lookupError(from: error) as NSError).code
+    }
+
+    func testWhenItemIsFileThenCapabilitiesAllowReparentingAndDeletingButNotTrashing() {
+        let source = StubItem(identifier: fileIdentifier, parent: .rootContainer, filename: "report.pdf")
+
+        let item = FileProviderItem.renamed(from: source, newFilename: "report.pdf")
+
+        let capabilities = item?.capabilities ?? []
+        XCTAssertTrue(capabilities.contains(.allowsReparenting))
+        XCTAssertTrue(capabilities.contains(.allowsDeleting))
+        XCTAssertFalse(capabilities.contains(.allowsTrashing))
+    }
+
+    func testWhenItemIsFolderThenCapabilitiesAllowReparentingAndDeletingButNotTrashing() {
+        let source = StubItem(identifier: folderIdentifier, parent: .rootContainer, filename: "Docs")
+
+        let item = FileProviderItem.renamed(from: source, newFilename: "Docs")
+
+        let capabilities = item?.capabilities ?? []
+        XCTAssertTrue(capabilities.contains(.allowsReparenting))
+        XCTAssertTrue(capabilities.contains(.allowsDeleting))
+        XCTAssertFalse(capabilities.contains(.allowsTrashing))
+    }
+
+    func testWhenRenamingAFileThenItKeepsTheBaseNameWithoutExtension() {
+        let source = StubItem(identifier: fileIdentifier, parent: .rootContainer, filename: "old.pdf")
+
+        let item = FileProviderItem.renamed(from: source, newFilename: "renamed.pdf")
+
+        XCTAssertEqual(item?.filename, "renamed.pdf")
+    }
+
+    func testWhenRenamingAFileThenSplitProducesTheBaseNameOnly() {
+        let split = FileProviderItem.splitNameExtension("renamed.pdf", kind: .file)
+
+        XCTAssertEqual(split.base, "renamed")
+    }
+
+    func testWhenRenamingAFolderThenItUsesTheFullName() {
+        let split = FileProviderItem.splitNameExtension("My Folder", kind: .folder)
+
+        XCTAssertEqual(split.base, "My Folder")
+    }
+
+    func testWhenAMoveSucceedsThenTheReturnedItemKeepsItsIdentifierAndDestinationParent() {
+        let moved = StubItem(identifier: fileIdentifier, parent: destinationIdentifier, filename: "report.pdf")
+
+        let item = FileProviderItem.renamed(from: moved, newFilename: "report.pdf")
+
+        XCTAssertEqual(item?.itemIdentifier, fileIdentifier)
+        XCTAssertEqual(item?.parentItemIdentifier, destinationIdentifier)
+    }
+
+    func testWhenTheDestinationParentIdentifierIsInvalidThenFolderUuidIsNil() {
+        let invalidParent = NSFileProviderItemIdentifier("not-a-valid-id")
+
+        let resolved = FileProviderItemID.folderUuid(for: invalidParent)
+
+        XCTAssertNil(resolved)
+    }
+
+    func testWhenDeletingAFileThenTrashItemsUseTheFileType() {
+        let items = FileProviderMutationService.trashItems(for: decodedFile())
+
+        XCTAssertEqual(items.first?.type, ItemToTrashType.File.rawValue)
+    }
+
+    func testWhenDeletingAFolderThenTrashItemsUseTheFolderType() {
+        let items = FileProviderMutationService.trashItems(for: decodedFolder())
+
+        XCTAssertEqual(items.first?.type, ItemToTrashType.Folder.rawValue)
+    }
+
+    func testWhenDeletingAnItemThenTrashItemCarriesItsUuid() {
+        let items = FileProviderMutationService.trashItems(for: decodedFile())
+
+        XCTAssertEqual(items.first?.uuid, "file-uuid")
+    }
+
+    func testWhenTheMoveApiThrowsA409ConflictThenFilenameCollision() {
+        let code = mappedCode(from: apiError(statusCode: 409))
+
+        XCTAssertEqual(code, NSFileProviderError.Code.filenameCollision.rawValue)
+    }
+
+    func testWhenTheTrashBackendReturnsFalseThenTheOutcomeThrows() {
+        XCTAssertThrowsError(try FileProviderMutationService.validateTrashOutcome(false))
+    }
+
+    func testWhenTheTrashBackendReturnsFalseThenTheErrorMapsToServerUnreachable() {
+        do {
+            try FileProviderMutationService.validateTrashOutcome(false)
+            XCTFail("expected validateTrashOutcome to throw on false")
+        } catch {
+            XCTAssertEqual(mappedCode(from: error), NSFileProviderError.Code.serverUnreachable.rawValue)
+        }
+    }
+
+    func testWhenTheTrashBackendReturnsTrueThenTheOutcomeDoesNotThrow() {
+        XCTAssertNoThrow(try FileProviderMutationService.validateTrashOutcome(true))
+    }
+}


### PR DESCRIPTION
Implement modifyItem move/rename and deleteItem-to-backend-trash in the File Provider extension. Item capabilities use .allowsDeleting (not .allowsTrashing) so the system routes deletes through deleteItem, which maps to the Drive backend trash endpoint instead of a local-only trash.