### PR TITLE
[PB-6498] feature/Lock Photos

### DIFF
--- a/assets/lang/strings.ts
+++ b/assets/lang/strings.ts
@@ -195,7 +195,7 @@ const translations = {
         photosLocked: {
           title: 'Photos is locked',
           body: 'Automatically back up, organize, and protect your photos in one private space.',
-          upgradeLine: 'Upgrade to Ultimate to unlock Photos.',
+          upgradeLine: 'Upgrade to unlock Photos.',
           upgradeCta: 'Upgrade',
         },
         enableSheet: {
@@ -1192,7 +1192,7 @@ const translations = {
         photosLocked: {
           title: 'Photos está bloqueado',
           body: 'Haz copias de seguridad, organiza y protege tus fotos automáticamente en un espacio privado.',
-          upgradeLine: 'Actualiza a Ultimate para desbloquear Fotos.',
+          upgradeLine: 'Actualiza para desbloquear Fotos.',
           upgradeCta: 'Mejorar plan',
         },
         enableSheet: {

--- a/src/components/SettingsGroup/index.tsx
+++ b/src/components/SettingsGroup/index.tsx
@@ -21,24 +21,25 @@ interface SettingsGroupProps extends ViewProps {
   items: SettingsGroupItemWithKey[];
 }
 
+const SettingsGroupItem = (props: SettingsGroupItemProps) => {
+  const getColor = useGetColor();
+  return (
+    <TouchableHighlight
+      disabled={!props.onPress || props.loading}
+      underlayColor={getColor('bg-gray-5')}
+      onPress={(event) => {
+        props.onPress && props.onPress(event);
+      }}
+      style={{ backgroundColor: getColor('bg-surface') }}
+    >
+      {props.template}
+    </TouchableHighlight>
+  );
+};
+
 function SettingsGroup({ style, title, items, advice, ...rest }: SettingsGroupProps) {
   const tailwind = useTailwind();
   const getColor = useGetColor();
-
-  const SettingsGroupItem = (props: SettingsGroupItemProps) => {
-    return (
-      <TouchableHighlight
-        disabled={!props.onPress || props.loading}
-        underlayColor={getColor('bg-gray-5')}
-        onPress={(event) => {
-          props.onPress && props.onPress(event);
-        }}
-        style={{ backgroundColor: getColor('bg-surface') }}
-      >
-        {props.template}
-      </TouchableHighlight>
-    );
-  };
 
   const renderItems = () =>
     items.map((i, index) => {

--- a/src/screens/PhotosScreen/components/LockBadgeIcon.tsx
+++ b/src/screens/PhotosScreen/components/LockBadgeIcon.tsx
@@ -1,0 +1,28 @@
+import Svg, { G, Path } from 'react-native-svg';
+import useGetColor from 'src/hooks/useColor';
+
+interface LockBadgeIconProps {
+  size: number;
+}
+
+const LOCK_PATH =
+  'M17.4219 2.51074C19.5226 2.61506 21.5164 3.49492 23.0107 4.98926C24.6048 6.58332 25.5 8.74566 25.5 11V11.5H27C28.1189 11.5 29.195 11.9166 30.0205 12.6641L30.1816 12.8184L30.3359 12.9795C31.0834 13.805 31.5 14.8811 31.5 16V30C31.5 31.1935 31.0256 32.3377 30.1816 33.1816C29.3377 34.0256 28.1935 34.5 27 34.5H7C5.80652 34.5 4.66227 34.0256 3.81836 33.1816C2.97445 32.3377 2.5 31.1935 2.5 30V16L2.50586 15.7773C2.56093 14.6649 3.02708 13.6096 3.81836 12.8184L3.97949 12.6641C4.80498 11.9166 5.88108 11.5 7 11.5H8.5V11C8.5 8.74566 9.3952 6.58332 10.9893 4.98926C12.5833 3.3952 14.7457 2.5 17 2.5L17.4219 2.51074ZM16.8516 9.50781C16.5083 9.54195 16.1855 9.69337 15.9395 9.93945C15.6581 10.2208 15.5 10.6022 15.5 11V11.5H18.5V11L18.4922 10.8516C18.458 10.5083 18.3066 10.1855 18.0605 9.93945C17.7792 9.65815 17.3978 9.5 17 9.5L16.8516 9.50781Z';
+
+const LockBadgeIcon = ({ size }: LockBadgeIconProps): JSX.Element => {
+  const getColor = useGetColor();
+
+  return (
+    <Svg width={size} height={size * (37 / 34)} viewBox="0 0 34 37" fill="none">
+      <G>
+        <Path
+          d={LOCK_PATH}
+          fill={getColor('text-gray-60')}
+          stroke={getColor('bg-surface')}
+          strokeWidth={5}
+        />
+      </G>
+    </Svg>
+  );
+};
+
+export default LockBadgeIcon;

--- a/src/screens/PhotosScreen/components/PhotosLockedOverlay.tsx
+++ b/src/screens/PhotosScreen/components/PhotosLockedOverlay.tsx
@@ -1,6 +1,7 @@
-import { ImageIcon, LockSimpleIcon } from 'phosphor-react-native';
+import { ImageIcon } from 'phosphor-react-native';
 import { StyleSheet, View } from 'react-native';
 import AppButton from 'src/components/AppButton';
+import LockBadgeIcon from './LockBadgeIcon';
 import AppText from 'src/components/AppText';
 import useGetColor from 'src/hooks/useColor';
 import { useTailwind } from 'tailwind-rn';
@@ -20,13 +21,13 @@ const PhotosLockedOverlay = ({ onUpgradePress }: PhotosLockedOverlayProps): JSX.
         <View
           style={[styles.iconTile, { backgroundColor: getColor('bg-gray-1'), borderColor: getColor('border-gray-10') }]}
         >
-          <ImageIcon size={40} color={getColor('text-primary')} weight="regular" />
+          <ImageIcon size={64} color={getColor('text-primary')} weight="regular" />
           <View style={styles.lockBadge}>
-            <LockSimpleIcon size={20} color={getColor('text-gray-60')} weight="fill" />
+            <LockBadgeIcon size={32} />
           </View>
         </View>
 
-        <View style={tailwind('items-center gap-y-2 w-full')}>
+        <View style={tailwind('items-center w-full')}>
           <AppText semibold style={[tailwind('text-xl text-center'), { color: getColor('text-gray-100') }]}>
             {strings.screens.photos.photosLocked.title}
           </AppText>
@@ -75,8 +76,8 @@ const styles = StyleSheet.create({
   },
   lockBadge: {
     position: 'absolute',
-    bottom: -6,
-    right: -6,
+    bottom: -8,
+    left: -16,
   },
 });
 

--- a/src/screens/PhotosScreen/index.tsx
+++ b/src/screens/PhotosScreen/index.tsx
@@ -5,6 +5,7 @@ import { View } from 'react-native';
 import AppScreen from 'src/components/AppScreen';
 import { ConfirmModal } from 'src/components/modals/ConfirmModal/ConfirmModal';
 import { useAppDispatch, useAppSelector } from 'src/store/hooks';
+import { paymentsThunks } from 'src/store/slices/payments';
 import {
   forceRefreshThunk,
   pauseBackupThunk,
@@ -12,6 +13,7 @@ import {
   resumeBackupThunk,
   runBackupCycleThunk,
 } from 'src/store/slices/photos';
+import { hasPhotosFeatureAccess } from 'src/store/slices/photos/selectors';
 import { uiActions } from 'src/store/slices/ui';
 import { TabExplorerScreenNavigationProp } from 'src/types/navigation';
 import { useTailwind } from 'tailwind-rn';
@@ -39,6 +41,7 @@ const PhotosScreen = (): JSX.Element => {
   const dispatch = useAppDispatch();
   const navigation = useNavigation<TabExplorerScreenNavigationProp<'Photos'>>();
   const enabled = useAppSelector((state) => state.photos.enabled);
+  const hasAccess = useAppSelector(hasPhotosFeatureAccess);
   const permissionStatus = useAppSelector((state) => state.photos.permissionStatus);
   const [isEnableBackupSheetOpen, setIsEnableBackupSheetOpen] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
@@ -88,10 +91,17 @@ const PhotosScreen = (): JSX.Element => {
     [selection],
   );
 
-  const accessState = useMemo<PhotosAccessState>(
-    () => (enabled ? { type: 'available' } : { type: 'backup-off' }),
-    [enabled],
-  );
+  const accessState = useMemo<PhotosAccessState>(() => {
+    if (!hasAccess) {
+      return { type: 'photos-locked' };
+    }
+    if (enabled) {
+      return { type: 'available' };
+    }
+    return { type: 'backup-off' };
+  }, [hasAccess, enabled]);
+
+  const handleUpgradePress = useCallback(() => navigation.navigate('Settings'), [navigation]);
 
   const handleSelectPress = useCallback(() => selection.enterSelectMode(), [selection]);
 
@@ -100,8 +110,13 @@ const PhotosScreen = (): JSX.Element => {
   const handleSelectMorePhotos = useSelectMorePhotos(reloadLocal);
 
   const listHeader = useMemo(() => {
-    if (accessState.type === 'backup-off') return <BackupDisabledBanner onEnablePress={handleEnableBackup} />;
-    if (permissionStatus === 'limited') return <LimitedAccessBanner onSelectMorePress={handleSelectMorePhotos} />;
+    if (accessState.type === 'backup-off') {
+      return <BackupDisabledBanner onEnablePress={handleEnableBackup} />;
+    }
+    if (permissionStatus === 'limited') {
+      return <LimitedAccessBanner onSelectMorePress={handleSelectMorePhotos} />;
+    }
+
     return undefined;
   }, [accessState.type, permissionStatus, handleEnableBackup, handleSelectMorePhotos]);
 
@@ -163,6 +178,8 @@ const PhotosScreen = (): JSX.Element => {
 
   useFocusEffect(
     useCallback(() => {
+      dispatch(paymentsThunks.loadFileLimitsThunk());
+
       if (enabled) {
         dispatch(runBackupCycleThunk());
       }
@@ -199,7 +216,7 @@ const PhotosScreen = (): JSX.Element => {
           onPausePress={handlePausePress}
           onResumePress={handleResumePress}
         />
-        {accessState.type === 'photos-locked' && <PhotosLockedOverlay onUpgradePress={() => undefined} />}
+        {accessState.type === 'photos-locked' && <PhotosLockedOverlay onUpgradePress={handleUpgradePress} />}
       </View>
 
       <SelectionToolbar

--- a/src/screens/SettingsScreen/index.tsx
+++ b/src/screens/SettingsScreen/index.tsx
@@ -32,6 +32,7 @@ import appService from '../../services/AppService';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { authSelectors } from '../../store/slices/auth';
 import { disableBackupThunk, setNetworkConditionThunk } from '../../store/slices/photos';
+import { hasPhotosFeatureAccess } from '../../store/slices/photos/selectors';
 import { uiActions } from '../../store/slices/ui';
 import { SettingsScreenProps } from '../../types/navigation';
 
@@ -56,6 +57,7 @@ function SettingsScreen({ navigation }: SettingsScreenProps<'SettingsHome'>): JS
   useLanguage();
 
   const photosEnabled = useAppSelector((state) => state.photos.enabled);
+  const hasPhotosAccess = useAppSelector(hasPhotosFeatureAccess);
   const networkCondition = useAppSelector((state) => state.photos.networkCondition);
   const showBilling = useAppSelector(paymentsSelectors.shouldShowBilling);
   const usagePercent = useAppSelector(storageSelectors.usagePercent);
@@ -352,6 +354,10 @@ function SettingsScreen({ navigation }: SettingsScreenProps<'SettingsHome'>): JS
                     </View>
                   ),
                   onPress: () => {
+                    if (!hasPhotosAccess) {
+                      navigation.navigate('Plan');
+                      return;
+                    }
                     if (photosEnabled) {
                       dispatch(disableBackupThunk());
                     } else {

--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -1,5 +1,4 @@
 import { SdkManager } from '@internxt-mobile/services/common';
-import packageJson from '../../package.json';
 import {
   DisplayPrice,
   Invoice,
@@ -7,6 +6,7 @@ import {
   UserSubscription,
   UserType,
 } from '@internxt/sdk/dist/drive/payments/types/types';
+import packageJson from '../../package.json';
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import axios from 'axios';
@@ -77,6 +77,16 @@ class PaymentService {
     await AsyncStorage.setItem('tmpCheckoutSessionId', sessionId);
 
     Linking.openURL(link);
+  }
+
+  async getFileLimits(): Promise<{ photosAccess: boolean } | null> {
+    try {
+      const limits = (await this.sdk.storageV2.getFileVersionLimits()) as { photosAccess?: boolean };
+      return { photosAccess: limits.photosAccess ?? false };
+    } catch (error) {
+      this.catchUserNotFoundError(error as Error);
+      return null;
+    }
   }
 
   async getUserSubscription(): Promise<UserSubscription> {

--- a/src/services/common/httpStatusCodes.ts
+++ b/src/services/common/httpStatusCodes.ts
@@ -1,5 +1,6 @@
 export const HTTP_BAD_REQUEST = 400;
 export const HTTP_UNAUTHORIZED = 401;
+export const HTTP_PAYMENT_REQUIRED = 402;
 export const HTTP_NOT_FOUND = 404;
 export const HTTP_CONFLICT = 409;
 export const HTTP_QUOTA_EXCEEDED = 420;

--- a/src/store/slices/payments/index.spec.ts
+++ b/src/store/slices/payments/index.spec.ts
@@ -1,0 +1,95 @@
+import { configureStore } from '@reduxjs/toolkit';
+import paymentService from 'src/services/PaymentService';
+import { AppDispatch } from 'src/store';
+import paymentsReducer, { paymentsSelectors, paymentsThunks } from './index';
+
+const makeStore = (preloaded?: Parameters<typeof configureStore>[0]['preloadedState']) => {
+  const store = configureStore({ reducer: { payments: paymentsReducer }, preloadedState: preloaded });
+  return { ...store, dispatch: store.dispatch as unknown as AppDispatch };
+};
+
+jest.mock('src/services/PaymentService', () => ({
+  __esModule: true,
+  default: {
+    getPrices: jest.fn().mockResolvedValue([]),
+    getUserSubscription: jest.fn().mockResolvedValue({ type: 'free' }),
+    getInvoices: jest.fn().mockResolvedValue([]),
+    getDefaultPaymentMethod: jest.fn().mockResolvedValue(null),
+    billingEnabled: jest.fn().mockResolvedValue(false),
+    getFileLimits: jest.fn(),
+  },
+}));
+
+jest.mock('src/services/AuthService', () => ({
+  default: { getAuthCredentials: jest.fn().mockResolvedValue({ credentials: null }) },
+}));
+
+jest.mock('src/services/NotificationsService', () => ({
+  default: { show: jest.fn() },
+}));
+
+jest.mock('assets/lang/strings', () => ({ errors: { loadPrices: '', cancelSubscription: '' } }));
+
+const mockPaymentService = paymentService as jest.Mocked<typeof paymentService>;
+
+describe('payments slice — loadFileLimitsThunk', () => {
+  test('when the thunk resolves with photos access, then photosAccess is true in state', async () => {
+    mockPaymentService.getFileLimits.mockResolvedValue({ photosAccess: true });
+    const store = makeStore();
+    await store.dispatch(paymentsThunks.loadFileLimitsThunk());
+    expect(store.getState().payments.photosAccess).toBe(true);
+  });
+
+  test('when the thunk resolves without photos access, then photosAccess is false in state', async () => {
+    mockPaymentService.getFileLimits.mockResolvedValue({ photosAccess: false });
+    const store = makeStore();
+    await store.dispatch(paymentsThunks.loadFileLimitsThunk());
+    expect(store.getState().payments.photosAccess).toBe(false);
+  });
+
+  test('when the thunk resolves with null, then photosAccess remains undefined', async () => {
+    mockPaymentService.getFileLimits.mockResolvedValue(null);
+    const store = makeStore();
+    await store.dispatch(paymentsThunks.loadFileLimitsThunk());
+    expect(store.getState().payments.photosAccess).toBeUndefined();
+  });
+});
+
+describe('payments selectors — hasPhotosAccess', () => {
+  test('when photosAccess is not loaded yet, then returns false', () => {
+    const store = makeStore();
+    expect(paymentsSelectors.hasPhotosAccess(store.getState() as any)).toBe(false);
+  });
+
+  test('when photosAccess is true, then returns true', () => {
+    const store = makeStore({
+      payments: {
+        isLoading: false,
+        showBilling: false,
+        prices: [],
+        subscription: { type: 'free' },
+        sessionId: '',
+        invoices: [],
+        defaultPaymentMethod: null,
+        photosAccess: true,
+      },
+    });
+    expect(paymentsSelectors.hasPhotosAccess(store.getState() as any)).toBe(true);
+  });
+
+  test('when photosAccess is false, then returns false', () => {
+    const store = makeStore({
+      payments: {
+        isLoading: false,
+        showBilling: false,
+        prices: [],
+        subscription: { type: 'free' },
+        sessionId: '',
+        invoices: [],
+        defaultPaymentMethod: null,
+        photosAccess: false,
+      },
+    });
+    expect(paymentsSelectors.hasPhotosAccess(store.getState() as any)).toBe(false);
+  });
+});

--- a/src/store/slices/payments/index.ts
+++ b/src/store/slices/payments/index.ts
@@ -26,6 +26,7 @@ export interface PaymentsState {
   sessionId: string;
   invoices: Invoice[] | null;
   defaultPaymentMethod: DefaultPaymentMethod | null;
+  photosAccess?: boolean;
 }
 
 const initialState: PaymentsState = {
@@ -52,6 +53,7 @@ const initializeThunk = createAsyncThunk<void, void, { state: RootState }>(
         dispatch(loadInvoicesThunk());
         dispatch(loadDefaultPaymentMethodThunk());
         dispatch(checkShouldDisplayBilling());
+        dispatch(loadFileLimitsThunk());
       }
     } catch (err) {
       // Pass
@@ -96,6 +98,13 @@ const checkShouldDisplayBilling = createAsyncThunk<boolean, void, { state: RootS
   },
 );
 
+const loadFileLimitsThunk = createAsyncThunk<{ photosAccess: boolean } | null, void, { state: RootState }>(
+  'payments/loadFileLimits',
+  async () => {
+    return paymentService.getFileLimits();
+  },
+);
+
 const cancelSubscriptionThunk = createAsyncThunk<void, void, { state: RootState }>(
   'payments/cancelSubscription',
   async () => {
@@ -112,6 +121,9 @@ export const paymentsSlice = createSlice({
     },
     setSubscriptionAsFree: (state) => {
       state.subscription = { type: 'free' };
+    },
+    setPhotosAccess: (state, action: PayloadAction<boolean>) => {
+      state.photosAccess = action.payload;
     },
   },
   extraReducers(builder) {
@@ -148,6 +160,12 @@ export const paymentsSlice = createSlice({
       state.showBilling = false;
     });
 
+    builder.addCase(loadFileLimitsThunk.fulfilled, (state, action) => {
+      if (action.payload) {
+        state.photosAccess = action.payload.photosAccess;
+      }
+    });
+
     builder.addCase(cancelSubscriptionThunk.rejected, () => {
       notificationsService.show({ type: NotificationType.Error, text1: strings.errors.cancelSubscription });
     });
@@ -162,6 +180,7 @@ export const paymentsSelectors = {
   hasSubscription: (state: RootState) => state.payments.subscription.type === 'subscription',
   hasLifetime: (state: RootState) => state.payments.subscription.type === 'lifetime',
   shouldShowBilling: (state: RootState) => state.payments.showBilling,
+  hasPhotosAccess: (state: RootState) => state.payments.photosAccess ?? false,
 };
 
 export const paymentsThunks = {
@@ -169,6 +188,7 @@ export const paymentsThunks = {
   loadPricesThunk,
   loadUserSubscriptionThunk,
   loadInvoicesThunk,
+  loadFileLimitsThunk,
   cancelSubscriptionThunk,
   checkShouldDisplayBilling,
 };

--- a/src/store/slices/photos/index.spec.ts
+++ b/src/store/slices/photos/index.spec.ts
@@ -11,6 +11,7 @@ import { PhotoUploadQueue } from 'src/services/photos/PhotoUploadQueue';
 import { photosLocalDB } from 'src/services/photos/database/photosLocalDB';
 import { AppDispatch } from 'src/store';
 import { storageSelectors } from 'src/store/slices/storage';
+import { hasPhotosFeatureAccess } from './selectors';
 import photosReducer, {
   checkPermissionRevocationThunk,
   disableBackupThunk,
@@ -85,6 +86,10 @@ jest.mock('src/store/slices/storage', () => ({
   },
 }));
 
+jest.mock('./selectors', () => ({
+  hasPhotosFeatureAccess: jest.fn().mockReturnValue(true),
+}));
+
 jest.mock('src/services/photos/database/photosLocalDB', () => ({
   photosLocalDB: {
     init: jest.fn().mockResolvedValue(undefined),
@@ -101,6 +106,7 @@ jest.mock('src/services/photos/database/photosLocalDB', () => ({
 }));
 
 const mockStorageSelectors = storageSelectors as jest.Mocked<typeof storageSelectors>;
+const mockHasPhotosFeatureAccess = hasPhotosFeatureAccess as jest.MockedFunction<typeof hasPhotosFeatureAccess>;
 const mockAsyncStorage = asyncStorageService as jest.Mocked<typeof asyncStorageService>;
 const mockCloudBrowser = photoCloudBrowser as jest.Mocked<typeof photoCloudBrowser>;
 const mockPermissionService = photoPermissionService as jest.Mocked<typeof photoPermissionService>;
@@ -149,6 +155,7 @@ describe('photos slice', () => {
     mockCloudBrowser.syncAllHistory.mockResolvedValue(undefined);
     // Prevent checkPermissionRevocationThunk from overwriting permissionStatus with undefined
     mockPermissionService.getStatus.mockResolvedValue('granted');
+    mockHasPhotosFeatureAccess.mockReturnValue(true);
     (Network.getNetworkStateAsync as jest.Mock).mockResolvedValue({
       type: Network.NetworkStateType.WIFI,
       isConnected: true,
@@ -245,6 +252,17 @@ describe('photos slice', () => {
     await store.dispatch(hydratePhotosStateThunk());
 
     expect(store.getState().photos.enabled).toBe(false);
+  });
+
+  test('when the user tries to enable backup but their plan does not include access, then backup is denied without requesting permission', async () => {
+    mockHasPhotosFeatureAccess.mockReturnValue(false);
+    const store = makeStore();
+
+    const result = await store.dispatch(enableBackupThunk()).unwrap();
+
+    expect(result.isGranted).toBe(false);
+    expect(store.getState().photos.enabled).toBe(false);
+    expect(mockPermissionService.requestPermission).not.toHaveBeenCalled();
   });
 
   test('when the user enables backup and grants permission, then backup is turned on and saved', async () => {
@@ -710,6 +728,40 @@ describe('photos slice', () => {
       expect(mockPhotoDeviceManager.ensureDeviceFolder).toHaveBeenCalledTimes(1);
       expect(store.getState().photos.deviceId).toBe('recreated-device-id');
       expect(store.getState().photos.photosBucket).toBe('recreated-bucket');
+    });
+
+    test('when the user does not have plan access and backup is active, then backup is disabled and the reason is set to plan-restricted', async () => {
+      mockHasPhotosFeatureAccess.mockReturnValue(false);
+      const store = makeStore();
+      store.dispatch(photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted' }));
+
+      await store.dispatch(runBackupCycleThunk());
+
+      expect(store.getState().photos.enabled).toBe(false);
+      expect(store.getState().photos.disabledReason).toBe('plan-restricted');
+      expect(mockPhotoDeviceManager.ensureDeviceFolder).not.toHaveBeenCalled();
+    });
+
+    test('when the user does not have plan access and backup is already off, then the thunk exits without re-disabling', async () => {
+      mockHasPhotosFeatureAccess.mockReturnValue(false);
+      const store = makeStore();
+
+      await store.dispatch(runBackupCycleThunk());
+
+      expect(store.getState().photos.enabled).toBe(false);
+      expect(store.getState().photos.disabledReason).toBeNull();
+      expect(mockPhotoDeviceManager.ensureDeviceFolder).not.toHaveBeenCalled();
+    });
+
+    test('when the user has plan access, then the backup cycle runs without interruption', async () => {
+      const store = makeStore();
+      store.dispatch(photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted' }));
+      mockPermissionService.getStatus.mockResolvedValue('granted');
+
+      await store.dispatch(runBackupCycleThunk());
+
+      expect(mockPhotoDeviceManager.ensureDeviceFolder).toHaveBeenCalled();
+      expect(mockCloudBrowser.syncAllHistory).toHaveBeenCalled();
     });
 
     test('when the backup cycle runs while paused, then discovery runs but the upload is skipped and sync status is paused', async () => {

--- a/src/store/slices/photos/index.ts
+++ b/src/store/slices/photos/index.ts
@@ -1,4 +1,7 @@
+import { AxiosResponseError } from '@internxt/sdk/dist/shared/types/errors';
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { HTTP_PAYMENT_REQUIRED } from 'src/services/common/httpStatusCodes';
+import { paymentsActions } from 'src/store/slices/payments';
 import * as Network from 'expo-network';
 import { Platform } from 'react-native';
 import asyncStorageService from 'src/services/AsyncStorageService';
@@ -19,6 +22,7 @@ import { AsyncStorageKey } from 'src/types';
 import { logger } from '../../../services/common';
 import { RootState } from '../../index';
 import { runUploadThunk } from './thunks/upload';
+import { hasPhotosFeatureAccess } from './selectors';
 export { runUploadThunk };
 
 export type PhotoNetworkCondition = 'wifi-only' | 'wifi-and-data';
@@ -32,7 +36,7 @@ export type PhotoSyncStatus =
   | 'paused-no-wifi'
   | 'paused-no-connection'
   | 'error';
-export type PhotosDisabledReason = 'quota-exceeded' | null;
+export type PhotosDisabledReason = 'quota-exceeded' | 'plan-restricted' | null;
 
 export interface PhotosState {
   enabled: boolean;
@@ -148,6 +152,10 @@ export const enableBackupThunk = createAsyncThunk<
   void,
   { state: RootState }
 >('photos/enableBackup', async (_, { getState, dispatch }) => {
+  if (!hasPhotosFeatureAccess(getState())) {
+    return { isGranted: false, permissionStatus: getState().photos.permissionStatus };
+  }
+
   const currentStatus = await photoPermissionService.getStatus();
 
   let permissionStatus: PhotoPermissionStatus;
@@ -199,10 +207,17 @@ export const checkPermissionRevocationThunk = createAsyncThunk<void, void, { sta
 export const initDeviceIdThunk = createAsyncThunk<string, void, { state: RootState }>(
   'photos/initDeviceId',
   async (_, { dispatch }) => {
-    const { deviceId, bucket } = await PhotoDeviceManager.ensureDeviceFolder();
-    dispatch(photosSlice.actions.setDeviceId(deviceId));
-    dispatch(photosSlice.actions.setPhotosBucket(bucket));
-    return deviceId;
+    try {
+      const { deviceId, bucket } = await PhotoDeviceManager.ensureDeviceFolder();
+      dispatch(photosSlice.actions.setDeviceId(deviceId));
+      dispatch(photosSlice.actions.setPhotosBucket(bucket));
+      return deviceId;
+    } catch (err) {
+      if (err instanceof AxiosResponseError && err.status === HTTP_PAYMENT_REQUIRED) {
+        dispatch(paymentsActions.setPhotosAccess(false));
+      }
+      throw err;
+    }
   },
 );
 
@@ -331,6 +346,14 @@ export const runBackupCycleThunk = createAsyncThunk<void, void, { state: RootSta
   async (_, { getState, dispatch }) => {
     const { syncStatus } = getState().photos;
     if (syncStatus === 'scanning' || syncStatus === 'uploading' || syncStatus === 'pausing') {
+      return;
+    }
+
+    if (!hasPhotosFeatureAccess(getState())) {
+      if (getState().photos.enabled) {
+        await dispatch(disableBackupThunk());
+        dispatch(photosSlice.actions.setDisabledReason('plan-restricted'));
+      }
       return;
     }
 

--- a/src/store/slices/photos/selectors.spec.ts
+++ b/src/store/slices/photos/selectors.spec.ts
@@ -1,0 +1,20 @@
+import { hasPhotosFeatureAccess } from './selectors';
+import { paymentsSelectors } from 'src/store/slices/payments';
+
+jest.mock('src/store/slices/payments', () => ({
+  paymentsSelectors: {
+    hasPhotosAccess: jest.fn(),
+  },
+}));
+
+describe('hasPhotosFeatureAccess', () => {
+  test('when photos access is granted by the plan, then returns true', () => {
+    (paymentsSelectors.hasPhotosAccess as jest.Mock).mockReturnValue(true);
+    expect(hasPhotosFeatureAccess({} as any)).toBe(true);
+  });
+
+  test('when photos access is not granted by the plan, then returns false', () => {
+    (paymentsSelectors.hasPhotosAccess as jest.Mock).mockReturnValue(false);
+    expect(hasPhotosFeatureAccess({} as any)).toBe(false);
+  });
+});

--- a/src/store/slices/photos/selectors.ts
+++ b/src/store/slices/photos/selectors.ts
@@ -1,0 +1,4 @@
+import { RootState } from 'src/store';
+import { paymentsSelectors } from 'src/store/slices/payments';
+
+export const hasPhotosFeatureAccess = (state: RootState): boolean => paymentsSelectors.hasPhotosAccess(state);


### PR DESCRIPTION
Lock Photos feature to users whose subscription plan not include it.

## Summary
  - **`PaymentService`**: new `getFileLimits()
  - **`httpStatusCodes`**: added `HTTP_PAYMENT_REQUIRED`
  - **`payments/index.ts`**: `photosAccess` state, `loadFileLimitsThunk`, `setPhotosAccess` action, `hasPhotosAccess` selector
  - **`photos/selectors.ts`**: new `hasPhotosFeatureAccess` selector
  - **`photos/index.ts`**: plan access guards in `enableBackupThunk` and `runBackupCycleThunk` and 402 catch in `initDeviceIdThunk`
  - **`PhotosScreen`**: `accessState` wired to plan access and `useFocusEffect` refreshes limits on tab entry
  - **`PhotosLockedOverlay`**: updated to match Figma design
  - **`LockBadgeIcon`**: new SVG component extracted from Figma asset
  - **`SettingsScreen`**: photos backup toggle redirects to Plan when user has no access
  - **`SettingsGroup`**: `SettingsGroupItem` moved outside render function to prevent switch remount glitch
