### PR TITLE
[_] bugfix/Improve asset changes detection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import LinkCopiedModal from './components/modals/LinkCopiedModal';
 import SignOutModal from './components/modals/SignOutModal';
 
 import { useNavigationContainerRef } from '@react-navigation/native';
+import { useKeepAwake } from 'expo-keep-awake';
 import { DriveContextProvider } from './contexts/Drive';
 import { ThemeProvider, useTheme } from './contexts/Theme';
 import { getRemoteUpdateIfAvailable, useLoadFonts } from './helpers';
@@ -53,6 +54,7 @@ function AppContent(): JSX.Element {
   const { screenLocked, lastScreenLock, initialScreenLocked, screenLockEnabled } = useAppSelector((state) => state.app);
   const { performPeriodicSecurityCheck } = useSecurity();
 
+  useKeepAwake();
   useScreenProtection();
 
   const [isAppInitialized, setIsAppInitialized] = useState(false);
@@ -71,6 +73,7 @@ function AppContent(): JSX.Element {
     await dispatch(authThunks.silentSignInThunk());
     await dispatch(authThunks.refreshTokensThunk());
     dispatch(hydratePhotosStateThunk());
+    await dispatch(paymentsThunks.loadFileLimitsThunk());
   };
 
   const onLinkCopiedModalClosed = () => dispatch(uiActions.setIsLinkCopiedModalOpen(false));

--- a/src/hooks/useDebouncedValue.spec.ts
+++ b/src/hooks/useDebouncedValue.spec.ts
@@ -1,0 +1,85 @@
+import { act, renderHook } from '@testing-library/react-native';
+import useDebouncedValue from './useDebouncedValue';
+
+jest.useFakeTimers();
+
+describe('useDebouncedValue', () => {
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  test('when the hook mounts, then the initial value is returned immediately', () => {
+    const { result } = renderHook(() => useDebouncedValue('hello', 300));
+
+    expect(result.current).toBe('hello');
+  });
+
+  test('when the value changes, then the debounced value does not update before the delay elapses', () => {
+    const { result, rerender } = renderHook(({ value }) => useDebouncedValue(value, 300), {
+      initialProps: { value: 'first' },
+    });
+
+    rerender({ value: 'second' });
+    act(() => {
+      jest.advanceTimersByTime(299);
+    });
+
+    expect(result.current).toBe('first');
+  });
+
+  test('when the delay elapses after a value change, then the debounced value updates', () => {
+    const { result, rerender } = renderHook(({ value }) => useDebouncedValue(value, 300), {
+      initialProps: { value: 'first' },
+    });
+
+    rerender({ value: 'second' });
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(result.current).toBe('second');
+  });
+
+  test('when the value changes multiple times before the delay elapses, then only the last value is applied', () => {
+    const { result, rerender } = renderHook(({ value }) => useDebouncedValue(value, 300), {
+      initialProps: { value: 'first' },
+    });
+
+    rerender({ value: 'second' });
+    act(() => jest.advanceTimersByTime(100));
+
+    rerender({ value: 'third' });
+    act(() => jest.advanceTimersByTime(100));
+
+    rerender({ value: 'fourth' });
+    act(() => jest.advanceTimersByTime(300));
+
+    expect(result.current).toBe('fourth');
+  });
+
+  test('when the hook unmounts before the delay elapses, then the debounced value does not update', () => {
+    const { result, rerender, unmount } = renderHook(({ value }) => useDebouncedValue(value, 300), {
+      initialProps: { value: 'first' },
+    });
+
+    rerender({ value: 'second' });
+    unmount();
+    act(() => jest.advanceTimersByTime(300));
+
+    expect(result.current).toBe('first');
+  });
+
+  test('when used with an array value, then it debounces reference changes correctly', () => {
+    const initialIds = ['a', 'b'];
+    const { result, rerender } = renderHook(({ ids }) => useDebouncedValue(ids, 400), {
+      initialProps: { ids: initialIds },
+    });
+
+    const updatedIds = ['a', 'b', 'c'];
+    rerender({ ids: updatedIds });
+    act(() => jest.advanceTimersByTime(400));
+
+    expect(result.current).toEqual(['a', 'b', 'c']);
+    expect(result.current).toBe(updatedIds);
+  });
+});

--- a/src/hooks/useDebouncedValue.spec.ts
+++ b/src/hooks/useDebouncedValue.spec.ts
@@ -1,9 +1,11 @@
 import { act, renderHook } from '@testing-library/react-native';
 import useDebouncedValue from './useDebouncedValue';
 
-jest.useFakeTimers();
-
 describe('useDebouncedValue', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
   afterEach(() => {
     jest.clearAllTimers();
   });

--- a/src/hooks/useDebouncedValue.ts
+++ b/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Returns a debounced copy of `value` that only updates after `delayMs`
+ * milliseconds have elapsed since the last change. Useful for coalescing
+ * rapid value changes into a single downstream update (e.g. avoiding
+ * repeated expensive calls while a source value is still settling).
+ *
+ * The timer resets on every value change, so the debounced value only
+ * resolves once the source has been stable for the full delay.
+ * The pending timer is cancelled automatically on unmount.
+ *
+ * @param value - The value to debounce.
+ * @param delayMs - Debounce delay in milliseconds.
+ * @returns The debounced value.
+ */
+const useDebouncedValue = <T>(value: T, delayMs: number): T => {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+    timerRef.current = setTimeout(() => setDebouncedValue(value), delayMs);
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [value, delayMs]);
+
+  return debouncedValue;
+};
+
+export default useDebouncedValue;

--- a/src/screens/PhotoPreviewScreen/components/PreviewHeader.tsx
+++ b/src/screens/PhotoPreviewScreen/components/PreviewHeader.tsx
@@ -1,7 +1,16 @@
 import { LinearGradient } from 'expo-linear-gradient';
 import { ArrowUpIcon, CloudSlashIcon, DotsThreeVerticalIcon, XIcon } from 'phosphor-react-native';
+import { useEffect } from 'react';
 import { TouchableOpacity, View } from 'react-native';
-import Animated, { Easing, useAnimatedStyle, withTiming } from 'react-native-reanimated';
+import Animated, {
+  cancelAnimation,
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTailwind } from 'tailwind-rn';
 import strings from '../../../../assets/lang/strings';
@@ -34,6 +43,31 @@ const getBackedBurstLabel = (isBurst: boolean, isUploading: boolean, burstTotal:
   return null;
 };
 
+const AnimatedArrowUp = ({ size, color }: { size: number; color: string }): JSX.Element => {
+  const y = useSharedValue(0);
+  const opacity = useSharedValue(1);
+
+  useEffect(() => {
+    y.value = withRepeat(withSequence(withTiming(-8, { duration: 1200 }), withTiming(0, { duration: 0 })), -1, false);
+    opacity.value = withRepeat(
+      withSequence(withTiming(0, { duration: 1200 }), withTiming(1, { duration: 0 })),
+      -1,
+      false,
+    );
+    return () => {
+      cancelAnimation(y);
+      cancelAnimation(opacity);
+    };
+  }, []);
+
+  const style = useAnimatedStyle(() => ({ transform: [{ translateY: y.value }], opacity: opacity.value }));
+
+  return (
+    <Animated.View style={style}>
+      <ArrowUpIcon size={size} color={color} />
+    </Animated.View>
+  );
+};
 interface TimelineInfoProps {
   isWaitingToUpload: boolean;
   isUploading: boolean;
@@ -78,7 +112,7 @@ const TimelineInfo = ({
       )}
       {isUploading && (
         <View style={[tailwind('flex-row items-center'), { gap: 4 }]}>
-          <ArrowUpIcon size={16} color="white" />
+          <AnimatedArrowUp size={16} color="white" />
           <AppText style={tailwind('text-sm text-white')}>{uploadLabel}</AppText>
         </View>
       )}

--- a/src/screens/PhotosScreen/components/PhotoItem.tsx
+++ b/src/screens/PhotosScreen/components/PhotoItem.tsx
@@ -26,8 +26,8 @@ const SkeletonCell = (): JSX.Element => {
   useEffect(() => {
     const anim = Animated.loop(
       Animated.sequence([
-        Animated.timing(fadeAnim, { toValue: 0.2, duration: 1500, easing: Easing.linear, useNativeDriver: false }),
-        Animated.timing(fadeAnim, { toValue: 1, duration: 800, easing: Easing.linear, useNativeDriver: false }),
+        Animated.timing(fadeAnim, { toValue: 0.2, duration: 1500, easing: Easing.linear, useNativeDriver: true }),
+        Animated.timing(fadeAnim, { toValue: 1, duration: 800, easing: Easing.linear, useNativeDriver: true }),
       ]),
     );
     anim.start();

--- a/src/screens/PhotosScreen/hooks/useCloudAssets.ts
+++ b/src/screens/PhotosScreen/hooks/useCloudAssets.ts
@@ -21,6 +21,7 @@ export const useCloudAssets = (): CloudAssetsResult => {
       photosLocalDB.getAllCloudAssets(),
       photosLocalDB.getSyncedRemoteFileIds(),
     ]);
+
     const deduplicated = allCloud.filter(
       (cloudEntry) => !syncedRemoteIds.has(cloudEntry.remoteFileId) && cloudEntry.livePhotoRole !== 'paired_video',
     );

--- a/src/screens/PhotosScreen/hooks/useLocalAssets.spec.ts
+++ b/src/screens/PhotosScreen/hooks/useLocalAssets.spec.ts
@@ -9,6 +9,7 @@ jest.mock('expo-media-library', () => ({
   MediaType: { photo: 'photo', video: 'video' },
   SortBy: { creationTime: 'creationTime' },
   getAssetsAsync: jest.fn(),
+  addListener: jest.fn(),
 }));
 
 jest.mock('src/services/photos/database/photosLocalDB', () => ({
@@ -16,6 +17,8 @@ jest.mock('src/services/photos/database/photosLocalDB', () => ({
     init: jest.fn().mockResolvedValue(undefined),
     getSyncedEntries: jest.fn(),
     getIncompleteBurstAssets: jest.fn().mockResolvedValue([]),
+    deleteAssetSync: jest.fn().mockResolvedValue(undefined),
+    cleanupOrphanedAssetSync: jest.fn().mockResolvedValue(0),
   },
 }));
 
@@ -33,8 +36,10 @@ const photosState = {
   isFetchingCloudHistory: false,
 };
 
-const makeAsset = (id: string): MediaLibrary.Asset =>
-  ({ id, uri: `file://${id}.jpg`, creationTime: 1000, mediaType: 'photo' }) as never;
+const makeAsset = (id: string, creationTime = 1000): MediaLibrary.Asset =>
+  ({ id, uri: `file://${id}.jpg`, creationTime, mediaType: 'photo' }) as never;
+
+const flushPromises = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
 const makePage = (
   assets: MediaLibrary.Asset[],
@@ -109,12 +114,12 @@ describe('useLocalAssets', () => {
     expect(mockMediaLibrary.getAssetsAsync).toHaveBeenCalledTimes(1);
   });
 
-  test('when the app returns to the foreground, then assets reload from the start', async () => {
-    const firstLoad = [makeAsset('a1')];
-    const reloadAssets = [makeAsset('a2'), makeAsset('a3')];
+  test('when the app returns to the foreground and a recent photo was deleted while locked, then the deleted photo is removed from the gallery', async () => {
+    const firstLoad = [makeAsset('a1'), makeAsset('a2')];
+    const afterDelete = [makeAsset('a2')];
     mockMediaLibrary.getAssetsAsync
       .mockResolvedValueOnce(makePage(firstLoad))
-      .mockResolvedValueOnce(makePage(reloadAssets));
+      .mockResolvedValueOnce(makePage(afterDelete));
 
     let appStateCallback: ((state: string) => void) | undefined;
     jest.spyOn(AppState, 'addEventListener').mockImplementation((_event, cb) => {
@@ -134,7 +139,68 @@ describe('useLocalAssets', () => {
       await Promise.resolve();
     });
 
-    expect(result.current.assets).toEqual(reloadAssets);
+    expect(result.current.assets).toEqual(afterDelete);
+  });
+
+  test('when the device is unlocked after a photo was taken while locked, then the new photo appears at the top without discarding the already-loaded gallery', async () => {
+    const existingAssets = [makeAsset('a1', 2000), makeAsset('a2', 1000)];
+    const newPhoto = makeAsset('new', 3000);
+    mockMediaLibrary.getAssetsAsync
+      .mockResolvedValueOnce(makePage(existingAssets, false))
+      .mockResolvedValueOnce(makePage([newPhoto, ...existingAssets], false));
+
+    let appStateCallback: ((state: string) => void) | undefined;
+    jest.spyOn(AppState, 'addEventListener').mockImplementation((_event, cb) => {
+      appStateCallback = cb as (state: string) => void;
+      return { remove: jest.fn() } as never;
+    });
+
+    const { result } = renderHook(() => useLocalAssets());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      appStateCallback?.('background');
+      appStateCallback?.('active');
+      await Promise.resolve();
+    });
+
+    expect(result.current.assets[0]).toEqual(newPhoto);
+    expect(result.current.assets).toContainEqual(existingAssets[0]);
+    expect(result.current.assets).toContainEqual(existingAssets[1]);
+  });
+
+  test('when the device is unlocked mid-gallery, then assets loaded beyond the first page are preserved without re-pagination', async () => {
+    const headAssets = [makeAsset('head1', 3000), makeAsset('head2', 2000)];
+    const tailAssets = [makeAsset('tail1', 100), makeAsset('tail2', 50)];
+    mockMediaLibrary.getAssetsAsync
+      .mockResolvedValueOnce(makePage(headAssets, true, 'cursor-1'))
+      .mockResolvedValueOnce(makePage(tailAssets, false))
+      .mockResolvedValueOnce(makePage(headAssets, false));
+
+    let appStateCallback: ((state: string) => void) | undefined;
+    jest.spyOn(AppState, 'addEventListener').mockImplementation((_event, cb) => {
+      appStateCallback = cb as (state: string) => void;
+      return { remove: jest.fn() } as never;
+    });
+
+    const { result } = renderHook(() => useLocalAssets());
+
+    await act(async () => { await Promise.resolve(); }); // page 1
+    await act(async () => { await Promise.resolve(); }); // page 2 eager
+
+    expect(result.current.assets).toEqual([...headAssets, ...tailAssets]);
+
+    await act(async () => {
+      appStateCallback?.('background');
+      appStateCallback?.('active');
+      await Promise.resolve();
+    });
+
+    expect(result.current.assets).toEqual([...headAssets, ...tailAssets]);
+    expect(mockMediaLibrary.getAssetsAsync).toHaveBeenCalledTimes(3);
   });
 
   test('when the first page has more pages, then all remaining pages are loaded on mount without waiting for a scroll', async () => {
@@ -226,6 +292,151 @@ describe('useLocalAssets', () => {
 
     expect(result.current.syncedIds.has('a1')).toBe(false);
     expect(result.current.cloudDeletedIds.has('a1')).toBe(true);
+  });
+
+  test('when a photo is deleted from the device while the app is open, then it is removed from the gallery immediately and the cloud copy becomes visible', async () => {
+    const existingAssets = [makeAsset('a1', 3000), makeAsset('a2', 2000), makeAsset('old', 100)];
+    mockMediaLibrary.getAssetsAsync.mockResolvedValueOnce(makePage(existingAssets));
+
+    let libraryChangeCallback: ((event: MediaLibrary.MediaLibraryAssetsChangeEvent) => void) | undefined;
+    (mockMediaLibrary.addListener as jest.Mock).mockImplementation((cb) => {
+      libraryChangeCallback = cb;
+      return { remove: jest.fn() };
+    });
+
+    const { result } = renderHook(() => useLocalAssets());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      libraryChangeCallback?.({
+        hasIncrementalChanges: true,
+        deletedAssets: [makeAsset('old', 100)],
+        insertedAssets: [],
+        updatedAssets: [],
+      });
+      await flushPromises();
+    });
+
+    expect(result.current.assets.find((a) => a.id === 'old')).toBeUndefined();
+    expect(result.current.assets).toHaveLength(2);
+    expect(mockPhotosLocalDB.deleteAssetSync).toHaveBeenCalledWith('old');
+    expect(result.current.localDeletionDetectedCount).toBe(1);
+    // getAssetsAsync should NOT have been called for the incremental update
+    expect(mockMediaLibrary.getAssetsAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test('when a new photo is taken while the app is open, then it appears at the top of the gallery immediately', async () => {
+    const existingAssets = [makeAsset('a1', 2000), makeAsset('a2', 1000)];
+    const newPhoto = makeAsset('new', 3000);
+    mockMediaLibrary.getAssetsAsync.mockResolvedValueOnce(makePage(existingAssets));
+
+    let libraryChangeCallback: ((event: MediaLibrary.MediaLibraryAssetsChangeEvent) => void) | undefined;
+    (mockMediaLibrary.addListener as jest.Mock).mockImplementation((cb) => {
+      libraryChangeCallback = cb;
+      return { remove: jest.fn() };
+    });
+
+    const { result } = renderHook(() => useLocalAssets());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      libraryChangeCallback?.({
+        hasIncrementalChanges: true,
+        insertedAssets: [newPhoto],
+        deletedAssets: [],
+        updatedAssets: [],
+      });
+      await flushPromises();
+    });
+
+    expect(result.current.assets[0]).toEqual(newPhoto);
+    expect(result.current.assets).toHaveLength(3);
+    expect(mockMediaLibrary.getAssetsAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test('when a photo is edited on the device while the app is open, then its data is updated in place without triggering a cloud reload', async () => {
+    const originalAsset = makeAsset('a1', 2000);
+    const editedAsset = { ...originalAsset, uri: 'file://a1-edited.jpg', modificationTime: 9999 } as MediaLibrary.Asset;
+    mockMediaLibrary.getAssetsAsync.mockResolvedValueOnce(makePage([originalAsset, makeAsset('a2', 1000)]));
+
+    let libraryChangeCallback: ((event: MediaLibrary.MediaLibraryAssetsChangeEvent) => void) | undefined;
+    (mockMediaLibrary.addListener as jest.Mock).mockImplementation((cb) => {
+      libraryChangeCallback = cb;
+      return { remove: jest.fn() };
+    });
+
+    const { result } = renderHook(() => useLocalAssets());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      libraryChangeCallback?.({
+        hasIncrementalChanges: true,
+        updatedAssets: [editedAsset],
+        insertedAssets: [],
+        deletedAssets: [],
+      });
+      await flushPromises();
+    });
+
+    expect(result.current.assets.find((a) => a.id === 'a1')).toEqual(editedAsset);
+    expect(result.current.localDeletionDetectedCount).toBe(0);
+    expect(mockPhotosLocalDB.deleteAssetSync).not.toHaveBeenCalled();
+  });
+
+  test('when the media library fires a non-incremental event, then it falls back to a head-window reconcile fetch', async () => {
+    jest.useFakeTimers();
+    const initialAssets = [makeAsset('a1', 2000)];
+    mockMediaLibrary.getAssetsAsync
+      .mockResolvedValueOnce(makePage(initialAssets))
+      .mockResolvedValueOnce(makePage(initialAssets));
+
+    let libraryChangeCallback: ((event: MediaLibrary.MediaLibraryAssetsChangeEvent) => void) | undefined;
+    (mockMediaLibrary.addListener as jest.Mock).mockImplementation((cb) => {
+      libraryChangeCallback = cb;
+      return { remove: jest.fn() };
+    });
+
+    const { result } = renderHook(() => useLocalAssets());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      libraryChangeCallback?.({ hasIncrementalChanges: false });
+      jest.runAllTimers();
+      await Promise.resolve();
+    });
+
+    expect(mockMediaLibrary.getAssetsAsync).toHaveBeenCalledTimes(2);
+    expect(result.current.assets).toEqual(initialAssets);
+    jest.useRealTimers();
+  });
+
+  test('when the hook unmounts, then the media library listener is removed', async () => {
+    mockMediaLibrary.getAssetsAsync.mockResolvedValueOnce(makePage([makeAsset('a1')]));
+
+    const removeMock = jest.fn();
+    (mockMediaLibrary.addListener as jest.Mock).mockReturnValue({ remove: removeMock });
+
+    const { unmount } = renderHook(() => useLocalAssets());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    unmount();
+
+    expect(removeMock).toHaveBeenCalledTimes(1);
   });
 
   test('when an asset is cloud deleted, then it appears in cloudDeletedIds and not in syncedIds', async () => {

--- a/src/screens/PhotosScreen/hooks/useLocalAssets.ts
+++ b/src/screens/PhotosScreen/hooks/useLocalAssets.ts
@@ -1,12 +1,13 @@
 import * as MediaLibrary from 'expo-media-library';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AppState } from 'react-native';
+import useDebouncedValue from 'src/hooks/useDebouncedValue';
 import { logger } from 'src/services/common';
 import { BurstNativeModule } from 'src/services/photos/burst/BurstNativeModule';
 import { photosLocalDB } from 'src/services/photos/database/photosLocalDB';
 import { useAppSelector } from 'src/store/hooks';
 
-const PAGE_SIZE = 200;
+const PAGE_SIZE = 1000;
 const MEDIA_TYPES = [MediaLibrary.MediaType.photo, MediaLibrary.MediaType.video];
 
 export interface LocalAssetsResult {
@@ -116,14 +117,15 @@ export const useLocalAssets = (): LocalAssetsResult => {
   }, [assets]);
 
   const assetIds = useMemo(() => assets.map((asset) => asset.id), [assets]);
+  const debouncedAssetIds = useDebouncedValue(assetIds, 400);
   useEffect(() => {
-    if (assetIds.length === 0) {
+    if (debouncedAssetIds.length === 0) {
       return;
     }
-    BurstNativeModule.getBurstRepresentativeIds(assetIds)
+    BurstNativeModule.getBurstRepresentativeIds(debouncedAssetIds)
       .then((ids) => setBurstRepresentativeIdSet(new Set(ids)))
       .catch((err) => logger.error(`[LocalAssets] getBurstRepresentativeIds failed: ${err}`));
-  }, [assetIds]);
+  }, [debouncedAssetIds]);
 
   const reloadFromStart = useCallback(async () => {
     cursorRef.current = undefined;
@@ -131,7 +133,10 @@ export const useLocalAssets = (): LocalAssetsResult => {
     const page = await fetchLocalPage();
     applyPage(page, { replace: true });
     logger.info(`[LocalAssets] Reloaded from start — ${page.assets.length} assets (hasNextPage: ${page.hasNextPage})`);
-  }, [fetchLocalPage, applyPage]);
+    if (page.hasNextPage) {
+      loadAllRemainingPages();
+    }
+  }, [fetchLocalPage, applyPage, loadAllRemainingPages]);
 
   useEffect(() => {
     const loadFirstPage = async () => {

--- a/src/screens/PhotosScreen/hooks/useLocalAssets.ts
+++ b/src/screens/PhotosScreen/hooks/useLocalAssets.ts
@@ -18,6 +18,7 @@ export interface LocalAssetsResult {
   uploadingIdSet: Set<string>;
   burstRepresentativeIdSet: Set<string>;
   incompleteUploadBurstIdSet: Set<string>;
+  localDeletionDetectedCount: number;
   loadNextPage: () => void;
   reload: () => Promise<void>;
 }
@@ -28,6 +29,7 @@ export const useLocalAssets = (): LocalAssetsResult => {
   const [syncedIds, setSyncedIds] = useState<Set<string>>(new Set());
   // TODO: Reserved for show a distinct icon for cloud-deleted vs never-backed assets. Remove if finally will be the same.
   const [cloudDeletedIds, setCloudDeletedIds] = useState<Set<string>>(new Set());
+  const [localDeletionDetectedCount, setLocalDeletionDetectedCount] = useState(0);
   const [burstRepresentativeIdSet, setBurstRepresentativeIdSet] = useState<Set<string>>(new Set());
   const [incompleteUploadBurstIdSet, setIncompleteUploadBurstIdSet] = useState<Set<string>>(new Set());
 
@@ -35,6 +37,8 @@ export const useLocalAssets = (): LocalAssetsResult => {
   const hasMoreRef = useRef(true);
   const isLoadingMoreRef = useRef(false);
   const appStateRef = useRef(AppState.currentState);
+  const mediaLibrarySubscriptionRef = useRef<ReturnType<typeof MediaLibrary.addListener> | null>(null);
+  const libraryChangeDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const syncStatus = useAppSelector((state) => state.photos.syncStatus);
   const uploadingAssetIds = useAppSelector((state) => state.photos.uploadingAssetIds);
@@ -127,16 +131,94 @@ export const useLocalAssets = (): LocalAssetsResult => {
       .catch((err) => logger.error(`[LocalAssets] getBurstRepresentativeIds failed: ${err}`));
   }, [debouncedAssetIds]);
 
-  const reloadFromStart = useCallback(async () => {
+  const hardReloadAndReconcile = useCallback(async () => {
     cursorRef.current = undefined;
     hasMoreRef.current = true;
-    const page = await fetchLocalPage();
-    applyPage(page, { replace: true });
-    logger.info(`[LocalAssets] Reloaded from start — ${page.assets.length} assets (hasNextPage: ${page.hasNextPage})`);
-    if (page.hasNextPage) {
-      loadAllRemainingPages();
+    isLoadingMoreRef.current = true;
+
+    const allIds = new Set<string>();
+    try {
+      let isFirstPage = true;
+      while (isFirstPage || (hasMoreRef.current && cursorRef.current)) {
+        const page = await fetchLocalPage(isFirstPage ? undefined : cursorRef.current);
+        applyPage(page, { replace: isFirstPage });
+        page.assets.forEach((a) => allIds.add(a.id));
+        isFirstPage = false;
+      }
+    } finally {
+      isLoadingMoreRef.current = false;
     }
-  }, [fetchLocalPage, applyPage, loadAllRemainingPages]);
+
+    logger.info(`[LocalAssets] Reloaded from start — ${allIds.size} total assets`);
+
+    await photosLocalDB.init();
+    const orphanedAssetsSyncRemovedCount = await photosLocalDB.cleanupOrphanedAssetSync(allIds);
+    if (orphanedAssetsSyncRemovedCount > 0) {
+      logger.info(`[LocalAssets] Cleaned up ${orphanedAssetsSyncRemovedCount} orphaned asset_sync entries`);
+      setLocalDeletionDetectedCount((prev) => prev + 1);
+    }
+  }, [fetchLocalPage, applyPage]);
+
+  const applyIncrementalLibraryChange = useCallback(async (event: MediaLibrary.MediaLibraryAssetsChangeEvent) => {
+    const { insertedAssets = [], deletedAssets = [], updatedAssets = [] } = event;
+
+    const deletedAssetIds = deletedAssets.map((a) => a.id);
+    const deletedAssetIdSet = new Set(deletedAssetIds);
+    const updatedAssetMap = new Map(updatedAssets.map((a) => [a.id, a]));
+
+    setAssets((prevAssets) => {
+      const insertedAssetsNotAlreadyPresent = insertedAssets.filter((a) => !prevAssets.some((p) => p.id === a.id));
+      const nextAssets = prevAssets
+        .filter((a) => !deletedAssetIdSet.has(a.id))
+        .map((a) => updatedAssetMap.get(a.id) ?? a);
+
+      if (insertedAssetsNotAlreadyPresent.length > 0) {
+        logger.info(`[LocalAssets] Library change: prepending ${insertedAssetsNotAlreadyPresent.length} new assets`);
+      }
+
+      return [...insertedAssetsNotAlreadyPresent, ...nextAssets];
+    });
+
+    if (deletedAssetIds.length > 0) {
+      logger.info(`[LocalAssets] Library change: removing ${deletedAssetIds.length} deleted assets from asset_sync`);
+      await photosLocalDB.init();
+      await Promise.all(deletedAssetIds.map((id) => photosLocalDB.deleteAssetSync(id)));
+      setLocalDeletionDetectedCount((prev) => prev + 1);
+    }
+  }, []);
+
+  const reconcileOnForeground = useCallback(async () => {
+    const page = await fetchLocalPage();
+    if (page.assets.length === 0) {
+      return;
+    }
+
+    const freshIds = new Set(page.assets.map((a) => a.id));
+    const headMinTime = Math.min(...page.assets.map((a) => a.creationTime));
+
+    let droppedAssetsIds: string[] = [];
+    setAssets((prevAssets) => {
+      const newAssets = page.assets.filter((a) => !prevAssets.some((p) => p.id === a.id));
+      const droppedAssets = prevAssets.filter((a) => a.creationTime >= headMinTime && !freshIds.has(a.id));
+      droppedAssetsIds = droppedAssets.map((a) => a.id);
+      const preservedAssets = prevAssets.filter((a) => a.creationTime < headMinTime || freshIds.has(a.id));
+      if (newAssets.length > 0) {
+        logger.info(`[LocalAssets] Reconcile prepended ${newAssets.length} new assets`);
+      }
+      return [...newAssets, ...preservedAssets];
+    });
+
+    if (droppedAssetsIds.length > 0) {
+      logger.info(
+        `[LocalAssets] Reconcile dropped ${droppedAssetsIds.length} locally deleted assets: ${droppedAssetsIds.join(', ')}`,
+      );
+      await photosLocalDB.init();
+      await Promise.all(droppedAssetsIds.map((id) => photosLocalDB.deleteAssetSync(id)));
+      setLocalDeletionDetectedCount((prev) => prev + 1);
+    }
+
+    logger.info(`[LocalAssets] Reconciled on foreground — ${page.assets.length} fresh assets`);
+  }, [fetchLocalPage]);
 
   useEffect(() => {
     const loadFirstPage = async () => {
@@ -159,12 +241,40 @@ export const useLocalAssets = (): LocalAssetsResult => {
   useEffect(() => {
     const subscription = AppState.addEventListener('change', (nextState) => {
       if (appStateRef.current !== 'active' && nextState === 'active') {
-        reloadFromStart();
+        reconcileOnForeground();
       }
       appStateRef.current = nextState;
     });
     return () => subscription.remove();
-  }, [reloadFromStart]);
+  }, [reconcileOnForeground]);
+
+  useEffect(() => {
+    mediaLibrarySubscriptionRef.current = MediaLibrary.addListener((event) => {
+      if (event.hasIncrementalChanges) {
+        // iOS: we have the exact set of inserted/deleted/updated assets. Apply without a fetch.
+        applyIncrementalLibraryChange(event);
+      } else {
+        // Android (empty event) or iOS large change:
+        // debounce to coalesce rapid bursts before fetching.
+        if (libraryChangeDebounceRef.current) {
+          clearTimeout(libraryChangeDebounceRef.current);
+        }
+        libraryChangeDebounceRef.current = setTimeout(() => {
+          libraryChangeDebounceRef.current = null;
+          reconcileOnForeground();
+        }, 400);
+      }
+    });
+
+    return () => {
+      mediaLibrarySubscriptionRef.current?.remove();
+      mediaLibrarySubscriptionRef.current = null;
+      if (libraryChangeDebounceRef.current) {
+        clearTimeout(libraryChangeDebounceRef.current);
+        libraryChangeDebounceRef.current = null;
+      }
+    };
+  }, [applyIncrementalLibraryChange, reconcileOnForeground]);
 
   useEffect(() => {
     refreshSyncStatusFromDB();
@@ -178,7 +288,8 @@ export const useLocalAssets = (): LocalAssetsResult => {
     uploadingIdSet,
     burstRepresentativeIdSet,
     incompleteUploadBurstIdSet: incompleteUploadBurstIdSet,
+    localDeletionDetectedCount,
     loadNextPage,
-    reload: reloadFromStart,
+    reload: hardReloadAndReconcile,
   };
 };

--- a/src/screens/PhotosScreen/hooks/usePhotosTimeline.ts
+++ b/src/screens/PhotosScreen/hooks/usePhotosTimeline.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useAppSelector } from 'src/store/hooks';
 import { TimelineDateGroup } from '../components/PhotosTimeline';
 import { getGroupSyncStatus, groupAssetsByDate, mergeCloudIntoGroups } from '../utils/photoTimelineGroups';
@@ -21,10 +21,19 @@ export const usePhotosTimeline = (): PhotosTimelineResult => {
     uploadingIdSet,
     burstRepresentativeIdSet,
     incompleteUploadBurstIdSet: incompleteBurstIdSet,
+    localDeletionDetectedCount,
     loadNextPage,
     reload: reloadLocal,
   } = useLocalAssets();
   const { cloudItems, reloadCloud } = useCloudAssets();
+
+  // When local assets are deleted, their asset_sync entries are removed so the cloud
+  // copies become visible as cloud-only. Reload the cloud view to reflect that.
+  useEffect(() => {
+    if (localDeletionDetectedCount > 0) {
+      reloadCloud();
+    }
+  }, [localDeletionDetectedCount, reloadCloud]);
 
   const syncStatus = useAppSelector((state) => state.photos.syncStatus);
   const sessionTotalAssets = useAppSelector((state) => state.photos.sessionTotalAssets);

--- a/src/services/photos/PhotoAssetScanner.ts
+++ b/src/services/photos/PhotoAssetScanner.ts
@@ -1,7 +1,7 @@
 import * as MediaLibrary from 'expo-media-library';
 import { logger } from 'src/services/common';
 
-const PAGE_SIZE = 200;
+const PAGE_SIZE = 1000;
 const MEDIA_TYPES = [MediaLibrary.MediaType.photo, MediaLibrary.MediaType.video];
 
 async function* streamAssets(

--- a/src/services/photos/database/photosLocalDB.spec.ts
+++ b/src/services/photos/database/photosLocalDB.spec.ts
@@ -722,4 +722,14 @@ describe('photosLocalDB cloud asset methods', () => {
 
     expect(result).toEqual(new Set());
   });
+
+  test('when fetching remote file ids, then assets with cloud deleted or deleted status are excluded from the query', async () => {
+    mockSqlite.getAllAsync.mockResolvedValueOnce([]);
+
+    await photosLocalDB.getSyncedRemoteFileIds();
+
+    const [, sql] = mockSqlite.getAllAsync.mock.calls[0];
+    expect(sql).toContain('status NOT IN (\'cloud_deleted\', \'deleted\')');
+    expect(sql).not.toContain('status = \'synced\'');
+  });
 });

--- a/src/services/photos/database/photosLocalDB.ts
+++ b/src/services/photos/database/photosLocalDB.ts
@@ -416,6 +416,24 @@ class PhotosLocalDB {
     await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.deleteById, [assetId]);
   }
 
+  async cleanupOrphanedAssetSync(localAssetIds: Set<string>): Promise<number> {
+    const allsyncedAssets = await sqliteService.getAllAsync<{ asset_id: string }>(
+      DB_NAME,
+      assetSyncTable.statements.getAllTrackedAssetIds,
+    );
+    const orphanAssetsIds = allsyncedAssets.filter((a) => !localAssetIds.has(a.asset_id)).map((a) => a.asset_id);
+    if (orphanAssetsIds.length === 0) {
+      return 0;
+    }
+    for (let i = 0; i < orphanAssetsIds.length; i += CHUNK_SIZE) {
+      const orphanAssetsChunk = orphanAssetsIds.slice(i, i + CHUNK_SIZE);
+      await Promise.all(
+        orphanAssetsChunk.map((id) => sqliteService.executeSql(DB_NAME, assetSyncTable.statements.deleteById, [id])),
+      );
+    }
+    return orphanAssetsIds.length;
+  }
+
   async reset(): Promise<void> {
     await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.reset);
   }

--- a/src/services/photos/database/tables/asset_sync.ts
+++ b/src/services/photos/database/tables/asset_sync.ts
@@ -165,7 +165,7 @@ const statements = {
   `,
   deleteById: `DELETE FROM ${TABLE_NAME} WHERE asset_id = ?;`,
   reset: `DELETE FROM ${TABLE_NAME};`,
-  getSyncedRemoteFileIds: `SELECT remote_file_id FROM ${TABLE_NAME} WHERE status = 'synced' AND remote_file_id IS NOT NULL;`,
+  getSyncedRemoteFileIds: `SELECT remote_file_id FROM ${TABLE_NAME} WHERE remote_file_id IS NOT NULL AND status NOT IN ('cloud_deleted', 'deleted');`,
 
   getSyncedMonths: `
     SELECT DISTINCT

--- a/src/services/photos/database/tables/asset_sync.ts
+++ b/src/services/photos/database/tables/asset_sync.ts
@@ -166,6 +166,7 @@ const statements = {
   deleteById: `DELETE FROM ${TABLE_NAME} WHERE asset_id = ?;`,
   reset: `DELETE FROM ${TABLE_NAME};`,
   getSyncedRemoteFileIds: `SELECT remote_file_id FROM ${TABLE_NAME} WHERE remote_file_id IS NOT NULL AND status NOT IN ('cloud_deleted', 'deleted');`,
+  getAllTrackedAssetIds: `SELECT asset_id FROM ${TABLE_NAME} WHERE remote_file_id IS NOT NULL AND status NOT IN ('cloud_deleted', 'deleted');`,
 
   getSyncedMonths: `
     SELECT DISTINCT

--- a/src/store/slices/payments/index.ts
+++ b/src/store/slices/payments/index.ts
@@ -2,11 +2,14 @@ import { DisplayPrice, Invoice, PaymentMethod, UserSubscription } from '@internx
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import strings from 'assets/lang/strings';
 import _ from 'lodash';
+import asyncStorageService from 'src/services/AsyncStorageService';
 import authService from 'src/services/AuthService';
 import notificationsService from 'src/services/NotificationsService';
 import paymentService from 'src/services/PaymentService';
 import { RootState } from 'src/store';
-import { NotificationType } from 'src/types';
+import { AsyncStorageKey, NotificationType } from 'src/types';
+
+const PHOTOS_ACCESS_TTL_MS = 24 * 60 * 60 * 1000;
 
 export type Paypal = {
   paypal?: {
@@ -101,7 +104,22 @@ const checkShouldDisplayBilling = createAsyncThunk<boolean, void, { state: RootS
 const loadFileLimitsThunk = createAsyncThunk<{ photosAccess: boolean } | null, void, { state: RootState }>(
   'payments/loadFileLimits',
   async () => {
-    return paymentService.getFileLimits();
+    const cached = await asyncStorageService.getItem(AsyncStorageKey.PhotosAccessCache);
+    if (cached) {
+      const { photosAccess, cachedAt } = JSON.parse(cached) as { photosAccess: boolean; cachedAt: number };
+      if (Date.now() - cachedAt < PHOTOS_ACCESS_TTL_MS) {
+        return { photosAccess };
+      }
+    }
+
+    const limits = await paymentService.getFileLimits();
+    if (limits) {
+      await asyncStorageService.saveItem(
+        AsyncStorageKey.PhotosAccessCache,
+        JSON.stringify({ photosAccess: limits.photosAccess, cachedAt: Date.now() }),
+      );
+    }
+    return limits;
   },
 );
 

--- a/src/store/slices/photos/index.spec.ts
+++ b/src/store/slices/photos/index.spec.ts
@@ -102,6 +102,7 @@ jest.mock('src/services/photos/database/photosLocalDB', () => ({
     markError: jest.fn().mockResolvedValue(undefined),
     getStatus: jest.fn().mockResolvedValue(null),
     getIncompleteBurstAssets: jest.fn().mockResolvedValue([]),
+    cleanupOrphanedAssetSync: jest.fn().mockResolvedValue(0),
   },
 }));
 

--- a/src/store/slices/photos/index.ts
+++ b/src/store/slices/photos/index.ts
@@ -268,6 +268,12 @@ export const runDiscoveryThunk = createAsyncThunk<void, void, { state: RootState
           }),
         ),
       ]);
+      const localAssetIdSet = new Set(scannedAssets.map((a) => a.id));
+      const orphanedAssetsSyncRemovedCount = await photosLocalDB.cleanupOrphanedAssetSync(localAssetIdSet);
+      if (orphanedAssetsSyncRemovedCount > 0) {
+        logger.info(`[Discovery] Removed ${orphanedAssetsSyncRemovedCount} asset_sync entries for locally deleted assets`);
+      }
+
       const allPendingAssets = await photosLocalDB.getPendingAssets();
       dispatch(
         photosSlice.actions.setDiscoveryResult({

--- a/src/store/slices/photos/index.ts
+++ b/src/store/slices/photos/index.ts
@@ -521,6 +521,7 @@ export const photosActions = photosSlice.actions;
 export const signOutThunk = createAsyncThunk<void, void, { state: RootState }>(
   'photos/signOut',
   async (_, { dispatch }) => {
+    PhotoUploadQueue.abortAll();
     await Promise.all([photosLocalDB.reset(), photosLocalDB.resetCloudAssets()]).catch(errorService.reportError);
     dispatch(photosActions.resetState());
   },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -104,6 +104,7 @@ export enum AsyncStorageKey {
   PhotosDiscoverSeen = 'photosDiscoverSeen',
   PhotosDeviceId = 'photos-device-id',
   PhotosDeviceKey = 'photos-device-key',
+  PhotosAccessCache = 'photosAccessCache',
 }
 
 export type ProgressCallback = (progress: number) => void;


### PR DESCRIPTION
Fix locally deleted photos not appearing as cloud-only, add real-time gallery sync, and improve photos startup performance

  - **`useLocalAssets`**: replaced AppState-only reconcile with `MediaLibrary.addListener` for real time change detection while the app is open. iOS incremental events (inserted/deleted/updated assets) are applied without a fetch. Non-incremental events (Android, bulk changes) fall back to a debounced `reconcileOnForeground`. AppState listener kept as safety net for frozen process resume.
  - **`photosLocalDB` / `asset_sync`**: added `cleanupOrphanedAssetSync(localAssetIds)` that removes `asset_sync` entries for assets no longer on device and `getAllTrackedAssetIds` to support it.
  - **`runDiscoveryThunk`**: calls `cleanupOrphanedAssetSync` after each scan so historical local deletions are reconciled every backup cycle.
  - **`usePhotosTimeline`**: watches `localDeletionDetectedCount` and calls `reloadCloud` whenever local deletions are detected, so cloud copies surface as cloud-only immediately.
  - **`PhotoAssetScanner`**: increased scan page size from 200 → 1000 to reduce the number of async iterations on large libraries.
  - **`payments/index`**: added 24 h TTL cache (AsyncStorage) for the photos access check to avoid a network call on every cold start.
  - **`App`**: added `useKeepAwake()` to prevent the screen from sleeping during backup, and dispatches `loadFileLimitsThunk` on init.
  - **`PreviewHeader`**: upload arrow icon now animates while a photo is being uploaded.
  - **`PhotoItem`**: fixed skeleton animation to use `useNativeDriver: true`.
  - **`useDebouncedValue`**: new generic debounce hook used by `useLocalAssets` to coalesce burst queries.