### PR TITLE
[_] bugfix/Infinite backup loop in Photos and upload error state in header

### DIFF
--- a/assets/lang/strings.ts
+++ b/assets/lang/strings.ts
@@ -191,6 +191,7 @@ const translations = {
           backupCompleted: 'Backup completed',
           gettingPhotos: 'Getting photos from the cloud',
           scanningGallery: 'Scanning gallery',
+          withError: 'with error',
         },
         photosLocked: {
           title: 'Photos is locked',
@@ -1188,6 +1189,7 @@ const translations = {
           backupCompleted: 'Backup completado',
           gettingPhotos: 'Obteniendo fotos de la nube',
           scanningGallery: 'Escaneando galería',
+          withError: 'con error',
         },
         photosLocked: {
           title: 'Photos está bloqueado',

--- a/src/screens/HomeScreen/useDiscoverPhotosSheet.spec.tsx
+++ b/src/screens/HomeScreen/useDiscoverPhotosSheet.spec.tsx
@@ -46,6 +46,7 @@ const makeWrapper = (photosState?: Partial<PhotosState>) => {
         isFetchingCloudHistory: false,
         disabledReason: null,
         sessionCompletedAssetIds: [],
+        assetUploadErroredCount: 0,
         ...photosState,
       },
     },

--- a/src/screens/PhotosScreen/components/GroupHeader/GroupHeaderStatus.tsx
+++ b/src/screens/PhotosScreen/components/GroupHeader/GroupHeaderStatus.tsx
@@ -191,3 +191,21 @@ export const GroupHeaderCompleted = ({ color }: ColorProps): JSX.Element => {
     </>
   );
 };
+
+interface UploadErrorProps {
+  count: number;
+  color: string;
+  onPress?: () => void;
+}
+
+export const GroupHeaderUploadError = ({ count, color, onPress }: UploadErrorProps): JSX.Element => {
+  const tailwind = useTailwind();
+  return (
+    <TouchableOpacity onPress={onPress} hitSlop={ICON_HIT_SLOP} style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+      <AppText medium style={[tailwind('text-base'), { color }]}>
+        {count.toLocaleString()} {strings.screens.photos.groupHeader.withError}
+      </AppText>
+      <WarningCircleIcon size={24} color={color} weight="fill" />
+    </TouchableOpacity>
+  );
+};

--- a/src/screens/PhotosScreen/components/GroupHeader/PhotosGroupHeader.tsx
+++ b/src/screens/PhotosScreen/components/GroupHeader/PhotosGroupHeader.tsx
@@ -15,6 +15,7 @@ import {
   GroupHeaderPausing,
   GroupHeaderScanning,
   GroupHeaderUploading,
+  GroupHeaderUploadError,
 } from './GroupHeaderStatus';
 
 export type GroupSyncStatus =
@@ -28,6 +29,7 @@ export type GroupSyncStatus =
   | { type: 'paused-no-wifi' }
   | { type: 'paused-no-connection' }
   | { type: 'completed' }
+  | { type: 'upload-error'; count: number }
   | { type: 'none' };
 
 interface PhotosGroupHeaderProps {
@@ -37,6 +39,7 @@ interface PhotosGroupHeaderProps {
   stickyOpacity?: Animated.AnimatedInterpolation<number>;
   onPausePress?: () => void;
   onResumePress?: () => void;
+  onRetryPress?: () => void;
 }
 
 const GRADIENT_LOCATIONS: [number, number, number] = [0, 0.35, 1];
@@ -63,6 +66,7 @@ const PhotosGroupHeader = memo(
     stickyOpacity,
     onPausePress,
     onResumePress,
+    onRetryPress,
   }: PhotosGroupHeaderProps): JSX.Element => {
     const tailwind = useTailwind();
     const getColor = useGetColor();
@@ -129,6 +133,9 @@ const PhotosGroupHeader = memo(
             {syncStatus.type === 'paused-no-wifi' && <GroupHeaderPausedNoWifi color={statusColor} />}
             {syncStatus.type === 'paused-no-connection' && <GroupHeaderPausedNoConnection color={statusColor} />}
             {syncStatus.type === 'completed' && <GroupHeaderCompleted color={labelColor} />}
+            {syncStatus.type === 'upload-error' && (
+              <GroupHeaderUploadError count={syncStatus.count} color={statusColor} onPress={onRetryPress} />
+            )}
           </View>
         </View>
       </View>

--- a/src/screens/PhotosScreen/components/PhotosTimeline.tsx
+++ b/src/screens/PhotosScreen/components/PhotosTimeline.tsx
@@ -49,6 +49,7 @@ interface PhotosTimelineProps {
   onRefresh?: () => void;
   onPausePress?: () => void;
   onResumePress?: () => void;
+  onRetryPress?: () => void;
 }
 
 const getItemType = (item: FlatItem) => item.type;
@@ -76,6 +77,7 @@ const PhotosTimeline = forwardRef<PhotosTimelineHandle, PhotosTimelineProps>(
       onRefresh,
       onPausePress,
       onResumePress,
+      onRetryPress,
     },
     ref,
   ) => {
@@ -86,8 +88,8 @@ const PhotosTimeline = forwardRef<PhotosTimelineHandle, PhotosTimelineProps>(
     }, [assetsGroupsByDate, isLoading]);
 
     const extraData = useMemo(
-      () => ({ isSelectMode, selectedIds, onPausePress, onResumePress }),
-      [isSelectMode, selectedIds, onPausePress, onResumePress],
+      () => ({ isSelectMode, selectedIds, onPausePress, onResumePress, onRetryPress }),
+      [isSelectMode, selectedIds, onPausePress, onResumePress, onRetryPress],
     );
 
     const scrollY = useRef(new Animated.Value(0)).current;
@@ -138,6 +140,7 @@ const PhotosTimeline = forwardRef<PhotosTimelineHandle, PhotosTimelineProps>(
               stickyOpacity={isSticky ? stickyOpacity : undefined}
               onPausePress={onPausePress}
               onResumePress={onResumePress}
+              onRetryPress={onRetryPress}
             />
           );
         }
@@ -153,7 +156,7 @@ const PhotosTimeline = forwardRef<PhotosTimelineHandle, PhotosTimelineProps>(
           </View>
         );
       },
-      [isSelectMode, selectedIds, onPhotoPress, onPhotoLongPress, stickyOpacity, onPausePress, onResumePress],
+      [isSelectMode, selectedIds, onPhotoPress, onPhotoLongPress, stickyOpacity, onPausePress, onResumePress, onRetryPress],
     );
 
     const isEmpty = !isLoading && assetsGroupsByDate.length === 0;

--- a/src/screens/PhotosScreen/hooks/useLocalAssets.spec.ts
+++ b/src/screens/PhotosScreen/hooks/useLocalAssets.spec.ts
@@ -454,4 +454,20 @@ describe('useLocalAssets', () => {
     expect(result.current.cloudDeletedIds.has('a1')).toBe(true);
     expect(result.current.syncedIds.has('a1')).toBe(false);
   });
+
+  test('when an asset failed to upload, then it does not appear in syncedIds or cloudDeletedIds', async () => {
+    mockMediaLibrary.getAssetsAsync.mockResolvedValueOnce(makePage([makeAsset('a1')]));
+    mockPhotosLocalDB.getSyncedEntries.mockResolvedValue(
+      new Map([['a1', { modificationTime: null, status: 'error' as const }]]),
+    );
+
+    const { result } = renderHook(() => useLocalAssets());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.syncedIds.has('a1')).toBe(false);
+    expect(result.current.cloudDeletedIds.has('a1')).toBe(false);
+  });
 });

--- a/src/screens/PhotosScreen/hooks/useLocalAssets.ts
+++ b/src/screens/PhotosScreen/hooks/useLocalAssets.ts
@@ -109,8 +109,11 @@ export const useLocalAssets = (): LocalAssetsResult => {
     for (const [id, info] of entries) {
       if (info.status === 'cloud_deleted') {
         cloudDeleted.add(id);
-      } else {
+      } else if (info.status === 'synced') {
         synced.add(id);
+      } else if (info.status === 'error') {
+        // to not mark as synced, but still track as known asset
+        // leave this to fill if we add a Icon for error state in the future
       }
     }
     setSyncedIds(synced);

--- a/src/screens/PhotosScreen/hooks/usePhotosTimeline.ts
+++ b/src/screens/PhotosScreen/hooks/usePhotosTimeline.ts
@@ -42,6 +42,7 @@ export const usePhotosTimeline = (): PhotosTimelineResult => {
   const isPaused = useAppSelector((state) => state.photos.isPaused);
   const pendingBackupAssets = useAppSelector((state) => state.photos.pendingBackupAssets);
   const disabledReason = useAppSelector((state) => state.photos.disabledReason);
+  const assetUploadErroredCount = useAppSelector((state) => state.photos.assetUploadErroredCount);
 
   const localGroups = useMemo(
     () => groupAssetsByDate(assets, syncedIds, uploadingIdSet, burstRepresentativeIdSet, incompleteBurstIdSet),
@@ -65,6 +66,7 @@ export const usePhotosTimeline = (): PhotosTimelineResult => {
         isFetchingCloudHistory,
         isPaused,
         disabledReason,
+        assetUploadErroredCount,
       }),
     })) as TimelineDateGroup[];
   }, [
@@ -76,6 +78,7 @@ export const usePhotosTimeline = (): PhotosTimelineResult => {
     isPaused,
     pendingBackupAssets,
     disabledReason,
+    assetUploadErroredCount,
   ]);
 
   return { timelineDateGroups, isLoading, loadNextPage, reloadLocal, reloadCloud };

--- a/src/screens/PhotosScreen/index.tsx
+++ b/src/screens/PhotosScreen/index.tsx
@@ -215,6 +215,7 @@ const PhotosScreen = (): JSX.Element => {
           selectedIds={selection.selectedIds}
           onPausePress={handlePausePress}
           onResumePress={handleResumePress}
+          onRetryPress={handleRefresh}
         />
         {accessState.type === 'photos-locked' && <PhotosLockedOverlay onUpgradePress={handleUpgradePress} />}
       </View>

--- a/src/screens/PhotosScreen/utils/photoTimelineGroups.spec.ts
+++ b/src/screens/PhotosScreen/utils/photoTimelineGroups.spec.ts
@@ -182,6 +182,7 @@ describe('group sync status', () => {
         isFetchingCloudHistory: false,
         isPaused: false,
         disabledReason: null,
+        assetUploadErroredCount: 0,
       }),
     ).toEqual({ type: 'scanning' });
   });
@@ -196,6 +197,7 @@ describe('group sync status', () => {
         isFetchingCloudHistory: false,
         isPaused: false,
         disabledReason: null,
+        assetUploadErroredCount: 0,
       }),
     ).toEqual({
       type: 'uploading',
@@ -214,6 +216,7 @@ describe('group sync status', () => {
         isFetchingCloudHistory: true,
         isPaused: false,
         disabledReason: null,
+        assetUploadErroredCount: 0,
       }),
     ).toEqual({ type: 'fetching' });
   });
@@ -228,6 +231,7 @@ describe('group sync status', () => {
         isFetchingCloudHistory: false,
         isPaused: false,
         disabledReason: null,
+        assetUploadErroredCount: 0,
       }),
     ).toEqual({ type: 'count', count: 2 });
   });
@@ -242,6 +246,7 @@ describe('group sync status', () => {
         isFetchingCloudHistory: false,
         isPaused: false,
         disabledReason: null,
+        assetUploadErroredCount: 0,
       }),
     ).toEqual({ type: 'completed' });
   });
@@ -256,6 +261,7 @@ describe('group sync status', () => {
         isFetchingCloudHistory: true,
         isPaused: false,
         disabledReason: null,
+        assetUploadErroredCount: 0,
       }),
     ).toEqual({ type: 'fetching' });
   });
@@ -270,6 +276,7 @@ describe('group sync status', () => {
         isFetchingCloudHistory: false,
         isPaused: false,
         disabledReason: null,
+        assetUploadErroredCount: 0,
       }),
     ).toEqual({ type: 'paused', count: 5 });
   });
@@ -284,6 +291,7 @@ describe('group sync status', () => {
         isFetchingCloudHistory: false,
         isPaused: true,
         disabledReason: null,
+        assetUploadErroredCount: 0,
       }),
     ).toEqual({ type: 'paused', count: 5 });
   });
@@ -298,6 +306,7 @@ describe('group sync status', () => {
         isFetchingCloudHistory: false,
         isPaused: true,
         disabledReason: null,
+        assetUploadErroredCount: 0,
       }),
     ).toEqual({ type: 'paused', count: 5 });
   });
@@ -312,6 +321,7 @@ describe('group sync status', () => {
         isFetchingCloudHistory: false,
         isPaused: true,
         disabledReason: null,
+        assetUploadErroredCount: 0,
       }),
     ).toEqual({ type: 'pausing' });
   });
@@ -326,6 +336,7 @@ describe('group sync status', () => {
         isFetchingCloudHistory: true,
         isPaused: true,
         disabledReason: null,
+        assetUploadErroredCount: 0,
       }),
     ).toEqual({ type: 'paused', count: 5 });
   });
@@ -340,6 +351,7 @@ describe('group sync status', () => {
         isFetchingCloudHistory: false,
         isPaused: false,
         disabledReason: 'quota-exceeded',
+        assetUploadErroredCount: 0,
       }),
     ).toEqual({ type: 'paused-storage-full' });
   });
@@ -354,6 +366,7 @@ describe('group sync status', () => {
         isFetchingCloudHistory: false,
         isPaused: true,
         disabledReason: 'quota-exceeded',
+        assetUploadErroredCount: 0,
       }),
     ).toEqual({ type: 'paused-storage-full' });
   });

--- a/src/screens/PhotosScreen/utils/photoTimelineGroups.ts
+++ b/src/screens/PhotosScreen/utils/photoTimelineGroups.ts
@@ -99,6 +99,7 @@ export const getGroupSyncStatus = ({
   isFetchingCloudHistory,
   isPaused,
   disabledReason,
+  assetUploadErroredCount,
 }: {
   group: PhotoDateGroup;
   syncStatus: PhotoSyncStatus;
@@ -107,6 +108,7 @@ export const getGroupSyncStatus = ({
   isFetchingCloudHistory: boolean;
   isPaused: boolean;
   disabledReason: PhotosDisabledReason;
+  assetUploadErroredCount: number;
 }): GroupSyncStatus => {
   if (disabledReason === 'quota-exceeded') {
     return { type: 'paused-storage-full' };
@@ -127,6 +129,9 @@ export const getGroupSyncStatus = ({
       if (isFetchingCloudHistory) {
         return { type: 'fetching' };
       }
+      if (assetUploadErroredCount > 0) {
+        return { type: 'upload-error', count: assetUploadErroredCount };
+      }
       return { type: 'completed' };
     case 'paused':
       return { type: 'paused', count: remainingCount };
@@ -137,6 +142,9 @@ export const getGroupSyncStatus = ({
     default:
       if (isFetchingCloudHistory) {
         return { type: 'fetching' };
+      }
+      if (assetUploadErroredCount > 0) {
+        return { type: 'upload-error', count: assetUploadErroredCount };
       }
       return { type: 'count', count: group.photos.length };
   }

--- a/src/services/photos/PhotoDeduplicator.spec.ts
+++ b/src/services/photos/PhotoDeduplicator.spec.ts
@@ -146,4 +146,15 @@ describe('PhotoDeduplicator', () => {
     expect(newAssets).toHaveLength(0);
     expect(editedAssets).toHaveLength(0);
   });
+
+  test('when a photo failed to upload, then it is not re-queued as new or edited by discovery', async () => {
+    mockDB.getSyncedEntries.mockResolvedValueOnce(
+      new Map([['a', { modificationTime: null, status: 'error' as const }]]),
+    );
+
+    const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([makeAsset('a', 1000)]);
+
+    expect(newAssets).toHaveLength(0);
+    expect(editedAssets).toHaveLength(0);
+  });
 });

--- a/src/services/photos/PhotoDeduplicator.ts
+++ b/src/services/photos/PhotoDeduplicator.ts
@@ -40,6 +40,8 @@ export const PhotoDeduplicator = {
         if (hasBeenEdited(asset, syncedInfo.modificationTime)) {
           newAssets.push(asset);
         }
+      } else if (syncedInfo.status === 'error') {
+        // already tracked; retry is governed by the backoff in getPendingAssets
       } else if (hasBeenEdited(asset, syncedInfo.modificationTime)) {
         editedAssets.push(asset);
       }

--- a/src/services/photos/database/photosLocalDB.spec.ts
+++ b/src/services/photos/database/photosLocalDB.spec.ts
@@ -139,13 +139,13 @@ describe('photosLocalDB', () => {
     expect(stmt).toContain('status != \'synced\'');
   });
 
-  test('when looking up synced photos, then both synced and cloud_deleted statuses are queried', async () => {
+  test('when looking up synced photos, then synced, cloud_deleted and error statuses are queried', async () => {
     mockSqlite.getAllAsync.mockResolvedValueOnce([]);
 
     await photosLocalDB.getSyncedEntries(['asset-1']);
 
     const [, stmt] = mockSqlite.getAllAsync.mock.calls[0];
-    expect(stmt).toContain('status IN (\'synced\', \'cloud_deleted\')');
+    expect(stmt).toContain('status IN (\'synced\', \'cloud_deleted\', \'error\')');
   });
 
   test('when looking up 300 photos at once, then a single database query is made with all ids', async () => {
@@ -731,5 +731,90 @@ describe('photosLocalDB cloud asset methods', () => {
     const [, sql] = mockSqlite.getAllAsync.mock.calls[0];
     expect(sql).toContain('status NOT IN (\'cloud_deleted\', \'deleted\')');
     expect(sql).not.toContain('status = \'synced\'');
+  });
+
+  describe('when fetching pending assets', () => {
+    test('when pending assets are fetched, then pending and pending_edit assets are always included', async () => {
+      mockSqlite.getAllAsync.mockResolvedValueOnce([]);
+
+      await photosLocalDB.getPendingAssets();
+
+      const [, sql] = mockSqlite.getAllAsync.mock.calls[0];
+      expect(sql).toContain("status IN ('pending', 'pending_edit')");
+    });
+
+    test('when pending assets are fetched, then error assets beyond the maximum attempt count are excluded', async () => {
+      mockSqlite.getAllAsync.mockResolvedValueOnce([]);
+
+      await photosLocalDB.getPendingAssets();
+
+      const [, sql] = mockSqlite.getAllAsync.mock.calls[0];
+      expect(sql).toContain('attempt_count < 5');
+    });
+
+    test('when pending assets are fetched, then error assets within the backoff window are excluded via a time check', async () => {
+      mockSqlite.getAllAsync.mockResolvedValueOnce([]);
+
+      await photosLocalDB.getPendingAssets();
+
+      const [, sql] = mockSqlite.getAllAsync.mock.calls[0];
+      expect(sql).toContain('last_attempt_at IS NOT NULL');
+      expect(sql).toContain('last_attempt_at <');
+      expect(sql).toContain('unixepoch()');
+    });
+
+    test('when pending assets are fetched, then the backoff grows with each failed attempt', async () => {
+      mockSqlite.getAllAsync.mockResolvedValueOnce([]);
+
+      await photosLocalDB.getPendingAssets();
+
+      const [, sql] = mockSqlite.getAllAsync.mock.calls[0];
+      expect(sql).toContain('CASE');
+      expect(sql).toContain('300000');
+      expect(sql).toContain('900000');
+      expect(sql).toContain('3600000');
+      expect(sql).toContain('14400000');
+    });
+
+    test('when pending assets are fetched, then synced, deleted and cloud deleted assets are excluded', async () => {
+      mockSqlite.getAllAsync.mockResolvedValueOnce([]);
+
+      await photosLocalDB.getPendingAssets();
+
+      const [, sql] = mockSqlite.getAllAsync.mock.calls[0];
+      expect(sql).not.toContain("'synced'");
+      expect(sql).not.toContain("'deleted'");
+      expect(sql).not.toContain("'cloud_deleted'");
+    });
+
+    test('when all remaining assets have failed and are within the backoff window, then no pending assets are returned', async () => {
+      mockSqlite.getAllAsync.mockResolvedValueOnce([]);
+
+      const result = await photosLocalDB.getPendingAssets();
+
+      expect(result).toHaveLength(0);
+    });
+
+    test('when error assets have been reset to pending, then they are returned as pending assets', async () => {
+      mockSqlite.getAllAsync.mockResolvedValueOnce([
+        { asset_id: 'asset-1', status: 'pending', remote_file_id: null, is_burst: 0, burst_member_count: null },
+        { asset_id: 'asset-2', status: 'pending', remote_file_id: null, is_burst: 0, burst_member_count: null },
+      ]);
+
+      const result = await photosLocalDB.getPendingAssets();
+
+      expect(result).toHaveLength(2);
+      expect(result.map((a) => a.assetId)).toEqual(['asset-1', 'asset-2']);
+      expect(result.every((a) => a.status === 'pending')).toBe(true);
+    });
+
+    test('when error assets are reset to pending, then the reset query targets only error status rows', async () => {
+      await photosLocalDB.resetErrorsToPending();
+
+      const [, sql] = mockSqlite.executeSql.mock.calls[0];
+      expect(sql).toContain("status = 'pending'");
+      expect(sql).toContain("WHERE status = 'error'");
+      expect(sql).toContain('last_attempt_at = NULL');
+    });
   });
 });

--- a/src/services/photos/database/photosLocalDB.spec.ts
+++ b/src/services/photos/database/photosLocalDB.spec.ts
@@ -740,7 +740,7 @@ describe('photosLocalDB cloud asset methods', () => {
       await photosLocalDB.getPendingAssets();
 
       const [, sql] = mockSqlite.getAllAsync.mock.calls[0];
-      expect(sql).toContain("status IN ('pending', 'pending_edit')");
+      expect(sql).toContain('status IN (\'pending\', \'pending_edit\')');
     });
 
     test('when pending assets are fetched, then error assets beyond the maximum attempt count are excluded', async () => {
@@ -782,9 +782,9 @@ describe('photosLocalDB cloud asset methods', () => {
       await photosLocalDB.getPendingAssets();
 
       const [, sql] = mockSqlite.getAllAsync.mock.calls[0];
-      expect(sql).not.toContain("'synced'");
-      expect(sql).not.toContain("'deleted'");
-      expect(sql).not.toContain("'cloud_deleted'");
+      expect(sql).not.toContain('\'synced\'');
+      expect(sql).not.toContain('\'deleted\'');
+      expect(sql).not.toContain('\'cloud_deleted\'');
     });
 
     test('when all remaining assets have failed and are within the backoff window, then no pending assets are returned', async () => {
@@ -812,9 +812,37 @@ describe('photosLocalDB cloud asset methods', () => {
       await photosLocalDB.resetErrorsToPending();
 
       const [, sql] = mockSqlite.executeSql.mock.calls[0];
-      expect(sql).toContain("status = 'pending'");
-      expect(sql).toContain("WHERE status = 'error'");
+      expect(sql).toContain('status = \'pending\'');
+      expect(sql).toContain('WHERE status = \'error\'');
       expect(sql).toContain('last_attempt_at = NULL');
+    });
+  });
+
+  describe('when counting assets with errors', () => {
+    test('when there are assets in error status, then the count reflects all of them regardless of attempt count', async () => {
+      mockSqlite.getAllAsync.mockResolvedValueOnce([{ count: 3 }]);
+
+      const result = await photosLocalDB.getAssetUploadErroredCount();
+
+      expect(result).toBe(3);
+      const [, sql] = mockSqlite.getAllAsync.mock.calls[0];
+      expect(sql).toContain('status = \'error\'');
+    });
+
+    test('when there are no assets in error status, then the count is zero', async () => {
+      mockSqlite.getAllAsync.mockResolvedValueOnce([{ count: 0 }]);
+
+      const result = await photosLocalDB.getAssetUploadErroredCount();
+
+      expect(result).toBe(0);
+    });
+
+    test('when the database returns an empty result, then the count defaults to zero', async () => {
+      mockSqlite.getAllAsync.mockResolvedValueOnce([]);
+
+      const result = await photosLocalDB.getAssetUploadErroredCount();
+
+      expect(result).toBe(0);
     });
   });
 });

--- a/src/services/photos/database/photosLocalDB.ts
+++ b/src/services/photos/database/photosLocalDB.ts
@@ -283,6 +283,11 @@ class PhotosLocalDB {
     await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.markError, [assetId, errorMessage ?? null]);
   }
 
+  async getAssetUploadErroredCount(): Promise<number> {
+    const rows = await sqliteService.getAllAsync<{ count: number }>(DB_NAME, assetSyncTable.statements.getAssetUploadErroredCount);
+    return rows[0]?.count ?? 0;
+  }
+
   async cacheAssetFileSize(assetId: string, fileSize: number): Promise<void> {
     await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.cacheFileSize, [fileSize, assetId]);
   }

--- a/src/services/photos/database/photosLocalDB.ts
+++ b/src/services/photos/database/photosLocalDB.ts
@@ -123,7 +123,7 @@ interface AssetSyncRow {
 
 export interface SyncedAssetInfo {
   modificationTime: number | null;
-  status: 'synced' | 'cloud_deleted';
+  status: 'synced' | 'cloud_deleted' | 'error';
 }
 
 export interface IncompleteBurstAsset {
@@ -275,6 +275,10 @@ class PhotosLocalDB {
     ]);
   }
 
+  async resetErrorsToPending(): Promise<void> {
+    await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.resetErrorsToPending);
+  }
+
   async markError(assetId: string, errorMessage?: string): Promise<void> {
     await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.markError, [assetId, errorMessage ?? null]);
   }
@@ -297,7 +301,7 @@ class PhotosLocalDB {
         return sqliteService.getAllAsync<{
           asset_id: string;
           modification_time: number | null;
-          status: 'synced' | 'cloud_deleted';
+          status: 'synced' | 'cloud_deleted' | 'error';
         }>(DB_NAME, assetSyncTable.statements.getSyncedInList(placeholders), chunk);
       }),
     );

--- a/src/services/photos/database/tables/asset_sync.ts
+++ b/src/services/photos/database/tables/asset_sync.ts
@@ -183,6 +183,7 @@ const statements = {
     SET status = 'pending', last_attempt_at = NULL
     WHERE status = 'error';
   `,
+  getAssetUploadErroredCount: `SELECT COUNT(*) AS count FROM ${TABLE_NAME} WHERE status = 'error';`,
   deleteById: `DELETE FROM ${TABLE_NAME} WHERE asset_id = ?;`,
   reset: `DELETE FROM ${TABLE_NAME};`,
   getSyncedRemoteFileIds: `SELECT remote_file_id FROM ${TABLE_NAME} WHERE remote_file_id IS NOT NULL AND status NOT IN ('cloud_deleted', 'deleted');`,

--- a/src/services/photos/database/tables/asset_sync.ts
+++ b/src/services/photos/database/tables/asset_sync.ts
@@ -134,7 +134,7 @@ const statements = {
     FROM ${TABLE_NAME} WHERE asset_id = ?;
   `,
   getSyncedInList: (placeholders: string) =>
-    `SELECT asset_id, modification_time, status FROM ${TABLE_NAME} WHERE asset_id IN (${placeholders}) AND status IN ('synced', 'cloud_deleted');`,
+    `SELECT asset_id, modification_time, status FROM ${TABLE_NAME} WHERE asset_id IN (${placeholders}) AND status IN ('synced', 'cloud_deleted', 'error');`,
   getSyncedRemoteIdsByCreationMonth: `
     SELECT remote_file_id FROM ${TABLE_NAME}
     WHERE status = 'synced'
@@ -142,7 +142,22 @@ const statements = {
       AND creation_time >= ?
       AND creation_time < ?;
   `,
-  getPendingAssets: `SELECT asset_id, status, remote_file_id, is_burst, burst_member_count FROM ${TABLE_NAME} WHERE status NOT IN ('synced', 'deleted', 'cloud_deleted') ORDER BY creation_time DESC NULLS LAST;`,
+  getPendingAssets: `
+    SELECT asset_id, status, remote_file_id, is_burst, burst_member_count FROM ${TABLE_NAME}
+    WHERE status IN ('pending', 'pending_edit')
+       OR (
+         status = 'error'
+         AND attempt_count < 5
+         AND last_attempt_at IS NOT NULL
+         AND last_attempt_at < (unixepoch() * 1000) - CASE
+           WHEN attempt_count <= 1 THEN  300000
+           WHEN attempt_count <= 2 THEN  900000
+           WHEN attempt_count <= 3 THEN 3600000
+           ELSE                        14400000
+         END
+       )
+    ORDER BY creation_time DESC NULLS LAST;
+  `,
   markDeleted: `
     INSERT INTO ${TABLE_NAME} (asset_id, status, deleted_at)
     VALUES (?, 'deleted', (unixepoch() * 1000))
@@ -162,6 +177,11 @@ const statements = {
       paired_video_remote_file_id = NULL,
       paired_video_status = NULL
     WHERE status = 'synced';
+  `,
+  resetErrorsToPending: `
+    UPDATE ${TABLE_NAME}
+    SET status = 'pending', last_attempt_at = NULL
+    WHERE status = 'error';
   `,
   deleteById: `DELETE FROM ${TABLE_NAME} WHERE asset_id = ?;`,
   reset: `DELETE FROM ${TABLE_NAME};`,

--- a/src/store/slices/photos/index.spec.ts
+++ b/src/store/slices/photos/index.spec.ts
@@ -104,6 +104,7 @@ jest.mock('src/services/photos/database/photosLocalDB', () => ({
     getIncompleteBurstAssets: jest.fn().mockResolvedValue([]),
     cleanupOrphanedAssetSync: jest.fn().mockResolvedValue(0),
     resetErrorsToPending: jest.fn().mockResolvedValue(undefined),
+    getAssetUploadErroredCount: jest.fn().mockResolvedValue(0),
   },
 }));
 
@@ -196,6 +197,7 @@ describe('photos slice', () => {
       isFetchingCloudHistory: false,
       disabledReason: null,
       sessionCompletedAssetIds: [],
+      assetUploadErroredCount: 0,
     };
     mockAsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(saved));
 

--- a/src/store/slices/photos/index.spec.ts
+++ b/src/store/slices/photos/index.spec.ts
@@ -103,6 +103,7 @@ jest.mock('src/services/photos/database/photosLocalDB', () => ({
     getStatus: jest.fn().mockResolvedValue(null),
     getIncompleteBurstAssets: jest.fn().mockResolvedValue([]),
     cleanupOrphanedAssetSync: jest.fn().mockResolvedValue(0),
+    resetErrorsToPending: jest.fn().mockResolvedValue(undefined),
   },
 }));
 

--- a/src/store/slices/photos/index.ts
+++ b/src/store/slices/photos/index.ts
@@ -58,6 +58,7 @@ export interface PhotosState {
   cloudFetchRevision: number;
   isFetchingCloudHistory: boolean;
   disabledReason: PhotosDisabledReason;
+  assetUploadErroredCount: number;
 }
 
 const initialState: PhotosState = {
@@ -80,6 +81,7 @@ const initialState: PhotosState = {
   cloudFetchRevision: 0,
   isFetchingCloudHistory: false,
   disabledReason: null,
+  assetUploadErroredCount: 0,
 };
 
 const persistPhotosSettings = async (state: PhotosState): Promise<void> => {
@@ -334,6 +336,7 @@ export const forceRefreshThunk = createAsyncThunk<void, void, { state: RootState
     dispatch(runFullCloudHistorySyncThunk({ force: true }));
 
     await photosLocalDB.resetErrorsToPending();
+    dispatch(photosSlice.actions.setAssetUploadErroredCount(await photosLocalDB.getAssetUploadErroredCount()));
     await dispatch(runDiscoveryThunk()).unwrap();
     const pending = getState().photos.pendingBackupAssets;
     const incompleteBursts = Platform.OS === 'ios' ? await photosLocalDB.getIncompleteBurstAssets() : [];
@@ -375,6 +378,7 @@ export const runBackupCycleThunk = createAsyncThunk<void, void, { state: RootSta
     dispatch(runFullCloudHistorySyncThunk());
 
     await dispatch(runDiscoveryThunk());
+    dispatch(photosSlice.actions.setAssetUploadErroredCount(await photosLocalDB.getAssetUploadErroredCount()));
 
     const { isPaused, pendingBackupAssets } = getState().photos;
 
@@ -515,6 +519,9 @@ export const photosSlice = createSlice({
     },
     setDisabledReason: (state, action: PayloadAction<PhotosDisabledReason>) => {
       state.disabledReason = action.payload;
+    },
+    setAssetUploadErroredCount: (state, action: PayloadAction<number>) => {
+      state.assetUploadErroredCount = action.payload;
     },
     pauseForQuotaExceeded: (state) => {
       state.syncStatus = 'paused';

--- a/src/store/slices/photos/index.ts
+++ b/src/store/slices/photos/index.ts
@@ -333,6 +333,7 @@ export const forceRefreshThunk = createAsyncThunk<void, void, { state: RootState
     await dispatch(initDeviceIdThunk());
     dispatch(runFullCloudHistorySyncThunk({ force: true }));
 
+    await photosLocalDB.resetErrorsToPending();
     await dispatch(runDiscoveryThunk()).unwrap();
     const pending = getState().photos.pendingBackupAssets;
     const incompleteBursts = Platform.OS === 'ios' ? await photosLocalDB.getIncompleteBurstAssets() : [];

--- a/src/store/slices/photos/thunks/upload.ts
+++ b/src/store/slices/photos/thunks/upload.ts
@@ -257,6 +257,7 @@ export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean }
       }
       dispatch(photosSlice.actions.setSyncStatus(finalIsPaused || finalDisabledReason !== null ? 'paused' : 'synced'));
       dispatch(photosSlice.actions.clearUploadProgress());
+      dispatch(photosSlice.actions.setAssetUploadErroredCount(await photosLocalDB.getAssetUploadErroredCount()));
 
       if (!finalIsPaused && finalDisabledReason === null && (await hasRemainingAssets(isIOS))) {
         logger.info('[Upload] Work remains after this cycle — restarting');


### PR DESCRIPTION
When an asset fails to upload persistently, the backup cycle entered a loop: discovery + upload restarted indefinitely. Two bugs combined to cause this:
1. Discovery re-queued errored assets as "new" on every cycle because `getSyncedInList` did not include `status='error'`, so the deduplicator treated them as unknown assets.
2. `getPendingAssets` returned `error` assets with no backoff or retry cap, so `hasRemainingAssets` always returned `true` and the cycle never stopped.

Additionally, assets that were permanently stuck had no representation in the UI — the header showed "Backup completed" as if everything had succeeded.

