### PR TITLE
[PB-6278]: working-set change-feed signaling for File Provider

### DIFF
--- a/ios/Internxt.xcodeproj/project.pbxproj
+++ b/ios/Internxt.xcodeproj/project.pbxproj
@@ -16,6 +16,13 @@
 		7D373856C83A43879BFBE604 /* InternxtShareExtension.appex in Copy Files */ = {isa = PBXBuildFile; fileRef = 7F5486528A7D46DD91A7910F /* InternxtShareExtension.appex */; };
 		8F8148045BC14A539BD1917D /* ShareExtensionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6F72E1B98D469883DAFB30 /* ShareExtensionViewController.swift */; };
 		AA0100012F87A94000E14783 /* SharedAuthKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100002F87A94000E14783 /* SharedAuthKeychain.swift */; };
+		FF2010002F90000000E14783 /* FileProviderModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1010002F90000000E14783 /* FileProviderModule.swift */; };
+		FF2010012F90000000E14783 /* FileProviderModule.m in Sources */ = {isa = PBXBuildFile; fileRef = FF1010012F90000000E14783 /* FileProviderModule.m */; };
+		FF2010062F90000000E14783 /* FileProviderItemIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47722F87A94000E14783 /* FileProviderItemIdentifier.swift */; };
+		FF2010022F90000000E14783 /* SyncAnchorStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1010022F90000000E14783 /* SyncAnchorStore.swift */; };
+		FF2010032F90000000E14783 /* SyncAnchorStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1010022F90000000E14783 /* SyncAnchorStore.swift */; };
+		FF2010042F90000000E14783 /* SyncAnchorStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1010022F90000000E14783 /* SyncAnchorStore.swift */; };
+		FF2010052F90000000E14783 /* SyncAnchorStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1010032F90000000E14783 /* SyncAnchorStoreTests.swift */; };
 		AA0100032F87A94000E14783 /* FileProviderDomainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100022F87A94000E14783 /* FileProviderDomainManager.swift */; };
 		AA0100052F87A94000E14783 /* InternxtAuthCredentialsModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100042F87A94000E14783 /* InternxtAuthCredentialsModule.swift */; };
 		AA0100072F87A94000E14783 /* InternxtAuthCredentialsModule.m in Sources */ = {isa = PBXBuildFile; fileRef = AA0100062F87A94000E14783 /* InternxtAuthCredentialsModule.m */; };
@@ -107,6 +114,10 @@
 		8C48FB43821216C363EBF3FC /* Pods-InternxtFileProvider.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtFileProvider.release.xcconfig"; path = "Target Support Files/Pods-InternxtFileProvider/Pods-InternxtFileProvider.release.xcconfig"; sourceTree = "<group>"; };
 		A4921399A370F5CE6EE7EA0F /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-InternxtShareExtension/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 		AA0100002F87A94000E14783 /* SharedAuthKeychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SharedAuthKeychain.swift; path = Internxt/SharedAuthKeychain.swift; sourceTree = "<group>"; };
+		FF1010002F90000000E14783 /* FileProviderModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FileProviderModule.swift; path = Internxt/FileProviderModule.swift; sourceTree = "<group>"; };
+		FF1010012F90000000E14783 /* FileProviderModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = FileProviderModule.m; path = Internxt/FileProviderModule.m; sourceTree = "<group>"; };
+		FF1010022F90000000E14783 /* SyncAnchorStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncAnchorStore.swift; sourceTree = "<group>"; };
+		FF1010032F90000000E14783 /* SyncAnchorStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncAnchorStoreTests.swift; sourceTree = "<group>"; };
 		AA0100022F87A94000E14783 /* FileProviderDomainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FileProviderDomainManager.swift; path = Internxt/FileProviderDomainManager.swift; sourceTree = "<group>"; };
 		AA0100042F87A94000E14783 /* InternxtAuthCredentialsModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = InternxtAuthCredentialsModule.swift; path = Internxt/InternxtAuthCredentialsModule.swift; sourceTree = "<group>"; };
 		AA0100062F87A94000E14783 /* InternxtAuthCredentialsModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = InternxtAuthCredentialsModule.m; path = Internxt/InternxtAuthCredentialsModule.m; sourceTree = "<group>"; };
@@ -191,6 +202,8 @@
 				AA0100022F87A94000E14783 /* FileProviderDomainManager.swift */,
 				AA0100042F87A94000E14783 /* InternxtAuthCredentialsModule.swift */,
 				AA0100062F87A94000E14783 /* InternxtAuthCredentialsModule.m */,
+				FF1010002F90000000E14783 /* FileProviderModule.swift */,
+				FF1010012F90000000E14783 /* FileProviderModule.m */,
 				F11748412D0307B40044C1D9 /* AppDelegate.swift */,
 				F11748442D0722820044C1D9 /* Internxt-Bridging-Header.h */,
 				BB2F792B24A3F905000567C9 /* Supporting */,
@@ -311,6 +324,7 @@
 			isa = PBXGroup;
 			children = (
 				DE1D47632F87A94000E14783 /* FileProviderExtension.swift */,
+				FF1010022F90000000E14783 /* SyncAnchorStore.swift */,
 				DE1D47642F87A94000E14783 /* FileProviderEnumerator.swift */,
 				DE1D47652F87A94000E14783 /* FileProviderItem.swift */,
 				AB1D47912F87A94000E14783 /* FileProviderErrorMapper.swift */,
@@ -333,6 +347,7 @@
 			children = (
 				FB1D480112F87A94000E14783 /* FileProviderErrorMapperTests.swift */,
 				FB1D481112F87A94000E14783 /* FileProviderMutationTests.swift */,
+				FF1010032F90000000E14783 /* SyncAnchorStoreTests.swift */,
 			);
 			path = InternxtFileProviderTests;
 			sourceTree = "<group>";
@@ -791,6 +806,10 @@
 				AA0100032F87A94000E14783 /* FileProviderDomainManager.swift in Sources */,
 				AA0100052F87A94000E14783 /* InternxtAuthCredentialsModule.swift in Sources */,
 				AA0100072F87A94000E14783 /* InternxtAuthCredentialsModule.m in Sources */,
+				FF2010002F90000000E14783 /* FileProviderModule.swift in Sources */,
+				FF2010012F90000000E14783 /* FileProviderModule.m in Sources */,
+				FF2010032F90000000E14783 /* SyncAnchorStore.swift in Sources */,
+				FF2010062F90000000E14783 /* FileProviderItemIdentifier.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -808,6 +827,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DE1D47602F87A94000E14783 /* FileProviderExtension.swift in Sources */,
+				FF2010022F90000000E14783 /* SyncAnchorStore.swift in Sources */,
 				DE1D47612F87A94000E14783 /* FileProviderEnumerator.swift in Sources */,
 				DE1D47622F87A94000E14783 /* FileProviderItem.swift in Sources */,
 				AB1D47902F87A94000E14783 /* FileProviderErrorMapper.swift in Sources */,
@@ -829,6 +849,8 @@
 				FB1D480012F87A94000E14783 /* FileProviderErrorMapperTests.swift in Sources */,
 				FB1D480212F87A94000E14783 /* FileProviderErrorMapper.swift in Sources */,
 				FB1D481012F87A94000E14783 /* FileProviderMutationTests.swift in Sources */,
+				FF2010042F90000000E14783 /* SyncAnchorStore.swift in Sources */,
+				FF2010052F90000000E14783 /* SyncAnchorStoreTests.swift in Sources */,
 				FB1D481212F87A94000E14783 /* FileProviderItem.swift in Sources */,
 				FB1D481312F87A94000E14783 /* FileProviderItemIdentifier.swift in Sources */,
 				FB1D481412F87A94000E14783 /* FileProviderMutationService.swift in Sources */,

--- a/ios/Internxt/FileProviderDomainManager.swift
+++ b/ios/Internxt/FileProviderDomainManager.swift
@@ -23,6 +23,13 @@ enum FileProviderDomainManager {
   }
 
   static func signalEnumeration(completion: @escaping (Error?) -> Void) {
+    signalEnumeration(for: .workingSet, completion: completion)
+  }
+
+  static func signalEnumeration(
+    for container: NSFileProviderItemIdentifier,
+    completion: @escaping (Error?) -> Void
+  ) {
     guard let manager = NSFileProviderManager(for: domain) else {
       completion(NSError(
         domain: "FileProviderDomainManager",
@@ -31,7 +38,7 @@ enum FileProviderDomainManager {
       ))
       return
     }
-    manager.signalEnumerator(for: .workingSet) { error in
+    manager.signalEnumerator(for: container) { error in
       completion(error)
     }
   }

--- a/ios/Internxt/FileProviderModule.m
+++ b/ios/Internxt/FileProviderModule.m
@@ -1,0 +1,7 @@
+#import <React/RCTBridgeModule.h>
+
+@interface RCT_EXTERN_MODULE(InternxtSignalingModule, NSObject)
+RCT_EXTERN_METHOD(notifyParentChanged:(NSString *)parentFolderUuid
+                  resolver:(RCTPromiseResolveBlock)resolver
+                  rejecter:(RCTPromiseRejectBlock)rejecter)
+@end

--- a/ios/Internxt/FileProviderModule.swift
+++ b/ios/Internxt/FileProviderModule.swift
@@ -1,0 +1,35 @@
+import FileProvider
+import Foundation
+import React
+
+@objc(InternxtSignalingModule)
+class FileProviderModule: NSObject {
+
+  @objc static func requiresMainQueueSetup() -> Bool { false }
+
+  @objc func notifyParentChanged(
+    _ parentFolderUuid: String,
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter _: @escaping RCTPromiseRejectBlock
+  ) {
+    guard #available(iOS 16.0, *) else {
+      resolver(nil)
+      return
+    }
+
+    let store = SyncAnchorStore()
+    _ = store?.recordChange(parentUuid: parentFolderUuid)
+
+    signalParent(parentFolderUuid, resolver: resolver)
+  }
+
+  @available(iOS 16.0, *)
+  private func signalParent(_ parentFolderUuid: String, resolver: @escaping RCTPromiseResolveBlock) {
+    let container = FileProviderItemID.parentIdentifier(folderUuid: parentFolderUuid)
+    FileProviderDomainManager.signalEnumeration(for: container) { _ in
+      FileProviderDomainManager.signalEnumeration { _ in
+        resolver(nil)
+      }
+    }
+  }
+}

--- a/ios/InternxtFileProvider/FileProviderEnumerator.swift
+++ b/ios/InternxtFileProvider/FileProviderEnumerator.swift
@@ -12,6 +12,7 @@ class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
 
   private static let pageSize = 50
   private static let order = "ASC"
+  private static let folderContainerAnchor = NSFileProviderSyncAnchor(SyncAnchorStore.encode(0))
 
   private enum Phase: String {
     case folders
@@ -40,7 +41,12 @@ class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
   }
 
   private let enumeratedItemIdentifier: NSFileProviderItemIdentifier
-  private let anchor = NSFileProviderSyncAnchor("an anchor".data(using: .utf8)!)
+  private let syncAnchorStore = SyncAnchorStore()
+  private var browsedChildIds: [String] = []
+
+  private var isWorkingSet: Bool {
+    enumeratedItemIdentifier == .workingSet
+  }
 
   init(enumeratedItemIdentifier: NSFileProviderItemIdentifier) {
     self.enumeratedItemIdentifier = enumeratedItemIdentifier
@@ -50,9 +56,7 @@ class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
   func invalidate() {}
 
   func enumerateItems(for observer: NSFileProviderEnumerationObserver, startingAt page: NSFileProviderPage) {
-    let cursor = Cursor.decode(page)
-
-    guard FileProviderItemID.isDriveFolderContainer(enumeratedItemIdentifier) else {
+    guard !isWorkingSet, FileProviderItemID.isDriveFolderContainer(enumeratedItemIdentifier) else {
       observer.didEnumerate([])
       observer.finishEnumerating(upTo: nil)
       return
@@ -64,6 +68,7 @@ class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
       return
     }
 
+    let cursor = Cursor.decode(page)
     Task {
       do {
         switch cursor.phase {
@@ -91,6 +96,7 @@ class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
       FileProviderItem(folder: $0, parent: enumeratedItemIdentifier)
     }
     observer.didEnumerate(items)
+    accumulate(items)
 
     if response.folders.count == Self.pageSize {
       observer.finishEnumerating(upTo: Cursor(phase: .folders, offset: offset + Self.pageSize).encoded())
@@ -112,12 +118,125 @@ class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
       FileProviderItem(file: $0, parent: enumeratedItemIdentifier)
     }
     observer.didEnumerate(items)
+    accumulate(items)
 
     if response.files.count == Self.pageSize {
       observer.finishEnumerating(upTo: Cursor(phase: .files, offset: offset + Self.pageSize).encoded())
     } else {
+      seedSnapshot(forFolderUuid: folderUuid)
       observer.finishEnumerating(upTo: nil)
     }
+  }
+
+  private func accumulate(_ items: [FileProviderItem]) {
+    browsedChildIds.append(contentsOf: items.map { $0.itemIdentifier.rawValue })
+  }
+
+  private func seedSnapshot(forFolderUuid folderUuid: String) {
+    syncAnchorStore?.saveSnapshot(browsedChildIds, forFolderUuid: folderUuid)
+  }
+
+  func currentSyncAnchor(completionHandler: @escaping (NSFileProviderSyncAnchor?) -> Void) {
+    completionHandler(isWorkingSet ? workingSetAnchor() : Self.folderContainerAnchor)
+  }
+
+  func enumerateChanges(for observer: NSFileProviderChangeObserver, from anchor: NSFileProviderSyncAnchor) {
+    guard isWorkingSet else {
+      observer.finishEnumeratingChanges(upTo: Self.folderContainerAnchor, moreComing: false)
+      return
+    }
+    enumerateWorkingSetChanges(for: observer, from: anchor)
+  }
+
+  private func enumerateWorkingSetChanges(for observer: NSFileProviderChangeObserver, from anchor: NSFileProviderSyncAnchor) {
+    let incoming = SyncAnchorStore.decode(anchor.rawValue) ?? 0
+    let current = workingSetAnchor()
+
+    guard let store = syncAnchorStore else {
+      observer.finishEnumeratingChanges(upTo: NSFileProviderSyncAnchor(SyncAnchorStore.encode(incoming)), moreComing: false)
+      return
+    }
+
+    let parents = store.changedParents(after: incoming)
+
+    guard !parents.isEmpty, let driveAPI = DriveAPIFactory.make() else {
+      observer.finishEnumeratingChanges(upTo: current, moreComing: false)
+      return
+    }
+
+    Task {
+      do {
+        for parentUuid in parents {
+          try await diffFolder(parentUuid, store: store, driveAPI: driveAPI, observer: observer)
+        }
+        observer.finishEnumeratingChanges(upTo: current, moreComing: false)
+      } catch {
+        observer.finishEnumeratingChanges(
+          upTo: NSFileProviderSyncAnchor(SyncAnchorStore.encode(incoming)),
+          moreComing: false
+        )
+      }
+    }
+  }
+
+  private func diffFolder(
+    _ parentUuid: String,
+    store: SyncAnchorStore,
+    driveAPI: DriveAPI,
+    observer: NSFileProviderChangeObserver
+  ) async throws {
+    let parent = FileProviderItemID.parentIdentifier(folderUuid: parentUuid)
+    let folderUuid = FileProviderItemID.folderUuid(for: parent) ?? parentUuid
+
+    let currentItems = try await currentChildren(of: folderUuid, parent: parent, driveAPI: driveAPI)
+    let currentIds = currentItems.map { $0.itemIdentifier.rawValue }
+    let prevIds = store.snapshot(forFolderUuid: parentUuid)
+    let deletedIds = Set(prevIds).subtracting(currentIds)
+
+    observer.didUpdate(currentItems)
+    if !deletedIds.isEmpty {
+      observer.didDeleteItems(withIdentifiers: deletedIds.map { NSFileProviderItemIdentifier($0) })
+    }
+    store.saveSnapshot(currentIds, forFolderUuid: parentUuid)
+  }
+
+  private func currentChildren(
+    of folderUuid: String,
+    parent: NSFileProviderItemIdentifier,
+    driveAPI: DriveAPI
+  ) async throws -> [FileProviderItem] {
+    var items: [FileProviderItem] = []
+    try await forEachPage { offset in
+      let response = try await driveAPI.getFolderFolders(
+        folderUuid: folderUuid, offset: offset, limit: Self.pageSize, order: Self.order
+      )
+      items.append(contentsOf: response.folders.map { FileProviderItem(folder: $0, parent: parent) })
+      return response.folders.count
+    }
+    try await forEachPage { offset in
+      let response = try await driveAPI.getFolderFilesV2(
+        folderUuid: folderUuid, offset: offset, limit: Self.pageSize, order: Self.order
+      )
+      items.append(contentsOf: response.files.map { FileProviderItem(file: $0, parent: parent) })
+      return response.files.count
+    }
+    return items
+  }
+
+  private func forEachPage(_ fetchPage: (_ offset: Int) async throws -> Int) async throws {
+    var offset = 0
+    while true {
+      let count = try await fetchPage(offset)
+      if count < Self.pageSize { break }
+      offset += Self.pageSize
+    }
+  }
+
+  private func workingSetAnchor() -> NSFileProviderSyncAnchor {
+    guard let store = syncAnchorStore else {
+      return NSFileProviderSyncAnchor(SyncAnchorStore.encode(0))
+    }
+    return NSFileProviderSyncAnchor(store.currentData)
   }
 
   private func notAuthenticatedError() -> Error {
@@ -129,13 +248,5 @@ class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
       return notAuthenticatedError()
     }
     return error
-  }
-
-  func enumerateChanges(for observer: NSFileProviderChangeObserver, from anchor: NSFileProviderSyncAnchor) {
-    observer.finishEnumeratingChanges(upTo: anchor, moreComing: false)
-  }
-
-  func currentSyncAnchor(completionHandler: @escaping (NSFileProviderSyncAnchor?) -> Void) {
-    completionHandler(anchor)
   }
 }

--- a/ios/InternxtFileProvider/SyncAnchorStore.swift
+++ b/ios/InternxtFileProvider/SyncAnchorStore.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+struct SyncAnchorStore {
+  static let appGroupIdentifier = "group.com.internxt.snacks"
+
+  private static let counterFileName = "InternxtFileProviderSyncAnchorCounter"
+  private static let changesFileName = "InternxtFileProviderPendingChanges"
+  private static let snapshotsFileName = "InternxtFileProviderFolderSnapshots"
+  private static let maxEntries = 50
+  private static let maxTrackedFolders = 50
+
+  private let counterURL: URL
+  private let changesURL: URL
+  private let snapshotsURL: URL
+
+  init?(appGroupIdentifier: String = SyncAnchorStore.appGroupIdentifier) {
+    guard let container = FileManager.default.containerURL(
+      forSecurityApplicationGroupIdentifier: appGroupIdentifier
+    ) else { return nil }
+    self.counterURL = container.appendingPathComponent(Self.counterFileName)
+    self.changesURL = container.appendingPathComponent(Self.changesFileName)
+    self.snapshotsURL = container.appendingPathComponent(Self.snapshotsFileName)
+  }
+
+  init(directory: URL) {
+    self.counterURL = directory.appendingPathComponent(Self.counterFileName)
+    self.changesURL = directory.appendingPathComponent(Self.changesFileName)
+    self.snapshotsURL = directory.appendingPathComponent(Self.snapshotsFileName)
+  }
+
+  var currentValue: UInt64 {
+    guard let data = try? Data(contentsOf: counterURL),
+          let value = Self.decode(data) else {
+      return 0
+    }
+    return value
+  }
+
+  var currentData: Data {
+    Self.encode(currentValue)
+  }
+
+  @discardableResult
+  func recordChange(parentUuid: String) -> UInt64 {
+    let next = currentValue &+ 1
+    try? Self.encode(next).write(to: counterURL, options: .atomic)
+
+    var map = readChanges()
+    map[parentUuid] = next
+    writeChanges(boundedChanges(map))
+
+    return next
+  }
+
+  func changedParents(after incoming: UInt64) -> [String] {
+    readChanges()
+      .filter { $0.value > incoming }
+      .sorted { $0.value < $1.value }
+      .map { $0.key }
+  }
+
+  func snapshot(forFolderUuid folderUuid: String) -> [String] {
+    readSnapshots()[folderUuid] ?? []
+  }
+
+  func saveSnapshot(_ identifiers: [String], forFolderUuid folderUuid: String) {
+    var snapshots = readSnapshots()
+    snapshots[folderUuid] = identifiers
+    writeSnapshots(boundedSnapshots(snapshots, keeping: folderUuid))
+  }
+
+  static func encode(_ value: UInt64) -> Data {
+    withUnsafeBytes(of: value.bigEndian) { Data($0) }
+  }
+
+  static func decode(_ data: Data) -> UInt64? {
+    guard data.count == MemoryLayout<UInt64>.size else { return nil }
+    return data.withUnsafeBytes { $0.load(as: UInt64.self).bigEndian }
+  }
+
+  private func readChanges() -> [String: UInt64] {
+    guard let data = try? Data(contentsOf: changesURL),
+          let map = try? JSONDecoder().decode([String: UInt64].self, from: data) else {
+      return [:]
+    }
+    return map
+  }
+
+  private func writeChanges(_ map: [String: UInt64]) {
+    guard let data = try? JSONEncoder().encode(map) else { return }
+    try? data.write(to: changesURL, options: .atomic)
+  }
+
+  private func boundedChanges(_ map: [String: UInt64]) -> [String: UInt64] {
+    guard map.count > Self.maxEntries else { return map }
+    let mostRecent = map.sorted { $0.value > $1.value }.prefix(Self.maxEntries)
+    return Dictionary(uniqueKeysWithValues: mostRecent.map { ($0.key, $0.value) })
+  }
+
+  private func readSnapshots() -> [String: [String]] {
+    guard let data = try? Data(contentsOf: snapshotsURL),
+          let map = try? JSONDecoder().decode([String: [String]].self, from: data) else {
+      return [:]
+    }
+    return map
+  }
+
+  private func writeSnapshots(_ map: [String: [String]]) {
+    guard let data = try? JSONEncoder().encode(map) else { return }
+    try? data.write(to: snapshotsURL, options: .atomic)
+  }
+
+  // Simple eviction: when over the cap, keep the folder just written and an
+  // arbitrary subset of the rest. The snapshot is only an optimization for
+  // detecting removals; a missing snapshot just means "no removals reported",
+  // never incorrect state.
+  private func boundedSnapshots(_ map: [String: [String]], keeping folderUuid: String) -> [String: [String]] {
+    guard map.count > Self.maxTrackedFolders else { return map }
+    var trimmed = map
+    for key in trimmed.keys where key != folderUuid {
+      if trimmed.count <= Self.maxTrackedFolders { break }
+      trimmed.removeValue(forKey: key)
+    }
+    return trimmed
+  }
+}

--- a/ios/InternxtFileProviderTests/SyncAnchorStoreTests.swift
+++ b/ios/InternxtFileProviderTests/SyncAnchorStoreTests.swift
@@ -22,7 +22,7 @@ final class SyncAnchorStoreTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_whenChangeRecorded_thenCurrentValueAdvancesByOne() {
+    func testWhenChangeRecordedThenCurrentValueAdvancesByOne() {
         let store = SyncAnchorStore(directory: directory)
         let before = store.currentValue
 
@@ -31,7 +31,7 @@ final class SyncAnchorStoreTests: XCTestCase {
         XCTAssertEqual(store.currentValue, before + 1)
     }
 
-    func test_whenChangeRecorded_thenCurrentDataDiffersFromBefore() {
+    func testWhenChangeRecordedThenCurrentDataDiffersFromBefore() {
         let store = SyncAnchorStore(directory: directory)
         let before = store.currentData
 
@@ -40,7 +40,7 @@ final class SyncAnchorStoreTests: XCTestCase {
         XCTAssertNotEqual(store.currentData, before)
     }
 
-    func test_whenReadFromSeparateInstance_thenSeesPersistedChange() {
+    func testWhenReadFromSeparateInstanceThenSeesPersistedChange() {
         SyncAnchorStore(directory: directory).recordChange(parentUuid: "parent-a")
 
         let reader = SyncAnchorStore(directory: directory)
@@ -48,7 +48,7 @@ final class SyncAnchorStoreTests: XCTestCase {
         XCTAssertEqual(reader.currentValue, 1)
     }
 
-    func test_whenChangeRecorded_thenChangedParentsAfterPreviousAnchorIncludesIt() {
+    func testWhenChangeRecordedThenChangedParentsAfterPreviousAnchorIncludesIt() {
         let store = SyncAnchorStore(directory: directory)
         let before = store.currentValue
 
@@ -57,14 +57,14 @@ final class SyncAnchorStoreTests: XCTestCase {
         XCTAssertEqual(store.changedParents(after: before), ["parent-a"])
     }
 
-    func test_whenAnchorIsAtRecordedValue_thenChangedParentsExcludesIt() {
+    func testWhenAnchorIsAtRecordedValueThenChangedParentsExcludesIt() {
         let store = SyncAnchorStore(directory: directory)
         let recordedAt = store.recordChange(parentUuid: "parent-a")
 
         XCTAssertEqual(store.changedParents(after: recordedAt), [])
     }
 
-    func test_whenMultipleParentsRecorded_thenChangedParentsReturnsOnlyNewerOnesInOrder() {
+    func testWhenMultipleParentsRecordedThenChangedParentsReturnsOnlyNewerOnesInOrder() {
         let store = SyncAnchorStore(directory: directory)
         let afterFirst = store.recordChange(parentUuid: "parent-a")
         store.recordChange(parentUuid: "parent-b")
@@ -73,7 +73,7 @@ final class SyncAnchorStoreTests: XCTestCase {
         XCTAssertEqual(store.changedParents(after: afterFirst), ["parent-b", "parent-c"])
     }
 
-    func test_whenSameParentRecordedTwice_thenItUsesTheLatestAnchorValue() {
+    func testWhenSameParentRecordedTwiceThenItUsesTheLatestAnchorValue() {
         let store = SyncAnchorStore(directory: directory)
         store.recordChange(parentUuid: "parent-a")
         let afterSecond = store.recordChange(parentUuid: "parent-b")
@@ -82,13 +82,13 @@ final class SyncAnchorStoreTests: XCTestCase {
         XCTAssertEqual(store.changedParents(after: afterSecond), ["parent-a"])
     }
 
-    func test_whenNoSnapshotSaved_thenSnapshotIsEmpty() {
+    func testWhenNoSnapshotSavedThenSnapshotIsEmpty() {
         let store = SyncAnchorStore(directory: directory)
 
         XCTAssertEqual(store.snapshot(forFolderUuid: "folder-a"), [])
     }
 
-    func test_whenSnapshotSaved_thenSnapshotRoundTrips() {
+    func testWhenSnapshotSavedThenSnapshotRoundTrips() {
         let store = SyncAnchorStore(directory: directory)
 
         store.saveSnapshot(["d:file-1", "f:folder-1"], forFolderUuid: "folder-a")
@@ -96,7 +96,7 @@ final class SyncAnchorStoreTests: XCTestCase {
         XCTAssertEqual(store.snapshot(forFolderUuid: "folder-a"), ["d:file-1", "f:folder-1"])
     }
 
-    func test_whenSnapshotSavedFromSeparateInstance_thenItIsPersisted() {
+    func testWhenSnapshotSavedFromSeparateInstanceThenItIsPersisted() {
         SyncAnchorStore(directory: directory).saveSnapshot(["d:file-1"], forFolderUuid: "folder-a")
 
         let reader = SyncAnchorStore(directory: directory)
@@ -104,7 +104,7 @@ final class SyncAnchorStoreTests: XCTestCase {
         XCTAssertEqual(reader.snapshot(forFolderUuid: "folder-a"), ["d:file-1"])
     }
 
-    func test_whenSnapshotSavedForDifferentFolders_thenTheyAreIndependent() {
+    func testWhenSnapshotSavedForDifferentFoldersThenTheyAreIndependent() {
         let store = SyncAnchorStore(directory: directory)
 
         store.saveSnapshot(["d:file-1"], forFolderUuid: "folder-a")
@@ -114,7 +114,7 @@ final class SyncAnchorStoreTests: XCTestCase {
         XCTAssertEqual(store.snapshot(forFolderUuid: "folder-b"), ["d:file-2"])
     }
 
-    func test_whenSnapshotSavedAgain_thenItReplacesThePrevious() {
+    func testWhenSnapshotSavedAgainThenItReplacesThePrevious() {
         let store = SyncAnchorStore(directory: directory)
         store.saveSnapshot(["d:file-1", "d:file-2"], forFolderUuid: "folder-a")
 
@@ -123,7 +123,7 @@ final class SyncAnchorStoreTests: XCTestCase {
         XCTAssertEqual(store.snapshot(forFolderUuid: "folder-a"), ["d:file-2"])
     }
 
-    func test_whenEncodingThenDecoding_thenRoundTripIsStable() {
+    func testWhenEncodingThenDecodingThenRoundTripIsStable() {
         let value: UInt64 = 42
 
         let decoded = SyncAnchorStore.decode(SyncAnchorStore.encode(value))
@@ -131,7 +131,7 @@ final class SyncAnchorStoreTests: XCTestCase {
         XCTAssertEqual(decoded, value)
     }
 
-    func test_whenDataLengthIsWrong_thenDecodeReturnsNil() {
+    func testWhenDataLengthIsWrongThenDecodeReturnsNil() {
         let malformed = Data([0x01, 0x02])
 
         let decoded = SyncAnchorStore.decode(malformed)

--- a/ios/InternxtFileProviderTests/SyncAnchorStoreTests.swift
+++ b/ios/InternxtFileProviderTests/SyncAnchorStoreTests.swift
@@ -1,0 +1,141 @@
+//
+//  SyncAnchorStoreTests.swift
+//  InternxtFileProviderTests
+//
+
+import XCTest
+
+final class SyncAnchorStoreTests: XCTestCase {
+
+    private var directory: URL!
+
+    override func setUp() {
+        super.setUp()
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SyncAnchorStoreTests.\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: directory)
+        directory = nil
+        super.tearDown()
+    }
+
+    func test_whenChangeRecorded_thenCurrentValueAdvancesByOne() {
+        let store = SyncAnchorStore(directory: directory)
+        let before = store.currentValue
+
+        store.recordChange(parentUuid: "parent-a")
+
+        XCTAssertEqual(store.currentValue, before + 1)
+    }
+
+    func test_whenChangeRecorded_thenCurrentDataDiffersFromBefore() {
+        let store = SyncAnchorStore(directory: directory)
+        let before = store.currentData
+
+        store.recordChange(parentUuid: "parent-a")
+
+        XCTAssertNotEqual(store.currentData, before)
+    }
+
+    func test_whenReadFromSeparateInstance_thenSeesPersistedChange() {
+        SyncAnchorStore(directory: directory).recordChange(parentUuid: "parent-a")
+
+        let reader = SyncAnchorStore(directory: directory)
+
+        XCTAssertEqual(reader.currentValue, 1)
+    }
+
+    func test_whenChangeRecorded_thenChangedParentsAfterPreviousAnchorIncludesIt() {
+        let store = SyncAnchorStore(directory: directory)
+        let before = store.currentValue
+
+        store.recordChange(parentUuid: "parent-a")
+
+        XCTAssertEqual(store.changedParents(after: before), ["parent-a"])
+    }
+
+    func test_whenAnchorIsAtRecordedValue_thenChangedParentsExcludesIt() {
+        let store = SyncAnchorStore(directory: directory)
+        let recordedAt = store.recordChange(parentUuid: "parent-a")
+
+        XCTAssertEqual(store.changedParents(after: recordedAt), [])
+    }
+
+    func test_whenMultipleParentsRecorded_thenChangedParentsReturnsOnlyNewerOnesInOrder() {
+        let store = SyncAnchorStore(directory: directory)
+        let afterFirst = store.recordChange(parentUuid: "parent-a")
+        store.recordChange(parentUuid: "parent-b")
+        store.recordChange(parentUuid: "parent-c")
+
+        XCTAssertEqual(store.changedParents(after: afterFirst), ["parent-b", "parent-c"])
+    }
+
+    func test_whenSameParentRecordedTwice_thenItUsesTheLatestAnchorValue() {
+        let store = SyncAnchorStore(directory: directory)
+        store.recordChange(parentUuid: "parent-a")
+        let afterSecond = store.recordChange(parentUuid: "parent-b")
+        store.recordChange(parentUuid: "parent-a")
+
+        XCTAssertEqual(store.changedParents(after: afterSecond), ["parent-a"])
+    }
+
+    func test_whenNoSnapshotSaved_thenSnapshotIsEmpty() {
+        let store = SyncAnchorStore(directory: directory)
+
+        XCTAssertEqual(store.snapshot(forFolderUuid: "folder-a"), [])
+    }
+
+    func test_whenSnapshotSaved_thenSnapshotRoundTrips() {
+        let store = SyncAnchorStore(directory: directory)
+
+        store.saveSnapshot(["d:file-1", "f:folder-1"], forFolderUuid: "folder-a")
+
+        XCTAssertEqual(store.snapshot(forFolderUuid: "folder-a"), ["d:file-1", "f:folder-1"])
+    }
+
+    func test_whenSnapshotSavedFromSeparateInstance_thenItIsPersisted() {
+        SyncAnchorStore(directory: directory).saveSnapshot(["d:file-1"], forFolderUuid: "folder-a")
+
+        let reader = SyncAnchorStore(directory: directory)
+
+        XCTAssertEqual(reader.snapshot(forFolderUuid: "folder-a"), ["d:file-1"])
+    }
+
+    func test_whenSnapshotSavedForDifferentFolders_thenTheyAreIndependent() {
+        let store = SyncAnchorStore(directory: directory)
+
+        store.saveSnapshot(["d:file-1"], forFolderUuid: "folder-a")
+        store.saveSnapshot(["d:file-2"], forFolderUuid: "folder-b")
+
+        XCTAssertEqual(store.snapshot(forFolderUuid: "folder-a"), ["d:file-1"])
+        XCTAssertEqual(store.snapshot(forFolderUuid: "folder-b"), ["d:file-2"])
+    }
+
+    func test_whenSnapshotSavedAgain_thenItReplacesThePrevious() {
+        let store = SyncAnchorStore(directory: directory)
+        store.saveSnapshot(["d:file-1", "d:file-2"], forFolderUuid: "folder-a")
+
+        store.saveSnapshot(["d:file-2"], forFolderUuid: "folder-a")
+
+        XCTAssertEqual(store.snapshot(forFolderUuid: "folder-a"), ["d:file-2"])
+    }
+
+    func test_whenEncodingThenDecoding_thenRoundTripIsStable() {
+        let value: UInt64 = 42
+
+        let decoded = SyncAnchorStore.decode(SyncAnchorStore.encode(value))
+
+        XCTAssertEqual(decoded, value)
+    }
+
+    func test_whenDataLengthIsWrong_thenDecodeReturnsNil() {
+        let malformed = Data([0x01, 0x02])
+
+        let decoded = SyncAnchorStore.decode(malformed)
+
+        XCTAssertNil(decoded)
+    }
+}


### PR DESCRIPTION
Add a per-folder snapshot/diff change-feed in the File Provider extension so working-set enumeration surfaces upload, create-folder, move, rename, trash and restore as changes. SyncAnchorStore persists the per-domain anchor; FileProviderModule exposes a native bridge so the host app can signal the enumerator on RN mutations.