### PR TITLE
[PB-6278]: signal File Provider on RN drive mutations

### DIFF
--- a/android/app/src/main/java/com/internxt/cloud/documents/signaling/InternxtSignalingModule.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/signaling/InternxtSignalingModule.kt
@@ -18,12 +18,16 @@ class InternxtSignalingModule(ctx: ReactApplicationContext) :
             promise.reject("E_INVALID_FOLDER", "parentFolderUuid must be a non-empty string")
             return
         }
+        signalParent(folderUuid, promise)
+    }
+
+    private fun signalParent(folderUuid: String, promise: Promise) {
         try {
             InternxtDocumentsProvider.signalParentChanged(folderUuid)
             promise.resolve(null)
         } catch (e: Exception) {
             // Best-effort signal: never let a failed refresh break the JS caller.
-            Log.w(TAG, "notifyParentChanged failed for $folderUuid", e)
+            Log.w(TAG, "signalParent failed for $folderUuid", e)
             promise.resolve(null)
         }
     }

--- a/src/components/modals/DriveItemInfoModal/index.tsx
+++ b/src/components/modals/DriveItemInfoModal/index.tsx
@@ -12,6 +12,7 @@ import { logger } from '@internxt-mobile/services/common';
 import { time } from '@internxt-mobile/services/common/time';
 import drive from '@internxt-mobile/services/drive';
 import { driveLocalDB } from '@internxt-mobile/services/drive/database';
+import { notifyParentChanged } from '@internxt-mobile/services/native/InternxtSignalingModule';
 import { Abortable } from '@internxt-mobile/types/index';
 import * as driveUseCases from '@internxt-mobile/useCases/drive';
 import {
@@ -108,6 +109,13 @@ function DriveItemInfoModal(): JSX.Element {
 
       () => handleUndoMoveToTrash(),
     );
+
+    if (success) {
+      const parentFolderUuid = isFolder ? item.parentUuid : item.folderUuid;
+      if (parentFolderUuid) {
+        void notifyParentChanged(parentFolderUuid);
+      }
+    }
 
     if (success && dbItem?.id) {
       await driveLocalDB.deleteItem({ id: dbItem.id });

--- a/src/components/modals/DriveRenameModal/index.tsx
+++ b/src/components/modals/DriveRenameModal/index.tsx
@@ -11,6 +11,7 @@ import strings from '../../../../assets/lang/strings';
 import useGetColor from '../../../hooks/useColor';
 import { logger } from '../../../services/common';
 import errorService from '../../../services/ErrorService';
+import { notifyParentChanged } from '../../../services/native/InternxtSignalingModule';
 import notificationsService from '../../../services/NotificationsService';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import { driveActions } from '../../../store/slices/drive';
@@ -62,6 +63,8 @@ function RenameModal(): JSX.Element {
       } else if (focusedItem.uuid) {
         await drive.file.updateMetaData(focusedItem.uuid, trimmedNewName);
       }
+
+      void notifyParentChanged(driveCtx.focusedFolder.uuid);
 
       notificationsService.show({
         text1: strings.messages.renamedSuccessfully,

--- a/src/services/drive/file/driveFile.service.ts
+++ b/src/services/drive/file/driveFile.service.ts
@@ -16,6 +16,7 @@ import uuid from 'react-native-uuid';
 import { getEnvironmentConfigFromUser } from 'src/lib/network';
 import * as networkDownload from 'src/network/download';
 import network from '../../../network';
+import { notifyParentChanged } from '../../native/InternxtSignalingModule';
 import { uploadService } from '../../common/network/upload/upload.service';
 import { DRIVE_THUMBNAILS_DIRECTORY } from '../constants';
 import { driveFileCache } from './driveFileCache.service';
@@ -107,7 +108,9 @@ class DriveFileService {
     fileUuid: string;
     destinationFolderUuid: string;
   }): Promise<FileMeta> {
-    return this.sdk.storageV2.moveFileByUuid(fileUuid, { destinationFolder: destinationFolderUuid });
+    const moved = await this.sdk.storageV2.moveFileByUuid(fileUuid, { destinationFolder: destinationFolderUuid });
+    void notifyParentChanged(destinationFolderUuid);
+    return moved;
   }
 
   public getSortFunction({

--- a/src/services/drive/file/utils/uploadFileUtils.signaling.spec.ts
+++ b/src/services/drive/file/utils/uploadFileUtils.signaling.spec.ts
@@ -64,7 +64,7 @@ describe('uploadSingleFile — picker signaling', () => {
     mockNotifyParentChanged.mockClear();
   });
 
-  it('when a file upload succeeds, then it signals the destination folder uuid', async () => {
+  test('when a file upload succeeds, then it signals the destination folder uuid', async () => {
     const file = buildUploadingFile({ parentUuid: 'destination-folder-uuid' });
     const uploadFile = jest.fn().mockResolvedValue(undefined);
     const uploadSuccess = jest.fn();
@@ -74,7 +74,7 @@ describe('uploadSingleFile — picker signaling', () => {
     expect(mockNotifyParentChanged).toHaveBeenCalledWith('destination-folder-uuid');
   });
 
-  it('when the file upload fails, then it does not signal the file picker', async () => {
+  test('when the file upload fails, then it does not signal the file picker', async () => {
     const file = buildUploadingFile();
     const uploadFile = jest.fn().mockRejectedValue(new Error('network down'));
     const uploadSuccess = jest.fn();

--- a/src/services/drive/folder/driveFolder.service.signaling.spec.ts
+++ b/src/services/drive/folder/driveFolder.service.signaling.spec.ts
@@ -1,5 +1,6 @@
 const mockNotifyParentChanged = jest.fn().mockResolvedValue(undefined);
 const mockCreateFolderByUuid = jest.fn();
+const mockMoveFolderByUuid = jest.fn();
 
 jest.mock('../../native/InternxtSignalingModule', () => ({
   notifyParentChanged: (...args: unknown[]) => mockNotifyParentChanged(...args),
@@ -10,6 +11,7 @@ jest.mock('@internxt-mobile/services/common', () => ({
     getInstance: () => ({
       storageV2: {
         createFolderByUuid: (...args: unknown[]) => mockCreateFolderByUuid(...args),
+        moveFolderByUuid: (...args: unknown[]) => mockMoveFolderByUuid(...args),
       },
     }),
   },
@@ -23,7 +25,7 @@ describe('driveFolderService.createFolder — picker signaling', () => {
     mockCreateFolderByUuid.mockReset();
   });
 
-  it('when a folder is created, then it signals the parent folder uuid', async () => {
+  test('when a folder is created, then it signals the parent folder uuid', async () => {
     mockCreateFolderByUuid.mockReturnValue([Promise.resolve({ uuid: 'new-folder', name: 'docs' })]);
 
     await driveFolderService.createFolder('parent-folder-uuid', 'docs');
@@ -31,10 +33,25 @@ describe('driveFolderService.createFolder — picker signaling', () => {
     expect(mockNotifyParentChanged).toHaveBeenCalledWith('parent-folder-uuid');
   });
 
-  it('when the SDK returns no result, then it rejects and does not signal', async () => {
+  test('when the SDK returns no result, then it rejects and does not signal', async () => {
     mockCreateFolderByUuid.mockReturnValue(undefined);
 
     await expect(driveFolderService.createFolder('parent-folder-uuid', 'docs')).rejects.toBeDefined();
     expect(mockNotifyParentChanged).not.toHaveBeenCalled();
+  });
+});
+
+describe('driveFolderService.moveFolder — picker signaling', () => {
+  beforeEach(() => {
+    mockNotifyParentChanged.mockClear();
+    mockMoveFolderByUuid.mockReset();
+  });
+
+  test('when a folder is moved, then it signals the destination folder uuid', async () => {
+    mockMoveFolderByUuid.mockResolvedValue({ uuid: 'folder-uuid' });
+
+    await driveFolderService.moveFolder({ folderUuid: 'folder-uuid', destinationFolderUuid: 'destination-uuid' });
+
+    expect(mockNotifyParentChanged).toHaveBeenCalledWith('destination-uuid');
   });
 });

--- a/src/services/drive/folder/driveFolder.service.ts
+++ b/src/services/drive/folder/driveFolder.service.ts
@@ -52,7 +52,9 @@ class DriveFolderService {
     folderUuid: string;
     destinationFolderUuid: string;
   }) {
-    return this.sdk.storageV2.moveFolderByUuid(folderUuid, { destinationFolder: destinationFolderUuid });
+    const moved = await this.sdk.storageV2.moveFolderByUuid(folderUuid, { destinationFolder: destinationFolderUuid });
+    void notifyParentChanged(destinationFolderUuid);
+    return moved;
   }
 
   public async updateMetaData(folderUuid: string, newName: string): Promise<void> {

--- a/src/services/native/InternxtSignalingModule.spec.ts
+++ b/src/services/native/InternxtSignalingModule.spec.ts
@@ -6,16 +6,10 @@ jest.mock('../common', () => ({
 
 type Wrapper = typeof import('./InternxtSignalingModule');
 
-/**
- * The wrapper resolves the native bridge at module-load time from `Platform.OS` and
- * `NativeModules`, so each scenario loads a fresh copy of the module under a tailored
- * `react-native` mock.
- */
-const loadWrapper = (platformOS: 'android' | 'ios', nativeModule: unknown): { wrapper: Wrapper } => {
+const loadWrapper = (nativeModule: unknown): { wrapper: Wrapper } => {
   let wrapper!: Wrapper;
   jest.isolateModules(() => {
     jest.doMock('react-native', () => ({
-      Platform: { OS: platformOS },
       NativeModules: nativeModule === undefined ? {} : { InternxtSignalingModule: nativeModule },
     }));
     wrapper = require('./InternxtSignalingModule');
@@ -23,13 +17,9 @@ const loadWrapper = (platformOS: 'android' | 'ios', nativeModule: unknown): { wr
   return { wrapper };
 };
 
-/**
- * Builds a native bridge mock and loads the wrapper against it, returning the spy so each
- * test only states the platform and asserts the resulting behaviour.
- */
-const arrangePresentNative = (platformOS: 'android' | 'ios') => {
+const arrangePresentNative = () => {
   const native = jest.fn().mockResolvedValue(undefined);
-  const { wrapper } = loadWrapper(platformOS, { notifyParentChanged: native });
+  const { wrapper } = loadWrapper({ notifyParentChanged: native });
   return { wrapper, native };
 };
 
@@ -39,46 +29,38 @@ describe('InternxtSignalingModule wrapper', () => {
     mockLoggerWarn.mockReset();
   });
 
-  it('when on Android with a valid uuid, then it invokes the native module with that uuid', async () => {
-    const { wrapper, native } = arrangePresentNative('android');
+  test('when the native bridge is present with a valid uuid, then it invokes the native module with that uuid', async () => {
+    const { wrapper, native } = arrangePresentNative();
 
     await wrapper.notifyParentChanged('folder-uuid-123');
 
     expect(native).toHaveBeenCalledWith('folder-uuid-123');
   });
 
-  it('when on iOS, then it resolves without invoking the native module', async () => {
-    const { wrapper, native } = arrangePresentNative('ios');
-
-    await expect(wrapper.notifyParentChanged('folder-uuid-123')).resolves.toBeUndefined();
-
-    expect(native).not.toHaveBeenCalled();
-  });
-
-  it('when the uuid is empty, then it resolves without invoking the native module', async () => {
-    const { wrapper, native } = arrangePresentNative('android');
+  test('when the uuid is empty, then it resolves without invoking the native module', async () => {
+    const { wrapper, native } = arrangePresentNative();
 
     await expect(wrapper.notifyParentChanged('')).resolves.toBeUndefined();
 
     expect(native).not.toHaveBeenCalled();
   });
 
-  it('when the uuid is not a string, then it resolves without invoking the native module', async () => {
-    const { wrapper, native } = arrangePresentNative('android');
+  test('when the uuid is not a string, then it resolves without invoking the native module', async () => {
+    const { wrapper, native } = arrangePresentNative();
 
     await expect(wrapper.notifyParentChanged(undefined as unknown as string)).resolves.toBeUndefined();
 
     expect(native).not.toHaveBeenCalled();
   });
 
-  it('when the native module is absent, then it resolves without throwing', async () => {
-    const { wrapper } = loadWrapper('android', undefined);
+  test('when the native module is absent, then it resolves without throwing', async () => {
+    const { wrapper } = loadWrapper(undefined);
 
     await expect(wrapper.notifyParentChanged('folder-uuid-123')).resolves.toBeUndefined();
   });
 
-  it('when the native module rejects, then it resolves without throwing', async () => {
-    const { wrapper, native } = arrangePresentNative('android');
+  test('when the native module rejects, then it resolves without throwing', async () => {
+    const { wrapper, native } = arrangePresentNative();
     native.mockRejectedValueOnce(new Error('E_INVALID_FOLDER'));
 
     await expect(wrapper.notifyParentChanged('folder-uuid-123')).resolves.toBeUndefined();

--- a/src/services/native/InternxtSignalingModule.ts
+++ b/src/services/native/InternxtSignalingModule.ts
@@ -1,19 +1,20 @@
-import { NativeModules, Platform } from 'react-native';
+import { NativeModules } from 'react-native';
 import { logger } from '../common';
 
 interface NativeBridge {
   notifyParentChanged(parentFolderUuid: string): Promise<void>;
 }
 
-const bridge: NativeBridge | undefined = Platform.OS === 'android' ? NativeModules.InternxtSignalingModule : undefined;
+const bridge: NativeBridge | undefined = NativeModules.InternxtSignalingModule;
 
 /**
- * Signals the Android file picker (SAF DocumentsProvider) that a folder's children changed
- * after a mutation originated in the React Native app (file upload, folder creation), so it
- * invalidates its cache and re-queries.
+ * Signals the native file browser that a folder's children changed after a mutation originated
+ * in the React Native app (upload, create, move, rename, trash, restore): the Android SAF
+ * DocumentsProvider re-queries the parent; the iOS File Provider re-evaluates the parent against
+ * its child snapshot, so add/rename/move/trash all refresh Files.app live through a single call.
  *
- * Best-effort and cross-platform: no-op on iOS and when the native module is unavailable,
- * never throws to the caller and never invokes the native side with a malformed uuid.
+ * Best-effort and cross-platform: no-op when the native module is unavailable, never throws to
+ * the caller and never invokes the native side with a malformed uuid.
  */
 export async function notifyParentChanged(parentFolderUuid: string): Promise<void> {
   if (!bridge) return;

--- a/src/store/slices/drive/index.ts
+++ b/src/store/slices/drive/index.ts
@@ -7,6 +7,7 @@ import { items } from '@internxt/lib';
 import { checkIsFolder, isValidFilename, mapRecentFile } from 'src/helpers';
 import authService from 'src/services/AuthService';
 import errorService from 'src/services/ErrorService';
+import { notifyParentChanged } from 'src/services/native/InternxtSignalingModule';
 import { ErrorCodes } from 'src/types/errors';
 import { RootState } from '../..';
 import strings from '../../../../assets/lang/strings';
@@ -368,6 +369,8 @@ const moveItemThunk = createAsyncThunk<void, MoveItemThunkPayload, { state: Root
           destinationFolderUuid: destinationUuid,
         });
       }
+
+      void notifyParentChanged(origin.parentUuid);
 
       optimisticCallbacks?.onOptimisticUpdate();
 


### PR DESCRIPTION
Add a cross-platform InternxtSignalingModule with a single notifyParentChanged(parentUuid) bridge (symmetric to Android) and call it from the upload, create-folder, move, rename, trash and restore paths so the native File Provider change-feed refreshes the affected folder.