### PR TITLE
[PB-6167]: open shared content in-tab instead of redirecting to Drive

### DIFF
--- a/src/navigation/SharedNavigator.tsx
+++ b/src/navigation/SharedNavigator.tsx
@@ -1,0 +1,15 @@
+import { SharedStackParamList } from '@internxt-mobile/types/navigation';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { SharedFolderScreen } from 'src/screens/drive/SharedFolderScreen';
+import { SharedScreen } from 'src/screens/drive/SharedScreen/SharedScreen';
+
+const SharedStack = createNativeStackNavigator<SharedStackParamList>();
+
+export const SharedNavigator = () => {
+  return (
+    <SharedStack.Navigator screenOptions={{ headerShown: false }}>
+      <SharedStack.Screen name="SharedRoot" component={SharedScreen} />
+      <SharedStack.Screen name="SharedFolder" component={SharedFolderScreen} options={{ animation: 'default' }} />
+    </SharedStack.Navigator>
+  );
+};

--- a/src/navigation/TabExplorerNavigator.tsx
+++ b/src/navigation/TabExplorerNavigator.tsx
@@ -18,7 +18,6 @@ import RunOutOfStorageModal from '../components/modals/RunOutOfStorageModal';
 import { SharedLinkInfoModal } from '../components/modals/SharedLinkInfoModal';
 import SignOutModal from '../components/modals/SignOutModal';
 import useGetColor from '../hooks/useColor';
-import { SharedScreen } from '../screens/drive/SharedScreen/SharedScreen';
 import EmptyScreen from '../screens/EmptyScreen';
 import HomeScreen from '../screens/HomeScreen';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
@@ -27,6 +26,7 @@ import { AsyncStorageKey } from '../types';
 import { RootStackScreenProps, TabExplorerStackParamList } from '../types/navigation';
 import { DriveNavigator } from './DriveNavigator';
 import { SettingsNavigator } from './SettingsNavigator';
+import { SharedNavigator } from './SharedNavigator';
 
 const Tab = createBottomTabNavigator<TabExplorerStackParamList>();
 
@@ -76,7 +76,7 @@ export default function TabExplorerNavigator(props: RootStackScreenProps<'TabExp
         <Tab.Screen name="Home" component={HomeScreen} />
         <Tab.Screen name="Drive" component={DriveNavigator} options={{ lazy: false }} />
         <Tab.Screen name="Add" component={EmptyScreen} />
-        <Tab.Screen name="Shared" component={SharedScreen} options={{ lazy: false }} />
+        <Tab.Screen name="Shared" component={SharedNavigator} options={{ lazy: false }} />
         <Tab.Screen name="Settings" component={SettingsNavigator} options={{ lazy: false }} />
       </Tab.Navigator>
 

--- a/src/screens/drive/SharedFolderScreen/SharedFolderScreen.tsx
+++ b/src/screens/drive/SharedFolderScreen/SharedFolderScreen.tsx
@@ -1,0 +1,121 @@
+import { useHardwareBackPress } from '@internxt-mobile/hooks/common';
+import { useDrive } from '@internxt-mobile/hooks/drive';
+import { SharedScreenProps, SharedStackParamList } from '@internxt-mobile/types/navigation';
+import { RouteProp, useRoute } from '@react-navigation/native';
+import _ from 'lodash';
+import React, { useEffect, useMemo, useState } from 'react';
+import { NativeScrollEvent, NativeSyntheticEvent, ScrollView, View } from 'react-native';
+import AppScreen from 'src/components/AppScreen';
+import { useTailwind } from 'tailwind-rn';
+import strings from '../../../../assets/lang/strings';
+import ScreenTitle from '../../../components/AppScreenTitle';
+import DriveItemSkinSkeleton from '../../../components/DriveItemSkinSkeleton';
+import useGetColor from '../../../hooks/useColor';
+import { useLanguage } from '../../../hooks/useLanguage';
+import { useAppSelector } from '../../../store/hooks';
+import { SharedDriveItem } from '../SharedScreen/SharedDriveItem';
+import { SharedFolderRouteParams } from '../SharedScreen/sharedNavigation';
+import { DriveFolderEmpty } from '../DriveFolderScreen/DriveFolderEmpty';
+import { DriveFolderError } from '../DriveFolderScreen/DriveFolderError';
+import { buildSharedFolderItems, isCloseToScrollEnd, loadSharedFolderContent } from './sharedFolderContent';
+
+export const SharedFolderScreen: React.FC<SharedScreenProps<'SharedFolder'>> = ({ navigation }) => {
+  const tailwind = useTailwind();
+  const getColor = useGetColor();
+  useLanguage();
+  const route = useRoute<RouteProp<SharedStackParamList, 'SharedFolder'>>();
+  const { folderUuid, folderName } = route.params;
+  const driveCtx = useDrive();
+  const { user } = useAppSelector((state) => state.auth);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+
+  const folder = driveCtx.driveFoldersTree[folderUuid];
+  const isLoading = folder?.loading ?? true;
+  const hasError = Boolean(folder?.error);
+
+  const items = useMemo(() => buildSharedFolderItems(folder, user?.bucket), [folder?.files, folder?.folders, user?.bucket]);
+
+  useEffect(() => {
+    loadSharedFolderContent(driveCtx, folderUuid);
+  }, [folderUuid]);
+
+  const onBackButtonPressed = () => {
+    navigation.goBack();
+  };
+
+  useHardwareBackPress(onBackButtonPressed);
+
+  const navigateToSharedFolder = (params: SharedFolderRouteParams) => {
+    navigation.push('SharedFolder', params);
+  };
+
+  const handleScroll = async (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    if (isLoadingMore || isLoading || !items.length || !isCloseToScrollEnd(event.nativeEvent)) return;
+
+    setIsLoadingMore(true);
+    await loadSharedFolderContent(driveCtx, folderUuid, { resetPagination: false });
+    setIsLoadingMore(false);
+  };
+
+  const renderContent = () => {
+    if (hasError) {
+      return (
+        <View style={tailwind('flex-1 flex justify-center px-8')}>
+          <DriveFolderError
+            error={{
+              title: strings.errors.driveFolderContent.title,
+              message: strings.errors.driveFolderContent.message,
+            }}
+            tryAgainLabel={strings.buttons.tryAgain}
+            onTryAgain={() => loadSharedFolderContent(driveCtx, folderUuid)}
+          />
+        </View>
+      );
+    }
+
+    if (isLoading && !items.length) {
+      return (
+        <View>
+          {_.times(20, (n) => (
+            <DriveItemSkinSkeleton key={n} />
+          ))}
+        </View>
+      );
+    }
+
+    if (!items.length) {
+      return (
+        <View style={tailwind('flex-1 flex justify-center px-8')}>
+          <DriveFolderEmpty
+            title={strings.screens.drive.emptyFolder.title}
+            message={strings.screens.drive.emptyFolder.message}
+          />
+        </View>
+      );
+    }
+
+    return items.map((item) => (
+      <SharedDriveItem
+        key={item.uuid}
+        data={item}
+        navigateToSharedFolder={navigateToSharedFolder}
+        parentFolderName={folderName}
+      />
+    ));
+  };
+
+  return (
+    <AppScreen safeAreaTop style={tailwind('flex-1 flex-grow')}>
+      <ScreenTitle text={folderName ?? folder?.name ?? ''} showBackButton onBackButtonPressed={onBackButtonPressed} />
+      <View style={[tailwind('flex-1'), { backgroundColor: getColor('bg-surface') }]}>
+        <ScrollView
+          contentContainerStyle={tailwind('flex-grow')}
+          onScroll={handleScroll}
+          scrollEventThrottle={400}
+        >
+          {renderContent()}
+        </ScrollView>
+      </View>
+    </AppScreen>
+  );
+};

--- a/src/screens/drive/SharedFolderScreen/index.ts
+++ b/src/screens/drive/SharedFolderScreen/index.ts
@@ -1,0 +1,1 @@
+export * from './SharedFolderScreen';

--- a/src/screens/drive/SharedFolderScreen/sharedFolderContent.ts
+++ b/src/screens/drive/SharedFolderScreen/sharedFolderContent.ts
@@ -1,0 +1,70 @@
+import errorService from '@internxt-mobile/services/ErrorService';
+import notificationsService from '@internxt-mobile/services/NotificationsService';
+import { DriveFileForTree } from '@internxt-mobile/types/drive/file';
+import { DriveFolderForTree } from '@internxt-mobile/types/drive/folder';
+import { DriveItemData } from '@internxt-mobile/types/drive/item';
+import { NotificationType } from '@internxt-mobile/types/index';
+import { NativeScrollEvent } from 'react-native';
+
+const SCROLL_END_THRESHOLD = 80;
+
+interface SharedFolderNode {
+  files?: DriveFileForTree[];
+  folders?: DriveFolderForTree[];
+}
+
+interface FolderContentLoader {
+  loadFolderContent: (folderUuid: string, options?: { resetPagination?: boolean; focusFolder?: boolean }) => Promise<void>;
+}
+
+const mapSharedFolderNode = (folder: DriveFolderForTree): DriveItemData => ({
+  id: folder.id,
+  uuid: folder.uuid,
+  name: folder.plainName,
+  parentId: folder.parentId,
+  parentUuid: folder.parentUuid,
+  updatedAt: folder.updatedAt,
+  createdAt: folder.createdAt,
+  isFolder: true,
+  currentThumbnail: null,
+  thumbnails: [],
+});
+
+const mapSharedFileNode = (file: DriveFileForTree, userBucket?: string | null): DriveItemData => ({
+  id: file.id,
+  uuid: file.uuid,
+  name: file.plainName,
+  fileId: file.fileId,
+  folderId: file.folderId,
+  folderUuid: file.folderUuid,
+  bucket: file.bucket || userBucket || undefined,
+  type: file.type,
+  size: file.size,
+  updatedAt: file.updatedAt,
+  createdAt: file.createdAt,
+  isFolder: false,
+  currentThumbnail: null,
+  thumbnails: file.thumbnails,
+});
+
+export const buildSharedFolderItems = (folder?: SharedFolderNode, userBucket?: string | null): DriveItemData[] => {
+  const folders = (folder?.folders ?? []).map(mapSharedFolderNode);
+  const files = (folder?.files ?? []).map((file) => mapSharedFileNode(file, userBucket));
+  return folders.concat(files);
+};
+
+export const isCloseToScrollEnd = ({ layoutMeasurement, contentOffset, contentSize }: NativeScrollEvent): boolean =>
+  layoutMeasurement.height + contentOffset.y >= contentSize.height - SCROLL_END_THRESHOLD;
+
+export const loadSharedFolderContent = (
+  driveCtx: FolderContentLoader,
+  folderUuid: string,
+  options: { resetPagination?: boolean } = {},
+): Promise<void> =>
+  driveCtx
+    .loadFolderContent(folderUuid, { resetPagination: options.resetPagination ?? true, focusFolder: false })
+    .catch((error) => {
+      errorService.reportError(error);
+      const castedError = errorService.castError(error, 'content');
+      notificationsService.show({ type: NotificationType.Error, text1: castedError.message });
+    });

--- a/src/screens/drive/SharedScreen/SharedDriveItem.tsx
+++ b/src/screens/drive/SharedScreen/SharedDriveItem.tsx
@@ -1,0 +1,30 @@
+import { SharedFiles, SharedFolders } from '@internxt-mobile/types/drive/shared';
+import { DriveItemStatus, DriveItemData } from '@internxt-mobile/types/drive/item';
+import { DriveListType, DriveListViewMode } from '@internxt-mobile/types/drive/ui';
+import React from 'react';
+import DriveItem from '../../../components/drive/lists/items';
+import { buildSharedItemOnPress, SharedFolderRouteParams } from './sharedNavigation';
+
+interface SharedDriveItemProps {
+  data: DriveItemData;
+  navigateToSharedFolder: (params: SharedFolderRouteParams) => void;
+  parentFolderName?: string;
+  shareLink?: SharedFiles & SharedFolders;
+}
+
+export const SharedDriveItem: React.FC<SharedDriveItemProps> = ({
+  data,
+  navigateToSharedFolder,
+  parentFolderName,
+  shareLink,
+}) => (
+  <DriveItem
+    type={shareLink ? DriveListType.Shared : DriveListType.Drive}
+    status={DriveItemStatus.Idle}
+    viewMode={DriveListViewMode.List}
+    data={data}
+    onPress={buildSharedItemOnPress(data, navigateToSharedFolder, parentFolderName)}
+    progress={-1}
+    shareLink={shareLink}
+  />
+);

--- a/src/screens/drive/SharedScreen/SharedScreen.tsx
+++ b/src/screens/drive/SharedScreen/SharedScreen.tsx
@@ -1,8 +1,7 @@
 import { UseCaseStatus, useUseCase } from '@internxt-mobile/hooks/common';
 import errorService from '@internxt-mobile/services/ErrorService';
 import { SharedFiles, SharedFolders } from '@internxt-mobile/types/drive/shared';
-import { DriveListType, DriveListViewMode } from '@internxt-mobile/types/drive/ui';
-import { TabExplorerScreenProps } from '@internxt-mobile/types/navigation';
+import { SharedScreenProps } from '@internxt-mobile/types/navigation';
 import * as driveUseCases from '@internxt-mobile/useCases/drive';
 import EmptySharesImage from 'assets/images/screens/empty-shares.svg';
 import NoResultsImage from 'assets/images/screens/no-results.svg';
@@ -14,18 +13,20 @@ import { SearchInput } from 'src/components/SearchInput';
 import { useTailwind } from 'tailwind-rn';
 import strings from '../../../../assets/lang/strings';
 import ScreenTitle from '../../../components/AppScreenTitle';
-import DriveItem from '../../../components/drive/lists/items';
 import DriveItemSkinSkeleton from '../../../components/DriveItemSkinSkeleton';
 import EmptyList from '../../../components/EmptyList';
 import useGetColor from '../../../hooks/useColor';
 import { useLanguage } from '../../../hooks/useLanguage';
-import { DriveItemStatus } from '../../../types/drive/item';
+import { useAppSelector } from '../../../store/hooks';
+import { SharedDriveItem } from './SharedDriveItem';
+import { mapSharedLinkToDriveItemData, SharedFolderRouteParams } from './sharedNavigation';
 
 type SharedItem = SharedFolders & SharedFiles;
-export const SharedScreen: React.FC<TabExplorerScreenProps<'Shared'>> = (props) => {
+export const SharedScreen: React.FC<SharedScreenProps<'SharedRoot'>> = (props) => {
   const tailwind = useTailwind();
   const getColor = useGetColor();
   useLanguage();
+  const { user } = useAppSelector((state) => state.auth);
   const { loading: sharedLoading, executeUseCase: getSharedItems } = useUseCase(driveUseCases.getSharedItems);
 
   const [sharedItemsPage, setSharedItemsPage] = useState(1);
@@ -122,6 +123,10 @@ export const SharedScreen: React.FC<TabExplorerScreenProps<'Shared'>> = (props) 
     onEndOfListReached();
   };
 
+  const navigateToSharedFolder = (params: SharedFolderRouteParams) => {
+    props.navigation.push('SharedFolder', params);
+  };
+
   const renderContent = () => {
     if (!sharedItems?.length) {
       return renderEmpty();
@@ -134,30 +139,13 @@ export const SharedScreen: React.FC<TabExplorerScreenProps<'Shared'>> = (props) 
     }
 
     if (sharedItemsToRender.length > 0) {
-      return sharedItemsToRender.map((sharedLink, i: React.Key) => {
+      return sharedItemsToRender.map((sharedLink) => {
         return (
-          <DriveItem
-            key={i}
-            onPress={() => {
-              props.navigation.navigate('Drive');
-            }}
-            type={DriveListType.Shared}
-            status={DriveItemStatus.Idle}
-            viewMode={DriveListViewMode.List}
-            data={{
-              ...sharedLink,
-              token: sharedLink.token === null ? undefined : sharedLink.token,
-              name: sharedLink?.plainName,
-              type: 'folderId' in sharedLink ? sharedLink.type : undefined,
-              shareId: sharedLink.id.toString(),
-              thumbnails: [],
-              currentThumbnail: null,
-              code: (sharedLink as unknown as { code: string }).code,
-              updatedAt: sharedLink.updatedAt,
-              createdAt: sharedLink.createdAt,
-              isFolder: sharedLink.type === 'folder',
-            }}
-            progress={-1}
+          <SharedDriveItem
+            key={sharedLink.id}
+            navigateToSharedFolder={navigateToSharedFolder}
+            parentFolderName={strings.screens.shared.title}
+            data={mapSharedLinkToDriveItemData(sharedLink, user?.bucket)}
             shareLink={sharedLink}
           />
         );

--- a/src/screens/drive/SharedScreen/sharedNavigation.ts
+++ b/src/screens/drive/SharedScreen/sharedNavigation.ts
@@ -1,0 +1,54 @@
+import { DriveItemData } from '@internxt-mobile/types/drive/item';
+import { SharedFiles, SharedFolders } from '@internxt-mobile/types/drive/shared';
+import { SharedStackParamList } from '@internxt-mobile/types/navigation';
+
+export type SharedFolderRouteParams = SharedStackParamList['SharedFolder'];
+
+type SharedLink = SharedFolders & SharedFiles;
+
+type SharedPressableItem = Pick<DriveItemData, 'isFolder' | 'uuid' | 'name'>;
+
+/**
+ * The shared-list API returns `bucket: null` on the item (network credentials
+ * come separately), so files fall back to the owner's bucket — these are links
+ * the user owns, so the file lives in their bucket. Without it download.ts
+ * rejects with "Download error code 1".
+ */
+export const mapSharedLinkToDriveItemData = (sharedLink: SharedLink, userBucket?: string | null): DriveItemData => {
+  const isFolder = sharedLink.type === 'folder';
+
+  return {
+    ...sharedLink,
+    token: sharedLink.token === null ? undefined : sharedLink.token,
+    name: sharedLink.plainName,
+    type: 'folderId' in sharedLink ? sharedLink.type : undefined,
+    shareId: sharedLink.id.toString(),
+    fileId: isFolder ? undefined : (sharedLink as unknown as { fileId?: string }).fileId,
+    bucket: isFolder ? sharedLink.bucket : (sharedLink.bucket ?? userBucket ?? undefined),
+    thumbnails: [],
+    currentThumbnail: null,
+    code: (sharedLink as unknown as { code: string }).code,
+    updatedAt: sharedLink.updatedAt,
+    createdAt: sharedLink.createdAt,
+    isFolder,
+  } as DriveItemData;
+};
+
+/**
+ * Files return undefined so DriveItem falls back to useDriveItem.onFilePressed
+ * (download + DrivePreview) instead of redirecting to the Drive tab.
+ */
+export const buildSharedItemOnPress = (
+  item: SharedPressableItem,
+  navigateToSharedFolder: (params: SharedFolderRouteParams) => void,
+  parentFolderName?: string,
+): (() => void) | undefined => {
+  if (!item.isFolder) return undefined;
+
+  return () =>
+    navigateToSharedFolder({
+      folderUuid: item.uuid,
+      folderName: item.name,
+      parentFolderName,
+    });
+};

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -45,7 +45,7 @@ export type TabExplorerStackParamList = {
   Home: undefined;
   Drive: { sharedFolderId: number } | undefined;
   Add: undefined;
-  Shared: undefined;
+  Shared: NavigatorScreenParams<SharedStackParamList> | undefined;
   Settings: undefined;
 };
 
@@ -60,6 +60,20 @@ export type DriveStackParamList = {
 
 export type DriveScreenProps<Screen extends keyof DriveStackParamList> = CompositeScreenProps<
   NativeStackScreenProps<DriveStackParamList, Screen>,
+  TabExplorerScreenProps<keyof TabExplorerStackParamList>
+>;
+
+export type SharedStackParamList = {
+  SharedRoot: undefined;
+  SharedFolder: {
+    folderUuid: string;
+    folderName?: string;
+    parentFolderName?: string;
+  };
+};
+
+export type SharedScreenProps<Screen extends keyof SharedStackParamList> = CompositeScreenProps<
+  NativeStackScreenProps<SharedStackParamList, Screen>,
   TabExplorerScreenProps<keyof TabExplorerStackParamList>
 >;
 


### PR DESCRIPTION
Tapping an item in the Shared tab redirected to the Drive tab. Shared folders now open in a dedicated in-tab stack (SharedNavigator + SharedFolderScreen) and files open the preview, matching Drive behavior.

Fix fileId/bucket mapping so shared file downloads resolve their network credentials: the shared-list API returns bucket null on the item, so files fall back to the owner bucket. Add pagination for shared folder contents.