### PR TITLE
[BR-2158]: decode percent-encoded URIs in document upload and thumbnail paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,4 @@ src/network/crypto.spec.ts                                   @TamaraFinogina
 src/shareExtension/services/shareEncryptionService.ts        @TamaraFinogina
 src/shareExtension/services/shareUploadService.ts            @TamaraFinogina
 src/network/NetworkFacade.ts                                 @TamaraFinogina
+android/app/src/main/java/com/internxt/cloud/documents/crypto/ @TamaraFinogina

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -192,4 +192,7 @@ dependencies {
     } else {
         implementation jscFlavor
     }
+
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("androidx.security:security-crypto:1.1.0-alpha06")
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -195,4 +195,8 @@ dependencies {
 
     implementation("com.squareup.okhttp3:okhttp:5.3.2")
     implementation("androidx.security:security-crypto:1.1.0")
+
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("com.squareup.okhttp3:mockwebserver:5.3.2")
+    testImplementation("org.json:json:20240303")
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -193,6 +193,6 @@ dependencies {
         implementation jscFlavor
     }
 
-    implementation("com.squareup.okhttp3:okhttp:4.12.0")
-    implementation("androidx.security:security-crypto:1.1.0-alpha06")
+    implementation("com.squareup.okhttp3:okhttp:5.3.2")
+    implementation("androidx.security:security-crypto:1.1.0")
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -200,8 +200,10 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:5.3.2")
     implementation("androidx.security:security-crypto:1.1.0")
     implementation("org.bouncycastle:bcprov-jdk15to18:1.78.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
 
     testImplementation("junit:junit:4.13.2")
     testImplementation("com.squareup.okhttp3:mockwebserver:5.3.2")
     testImplementation("org.json:json:20240303")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -199,6 +199,7 @@ dependencies {
 
     implementation("com.squareup.okhttp3:okhttp:5.3.2")
     implementation("androidx.security:security-crypto:1.1.0")
+    implementation("org.bouncycastle:bcprov-jdk15to18:1.78.1")
 
     testImplementation("junit:junit:4.13.2")
     testImplementation("com.squareup.okhttp3:mockwebserver:5.3.2")

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -4,6 +4,8 @@ apply plugin: "com.facebook.react"
 
 def projectRoot = rootDir.getAbsoluteFile().getParentFile().getAbsolutePath()
 
+def packageJson = new groovy.json.JsonSlurper().parse(file("${projectRoot}/package.json"))
+
 /**
  * This is the configuration block to customize your React Native Android app.
  * By default you don't need to apply any configuration, just uncomment the lines you need.
@@ -97,6 +99,8 @@ android {
         versionName "1.9.1"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
+        buildConfigField "String", "INTERNXT_CLIENT_NAME", "\"${packageJson.name}\""
+        buildConfigField "String", "INTERNXT_CLIENT_VERSION", "\"${packageJson.version}\""
     }
     flavorDimensions "react-native-capture-protection"
     productFlavors {

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -12,3 +12,4 @@
 -keep class com.facebook.react.turbomodule.** { *; }
 
 # Add any project specific keep options here:
+-keep class com.internxt.cloud.documents.** { *; }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -58,5 +58,17 @@
         <category android:name="android.intent.category.DEFAULT"/>
       </intent-filter>
     </activity>
+    <provider
+      android:name="com.internxt.cloud.documents.InternxtDocumentsProvider"
+      android:authorities="com.internxt.cloud.documents"
+      android:exported="true"
+      android:grantUriPermissions="true"
+      android:permission="android.permission.MANAGE_DOCUMENTS"
+      android:label="@string/documents_provider_label"
+      android:icon="@mipmap/ic_launcher">
+      <intent-filter>
+        <action android:name="android.content.action.DOCUMENTS_PROVIDER"/>
+      </intent-filter>
+    </provider>
   </application>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,9 @@
   <uses-permission android:name="android.permission.USE_FINGERPRINT"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
+  <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
   <queries>
     <intent>
       <action android:name="android.intent.action.VIEW"/>
@@ -58,6 +61,13 @@
         <category android:name="android.intent.category.DEFAULT"/>
       </intent-filter>
     </activity>
+    <service
+      android:name="com.internxt.cloud.documents.upload.UploadForegroundService"
+      android:foregroundServiceType="dataSync"
+      android:exported="false"/>
+    <receiver
+      android:name="com.internxt.cloud.documents.upload.CancelUploadReceiver"
+      android:exported="false"/>
     <provider
       android:name="com.internxt.cloud.documents.InternxtDocumentsProvider"
       android:authorities="com.internxt.cloud.documents"

--- a/android/app/src/main/java/com/internxt/cloud/MainApplication.kt
+++ b/android/app/src/main/java/com/internxt/cloud/MainApplication.kt
@@ -13,6 +13,8 @@ import com.facebook.react.common.ReleaseLevel
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
 import com.facebook.react.defaults.DefaultReactNativeHost
 
+import com.internxt.cloud.auth.InternxtAuthCredentialsPackage
+
 import expo.modules.ApplicationLifecycleDispatcher
 import expo.modules.ReactNativeHostWrapper
 
@@ -24,6 +26,7 @@ class MainApplication : Application(), ReactApplication {
         override fun getPackages(): List<ReactPackage> =
             PackageList(this).packages.apply {
               add(ShareIntentPackage())
+              add(InternxtAuthCredentialsPackage())
             }
 
           override fun getJSMainModuleName(): String = ".expo/.virtual-metro-entry"

--- a/android/app/src/main/java/com/internxt/cloud/MainApplication.kt
+++ b/android/app/src/main/java/com/internxt/cloud/MainApplication.kt
@@ -14,6 +14,7 @@ import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
 import com.facebook.react.defaults.DefaultReactNativeHost
 
 import com.internxt.cloud.auth.InternxtAuthCredentialsPackage
+import com.internxt.cloud.documents.signaling.InternxtSignalingPackage
 
 import expo.modules.ApplicationLifecycleDispatcher
 import expo.modules.ReactNativeHostWrapper
@@ -27,6 +28,7 @@ class MainApplication : Application(), ReactApplication {
             PackageList(this).packages.apply {
               add(ShareIntentPackage())
               add(InternxtAuthCredentialsPackage())
+              add(InternxtSignalingPackage())
             }
 
           override fun getJSMainModuleName(): String = ".expo/.virtual-metro-entry"

--- a/android/app/src/main/java/com/internxt/cloud/auth/InternxtAuthCredentialsModule.kt
+++ b/android/app/src/main/java/com/internxt/cloud/auth/InternxtAuthCredentialsModule.kt
@@ -1,0 +1,71 @@
+package com.internxt.cloud.auth
+
+import android.provider.DocumentsContract
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableMap
+import com.internxt.cloud.documents.InternxtDocumentsProvider
+import com.internxt.cloud.documents.auth.InternxtAuthManager
+
+class InternxtAuthCredentialsModule(private val ctx: ReactApplicationContext) :
+    ReactContextBaseJavaModule(ctx) {
+
+    private val authManager by lazy { InternxtAuthManager.create(ctx.applicationContext) }
+
+    override fun getName() = MODULE_NAME
+
+    @ReactMethod
+    fun setCredentials(map: ReadableMap, promise: Promise) {
+        try {
+            val creds = InternxtAuthManager.Credentials(
+                bearerToken = map.requireString("bearerToken"),
+                userId = map.requireString("userId"),
+                bridgeUser = map.requireString("bridgeUser"),
+                rootFolderUuid = map.requireString("rootFolderUuid"),
+                email = map.optString("email"),
+                driveBaseUrl = map.requireString("driveBaseUrl"),
+                bridgeBaseUrl = map.requireString("bridgeBaseUrl"),
+                desktopToken = map.optString("desktopToken"),
+            )
+            authManager.saveCredentials(creds)
+            notifyRootsChanged()
+            promise.resolve(null)
+        } catch (e: IllegalArgumentException) {
+            promise.reject("E_MISSING_FIELD", e.message, e)
+        } catch (e: Exception) {
+            promise.reject("E_SAVE_CREDENTIALS", e.message, e)
+        }
+    }
+
+    @ReactMethod
+    fun clearCredentials(promise: Promise) {
+        try {
+            authManager.clear()
+            notifyRootsChanged()
+            promise.resolve(null)
+        } catch (e: Exception) {
+            promise.reject("E_CLEAR_CREDENTIALS", e.message, e)
+        }
+    }
+
+    private fun notifyRootsChanged() {
+        ctx.contentResolver.notifyChange(
+            DocumentsContract.buildRootsUri(InternxtDocumentsProvider.AUTHORITY),
+            null,
+        )
+    }
+
+    private fun ReadableMap.nonBlankString(key: String): String? =
+        if (hasKey(key) && !isNull(key)) getString(key)?.takeIf { it.isNotBlank() } else null
+
+    private fun ReadableMap.requireString(key: String): String =
+        nonBlankString(key) ?: throw IllegalArgumentException("Missing or blank credential field: $key")
+
+    private fun ReadableMap.optString(key: String): String? = nonBlankString(key)
+
+    companion object {
+        const val MODULE_NAME = "InternxtAuthCredentialsModule"
+    }
+}

--- a/android/app/src/main/java/com/internxt/cloud/auth/InternxtAuthCredentialsModule.kt
+++ b/android/app/src/main/java/com/internxt/cloud/auth/InternxtAuthCredentialsModule.kt
@@ -27,6 +27,7 @@ class InternxtAuthCredentialsModule(private val ctx: ReactApplicationContext) :
                 bearerToken = map.requireString("bearerToken"),
                 userId = map.requireString("userId"),
                 bridgeUser = map.requireString("bridgeUser"),
+                mnemonic = map.requireString("mnemonic"),
                 rootFolderUuid = map.requireString("rootFolderUuid"),
                 email = map.optString("email"),
                 driveBaseUrl = map.requireString("driveBaseUrl"),

--- a/android/app/src/main/java/com/internxt/cloud/auth/InternxtAuthCredentialsModule.kt
+++ b/android/app/src/main/java/com/internxt/cloud/auth/InternxtAuthCredentialsModule.kt
@@ -18,6 +18,10 @@ class InternxtAuthCredentialsModule(private val ctx: ReactApplicationContext) :
 
     @ReactMethod
     fun setCredentials(map: ReadableMap, promise: Promise) {
+        val manager = authManager ?: run {
+            promise.reject("E_AUTH_UNAVAILABLE", "Encrypted credential storage unavailable")
+            return
+        }
         try {
             val creds = InternxtAuthManager.Credentials(
                 bearerToken = map.requireString("bearerToken"),
@@ -29,7 +33,10 @@ class InternxtAuthCredentialsModule(private val ctx: ReactApplicationContext) :
                 bridgeBaseUrl = map.requireString("bridgeBaseUrl"),
                 desktopToken = map.optString("desktopToken"),
             )
-            authManager.saveCredentials(creds)
+            if (!manager.saveCredentials(creds)) {
+                promise.reject("E_SAVE_CREDENTIALS", "Failed to persist credentials")
+                return
+            }
             notifyRootsChanged()
             promise.resolve(null)
         } catch (e: IllegalArgumentException) {
@@ -41,8 +48,15 @@ class InternxtAuthCredentialsModule(private val ctx: ReactApplicationContext) :
 
     @ReactMethod
     fun clearCredentials(promise: Promise) {
+        val manager = authManager ?: run {
+            promise.reject("E_AUTH_UNAVAILABLE", "Encrypted credential storage unavailable")
+            return
+        }
         try {
-            authManager.clear()
+            if (!manager.clear()) {
+                promise.reject("E_CLEAR_CREDENTIALS", "Failed to clear credentials")
+                return
+            }
             notifyRootsChanged()
             promise.resolve(null)
         } catch (e: Exception) {

--- a/android/app/src/main/java/com/internxt/cloud/auth/InternxtAuthCredentialsPackage.kt
+++ b/android/app/src/main/java/com/internxt/cloud/auth/InternxtAuthCredentialsPackage.kt
@@ -1,0 +1,14 @@
+package com.internxt.cloud.auth
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class InternxtAuthCredentialsPackage : ReactPackage {
+    override fun createNativeModules(context: ReactApplicationContext): List<NativeModule> =
+        listOf(InternxtAuthCredentialsModule(context))
+
+    override fun createViewManagers(context: ReactApplicationContext): List<ViewManager<*, *>> =
+        emptyList()
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/BlockingIo.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/BlockingIo.kt
@@ -1,0 +1,16 @@
+package com.internxt.cloud.documents
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Bridges a binder thread to a suspending body, running it on [Dispatchers.IO].
+ *
+ * SAF entry points such as `openDocument` arrive on a binder thread governed by a StrictMode
+ * policy that forbids blocking network. Some collaborators (e.g. the synchronous OkHttp calls in
+ * InternxtApiClient) still block, so the body must not run on the caller thread or it trips
+ * NetworkOnMainThreadException. Plain `runBlocking { }` would do exactly that.
+ */
+internal fun <T> runBlockingIo(body: suspend CoroutineScope.() -> T): T =
+    runBlocking(Dispatchers.IO, body)

--- a/android/app/src/main/java/com/internxt/cloud/documents/DocumentId.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/DocumentId.kt
@@ -8,9 +8,15 @@ object DocumentId {
 
     private const val FOLDER_PREFIX = "f:"
     private const val FILE_PREFIX = "d:"
+    const val UPLOAD_PREFIX = "u:"
 
     fun encodeFolder(uuid: String): String = FOLDER_PREFIX + uuid
     fun encodeFile(uuid: String): String = FILE_PREFIX + uuid
+    fun encodeUpload(token: String): String = UPLOAD_PREFIX + token
+
+    fun isUploadToken(id: String): Boolean = id.startsWith(UPLOAD_PREFIX)
+    fun decodeUpload(id: String): String? =
+        if (isUploadToken(id)) id.removePrefix(UPLOAD_PREFIX) else null
 
     fun decode(id: String): Decoded? = when {
         id.startsWith(FOLDER_PREFIX) -> Decoded(Kind.FOLDER, id.removePrefix(FOLDER_PREFIX))

--- a/android/app/src/main/java/com/internxt/cloud/documents/DocumentId.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/DocumentId.kt
@@ -1,0 +1,20 @@
+package com.internxt.cloud.documents
+
+object DocumentId {
+
+    enum class Kind { FOLDER, FILE }
+
+    data class Decoded(val kind: Kind, val uuid: String)
+
+    private const val FOLDER_PREFIX = "f:"
+    private const val FILE_PREFIX = "d:"
+
+    fun encodeFolder(uuid: String): String = FOLDER_PREFIX + uuid
+    fun encodeFile(uuid: String): String = FILE_PREFIX + uuid
+
+    fun decode(id: String): Decoded? = when {
+        id.startsWith(FOLDER_PREFIX) -> Decoded(Kind.FOLDER, id.removePrefix(FOLDER_PREFIX))
+        id.startsWith(FILE_PREFIX) -> Decoded(Kind.FILE, id.removePrefix(FILE_PREFIX))
+        else -> null
+    }
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/DocumentNaming.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/DocumentNaming.kt
@@ -1,0 +1,34 @@
+package com.internxt.cloud.documents
+
+import java.util.UUID
+
+/** Pure naming helpers shared by the folder and file branches of [InternxtDocumentsProvider.createDocument]. */
+object DocumentNaming {
+
+    private const val MAX_SUFFIX_ATTEMPTS = 1000
+
+    /**
+     * Returns [requested] if it is not already in [existing]; otherwise appends a
+     * ` (n)` suffix (preserving any file extension) until a free name is found.
+     */
+    fun uniqueName(requested: String, existing: Set<String>): String {
+        if (requested !in existing) return requested
+        val (base, ext) = splitNameExt(requested)
+        for (i in 1..MAX_SUFFIX_ATTEMPTS) {
+            val candidate = "$base ($i)$ext"
+            if (candidate !in existing) return candidate
+        }
+        // Backstop for the (practically impossible) case where 1..1000 are all taken —
+        // the backend permits duplicate names, so a UUID-suffixed name is always safe.
+        return "$base (${UUID.randomUUID()})$ext"
+    }
+
+    fun splitNameExt(name: String): Pair<String, String> {
+        val dot = name.lastIndexOf('.')
+        val hasExt = dot > 0 && dot < name.length - 1
+        return if (hasExt) name.substring(0, dot) to name.substring(dot) else name to ""
+    }
+
+    fun joinNameType(plainName: String, type: String?): String =
+        if (type.isNullOrBlank()) plainName else "$plainName.$type"
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/DocumentRowBuilder.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/DocumentRowBuilder.kt
@@ -8,13 +8,22 @@ import java.time.format.DateTimeParseException
 
 object DocumentRowBuilder {
 
-    private const val FOLDER_FLAGS = Document.FLAG_DIR_SUPPORTS_CREATE
-    private const val FILE_FLAGS = 0
+    private const val MUTATION_FLAGS =
+        Document.FLAG_SUPPORTS_RENAME or
+            Document.FLAG_SUPPORTS_DELETE or
+            Document.FLAG_SUPPORTS_MOVE
 
-    fun folderRow(folder: DriveFolder): Map<String, Any?> = folderRow(
-        uuid = folder.uuid,
-        displayName = folder.plainName,
-        lastModified = parseIsoToMillis(folder.updatedAt),
+    private const val FOLDER_FLAGS_BASIC = Document.FLAG_DIR_SUPPORTS_CREATE
+    private const val FOLDER_FLAGS = FOLDER_FLAGS_BASIC or MUTATION_FLAGS
+    private const val FILE_FLAGS = MUTATION_FLAGS
+
+    fun folderRow(folder: DriveFolder): Map<String, Any?> = mapOf(
+        Document.COLUMN_DOCUMENT_ID to folder.uuid,
+        Document.COLUMN_MIME_TYPE to Document.MIME_TYPE_DIR,
+        Document.COLUMN_DISPLAY_NAME to folder.plainName,
+        Document.COLUMN_LAST_MODIFIED to parseIsoToMillis(folder.updatedAt),
+        Document.COLUMN_FLAGS to FOLDER_FLAGS,
+        Document.COLUMN_SIZE to null,
     )
 
     fun folderRow(uuid: String, displayName: String, lastModified: Long? = null): Map<String, Any?> = mapOf(
@@ -22,7 +31,7 @@ object DocumentRowBuilder {
         Document.COLUMN_MIME_TYPE to Document.MIME_TYPE_DIR,
         Document.COLUMN_DISPLAY_NAME to displayName,
         Document.COLUMN_LAST_MODIFIED to lastModified,
-        Document.COLUMN_FLAGS to FOLDER_FLAGS,
+        Document.COLUMN_FLAGS to FOLDER_FLAGS_BASIC,
         Document.COLUMN_SIZE to null,
     )
 

--- a/android/app/src/main/java/com/internxt/cloud/documents/DocumentRowBuilder.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/DocumentRowBuilder.kt
@@ -1,0 +1,46 @@
+package com.internxt.cloud.documents
+
+import android.provider.DocumentsContract.Document
+import com.internxt.cloud.documents.api.model.DriveFile
+import com.internxt.cloud.documents.api.model.DriveFolder
+import java.time.Instant
+import java.time.format.DateTimeParseException
+
+object DocumentRowBuilder {
+
+    private const val FOLDER_FLAGS = Document.FLAG_DIR_SUPPORTS_CREATE
+    private const val FILE_FLAGS = 0
+
+    fun folderRow(folder: DriveFolder): Map<String, Any?> = folderRow(
+        uuid = folder.uuid,
+        displayName = folder.plainName,
+        lastModified = parseIsoToMillis(folder.updatedAt),
+    )
+
+    fun folderRow(uuid: String, displayName: String, lastModified: Long? = null): Map<String, Any?> = mapOf(
+        Document.COLUMN_DOCUMENT_ID to uuid,
+        Document.COLUMN_MIME_TYPE to Document.MIME_TYPE_DIR,
+        Document.COLUMN_DISPLAY_NAME to displayName,
+        Document.COLUMN_LAST_MODIFIED to lastModified,
+        Document.COLUMN_FLAGS to FOLDER_FLAGS,
+        Document.COLUMN_SIZE to null,
+    )
+
+    fun fileRow(file: DriveFile): Map<String, Any?> = mapOf(
+        Document.COLUMN_DOCUMENT_ID to file.uuid,
+        Document.COLUMN_MIME_TYPE to MimeTypes.fromExtension(file.type),
+        Document.COLUMN_DISPLAY_NAME to file.plainName,
+        Document.COLUMN_LAST_MODIFIED to parseIsoToMillis(file.updatedAt),
+        Document.COLUMN_FLAGS to FILE_FLAGS,
+        Document.COLUMN_SIZE to file.size,
+    )
+
+    internal fun parseIsoToMillis(iso: String?): Long? {
+        if (iso.isNullOrBlank()) return null
+        return try {
+            Instant.parse(iso).toEpochMilli()
+        } catch (_: DateTimeParseException) {
+            null
+        }
+    }
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/DocumentRowBuilder.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/DocumentRowBuilder.kt
@@ -18,7 +18,7 @@ object DocumentRowBuilder {
     )
 
     fun folderRow(uuid: String, displayName: String, lastModified: Long? = null): Map<String, Any?> = mapOf(
-        Document.COLUMN_DOCUMENT_ID to uuid,
+        Document.COLUMN_DOCUMENT_ID to DocumentId.encodeFolder(uuid),
         Document.COLUMN_MIME_TYPE to Document.MIME_TYPE_DIR,
         Document.COLUMN_DISPLAY_NAME to displayName,
         Document.COLUMN_LAST_MODIFIED to lastModified,
@@ -27,7 +27,7 @@ object DocumentRowBuilder {
     )
 
     fun fileRow(file: DriveFile): Map<String, Any?> = mapOf(
-        Document.COLUMN_DOCUMENT_ID to file.uuid,
+        Document.COLUMN_DOCUMENT_ID to DocumentId.encodeFile(file.uuid),
         Document.COLUMN_MIME_TYPE to MimeTypes.fromExtension(file.type),
         Document.COLUMN_DISPLAY_NAME to file.plainName,
         Document.COLUMN_LAST_MODIFIED to parseIsoToMillis(file.updatedAt),

--- a/android/app/src/main/java/com/internxt/cloud/documents/DocumentRowBuilder.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/DocumentRowBuilder.kt
@@ -18,7 +18,7 @@ object DocumentRowBuilder {
     private const val FILE_FLAGS = MUTATION_FLAGS
 
     fun folderRow(folder: DriveFolder): Map<String, Any?> = mapOf(
-        Document.COLUMN_DOCUMENT_ID to folder.uuid,
+        Document.COLUMN_DOCUMENT_ID to DocumentId.encodeFolder(folder.uuid),
         Document.COLUMN_MIME_TYPE to Document.MIME_TYPE_DIR,
         Document.COLUMN_DISPLAY_NAME to folder.plainName,
         Document.COLUMN_LAST_MODIFIED to parseIsoToMillis(folder.updatedAt),

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -4,22 +4,35 @@ import android.database.Cursor
 import android.database.MatrixCursor
 import android.os.CancellationSignal
 import android.os.ParcelFileDescriptor
+import android.provider.DocumentsContract
 import android.provider.DocumentsContract.Document
 import android.provider.DocumentsContract.Root
 import android.provider.DocumentsProvider
 import com.internxt.cloud.R
+import com.internxt.cloud.documents.auth.InternxtAuthManager
 
 class InternxtDocumentsProvider : DocumentsProvider() {
 
-    override fun onCreate(): Boolean = true
+    private lateinit var authManager: InternxtAuthManager
+
+    override fun onCreate(): Boolean {
+        authManager = InternxtAuthManager.create(context!!.applicationContext)
+        return true
+    }
 
     override fun queryRoots(projection: Array<String>?): Cursor {
         val cursor = MatrixCursor(resolveRootProjection(projection))
+        val ctx = context ?: return cursor
+        cursor.setNotificationUri(ctx.contentResolver, DocumentsContract.buildRootsUri(AUTHORITY))
+
+        val rootUuid = authManager.authenticatedRootUuid() ?: return cursor
+
         cursor.newRow().apply {
             add(Root.COLUMN_ROOT_ID, ROOT_ID)
-            add(Root.COLUMN_DOCUMENT_ID, ROOT_DOCUMENT_ID)
-            add(Root.COLUMN_TITLE, context?.getString(R.string.documents_provider_label))
-            add(Root.COLUMN_FLAGS, 0)
+            add(Root.COLUMN_DOCUMENT_ID, rootUuid)
+            add(Root.COLUMN_TITLE, ctx.getString(R.string.documents_provider_label))
+            authManager.userEmail()?.let { add(Root.COLUMN_SUMMARY, it) }
+            add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_CREATE or Root.FLAG_SUPPORTS_IS_CHILD)
             add(Root.COLUMN_ICON, R.mipmap.ic_launcher)
         }
         return cursor
@@ -50,8 +63,7 @@ class InternxtDocumentsProvider : DocumentsProvider() {
 
     companion object {
         const val AUTHORITY = "com.internxt.cloud.documents"
-        private const val ROOT_ID = "root"
-        private const val ROOT_DOCUMENT_ID = "root"
+        private const val ROOT_ID = "internxt-root"
 
         private val DEFAULT_ROOT_PROJECTION = arrayOf(
             Root.COLUMN_ROOT_ID,

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -1,0 +1,75 @@
+package com.internxt.cloud.documents
+
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.os.CancellationSignal
+import android.os.ParcelFileDescriptor
+import android.provider.DocumentsContract.Document
+import android.provider.DocumentsContract.Root
+import android.provider.DocumentsProvider
+import com.internxt.cloud.R
+
+class InternxtDocumentsProvider : DocumentsProvider() {
+
+    override fun onCreate(): Boolean = true
+
+    override fun queryRoots(projection: Array<String>?): Cursor {
+        val cursor = MatrixCursor(resolveRootProjection(projection))
+        cursor.newRow().apply {
+            add(Root.COLUMN_ROOT_ID, ROOT_ID)
+            add(Root.COLUMN_DOCUMENT_ID, ROOT_DOCUMENT_ID)
+            add(Root.COLUMN_TITLE, context?.getString(R.string.documents_provider_label))
+            add(Root.COLUMN_FLAGS, 0)
+            add(Root.COLUMN_ICON, R.mipmap.ic_launcher)
+        }
+        return cursor
+    }
+
+    override fun queryDocument(documentId: String?, projection: Array<String>?): Cursor =
+        MatrixCursor(resolveDocumentProjection(projection))
+
+    override fun queryChildDocuments(
+        parentDocumentId: String?,
+        projection: Array<String>?,
+        sortOrder: String?
+    ): Cursor = MatrixCursor(resolveDocumentProjection(projection))
+
+    override fun openDocument(
+        documentId: String?,
+        mode: String?,
+        signal: CancellationSignal?
+    ): ParcelFileDescriptor {
+        throw UnsupportedOperationException("Not implemented yet")
+    }
+
+    private fun resolveRootProjection(projection: Array<String>?): Array<String> =
+        projection ?: DEFAULT_ROOT_PROJECTION
+
+    private fun resolveDocumentProjection(projection: Array<String>?): Array<String> =
+        projection ?: DEFAULT_DOCUMENT_PROJECTION
+
+    companion object {
+        const val AUTHORITY = "com.internxt.cloud.documents"
+        private const val ROOT_ID = "root"
+        private const val ROOT_DOCUMENT_ID = "root"
+
+        private val DEFAULT_ROOT_PROJECTION = arrayOf(
+            Root.COLUMN_ROOT_ID,
+            Root.COLUMN_FLAGS,
+            Root.COLUMN_ICON,
+            Root.COLUMN_TITLE,
+            Root.COLUMN_SUMMARY,
+            Root.COLUMN_DOCUMENT_ID,
+            Root.COLUMN_AVAILABLE_BYTES
+        )
+
+        private val DEFAULT_DOCUMENT_PROJECTION = arrayOf(
+            Document.COLUMN_DOCUMENT_ID,
+            Document.COLUMN_MIME_TYPE,
+            Document.COLUMN_DISPLAY_NAME,
+            Document.COLUMN_LAST_MODIFIED,
+            Document.COLUMN_FLAGS,
+            Document.COLUMN_SIZE
+        )
+    }
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -8,7 +8,10 @@ import android.provider.DocumentsContract
 import android.provider.DocumentsContract.Document
 import android.provider.DocumentsContract.Root
 import android.provider.DocumentsProvider
+import android.util.Log
 import com.internxt.cloud.R
+import com.internxt.cloud.documents.api.InternxtApiClient
+import com.internxt.cloud.documents.api.InternxtApiException
 import com.internxt.cloud.documents.auth.InternxtAuthManager
 
 class InternxtDocumentsProvider : DocumentsProvider() {
@@ -39,14 +42,89 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         return cursor
     }
 
-    override fun queryDocument(documentId: String?, projection: Array<String>?): Cursor =
-        MatrixCursor(resolveDocumentProjection(projection))
+    override fun queryDocument(documentId: String?, projection: Array<String>?): Cursor {
+        val cursor = MatrixCursor(resolveDocumentProjection(projection))
+        val ctx = context ?: return cursor
+        val id = documentId ?: return cursor
+        cursor.setNotificationUri(ctx.contentResolver, DocumentsContract.buildDocumentUri(AUTHORITY, id))
+        Log.d(TAG, "queryDocument id=$id")
+
+        if (id == authManager.authenticatedRootUuid()) {
+            cursor.addDocumentRow(
+                DocumentRowBuilder.folderRow(id, ctx.getString(R.string.documents_provider_label))
+            )
+            return cursor
+        }
+
+        val api = apiClient(op = "queryDocument")
+        val row = if (api == null) null else try {
+            api.getFolder(id)?.let { DocumentRowBuilder.folderRow(it) }
+                ?: api.getFile(id)?.let { DocumentRowBuilder.fileRow(it) }
+        } catch (e: InternxtApiException) {
+            Log.w(TAG, "queryDocument id=$id failed: ${e.javaClass.simpleName}: ${e.message}")
+            null
+        }
+
+        cursor.addDocumentRow(row ?: DocumentRowBuilder.folderRow(uuid = id, displayName = id))
+        return cursor
+    }
 
     override fun queryChildDocuments(
         parentDocumentId: String?,
         projection: Array<String>?,
         sortOrder: String?
-    ): Cursor = MatrixCursor(resolveDocumentProjection(projection))
+    ): Cursor {
+        val cursor = MatrixCursor(resolveDocumentProjection(projection))
+        val ctx = context ?: return cursor
+        val parent = parentDocumentId ?: return cursor
+        cursor.setNotificationUri(
+            ctx.contentResolver,
+            DocumentsContract.buildChildDocumentsUri(AUTHORITY, parent)
+        )
+        Log.d(TAG, "queryChildDocuments parent=$parent")
+
+        val api = apiClient(op = "queryChildDocuments") ?: return cursor
+
+        try {
+            paginate({ offset, size -> api.listFolderFolders(parent, offset, size) }) {
+                cursor.addDocumentRow(DocumentRowBuilder.folderRow(it))
+            }
+            paginate({ offset, size -> api.listFolderFiles(parent, offset, size) }) {
+                cursor.addDocumentRow(DocumentRowBuilder.fileRow(it))
+            }
+            Log.d(TAG, "queryChildDocuments parent=$parent rows=${cursor.count}")
+        } catch (e: InternxtApiException) {
+            Log.w(TAG, "queryChildDocuments parent=$parent failed: ${e.javaClass.simpleName}: ${e.message}")
+            return cursor
+        }
+
+        return cursor
+    }
+
+    private fun apiClient(op: String): InternxtApiClient? {
+        val cfg = authManager.loadAuthConfig()
+        if (cfg == null) {
+            Log.w(TAG, "$op: loadAuthConfig() returned null")
+            return null
+        }
+        return InternxtApiClient(cfg)
+    }
+
+    private inline fun <T> paginate(fetch: (offset: Int, size: Int) -> List<T>, onItem: (T) -> Unit) {
+        val pageSize = InternxtApiClient.DEFAULT_PAGE_SIZE
+        var offset = 0
+        while (true) {
+            val page = fetch(offset, pageSize)
+            page.forEach(onItem)
+            if (page.size < pageSize) break
+            offset += pageSize
+        }
+    }
+
+    private fun MatrixCursor.addDocumentRow(row: Map<String, Any?>) {
+        val builder = newRow()
+        row.forEach { (column, value) -> builder.add(column, value) }
+    }
 
     override fun openDocument(
         documentId: String?,
@@ -65,6 +143,7 @@ class InternxtDocumentsProvider : DocumentsProvider() {
     companion object {
         const val AUTHORITY = "com.internxt.cloud.documents"
         private const val ROOT_ID = "internxt-root"
+        private const val TAG = "InternxtDocsProvider"
 
         private val DEFAULT_ROOT_PROJECTION = arrayOf(
             Root.COLUMN_ROOT_ID,

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -76,7 +76,13 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         authManager = InternxtAuthManager.create(ctx.applicationContext) ?: return false
         // Process-scoped: ContentProvider has no shutdown hook, so the thread lives until the process dies.
         closeHandler = Handler(HandlerThread("InternxtDocsClose").apply { start() }.looper)
+        activeInstance = this
         return true
+    }
+
+    override fun shutdown() {
+        if (activeInstance === this) activeInstance = null
+        super.shutdown()
     }
 
     override fun queryRoots(projection: Array<String>?): Cursor {
@@ -919,6 +925,20 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         const val AUTHORITY = "com.internxt.cloud.documents"
         private const val ROOT_ID = "internxt-root"
         private const val TAG = "InternxtDocsProvider"
+
+        @Volatile
+        private var activeInstance: InternxtDocumentsProvider? = null
+
+        /**
+         * Entry point for the React Native app to signal that a folder's children changed
+         * (e.g. after uploading a file or creating a folder from the app UI). Reuses the same
+         * cache invalidation + notifyChange path as in-picker mutations. No-op if the provider
+         * is not currently alive in this process.
+         */
+        fun signalParentChanged(folderUuid: String) {
+            if (folderUuid.isBlank()) return
+            activeInstance?.invalidateChildren(DocumentId.encodeFolder(folderUuid))
+        }
 
         private const val MULTIPART_THRESHOLD = 100L * 1024L * 1024L
         private const val MULTIPART_PART_SIZE = 30L * 1024L * 1024L

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -37,6 +37,9 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         @Volatile var errorMessage: String? = null
         val rows = mutableListOf<Map<String, Any?>>()
     }
+    private val itemKinds = ConcurrentHashMap<String, ItemKind>()
+
+    private enum class ItemKind { FILE, FOLDER }
 
     override fun onCreate(): Boolean {
         val ctx = context ?: return false

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -14,7 +14,10 @@ import android.util.Log
 import com.internxt.cloud.R
 import com.internxt.cloud.documents.api.InternxtApiClient
 import com.internxt.cloud.documents.api.InternxtApiException
+import com.internxt.cloud.documents.api.model.TrashItem
 import com.internxt.cloud.documents.auth.InternxtAuthManager
+import java.io.FileNotFoundException
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 
@@ -35,6 +38,9 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         @Volatile var errorMessage: String? = null
         val rows = mutableListOf<Map<String, Any?>>()
     }
+    private val itemKinds = ConcurrentHashMap<String, ItemKind>()
+
+    private enum class ItemKind { FILE, FOLDER }
 
     private val loaderExecutor = Executors.newSingleThreadExecutor { r ->
         Thread(r, "InternxtDocsProvider-loader").apply { isDaemon = true }
@@ -96,10 +102,15 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         val api = apiClient(op = "queryDocument")
         val row = if (api == null) null else try {
             when (decoded?.kind) {
-                DocumentId.Kind.FOLDER -> api.getFolder(uuid)?.let { DocumentRowBuilder.folderRow(it) }
+                DocumentId.Kind.FOLDER -> api.getFolder(uuid)?.let {
+                itemKinds[id] = ItemKind.FOLDER
+                DocumentRowBuilder.folderRow(it)
                 DocumentId.Kind.FILE -> api.getFile(uuid)?.let { DocumentRowBuilder.fileRow(it) }
                 null -> api.getFolder(uuid)?.let { DocumentRowBuilder.folderRow(it) }
-                    ?: api.getFile(uuid)?.let { DocumentRowBuilder.fileRow(it) }
+                } ?: api.getFile(uuid)?.let {
+                itemKinds[id] = ItemKind.FILE
+                DocumentRowBuilder.fileRow(it)
+            }
             }
         } catch (e: InternxtApiException) {
             Log.w(TAG, "queryDocument id=$id failed: ${e.javaClass.simpleName}: ${e.message}")
@@ -212,6 +223,81 @@ class InternxtDocumentsProvider : DocumentsProvider() {
     private fun MatrixCursor.addDocumentRow(row: Map<String, Any?>) {
         val builder = newRow()
         row.forEach { (column, value) -> builder.add(column, value) }
+    }
+
+    override fun renameDocument(documentId: String, displayName: String): String? {
+        val api = apiClient(op = "renameDocument") ?: throw FileNotFoundException("No auth")
+        val kind = resolveKind(api, documentId) ?: throw FileNotFoundException("Not found: $documentId")
+        val parentUuid: String? = try {
+            when (kind) {
+                ItemKind.FILE -> {
+                    val parent = api.getFile(documentId)?.folderUuid
+                    api.renameFile(documentId, displayName)
+                    parent
+                }
+                ItemKind.FOLDER -> {
+                    val parent = api.getFolder(documentId)?.parentUuid
+                    api.renameFolder(documentId, displayName)
+                    parent
+                }
+            }
+        } catch (e: InternxtApiException) {
+            Log.w(TAG, "renameDocument $documentId failed: ${e.javaClass.simpleName}: ${e.message}")
+            throw FileNotFoundException(e.message)
+        }
+        parentUuid?.let { notifyChildren(it) }
+        return null
+    }
+
+    override fun moveDocument(
+        sourceDocumentId: String,
+        sourceParentDocumentId: String?,
+        targetParentDocumentId: String
+    ): String? {
+        val api = apiClient(op = "moveDocument") ?: throw FileNotFoundException("No auth")
+        val kind = resolveKind(api, sourceDocumentId) ?: throw FileNotFoundException("Not found: $sourceDocumentId")
+        try {
+            when (kind) {
+                ItemKind.FILE -> api.moveFile(sourceDocumentId, targetParentDocumentId)
+                ItemKind.FOLDER -> api.moveFolder(sourceDocumentId, targetParentDocumentId)
+            }
+        } catch (e: InternxtApiException) {
+            Log.w(TAG, "moveDocument $sourceDocumentId failed: ${e.javaClass.simpleName}: ${e.message}")
+            throw FileNotFoundException(e.message)
+        }
+        sourceParentDocumentId?.let { notifyChildren(it) }
+        notifyChildren(targetParentDocumentId)
+        return null
+    }
+
+    override fun deleteDocument(documentId: String) {
+        val api = apiClient(op = "deleteDocument") ?: throw FileNotFoundException("No auth")
+        val kind = resolveKind(api, documentId) ?: throw FileNotFoundException("Not found: $documentId")
+        val parentUuid: String? = when (kind) {
+            ItemKind.FILE -> api.getFile(documentId)?.folderUuid
+            ItemKind.FOLDER -> api.getFolder(documentId)?.parentUuid
+        }
+        val trashType = if (kind == ItemKind.FILE) TrashItem.Type.FILE else TrashItem.Type.FOLDER
+        try {
+            api.sendToTrash(listOf(TrashItem(documentId, trashType)))
+        } catch (e: InternxtApiException) {
+            Log.w(TAG, "deleteDocument $documentId failed: ${e.javaClass.simpleName}: ${e.message}")
+            throw FileNotFoundException(e.message)
+        }
+        itemKinds.remove(documentId)
+        parentUuid?.let { notifyChildren(it) }
+    }
+
+    private fun resolveKind(api: InternxtApiClient, uuid: String): ItemKind? =
+        itemKinds[uuid]
+            ?: api.getFolder(uuid)?.let { itemKinds[uuid] = ItemKind.FOLDER; ItemKind.FOLDER }
+            ?: api.getFile(uuid)?.let { itemKinds[uuid] = ItemKind.FILE; ItemKind.FILE }
+
+    private fun notifyChildren(parentUuid: String) {
+        context?.contentResolver?.notifyChange(
+            DocumentsContract.buildChildDocumentsUri(AUTHORITY, parentUuid),
+            null
+        )
     }
 
     override fun openDocument(

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -14,7 +14,9 @@ import android.util.Log
 import com.internxt.cloud.R
 import com.internxt.cloud.documents.api.InternxtApiClient
 import com.internxt.cloud.documents.api.InternxtApiException
+import com.internxt.cloud.documents.api.model.TrashItem
 import com.internxt.cloud.documents.auth.InternxtAuthManager
+import java.io.FileNotFoundException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 
@@ -48,7 +50,7 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         cursor.setNotificationUri(ctx.contentResolver, DocumentsContract.buildRootsUri(AUTHORITY))
 
         val rootUuid = authManager?.authenticatedRootUuid()
-        Log.d(TAG, "queryRoots: isLoggedIn=${authManager.isLoggedIn()} rootUuid=$rootUuid")
+        Log.d(TAG, "queryRoots: isLoggedIn=${authManager?.isLoggedIn()} rootUuid=$rootUuid")
         if (rootUuid == null) return cursor
 
         cursor.newRow().apply {
@@ -72,7 +74,7 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         val decoded = DocumentId.decode(id)
         val uuid = decoded?.uuid ?: id
 
-        if (decoded?.kind == DocumentId.Kind.FOLDER && uuid == authManager.authenticatedRootUuid()) {
+        if (decoded?.kind == DocumentId.Kind.FOLDER && uuid == authManager?.authenticatedRootUuid()) {
             cursor.addDocumentRow(
                 DocumentRowBuilder.folderRow(uuid, ctx.getString(R.string.documents_provider_label))
             )
@@ -81,12 +83,7 @@ class InternxtDocumentsProvider : DocumentsProvider() {
 
         val api = apiClient(op = "queryDocument")
         val row = if (api == null) null else try {
-            when (decoded?.kind) {
-                DocumentId.Kind.FOLDER -> api.getFolder(uuid)?.let { DocumentRowBuilder.folderRow(it) }
-                DocumentId.Kind.FILE -> api.getFile(uuid)?.let { DocumentRowBuilder.fileRow(it) }
-                null -> api.getFolder(uuid)?.let { DocumentRowBuilder.folderRow(it) }
-                    ?: api.getFile(uuid)?.let { DocumentRowBuilder.fileRow(it) }
-            }
+            fetchDocumentRow(api, decoded?.kind, uuid)
         } catch (e: InternxtApiException) {
             Log.w(TAG, "queryDocument id=$id failed: ${e.javaClass.simpleName}: ${e.message}")
             null
@@ -94,6 +91,17 @@ class InternxtDocumentsProvider : DocumentsProvider() {
 
         cursor.addDocumentRow(row ?: DocumentRowBuilder.folderRow(uuid = uuid, displayName = uuid))
         return cursor
+    }
+
+    private fun fetchDocumentRow(
+        api: InternxtApiClient,
+        kind: DocumentId.Kind?,
+        uuid: String,
+    ): Map<String, Any?>? = when (kind) {
+        DocumentId.Kind.FOLDER -> api.getFolder(uuid)?.let(DocumentRowBuilder::folderRow)
+        DocumentId.Kind.FILE -> api.getFile(uuid)?.let(DocumentRowBuilder::fileRow)
+        null -> api.getFolder(uuid)?.let(DocumentRowBuilder::folderRow)
+            ?: api.getFile(uuid)?.let(DocumentRowBuilder::fileRow)
     }
 
     override fun queryChildDocuments(
@@ -176,7 +184,7 @@ class InternxtDocumentsProvider : DocumentsProvider() {
     }
 
     private fun apiClient(op: String): InternxtApiClient? {
-        val cfg = authManager.loadAuthConfig()
+        val cfg = authManager?.loadAuthConfig()
         if (cfg == null) {
             Log.w(TAG, "$op: loadAuthConfig() returned null")
             return null
@@ -198,6 +206,131 @@ class InternxtDocumentsProvider : DocumentsProvider() {
     private fun MatrixCursor.addDocumentRow(row: Map<String, Any?>) {
         val builder = newRow()
         row.forEach { (column, value) -> builder.add(column, value) }
+    }
+
+    override fun renameDocument(documentId: String, displayName: String): String? =
+        mutate("renameDocument", documentId) { api, kind, uuid ->
+            val parent = parentUuidOf(api, kind, uuid)
+            when (kind) {
+                DocumentId.Kind.FILE -> api.renameFile(uuid, displayName)
+                DocumentId.Kind.FOLDER -> api.renameFolder(uuid, displayName)
+            }
+            notifyEncodedParent(parent) { encoded ->
+                patchRowDisplayName(encoded, documentId, displayName)
+            }
+            null
+        }
+
+    override fun moveDocument(
+        sourceDocumentId: String,
+        sourceParentDocumentId: String?,
+        targetParentDocumentId: String,
+    ): String? = mutate("moveDocument", sourceDocumentId) { api, kind, uuid ->
+        val targetUuid = rawUuid(targetParentDocumentId)
+        when (kind) {
+            DocumentId.Kind.FILE -> api.moveFile(uuid, targetUuid)
+            DocumentId.Kind.FOLDER -> api.moveFolder(uuid, targetUuid)
+        }
+        sourceParentDocumentId?.let {
+            removeRow(it, sourceDocumentId)
+            notifyChildren(it)
+        }
+        invalidateChildren(targetParentDocumentId)
+        null
+    }
+
+    override fun deleteDocument(documentId: String) {
+        mutate("deleteDocument", documentId) { api, kind, uuid ->
+            val parent = parentUuidOf(api, kind, uuid)
+            api.sendToTrash(listOf(TrashItem(uuid, trashTypeOf(kind))))
+            notifyEncodedParent(parent) { encoded ->
+                removeRow(encoded, documentId)
+            }
+        }
+    }
+
+    private inline fun <R> mutate(
+        op: String,
+        documentId: String,
+        block: (api: InternxtApiClient, kind: DocumentId.Kind, uuid: String) -> R,
+    ): R {
+        val api = apiClient(op) ?: throw FileNotFoundException("No auth")
+        val kind = resolveKind(api, documentId) ?: throw FileNotFoundException("Not found: $documentId")
+        return try {
+            block(api, kind, rawUuid(documentId))
+        } catch (e: InternxtApiException) {
+            Log.w(TAG, "$op $documentId failed: ${e.javaClass.simpleName}: ${e.message}")
+            throw FileNotFoundException(e.message)
+        }
+    }
+
+    private fun parentUuidOf(api: InternxtApiClient, kind: DocumentId.Kind, uuid: String): String? =
+        when (kind) {
+            DocumentId.Kind.FILE -> api.getFile(uuid)?.folderUuid
+            DocumentId.Kind.FOLDER -> api.getFolder(uuid)?.parentUuid
+        }
+
+    private fun trashTypeOf(kind: DocumentId.Kind): TrashItem.Type = when (kind) {
+        DocumentId.Kind.FILE -> TrashItem.Type.FILE
+        DocumentId.Kind.FOLDER -> TrashItem.Type.FOLDER
+    }
+
+    private inline fun notifyEncodedParent(rawParentUuid: String?, mutateCache: (encodedParent: String) -> Unit) {
+        rawParentUuid?.let {
+            val encoded = DocumentId.encodeFolder(it)
+            mutateCache(encoded)
+            notifyChildren(encoded)
+        }
+    }
+
+    private fun rawUuid(documentId: String): String =
+        DocumentId.decode(documentId)?.uuid ?: documentId
+
+    private fun resolveKind(api: InternxtApiClient, documentId: String): DocumentId.Kind? {
+        DocumentId.decode(documentId)?.kind?.let { return it }
+        return api.getFolder(documentId)?.let { DocumentId.Kind.FOLDER }
+            ?: api.getFile(documentId)?.let { DocumentId.Kind.FILE }
+    }
+
+    private fun notifyChildren(parentDocumentId: String) {
+        context?.contentResolver?.notifyChange(
+            DocumentsContract.buildChildDocumentsUri(AUTHORITY, parentDocumentId),
+            null,
+        )
+    }
+
+    private fun invalidateChildren(parentDocumentId: String) {
+        folderLoads.remove(parentDocumentId)
+        notifyChildren(parentDocumentId)
+    }
+
+    private fun patchRowDisplayName(parentDocumentId: String, documentId: String, displayName: String) {
+        updateRows(parentDocumentId) { rows ->
+            val idx = rows.indexOfFirst { it[Document.COLUMN_DOCUMENT_ID] == documentId }
+            if (idx >= 0) rows[idx] = rows[idx] + (Document.COLUMN_DISPLAY_NAME to displayName)
+        }
+    }
+
+    private fun removeRow(parentDocumentId: String, documentId: String) {
+        updateRows(parentDocumentId) { rows ->
+            rows.removeAll { it[Document.COLUMN_DOCUMENT_ID] == documentId }
+        }
+    }
+
+    private inline fun updateRows(
+        parentDocumentId: String,
+        action: (MutableList<Map<String, Any?>>) -> Unit,
+    ) {
+        val load = folderLoads[parentDocumentId] ?: return
+        synchronized(load) { action(load.rows) }
+    }
+
+    override fun refresh(uri: Uri, args: Bundle?, cancellationSignal: CancellationSignal?): Boolean {
+        val documentId = try { DocumentsContract.getDocumentId(uri) } catch (_: Exception) { null }
+        Log.d(TAG, "refresh uri=$uri documentId=$documentId")
+        if (documentId == null) return false
+        invalidateChildren(documentId)
+        return true
     }
 
     override fun openDocument(

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -1,5 +1,6 @@
 package com.internxt.cloud.documents
 
+import android.content.Context
 import android.database.Cursor
 import android.database.MatrixCursor
 import android.net.Uri
@@ -15,19 +16,30 @@ import android.provider.DocumentsContract.Root
 import android.provider.DocumentsProvider
 import android.util.Log
 import com.internxt.cloud.R
+import com.internxt.cloud.documents.api.AuthConfig
 import com.internxt.cloud.documents.api.InternxtApiClient
 import com.internxt.cloud.documents.api.InternxtApiException
+import com.internxt.cloud.documents.api.model.CreateFileEntry
+import com.internxt.cloud.documents.api.model.FinishUploadShard
 import com.internxt.cloud.documents.api.model.TrashItem
+import com.internxt.cloud.documents.api.model.UploadSlot
+import com.internxt.cloud.documents.api.model.UploadedPart
 import com.internxt.cloud.documents.auth.InternxtAuthManager
 import com.internxt.cloud.documents.cache.DocumentCache
 import com.internxt.cloud.documents.crypto.FileKeyDeriver
+import com.internxt.cloud.documents.crypto.awaitCryptoService
 import com.internxt.cloud.documents.crypto.toHex
 import com.internxt.cloud.documents.download.EncryptedFileDownloader
 import com.internxt.cloud.documents.http.HttpClients
+import com.internxt.cloud.documents.upload.EncryptedFileUploader
+import com.internxt.cloud.documents.upload.PendingUpload
 import com.rncrypto.util.CryptoService
 import java.io.File
 import java.io.FileNotFoundException
-import java.util.concurrent.CompletableFuture
+import java.io.IOException
+import java.security.SecureRandom
+import java.time.Instant
+import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 
@@ -44,6 +56,7 @@ class InternxtDocumentsProvider : DocumentsProvider() {
     }
 
     private val folderLoads = ConcurrentHashMap<String, FolderLoad>()
+    private val pendingUploads = ConcurrentHashMap<String, PendingUpload>()
 
     private enum class LoadState { LOADING, DONE, ERROR }
 
@@ -91,6 +104,13 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         val id = documentId ?: return cursor
         cursor.setNotificationUri(ctx.contentResolver, DocumentsContract.buildDocumentUri(AUTHORITY, id))
         Log.d(TAG, "queryDocument id=$id")
+
+        if (DocumentId.isUploadToken(id)) {
+            pendingUploads[DocumentId.decodeUpload(id)]?.let { pending ->
+                cursor.addDocumentRow(pendingUploadRow(id, pending))
+            }
+            return cursor
+        }
 
         val decoded = DocumentId.decode(id)
         val uuid = decoded?.uuid ?: id
@@ -171,7 +191,7 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         loaderExecutor.execute {
             val api = apiClient(op = "queryChildDocuments[bg]")
             if (api == null) {
-                finishLoad(load, notifyUri, LoadState.ERROR, "Not authenticated")
+                finishLoad(load, notifyUri, LoadState.ERROR, NOT_AUTHENTICATED)
                 return@execute
             }
             try {
@@ -361,8 +381,12 @@ class InternxtDocumentsProvider : DocumentsProvider() {
     ): ParcelFileDescriptor {
         val ctx = context ?: throw FileNotFoundException("No context")
         val id = documentId ?: throw FileNotFoundException("No document id")
-        if (mode != null && mode != "r") {
-            throw UnsupportedOperationException("Only read-only access is supported (mode=$mode)")
+        val effectiveMode = mode ?: "r"
+        if (effectiveMode.contains('w')) {
+            return openForWrite(ctx, id, signal)
+        }
+        if (effectiveMode != "r") {
+            throw UnsupportedOperationException("Unsupported mode=$effectiveMode")
         }
 
         val decoded = DocumentId.decode(id)
@@ -386,12 +410,12 @@ class InternxtDocumentsProvider : DocumentsProvider() {
     }
 
     private fun openDocumentBlocking(
-        ctx: android.content.Context,
+        ctx: Context,
         id: String,
         signal: CancellationSignal?,
         fileUuid: String,
     ): ParcelFileDescriptor {
-        val cfg = authManager?.loadAuthConfig() ?: throw FileNotFoundException("Not authenticated")
+        val cfg = authManager?.loadAuthConfig() ?: throw FileNotFoundException(NOT_AUTHENTICATED)
         if (cfg.mnemonic.isBlank()) {
             throw FileNotFoundException("Stored credentials have no mnemonic; sign out and back in")
         }
@@ -431,7 +455,7 @@ class InternxtDocumentsProvider : DocumentsProvider() {
     }
 
     private fun materializeIntoCache(
-        ctx: android.content.Context,
+        ctx: Context,
         id: String,
         api: InternxtApiClient,
         mnemonic: String,
@@ -468,28 +492,330 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         }
     }
 
-    private fun openCached(ctx: android.content.Context, id: String, cacheFile: File): ParcelFileDescriptor =
+    private fun openCached(ctx: Context, id: String, cacheFile: File): ParcelFileDescriptor =
         ParcelFileDescriptor.open(
             cacheFile,
             ParcelFileDescriptor.MODE_READ_ONLY,
             closeHandler,
         ) { DocumentCache.deleteTempsFor(ctx, id) }
 
-    private fun decryptBlocking(src: File, dst: File, hexKey: String, hexIv: String) {
-        val done = CompletableFuture<Unit>()
-        CryptoService.getInstance().decryptFile(
-            src.absolutePath,
-            dst.absolutePath,
-            hexKey,
-            hexIv,
-            /* runInBackground = */ true,
-        ) { err ->
-            if (err != null) done.completeExceptionally(err) else done.complete(Unit)
-        }
+    override fun createDocument(parentDocumentId: String, mimeType: String, displayName: String): String {
+        val api = apiClient("createDocument") ?: throw FileNotFoundException(NOT_AUTHENTICATED)
+        val parentUuid = rawUuid(parentDocumentId)
         try {
-            done.get()
-        } catch (e: java.util.concurrent.ExecutionException) {
-            throw e.cause ?: e
+            api.getFolder(parentUuid) ?: throw FileNotFoundException("Parent not found: $parentDocumentId")
+        } catch (e: InternxtApiException) {
+            throw FileNotFoundException("Parent lookup failed: ${e.message}")
+        }
+
+        val normalized = collapseRedundantExtensions(displayName, mimeType)
+        val resolvedName = pickUniqueName(api, parentUuid, normalized)
+        evictStalePendingUploads()
+        val token = UUID.randomUUID().toString()
+        pendingUploads[token] = PendingUpload(parentUuid, resolvedName, mimeType)
+        return DocumentId.encodeUpload(token)
+    }
+
+    private fun evictStalePendingUploads() {
+        val cutoff = System.currentTimeMillis() - PENDING_UPLOAD_TTL_MS
+        pendingUploads.entries.removeAll { it.value.createdAtMillis < cutoff }
+    }
+
+    private fun collapseRedundantExtensions(displayName: String, mimeType: String): String {
+        val canonicalExt = android.webkit.MimeTypeMap.getSingleton()
+            .getExtensionFromMimeType(mimeType)?.lowercase()
+        if (canonicalExt.isNullOrBlank()) return displayName
+        val suffix = ".$canonicalExt"
+        var name = displayName
+        while (name.length > suffix.length && name.endsWith(suffix, ignoreCase = true)) {
+            val candidate = name.dropLast(suffix.length)
+            if (candidate.endsWith(suffix, ignoreCase = true)) {
+                name = candidate
+            } else {
+                break
+            }
+        }
+        return name
+    }
+
+    private fun pickUniqueName(api: InternxtApiClient, parentUuid: String, requested: String): String {
+        val existing = HashSet<String>()
+        try {
+            streamPages({ offset, size -> api.listFolderFiles(parentUuid, offset, size) }) { page ->
+                page.forEach { existing.add(joinNameType(it.plainName, it.type)) }
+            }
+        } catch (e: InternxtApiException) {
+            Log.w(TAG, "pickUniqueName: listing failed, using requested name. ${e.message}")
+            return requested
+        }
+        if (requested !in existing) return requested
+        val (base, ext) = splitNameExt(requested)
+        for (i in 1..MAX_SUFFIX_ATTEMPTS) {
+            val candidate = "$base ($i)$ext"
+            if (candidate !in existing) return candidate
+        }
+        // Backstop for the (practically impossible) case where 1..1000 are all taken —
+        // the backend permits duplicate names, so a UUID-suffixed name is always safe.
+        return "$base (${UUID.randomUUID()})$ext"
+    }
+
+    private fun splitNameExt(name: String): Pair<String, String> {
+        val dot = name.lastIndexOf('.')
+        val hasExt = dot > 0 && dot < name.length - 1
+        return if (hasExt) name.substring(0, dot) to name.substring(dot) else name to ""
+    }
+
+    private fun joinNameType(plainName: String, type: String?): String =
+        if (type.isNullOrBlank()) plainName else "$plainName.$type"
+
+    private fun openForWrite(
+        ctx: Context,
+        documentId: String,
+        signal: CancellationSignal?,
+    ): ParcelFileDescriptor {
+        val token = DocumentId.decodeUpload(documentId)
+            ?: throw FileNotFoundException("Write only supported on pending uploads: $documentId")
+        val pending = pendingUploads[token]
+            ?: throw FileNotFoundException("Unknown upload token: $token")
+
+        try {
+            val cfg = authManager?.loadAuthConfig() ?: throw FileNotFoundException(NOT_AUTHENTICATED)
+            if (cfg.mnemonic.isBlank()) {
+                throw FileNotFoundException("Stored credentials have no mnemonic; sign out and back in")
+            }
+            val pipe = ParcelFileDescriptor.createReliablePipe()
+            val readEnd = pipe[0]
+            val writeEnd = pipe[1]
+            openExecutor.execute {
+                runUpload(ctx, token, pending, cfg, readEnd, signal)
+            }
+            return writeEnd
+        } catch (t: Throwable) {
+            pendingUploads.remove(token)
+            throw t
+        }
+    }
+
+    private fun runUpload(
+        ctx: Context,
+        token: String,
+        pending: PendingUpload,
+        cfg: AuthConfig,
+        readEnd: ParcelFileDescriptor,
+        signal: CancellationSignal?,
+    ) {
+        val temps = uploadTempsFor(ctx, token)
+        var failure: Throwable? = null
+        try {
+            val api = InternxtApiClient(cfg)
+            val bucketId = resolveBucket(api, pending.parentUuid)
+            val crypto = prepareEncryption(cfg.mnemonic, bucketId)
+            val encrypted = encryptInputToTemp(temps, readEnd, crypto, signal)
+            val outcome = uploadEncryptedFile(api, temps.enc, bucketId, encrypted, signal)
+            finalizeAndRecordFile(api, pending, bucketId, crypto.indexHex, encrypted.size, outcome)
+            invalidateChildren(DocumentId.encodeFolder(pending.parentUuid))
+        } catch (t: Throwable) {
+            if (t !is OperationCanceledException) {
+                Log.w(TAG, "upload failed token=$token: ${t.javaClass.simpleName}: ${t.message}")
+            }
+            failure = t
+        } finally {
+            closePipeEnd(readEnd, failure)
+            deleteTempQuietly(temps.plain)
+            deleteTempQuietly(temps.enc)
+            pendingUploads.remove(token)
+        }
+    }
+
+    /** `tempEnc` holds the ciphertext PUT to bridge; `plain` holds the pipe's plaintext
+     *  while we hand it to CryptoService (which only accepts file paths). */
+    private data class UploadTemps(val plain: File, val enc: File)
+
+    private fun uploadTempsFor(ctx: Context, token: String): UploadTemps {
+        val (enc, plain) = DocumentCache.tempPaths(ctx, token)
+        return UploadTemps(plain = plain, enc = enc)
+    }
+
+    private fun resolveBucket(api: InternxtApiClient, parentUuid: String): String {
+        val parent = api.getFolder(parentUuid)
+            ?: throw IOException("Parent folder not found: $parentUuid")
+        return parent.bucket
+            ?: throw IOException("Parent folder $parentUuid has no bucket")
+    }
+
+    private fun prepareEncryption(mnemonic: String, bucketId: String): EncryptionContext {
+        val indexHex = ByteArray(32).also { SecureRandom().nextBytes(it) }.toHex()
+        return EncryptionContext(
+            key = FileKeyDeriver.deriveFileKey(mnemonic, bucketId, indexHex),
+            iv = FileKeyDeriver.deriveIv(indexHex),
+            indexHex = indexHex,
+        )
+    }
+
+    private fun encryptInputToTemp(
+        temps: UploadTemps,
+        readEnd: ParcelFileDescriptor,
+        crypto: EncryptionContext,
+        signal: CancellationSignal?,
+    ): EncryptedFileUploader.Encrypted {
+        // Phase 1: drain the pipe into a plaintext file on disk — CryptoService is
+        // path-based, so we must materialize before encrypting. Cancellation lives here
+        // because this is the long-running streaming phase.
+        drainPipeToFile(readEnd, temps.plain, signal)
+        signal?.throwIfCanceled()
+        // Phase 2: hand the plaintext file to the official rn-crypto CryptoService — same
+        // call the RN side makes from NetworkFacade.ts, identical AES-CTR pipeline.
+        return EncryptedFileUploader.encryptFile(temps.plain, temps.enc, crypto.key, crypto.iv)
+    }
+
+    private fun drainPipeToFile(
+        readEnd: ParcelFileDescriptor,
+        target: File,
+        signal: CancellationSignal?,
+    ) {
+        val buffer = ByteArray(EncryptedFileUploader.COPY_BUFFER_SIZE)
+        // dup() so the InputStream owns its own FD; the original `readEnd` survives for
+        // the eventual close()/closeWithError() in `runUpload`'s finally.
+        readEnd.dup().use { dup ->
+            ParcelFileDescriptor.AutoCloseInputStream(dup).use { source ->
+                target.outputStream().use { sink ->
+                    while (true) {
+                        signal?.throwIfCanceled()
+                        val n = source.read(buffer)
+                        if (n == -1) break
+                        sink.write(buffer, 0, n)
+                    }
+                    sink.flush()
+                }
+            }
+        }
+    }
+
+    private fun uploadEncryptedFile(
+        api: InternxtApiClient,
+        tempEnc: File,
+        bucketId: String,
+        encrypted: EncryptedFileUploader.Encrypted,
+        signal: CancellationSignal?,
+    ): UploadOutcome {
+        val partsCount = if (encrypted.size >= MULTIPART_THRESHOLD) {
+            ((encrypted.size + MULTIPART_PART_SIZE - 1) / MULTIPART_PART_SIZE).toInt().coerceAtLeast(1)
+        } else 1
+
+        val slot = api.startUpload(bucketId, encrypted.size, partsCount).uploads.firstOrNull()
+            ?: throw IOException("Bridge /start returned no upload slot")
+
+        return when (slot) {
+            is UploadSlot.Single -> {
+                EncryptedFileUploader.uploadSingle(HttpClients.upload, tempEnc, slot.url, signal)
+                UploadOutcome.Single(slot.uuid, listOf(encrypted.wholeSha256Hex))
+            }
+            is UploadSlot.Multipart -> {
+                val partHashes = EncryptedFileUploader.computePartSha256(tempEnc, MULTIPART_PART_SIZE)
+                val parts = EncryptedFileUploader.uploadMultipart(
+                    HttpClients.upload, tempEnc, slot.urls, MULTIPART_PART_SIZE, signal,
+                )
+                UploadOutcome.Multipart(slot.uuid, partHashes, parts, slot.uploadId)
+            }
+        }
+    }
+
+    private fun finalizeAndRecordFile(
+        api: InternxtApiClient,
+        pending: PendingUpload,
+        bucketId: String,
+        indexHex: String,
+        encryptedSize: Long,
+        outcome: UploadOutcome,
+    ) {
+        val hash = EncryptedFileUploader.computeShardHash(outcome.partHashes)
+        val shard = when (outcome) {
+            is UploadOutcome.Single -> FinishUploadShard(uuid = outcome.slotUuid, hash = hash)
+            is UploadOutcome.Multipart -> FinishUploadShard(
+                uuid = outcome.slotUuid,
+                hash = hash,
+                uploadId = outcome.uploadId,
+                parts = outcome.parts,
+            )
+        }
+        val finish = api.finishUpload(bucketId, indexHex, listOf(shard))
+
+        val nowIso = Instant.now().toString()
+        val (basePlain, ext) = splitNameExt(pending.plainName)
+        api.createFileEntry(
+            CreateFileEntry(
+                fileId = finish.id,
+                type = ext.removePrefix("."),
+                size = encryptedSize,
+                plainName = basePlain,
+                bucket = bucketId,
+                folderUuid = pending.parentUuid,
+                modificationTime = nowIso,
+                creationTime = nowIso,
+            )
+        )
+    }
+
+    private fun closePipeEnd(readEnd: ParcelFileDescriptor, failure: Throwable?) {
+        try {
+            if (failure != null) {
+                readEnd.closeWithError(failure.message ?: "Upload failed")
+            } else {
+                readEnd.close()
+            }
+        } catch (e: IOException) {
+            Log.w(TAG, "closing readEnd failed: ${e.message}")
+        }
+    }
+
+    private fun deleteTempQuietly(tempEnc: File) {
+        if (!tempEnc.delete() && tempEnc.exists()) {
+            Log.w(TAG, "Failed to delete temp upload file: ${tempEnc.absolutePath}")
+        }
+    }
+
+    private data class EncryptionContext(
+        val key: ByteArray,
+        val iv: ByteArray,
+        val indexHex: String,
+    )
+
+    private sealed class UploadOutcome {
+        abstract val slotUuid: String
+        abstract val partHashes: List<String>
+
+        data class Single(
+            override val slotUuid: String,
+            override val partHashes: List<String>,
+        ) : UploadOutcome()
+
+        data class Multipart(
+            override val slotUuid: String,
+            override val partHashes: List<String>,
+            val parts: List<UploadedPart>,
+            val uploadId: String,
+        ) : UploadOutcome()
+    }
+
+    private fun pendingUploadRow(documentId: String, pending: PendingUpload): Map<String, Any?> = mapOf(
+        Document.COLUMN_DOCUMENT_ID to documentId,
+        Document.COLUMN_MIME_TYPE to pending.mimeType,
+        Document.COLUMN_DISPLAY_NAME to pending.plainName,
+        Document.COLUMN_LAST_MODIFIED to null,
+        Document.COLUMN_FLAGS to 0,
+        Document.COLUMN_SIZE to null,
+    )
+
+    private fun decryptBlocking(src: File, dst: File, hexKey: String, hexIv: String) {
+        awaitCryptoService("Decryption failed") { cb ->
+            CryptoService.getInstance().decryptFile(
+                src.absolutePath,
+                dst.absolutePath,
+                hexKey,
+                hexIv,
+                /* runInBackground = */ false,
+                cb,
+            )
         }
     }
 
@@ -503,6 +829,12 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         const val AUTHORITY = "com.internxt.cloud.documents"
         private const val ROOT_ID = "internxt-root"
         private const val TAG = "InternxtDocsProvider"
+
+        private const val MULTIPART_THRESHOLD = 100L * 1024L * 1024L
+        private const val MULTIPART_PART_SIZE = 30L * 1024L * 1024L
+        private const val MAX_SUFFIX_ATTEMPTS = 1000
+        private const val PENDING_UPLOAD_TTL_MS = 60L * 60L * 1000L
+        private const val NOT_AUTHENTICATED = "Not authenticated"
 
         private val DEFAULT_ROOT_PROJECTION = arrayOf(
             Root.COLUMN_ROOT_ID,

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -5,6 +5,9 @@ import android.database.MatrixCursor
 import android.net.Uri
 import android.os.Bundle
 import android.os.CancellationSignal
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.OperationCanceledException
 import android.os.ParcelFileDescriptor
 import android.provider.DocumentsContract
 import android.provider.DocumentsContract.Document
@@ -16,8 +19,16 @@ import com.internxt.cloud.documents.api.InternxtApiClient
 import com.internxt.cloud.documents.api.InternxtApiException
 import com.internxt.cloud.documents.api.model.TrashItem
 import com.internxt.cloud.documents.auth.InternxtAuthManager
+import com.internxt.cloud.documents.cache.DocumentCache
+import com.internxt.cloud.documents.crypto.FileKeyDeriver
+import com.internxt.cloud.documents.download.EncryptedFileDownloader
+import com.rncrypto.util.CryptoService
+import okhttp3.OkHttpClient
+import java.io.File
 import java.io.FileNotFoundException
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.Executors
 
 class InternxtDocumentsProvider : DocumentsProvider() {
@@ -38,12 +49,22 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         val rows = mutableListOf<Map<String, Any?>>()
     }
     private val itemKinds = ConcurrentHashMap<String, ItemKind>()
+    private lateinit var closeHandler: Handler
+    private val downloadClient: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(2, TimeUnit.MINUTES)
+            .writeTimeout(2, TimeUnit.MINUTES)
+            .callTimeout(0, TimeUnit.MILLISECONDS)
+            .build()
+    }
 
     private enum class ItemKind { FILE, FOLDER }
 
     override fun onCreate(): Boolean {
         val ctx = context ?: return false
         authManager = InternxtAuthManager.create(ctx.applicationContext) ?: return false
+        closeHandler = Handler(HandlerThread("InternxtDocsClose").apply { start() }.looper)
         return true
     }
 
@@ -341,7 +362,79 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         mode: String?,
         signal: CancellationSignal?
     ): ParcelFileDescriptor {
-        throw UnsupportedOperationException("Not implemented yet")
+        val ctx = context ?: throw FileNotFoundException("No context")
+        val id = documentId ?: throw FileNotFoundException("No document id")
+        if (mode != null && mode != "r") {
+            throw UnsupportedOperationException("Only read-only access is supported (mode=$mode)")
+        }
+
+        val cfg = authManager.loadAuthConfig() ?: throw FileNotFoundException("Not authenticated")
+        val api = InternxtApiClient(cfg)
+
+        val file = try {
+            api.getFile(id) ?: throw FileNotFoundException("File not found: $id")
+        } catch (e: InternxtApiException) {
+            throw FileNotFoundException("getFile $id failed: ${e.message}")
+        }
+        val bucket = file.bucket ?: throw FileNotFoundException("File $id has no bucket")
+        val fileId = file.fileId ?: throw FileNotFoundException("File $id has no fileId")
+        val updatedAt = file.updatedAt ?: throw FileNotFoundException("File $id has no updatedAt")
+
+        val cacheFile = DocumentCache.cacheFileFor(ctx, id, updatedAt)
+        if (cacheFile.exists() && cacheFile.length() > 0) {
+            Log.d(TAG, "openDocument cache hit id=$id")
+            return ParcelFileDescriptor.open(cacheFile, ParcelFileDescriptor.MODE_READ_ONLY)
+        }
+
+        val (tempEnc, tempDec) = DocumentCache.tempPaths(ctx, id)
+        try {
+            signal?.throwIfCanceled()
+            val links = api.getDownloadLinks(bucket, fileId)
+            EncryptedFileDownloader.download(downloadClient, links.shards, tempEnc, signal)
+
+            signal?.throwIfCanceled()
+            val key = FileKeyDeriver.deriveFileKey(cfg.mnemonic, bucket, links.index)
+            val iv = FileKeyDeriver.deriveIv(links.index)
+            decryptBlocking(tempEnc, tempDec, FileKeyDeriver.toHex(key), FileKeyDeriver.toHex(iv))
+
+            if (!tempDec.renameTo(cacheFile)) {
+                throw FileNotFoundException("Failed to promote temp file to cache for $id")
+            }
+            tempEnc.delete()
+            DocumentCache.pruneSiblings(ctx, id, cacheFile)
+
+            Log.d(TAG, "openDocument cached id=$id size=${cacheFile.length()}")
+            return ParcelFileDescriptor.open(
+                cacheFile,
+                ParcelFileDescriptor.MODE_READ_ONLY,
+                closeHandler,
+            ) { DocumentCache.deleteTempsFor(ctx, id) }
+        } catch (e: OperationCanceledException) {
+            tempEnc.delete(); tempDec.delete()
+            throw FileNotFoundException("openDocument $id cancelled").apply { initCause(e) }
+        } catch (e: Exception) {
+            tempEnc.delete(); tempDec.delete()
+            Log.w(TAG, "openDocument $id failed: ${e.javaClass.simpleName}: ${e.message}")
+            if (e is FileNotFoundException) throw e
+            throw FileNotFoundException("openDocument $id failed: ${e.message}").apply { initCause(e) }
+        }
+    }
+
+    private fun decryptBlocking(src: File, dst: File, hexKey: String, hexIv: String) {
+        val latch = CountDownLatch(1)
+        val errorRef = arrayOfNulls<Exception>(1)
+        CryptoService.getInstance().decryptFile(
+            src.absolutePath,
+            dst.absolutePath,
+            hexKey,
+            hexIv,
+            /* runInBackground = */ true,
+        ) { err ->
+            errorRef[0] = err
+            latch.countDown()
+        }
+        latch.await()
+        errorRef[0]?.let { throw it }
     }
 
     private fun resolveRootProjection(projection: Array<String>?): Array<String> =

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -33,6 +33,7 @@ import com.internxt.cloud.documents.download.EncryptedFileDownloader
 import com.internxt.cloud.documents.http.HttpClients
 import com.internxt.cloud.documents.upload.EncryptedFileUploader
 import com.internxt.cloud.documents.upload.PendingUpload
+import com.internxt.cloud.documents.upload.UploadForegroundService
 import com.rncrypto.util.CryptoService
 import java.io.File
 import java.io.FileNotFoundException
@@ -605,13 +606,17 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         signal: CancellationSignal?,
     ) {
         val temps = uploadTempsFor(ctx, token)
+        val uploadSignal = CancellationSignal()
+        signal?.setOnCancelListener { uploadSignal.cancel() }
+        UploadForegroundService.start(ctx, token, pending.plainName, uploadSignal)
+
         var failure: Throwable? = null
         try {
             val api = InternxtApiClient(cfg)
             val bucketId = resolveBucket(api, pending.parentUuid)
             val crypto = prepareEncryption(cfg.mnemonic, bucketId)
-            val encrypted = encryptInputToTemp(temps, readEnd, crypto, signal)
-            val outcome = uploadEncryptedFile(api, temps.enc, bucketId, encrypted, signal)
+            val encrypted = encryptInputToTemp(token, temps, readEnd, crypto, uploadSignal)
+            val outcome = uploadEncryptedFile(token, api, temps.enc, bucketId, encrypted, uploadSignal)
             finalizeAndRecordFile(api, pending, bucketId, crypto.indexHex, encrypted.size, outcome)
             invalidateChildren(DocumentId.encodeFolder(pending.parentUuid))
         } catch (t: Throwable) {
@@ -624,6 +629,7 @@ class InternxtDocumentsProvider : DocumentsProvider() {
             deleteTempQuietly(temps.plain)
             deleteTempQuietly(temps.enc)
             pendingUploads.remove(token)
+            notifyServiceOfOutcome(ctx, token, failure)
         }
     }
 
@@ -653,16 +659,22 @@ class InternxtDocumentsProvider : DocumentsProvider() {
     }
 
     private fun encryptInputToTemp(
+        token: String,
         temps: UploadTemps,
         readEnd: ParcelFileDescriptor,
         crypto: EncryptionContext,
-        signal: CancellationSignal?,
+        signal: CancellationSignal,
     ): EncryptedFileUploader.Encrypted {
         // Phase 1: drain the pipe into a plaintext file on disk — CryptoService is
-        // path-based, so we must materialize before encrypting. Cancellation lives here
-        // because this is the long-running streaming phase.
-        drainPipeToFile(readEnd, temps.plain, signal)
-        signal?.throwIfCanceled()
+        // path-based, so we must materialize before encrypting. Cancellation + per-byte
+        // progress live here because this is the long-running streaming phase.
+        val onProgress = throttledProgress { bytes ->
+            UploadForegroundService.reportProgress(
+                token, UploadForegroundService.Phase.ENCRYPTING, bytes, 0L,
+            )
+        }
+        drainPipeToFile(readEnd, temps.plain, signal, onProgress)
+        signal.throwIfCanceled()
         // Phase 2: hand the plaintext file to the official rn-crypto CryptoService — same
         // call the RN side makes from NetworkFacade.ts, identical AES-CTR pipeline.
         return EncryptedFileUploader.encryptFile(temps.plain, temps.enc, crypto.key, crypto.iv)
@@ -671,19 +683,23 @@ class InternxtDocumentsProvider : DocumentsProvider() {
     private fun drainPipeToFile(
         readEnd: ParcelFileDescriptor,
         target: File,
-        signal: CancellationSignal?,
+        signal: CancellationSignal,
+        onProgress: (Long) -> Unit,
     ) {
         val buffer = ByteArray(EncryptedFileUploader.COPY_BUFFER_SIZE)
+        var written = 0L
         // dup() so the InputStream owns its own FD; the original `readEnd` survives for
         // the eventual close()/closeWithError() in `runUpload`'s finally.
         readEnd.dup().use { dup ->
             ParcelFileDescriptor.AutoCloseInputStream(dup).use { source ->
                 target.outputStream().use { sink ->
                     while (true) {
-                        signal?.throwIfCanceled()
+                        signal.throwIfCanceled()
                         val n = source.read(buffer)
                         if (n == -1) break
                         sink.write(buffer, 0, n)
+                        written += n
+                        onProgress(written)
                     }
                     sink.flush()
                 }
@@ -692,11 +708,12 @@ class InternxtDocumentsProvider : DocumentsProvider() {
     }
 
     private fun uploadEncryptedFile(
+        token: String,
         api: InternxtApiClient,
         tempEnc: File,
         bucketId: String,
         encrypted: EncryptedFileUploader.Encrypted,
-        signal: CancellationSignal?,
+        signal: CancellationSignal,
     ): UploadOutcome {
         val partsCount = if (encrypted.size >= MULTIPART_THRESHOLD) {
             ((encrypted.size + MULTIPART_PART_SIZE - 1) / MULTIPART_PART_SIZE).toInt().coerceAtLeast(1)
@@ -705,15 +722,23 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         val slot = api.startUpload(bucketId, encrypted.size, partsCount).uploads.firstOrNull()
             ?: throw IOException("Bridge /start returned no upload slot")
 
+        val onProgress = throttledProgress { bytes ->
+            UploadForegroundService.reportProgress(
+                token, UploadForegroundService.Phase.UPLOADING, bytes, encrypted.size,
+            )
+        }
+
         return when (slot) {
             is UploadSlot.Single -> {
-                EncryptedFileUploader.uploadSingle(HttpClients.upload, tempEnc, slot.url, signal)
+                EncryptedFileUploader.uploadSingle(
+                    HttpClients.upload, tempEnc, slot.url, signal, onProgress,
+                )
                 UploadOutcome.Single(slot.uuid, listOf(encrypted.wholeSha256Hex))
             }
             is UploadSlot.Multipart -> {
                 val partHashes = EncryptedFileUploader.computePartSha256(tempEnc, MULTIPART_PART_SIZE)
                 val parts = EncryptedFileUploader.uploadMultipart(
-                    HttpClients.upload, tempEnc, slot.urls, MULTIPART_PART_SIZE, signal,
+                    HttpClients.upload, tempEnc, slot.urls, MULTIPART_PART_SIZE, signal, onProgress,
                 )
                 UploadOutcome.Multipart(slot.uuid, partHashes, parts, slot.uploadId)
             }
@@ -771,6 +796,45 @@ class InternxtDocumentsProvider : DocumentsProvider() {
     private fun deleteTempQuietly(tempEnc: File) {
         if (!tempEnc.delete() && tempEnc.exists()) {
             Log.w(TAG, "Failed to delete temp upload file: ${tempEnc.absolutePath}")
+        }
+    }
+
+    private fun notifyServiceOfOutcome(ctx: Context, token: String, failure: Throwable?) {
+        when {
+            failure == null -> UploadForegroundService.complete(token)
+            failure is OperationCanceledException -> UploadForegroundService.complete(token)
+            else -> UploadForegroundService.fail(token, friendlyUploadError(ctx, failure))
+        }
+    }
+
+    private fun friendlyUploadError(ctx: Context, t: Throwable): String {
+        if (t is InternxtApiException.ApiError) {
+            val body = t.body.orEmpty()
+            if (t.code == 420 || body.contains("Max space used", ignoreCase = true)) {
+                return ctx.getString(R.string.upload_error_storage_full)
+            }
+            if (t.code == 413) return ctx.getString(R.string.upload_error_too_large)
+            if (t.code in 500..599) return ctx.getString(R.string.upload_error_server)
+        }
+        if (t is InternxtApiException.UnauthorizedException) {
+            return ctx.getString(R.string.upload_error_signed_out)
+        }
+        if (t is InternxtApiException.NetworkException) {
+            return ctx.getString(R.string.upload_error_network)
+        }
+        return ctx.getString(R.string.upload_error_generic)
+    }
+
+    private fun throttledProgress(emit: (Long) -> Unit): (Long) -> Unit {
+        var lastEmittedMs = 0L
+        var lastEmittedBytes = -1L
+        return { bytes ->
+            val now = System.currentTimeMillis()
+            if (bytes != lastEmittedBytes && now - lastEmittedMs >= PROGRESS_THROTTLE_MS) {
+                lastEmittedMs = now
+                lastEmittedBytes = bytes
+                emit(bytes)
+            }
         }
     }
 
@@ -832,6 +896,7 @@ class InternxtDocumentsProvider : DocumentsProvider() {
 
         private const val MULTIPART_THRESHOLD = 100L * 1024L * 1024L
         private const val MULTIPART_PART_SIZE = 30L * 1024L * 1024L
+        private const val PROGRESS_THROTTLE_MS = 300L
         private const val MAX_SUFFIX_ATTEMPTS = 1000
         private const val PENDING_UPLOAD_TTL_MS = 60L * 60L * 1000L
         private const val NOT_AUTHENTICATED = "Not authenticated"

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -579,10 +579,6 @@ class InternxtDocumentsProvider : DocumentsProvider() {
             it.plainName
         }
 
-    /**
-     * Resolves [requested] to a name that does not collide with the parent's existing children
-     * (listed via [listPage], named via [nameOf]). Falls back to [requested] if the listing fails.
-     */
     private inline fun <T> uniqueChildName(
         op: String,
         requested: String,

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -509,8 +509,38 @@ class InternxtDocumentsProvider : DocumentsProvider() {
             throw FileNotFoundException("Parent lookup failed: ${e.message}")
         }
 
+        return if (mimeType == Document.MIME_TYPE_DIR) {
+            createFolderDocument(api, parentDocumentId, parentUuid, displayName)
+        } else {
+            createPendingFileDocument(api, parentUuid, mimeType, displayName)
+        }
+    }
+
+    private fun createFolderDocument(
+        api: InternxtApiClient,
+        parentDocumentId: String,
+        parentUuid: String,
+        displayName: String,
+    ): String {
+        val resolvedName = uniqueFolderName(api, parentUuid, displayName)
+        val folder = try {
+            api.createFolder(parentUuid, resolvedName)
+        } catch (e: InternxtApiException) {
+            Log.w(TAG, "createDocument folder failed parent=$parentDocumentId: ${e.javaClass.simpleName}: ${e.message}")
+            throw FileNotFoundException("Folder creation failed: ${e.message}")
+        }
+        invalidateChildren(parentDocumentId)
+        return DocumentId.encodeFolder(folder.uuid)
+    }
+
+    private fun createPendingFileDocument(
+        api: InternxtApiClient,
+        parentUuid: String,
+        mimeType: String,
+        displayName: String,
+    ): String {
         val normalized = collapseRedundantExtensions(displayName, mimeType)
-        val resolvedName = pickUniqueName(api, parentUuid, normalized)
+        val resolvedName = uniqueFileName(api, parentUuid, normalized)
         evictStalePendingUploads()
         val token = UUID.randomUUID().toString()
         pendingUploads[token] = PendingUpload(parentUuid, resolvedName, mimeType)
@@ -539,35 +569,35 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         return name
     }
 
-    private fun pickUniqueName(api: InternxtApiClient, parentUuid: String, requested: String): String {
+    private fun uniqueFileName(api: InternxtApiClient, parentUuid: String, requested: String): String =
+        uniqueChildName("uniqueFileName", requested, { offset, size -> api.listFolderFiles(parentUuid, offset, size) }) {
+            DocumentNaming.joinNameType(it.plainName, it.type)
+        }
+
+    private fun uniqueFolderName(api: InternxtApiClient, parentUuid: String, requested: String): String =
+        uniqueChildName("uniqueFolderName", requested, { offset, size -> api.listFolderFolders(parentUuid, offset, size) }) {
+            it.plainName
+        }
+
+    /**
+     * Resolves [requested] to a name that does not collide with the parent's existing children
+     * (listed via [listPage], named via [nameOf]). Falls back to [requested] if the listing fails.
+     */
+    private inline fun <T> uniqueChildName(
+        op: String,
+        requested: String,
+        listPage: (offset: Int, size: Int) -> List<T>,
+        nameOf: (T) -> String,
+    ): String {
         val existing = HashSet<String>()
         try {
-            streamPages({ offset, size -> api.listFolderFiles(parentUuid, offset, size) }) { page ->
-                page.forEach { existing.add(joinNameType(it.plainName, it.type)) }
-            }
+            streamPages(listPage) { page -> page.forEach { existing.add(nameOf(it)) } }
         } catch (e: InternxtApiException) {
-            Log.w(TAG, "pickUniqueName: listing failed, using requested name. ${e.message}")
+            Log.w(TAG, "$op: listing failed, using requested name. ${e.message}")
             return requested
         }
-        if (requested !in existing) return requested
-        val (base, ext) = splitNameExt(requested)
-        for (i in 1..MAX_SUFFIX_ATTEMPTS) {
-            val candidate = "$base ($i)$ext"
-            if (candidate !in existing) return candidate
-        }
-        // Backstop for the (practically impossible) case where 1..1000 are all taken —
-        // the backend permits duplicate names, so a UUID-suffixed name is always safe.
-        return "$base (${UUID.randomUUID()})$ext"
+        return DocumentNaming.uniqueName(requested, existing)
     }
-
-    private fun splitNameExt(name: String): Pair<String, String> {
-        val dot = name.lastIndexOf('.')
-        val hasExt = dot > 0 && dot < name.length - 1
-        return if (hasExt) name.substring(0, dot) to name.substring(dot) else name to ""
-    }
-
-    private fun joinNameType(plainName: String, type: String?): String =
-        if (type.isNullOrBlank()) plainName else "$plainName.$type"
 
     private fun openForWrite(
         ctx: Context,
@@ -766,7 +796,7 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         val finish = api.finishUpload(bucketId, indexHex, listOf(shard))
 
         val nowIso = Instant.now().toString()
-        val (basePlain, ext) = splitNameExt(pending.plainName)
+        val (basePlain, ext) = DocumentNaming.splitNameExt(pending.plainName)
         api.createFileEntry(
             CreateFileEntry(
                 fileId = finish.id,
@@ -897,7 +927,6 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         private const val MULTIPART_THRESHOLD = 100L * 1024L * 1024L
         private const val MULTIPART_PART_SIZE = 30L * 1024L * 1024L
         private const val PROGRESS_THROTTLE_MS = 300L
-        private const val MAX_SUFFIX_ATTEMPTS = 1000
         private const val PENDING_UPLOAD_TTL_MS = 60L * 60L * 1000L
         private const val NOT_AUTHENTICATED = "Not authenticated"
 

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -18,7 +18,6 @@ import com.internxt.cloud.documents.api.model.TrashItem
 import com.internxt.cloud.documents.auth.InternxtAuthManager
 import java.io.FileNotFoundException
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 
 class InternxtDocumentsProvider : DocumentsProvider() {
@@ -38,9 +37,6 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         @Volatile var errorMessage: String? = null
         val rows = mutableListOf<Map<String, Any?>>()
     }
-    private val itemKinds = ConcurrentHashMap<String, ItemKind>()
-
-    private enum class ItemKind { FILE, FOLDER }
 
     private val loaderExecutor = Executors.newSingleThreadExecutor { r ->
         Thread(r, "InternxtDocsProvider-loader").apply { isDaemon = true }
@@ -101,17 +97,7 @@ class InternxtDocumentsProvider : DocumentsProvider() {
 
         val api = apiClient(op = "queryDocument")
         val row = if (api == null) null else try {
-            when (decoded?.kind) {
-                DocumentId.Kind.FOLDER -> api.getFolder(uuid)?.let {
-                itemKinds[id] = ItemKind.FOLDER
-                DocumentRowBuilder.folderRow(it)
-                DocumentId.Kind.FILE -> api.getFile(uuid)?.let { DocumentRowBuilder.fileRow(it) }
-                null -> api.getFolder(uuid)?.let { DocumentRowBuilder.folderRow(it) }
-                } ?: api.getFile(uuid)?.let {
-                itemKinds[id] = ItemKind.FILE
-                DocumentRowBuilder.fileRow(it)
-            }
-            }
+            fetchDocumentRow(api, decoded?.kind, uuid)
         } catch (e: InternxtApiException) {
             Log.w(TAG, "queryDocument id=$id failed: ${e.javaClass.simpleName}: ${e.message}")
             null
@@ -119,6 +105,17 @@ class InternxtDocumentsProvider : DocumentsProvider() {
 
         cursor.addDocumentRow(row ?: DocumentRowBuilder.folderRow(uuid = uuid, displayName = uuid))
         return cursor
+    }
+
+    private fun fetchDocumentRow(
+        api: InternxtApiClient,
+        kind: DocumentId.Kind?,
+        uuid: String,
+    ): Map<String, Any?>? = when (kind) {
+        DocumentId.Kind.FOLDER -> api.getFolder(uuid)?.let(DocumentRowBuilder::folderRow)
+        DocumentId.Kind.FILE -> api.getFile(uuid)?.let(DocumentRowBuilder::fileRow)
+        null -> api.getFolder(uuid)?.let(DocumentRowBuilder::folderRow)
+            ?: api.getFile(uuid)?.let(DocumentRowBuilder::fileRow)
     }
 
     override fun queryChildDocuments(
@@ -225,79 +222,129 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         row.forEach { (column, value) -> builder.add(column, value) }
     }
 
-    override fun renameDocument(documentId: String, displayName: String): String? {
-        val api = apiClient(op = "renameDocument") ?: throw FileNotFoundException("No auth")
-        val kind = resolveKind(api, documentId) ?: throw FileNotFoundException("Not found: $documentId")
-        val parentUuid: String? = try {
+    override fun renameDocument(documentId: String, displayName: String): String? =
+        mutate("renameDocument", documentId) { api, kind, uuid ->
+            val parent = parentUuidOf(api, kind, uuid)
             when (kind) {
-                ItemKind.FILE -> {
-                    val parent = api.getFile(documentId)?.folderUuid
-                    api.renameFile(documentId, displayName)
-                    parent
-                }
-                ItemKind.FOLDER -> {
-                    val parent = api.getFolder(documentId)?.parentUuid
-                    api.renameFolder(documentId, displayName)
-                    parent
-                }
+                DocumentId.Kind.FILE -> api.renameFile(uuid, displayName)
+                DocumentId.Kind.FOLDER -> api.renameFolder(uuid, displayName)
             }
-        } catch (e: InternxtApiException) {
-            Log.w(TAG, "renameDocument $documentId failed: ${e.javaClass.simpleName}: ${e.message}")
-            throw FileNotFoundException(e.message)
+            notifyEncodedParent(parent) { encoded ->
+                patchRowDisplayName(encoded, documentId, displayName)
+            }
+            null
         }
-        parentUuid?.let { notifyChildren(it) }
-        return null
-    }
 
     override fun moveDocument(
         sourceDocumentId: String,
         sourceParentDocumentId: String?,
-        targetParentDocumentId: String
-    ): String? {
-        val api = apiClient(op = "moveDocument") ?: throw FileNotFoundException("No auth")
-        val kind = resolveKind(api, sourceDocumentId) ?: throw FileNotFoundException("Not found: $sourceDocumentId")
-        try {
-            when (kind) {
-                ItemKind.FILE -> api.moveFile(sourceDocumentId, targetParentDocumentId)
-                ItemKind.FOLDER -> api.moveFolder(sourceDocumentId, targetParentDocumentId)
-            }
-        } catch (e: InternxtApiException) {
-            Log.w(TAG, "moveDocument $sourceDocumentId failed: ${e.javaClass.simpleName}: ${e.message}")
-            throw FileNotFoundException(e.message)
+        targetParentDocumentId: String,
+    ): String? = mutate("moveDocument", sourceDocumentId) { api, kind, uuid ->
+        val targetUuid = rawUuid(targetParentDocumentId)
+        when (kind) {
+            DocumentId.Kind.FILE -> api.moveFile(uuid, targetUuid)
+            DocumentId.Kind.FOLDER -> api.moveFolder(uuid, targetUuid)
         }
-        sourceParentDocumentId?.let { notifyChildren(it) }
-        notifyChildren(targetParentDocumentId)
-        return null
+        sourceParentDocumentId?.let {
+            removeRow(it, sourceDocumentId)
+            notifyChildren(it)
+        }
+        invalidateChildren(targetParentDocumentId)
+        null
     }
 
     override fun deleteDocument(documentId: String) {
-        val api = apiClient(op = "deleteDocument") ?: throw FileNotFoundException("No auth")
-        val kind = resolveKind(api, documentId) ?: throw FileNotFoundException("Not found: $documentId")
-        val parentUuid: String? = when (kind) {
-            ItemKind.FILE -> api.getFile(documentId)?.folderUuid
-            ItemKind.FOLDER -> api.getFolder(documentId)?.parentUuid
+        mutate("deleteDocument", documentId) { api, kind, uuid ->
+            val parent = parentUuidOf(api, kind, uuid)
+            api.sendToTrash(listOf(TrashItem(uuid, trashTypeOf(kind))))
+            notifyEncodedParent(parent) { encoded ->
+                removeRow(encoded, documentId)
+            }
         }
-        val trashType = if (kind == ItemKind.FILE) TrashItem.Type.FILE else TrashItem.Type.FOLDER
-        try {
-            api.sendToTrash(listOf(TrashItem(documentId, trashType)))
-        } catch (e: InternxtApiException) {
-            Log.w(TAG, "deleteDocument $documentId failed: ${e.javaClass.simpleName}: ${e.message}")
-            throw FileNotFoundException(e.message)
-        }
-        itemKinds.remove(documentId)
-        parentUuid?.let { notifyChildren(it) }
     }
 
-    private fun resolveKind(api: InternxtApiClient, uuid: String): ItemKind? =
-        itemKinds[uuid]
-            ?: api.getFolder(uuid)?.let { itemKinds[uuid] = ItemKind.FOLDER; ItemKind.FOLDER }
-            ?: api.getFile(uuid)?.let { itemKinds[uuid] = ItemKind.FILE; ItemKind.FILE }
+    private inline fun <R> mutate(
+        op: String,
+        documentId: String,
+        block: (api: InternxtApiClient, kind: DocumentId.Kind, uuid: String) -> R,
+    ): R {
+        val api = apiClient(op) ?: throw FileNotFoundException("No auth")
+        val kind = resolveKind(api, documentId) ?: throw FileNotFoundException("Not found: $documentId")
+        return try {
+            block(api, kind, rawUuid(documentId))
+        } catch (e: InternxtApiException) {
+            Log.w(TAG, "$op $documentId failed: ${e.javaClass.simpleName}: ${e.message}")
+            throw FileNotFoundException(e.message)
+        }
+    }
 
-    private fun notifyChildren(parentUuid: String) {
+    private fun parentUuidOf(api: InternxtApiClient, kind: DocumentId.Kind, uuid: String): String? =
+        when (kind) {
+            DocumentId.Kind.FILE -> api.getFile(uuid)?.folderUuid
+            DocumentId.Kind.FOLDER -> api.getFolder(uuid)?.parentUuid
+        }
+
+    private fun trashTypeOf(kind: DocumentId.Kind): TrashItem.Type = when (kind) {
+        DocumentId.Kind.FILE -> TrashItem.Type.FILE
+        DocumentId.Kind.FOLDER -> TrashItem.Type.FOLDER
+    }
+
+    private inline fun notifyEncodedParent(rawParentUuid: String?, mutateCache: (encodedParent: String) -> Unit) {
+        rawParentUuid?.let {
+            val encoded = DocumentId.encodeFolder(it)
+            mutateCache(encoded)
+            notifyChildren(encoded)
+        }
+    }
+
+    private fun rawUuid(documentId: String): String =
+        DocumentId.decode(documentId)?.uuid ?: documentId
+
+    private fun resolveKind(api: InternxtApiClient, documentId: String): DocumentId.Kind? {
+        DocumentId.decode(documentId)?.kind?.let { return it }
+        return api.getFolder(documentId)?.let { DocumentId.Kind.FOLDER }
+            ?: api.getFile(documentId)?.let { DocumentId.Kind.FILE }
+    }
+
+    private fun notifyChildren(parentDocumentId: String) {
         context?.contentResolver?.notifyChange(
-            DocumentsContract.buildChildDocumentsUri(AUTHORITY, parentUuid),
-            null
+            DocumentsContract.buildChildDocumentsUri(AUTHORITY, parentDocumentId),
+            null,
         )
+    }
+
+    private fun invalidateChildren(parentDocumentId: String) {
+        folderLoads.remove(parentDocumentId)
+        notifyChildren(parentDocumentId)
+    }
+
+    private fun patchRowDisplayName(parentDocumentId: String, documentId: String, displayName: String) {
+        updateRows(parentDocumentId) { rows ->
+            val idx = rows.indexOfFirst { it[Document.COLUMN_DOCUMENT_ID] == documentId }
+            if (idx >= 0) rows[idx] = rows[idx] + (Document.COLUMN_DISPLAY_NAME to displayName)
+        }
+    }
+
+    private fun removeRow(parentDocumentId: String, documentId: String) {
+        updateRows(parentDocumentId) { rows ->
+            rows.removeAll { it[Document.COLUMN_DOCUMENT_ID] == documentId }
+        }
+    }
+
+    private inline fun updateRows(
+        parentDocumentId: String,
+        action: (MutableList<Map<String, Any?>>) -> Unit,
+    ) {
+        val load = folderLoads[parentDocumentId] ?: return
+        synchronized(load) { action(load.rows) }
+    }
+
+    override fun refresh(uri: Uri, args: Bundle?, cancellationSignal: CancellationSignal?): Boolean {
+        val documentId = try { DocumentsContract.getDocumentId(uri) } catch (_: Exception) { null }
+        Log.d(TAG, "refresh uri=$uri documentId=$documentId")
+        if (documentId == null) return false
+        invalidateChildren(documentId)
+        return true
     }
 
     override fun openDocument(

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -379,17 +379,15 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         val fileUuid = decoded.uuid
 
         val future = openExecutor.submit<ParcelFileDescriptor> {
-            openDocumentBlocking(ctx, id, mode, signal, fileUuid)
+            openDocumentBlocking(ctx, id, signal, fileUuid)
         }
         return try {
             future.get()
         } catch (e: java.util.concurrent.ExecutionException) {
             val cause = e.cause
-            when (cause) {
-                is FileNotFoundException -> throw cause
-                is UnsupportedOperationException -> throw cause
-                null -> throw FileNotFoundException("openDocument failed: ${e.message}")
-                else -> throw FileNotFoundException("openDocument failed: ${cause.javaClass.simpleName}: ${cause.message}").apply { initCause(cause) }
+            if (cause is FileNotFoundException) throw cause
+            throw FileNotFoundException("openDocument failed: ${cause?.message ?: e.message}").apply {
+                if (cause != null) initCause(cause)
             }
         }
     }
@@ -397,7 +395,6 @@ class InternxtDocumentsProvider : DocumentsProvider() {
     private fun openDocumentBlocking(
         ctx: android.content.Context,
         id: String,
-        mode: String?,
         signal: CancellationSignal?,
         fileUuid: String,
     ): ParcelFileDescriptor {

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -36,6 +36,20 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         val rows = mutableListOf<Map<String, Any?>>()
     }
 
+    private val loaderExecutor = Executors.newSingleThreadExecutor { r ->
+        Thread(r, "InternxtDocsProvider-loader").apply { isDaemon = true }
+    }
+
+    private val folderLoads = ConcurrentHashMap<String, FolderLoad>()
+
+    private enum class LoadState { LOADING, DONE, ERROR }
+
+    private class FolderLoad {
+        @Volatile var state: LoadState = LoadState.LOADING
+        @Volatile var errorMessage: String? = null
+        val rows = mutableListOf<Map<String, Any?>>()
+    }
+
     override fun onCreate(): Boolean {
         val ctx = context ?: return false
         authManager = InternxtAuthManager.create(ctx.applicationContext) ?: return false

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -39,6 +39,10 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         Thread(r, "InternxtDocsProvider-loader").apply { isDaemon = true }
     }
 
+    private val openExecutor = Executors.newCachedThreadPool { r ->
+        Thread(r, "InternxtDocsProvider-open").apply { isDaemon = true }
+    }
+
     private val folderLoads = ConcurrentHashMap<String, FolderLoad>()
 
     private enum class LoadState { LOADING, DONE, ERROR }
@@ -368,21 +372,52 @@ class InternxtDocumentsProvider : DocumentsProvider() {
             throw UnsupportedOperationException("Only read-only access is supported (mode=$mode)")
         }
 
-        val cfg = authManager.loadAuthConfig() ?: throw FileNotFoundException("Not authenticated")
+        val decoded = DocumentId.decode(id)
+        if (decoded?.kind != DocumentId.Kind.FILE) {
+            throw FileNotFoundException("openDocument requires a file id (got=$id)")
+        }
+        val fileUuid = decoded.uuid
+
+        val future = openExecutor.submit<ParcelFileDescriptor> {
+            openDocumentBlocking(ctx, id, mode, signal, fileUuid)
+        }
+        return try {
+            future.get()
+        } catch (e: java.util.concurrent.ExecutionException) {
+            val cause = e.cause
+            when (cause) {
+                is FileNotFoundException -> throw cause
+                is UnsupportedOperationException -> throw cause
+                null -> throw FileNotFoundException("openDocument failed: ${e.message}")
+                else -> throw FileNotFoundException("openDocument failed: ${cause.javaClass.simpleName}: ${cause.message}").apply { initCause(cause) }
+            }
+        }
+    }
+
+    private fun openDocumentBlocking(
+        ctx: android.content.Context,
+        id: String,
+        mode: String?,
+        signal: CancellationSignal?,
+        fileUuid: String,
+    ): ParcelFileDescriptor {
+        val cfg = authManager?.loadAuthConfig() ?: throw FileNotFoundException("Not authenticated")
+        if (cfg.mnemonic.isBlank()) {
+            throw FileNotFoundException("Stored credentials have no mnemonic; sign out and back in")
+        }
         val api = InternxtApiClient(cfg)
 
         val file = try {
-            api.getFile(id) ?: throw FileNotFoundException("File not found: $id")
+            api.getFile(fileUuid) ?: throw FileNotFoundException("File not found: $fileUuid")
         } catch (e: InternxtApiException) {
-            throw FileNotFoundException("getFile $id failed: ${e.message}")
+            throw FileNotFoundException("getFile $fileUuid failed: ${e.message}")
         }
-        val bucket = file.bucket ?: throw FileNotFoundException("File $id has no bucket")
-        val fileId = file.fileId ?: throw FileNotFoundException("File $id has no fileId")
-        val updatedAt = file.updatedAt ?: throw FileNotFoundException("File $id has no updatedAt")
+        val bucket = file.bucket ?: throw FileNotFoundException("File $fileUuid has no bucket")
+        val fileId = file.fileId ?: throw FileNotFoundException("File $fileUuid has no fileId")
+        val updatedAt = file.updatedAt ?: throw FileNotFoundException("File $fileUuid has no updatedAt")
 
         val cacheFile = DocumentCache.cacheFileFor(ctx, id, updatedAt)
         if (cacheFile.exists() && cacheFile.length() > 0) {
-            Log.d(TAG, "openDocument cache hit id=$id")
             return ParcelFileDescriptor.open(cacheFile, ParcelFileDescriptor.MODE_READ_ONLY)
         }
 
@@ -403,7 +438,6 @@ class InternxtDocumentsProvider : DocumentsProvider() {
             tempEnc.delete()
             DocumentCache.pruneSiblings(ctx, id, cacheFile)
 
-            Log.d(TAG, "openDocument cached id=$id size=${cacheFile.length()}")
             return ParcelFileDescriptor.open(
                 cacheFile,
                 ParcelFileDescriptor.MODE_READ_ONLY,
@@ -414,7 +448,6 @@ class InternxtDocumentsProvider : DocumentsProvider() {
             throw FileNotFoundException("openDocument $id cancelled").apply { initCause(e) }
         } catch (e: Exception) {
             tempEnc.delete(); tempDec.delete()
-            Log.w(TAG, "openDocument $id failed: ${e.javaClass.simpleName}: ${e.message}")
             if (e is FileNotFoundException) throw e
             throw FileNotFoundException("openDocument $id failed: ${e.message}").apply { initCause(e) }
         }

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -396,7 +396,12 @@ class InternxtDocumentsProvider : DocumentsProvider() {
             throw FileNotFoundException("Stored credentials have no mnemonic; sign out and back in")
         }
         val api = InternxtApiClient(cfg)
-        val file = requireFileMetadata(api, fileUuid)
+        val file = try {
+            requireFileMetadata(api, fileUuid)
+        } catch (e: FileNotFoundException) {
+            DocumentCache.existingCacheFor(ctx, id)?.let { return openCached(ctx, id, it) }
+            throw e
+        }
 
         val cacheFile = DocumentCache.cacheFileFor(ctx, id, file.updatedAt)
         if (cacheFile.exists() && cacheFile.length() > 0) {

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -2,6 +2,8 @@ package com.internxt.cloud.documents
 
 import android.database.Cursor
 import android.database.MatrixCursor
+import android.net.Uri
+import android.os.Bundle
 import android.os.CancellationSignal
 import android.os.ParcelFileDescriptor
 import android.provider.DocumentsContract
@@ -13,10 +15,26 @@ import com.internxt.cloud.R
 import com.internxt.cloud.documents.api.InternxtApiClient
 import com.internxt.cloud.documents.api.InternxtApiException
 import com.internxt.cloud.documents.auth.InternxtAuthManager
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
 
 class InternxtDocumentsProvider : DocumentsProvider() {
 
     private var authManager: InternxtAuthManager? = null
+
+    private val loaderExecutor = Executors.newSingleThreadExecutor { r ->
+        Thread(r, "InternxtDocsProvider-loader").apply { isDaemon = true }
+    }
+
+    private val folderLoads = ConcurrentHashMap<String, FolderLoad>()
+
+    private enum class LoadState { LOADING, DONE, ERROR }
+
+    private class FolderLoad {
+        @Volatile var state: LoadState = LoadState.LOADING
+        @Volatile var errorMessage: String? = null
+        val rows = mutableListOf<Map<String, Any?>>()
+    }
 
     override fun onCreate(): Boolean {
         val ctx = context ?: return false
@@ -29,11 +47,13 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         val ctx = context ?: return cursor
         cursor.setNotificationUri(ctx.contentResolver, DocumentsContract.buildRootsUri(AUTHORITY))
 
-        val rootUuid = authManager?.authenticatedRootUuid() ?: return cursor
+        val rootUuid = authManager?.authenticatedRootUuid()
+        Log.d(TAG, "queryRoots: isLoggedIn=${authManager.isLoggedIn()} rootUuid=$rootUuid")
+        if (rootUuid == null) return cursor
 
         cursor.newRow().apply {
             add(Root.COLUMN_ROOT_ID, ROOT_ID)
-            add(Root.COLUMN_DOCUMENT_ID, rootUuid)
+            add(Root.COLUMN_DOCUMENT_ID, DocumentId.encodeFolder(rootUuid))
             add(Root.COLUMN_TITLE, ctx.getString(R.string.documents_provider_label))
             authManager?.userEmail()?.let { add(Root.COLUMN_SUMMARY, it) }
             add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_CREATE or Root.FLAG_SUPPORTS_IS_CHILD)
@@ -49,23 +69,30 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         cursor.setNotificationUri(ctx.contentResolver, DocumentsContract.buildDocumentUri(AUTHORITY, id))
         Log.d(TAG, "queryDocument id=$id")
 
-        if (id == authManager.authenticatedRootUuid()) {
+        val decoded = DocumentId.decode(id)
+        val uuid = decoded?.uuid ?: id
+
+        if (decoded?.kind == DocumentId.Kind.FOLDER && uuid == authManager.authenticatedRootUuid()) {
             cursor.addDocumentRow(
-                DocumentRowBuilder.folderRow(id, ctx.getString(R.string.documents_provider_label))
+                DocumentRowBuilder.folderRow(uuid, ctx.getString(R.string.documents_provider_label))
             )
             return cursor
         }
 
         val api = apiClient(op = "queryDocument")
         val row = if (api == null) null else try {
-            api.getFolder(id)?.let { DocumentRowBuilder.folderRow(it) }
-                ?: api.getFile(id)?.let { DocumentRowBuilder.fileRow(it) }
+            when (decoded?.kind) {
+                DocumentId.Kind.FOLDER -> api.getFolder(uuid)?.let { DocumentRowBuilder.folderRow(it) }
+                DocumentId.Kind.FILE -> api.getFile(uuid)?.let { DocumentRowBuilder.fileRow(it) }
+                null -> api.getFolder(uuid)?.let { DocumentRowBuilder.folderRow(it) }
+                    ?: api.getFile(uuid)?.let { DocumentRowBuilder.fileRow(it) }
+            }
         } catch (e: InternxtApiException) {
             Log.w(TAG, "queryDocument id=$id failed: ${e.javaClass.simpleName}: ${e.message}")
             null
         }
 
-        cursor.addDocumentRow(row ?: DocumentRowBuilder.folderRow(uuid = id, displayName = id))
+        cursor.addDocumentRow(row ?: DocumentRowBuilder.folderRow(uuid = uuid, displayName = uuid))
         return cursor
     }
 
@@ -77,28 +104,75 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         val cursor = MatrixCursor(resolveDocumentProjection(projection))
         val ctx = context ?: return cursor
         val parent = parentDocumentId ?: return cursor
-        cursor.setNotificationUri(
-            ctx.contentResolver,
-            DocumentsContract.buildChildDocumentsUri(AUTHORITY, parent)
-        )
+        val notifyUri = DocumentsContract.buildChildDocumentsUri(AUTHORITY, parent)
+        cursor.setNotificationUri(ctx.contentResolver, notifyUri)
         Log.d(TAG, "queryChildDocuments parent=$parent")
 
-        val api = apiClient(op = "queryChildDocuments") ?: return cursor
-
-        try {
-            paginate({ offset, size -> api.listFolderFolders(parent, offset, size) }) {
-                cursor.addDocumentRow(DocumentRowBuilder.folderRow(it))
-            }
-            paginate({ offset, size -> api.listFolderFiles(parent, offset, size) }) {
-                cursor.addDocumentRow(DocumentRowBuilder.fileRow(it))
-            }
-            Log.d(TAG, "queryChildDocuments parent=$parent rows=${cursor.count}")
-        } catch (e: InternxtApiException) {
-            Log.w(TAG, "queryChildDocuments parent=$parent failed: ${e.javaClass.simpleName}: ${e.message}")
+        val decoded = DocumentId.decode(parent)
+        if (decoded?.kind == DocumentId.Kind.FILE) {
+            Log.w(TAG, "queryChildDocuments called with file id=$parent")
             return cursor
         }
+        val parentUuid = decoded?.uuid ?: parent
 
+        val load = folderLoads.computeIfAbsent(parent) {
+            FolderLoad().also { startBackgroundLoad(parentUuid, it, notifyUri) }
+        }
+
+        val snapshot: List<Map<String, Any?>>
+        val state: LoadState
+        val errorMessage: String?
+        synchronized(load) {
+            snapshot = load.rows.toList()
+            state = load.state
+            errorMessage = load.errorMessage
+        }
+        snapshot.forEach { cursor.addDocumentRow(it) }
+
+        cursor.extras = Bundle().apply {
+            putBoolean(DocumentsContract.EXTRA_LOADING, state == LoadState.LOADING)
+            if (state == LoadState.ERROR && errorMessage != null) {
+                putString(DocumentsContract.EXTRA_ERROR, errorMessage)
+            }
+        }
         return cursor
+    }
+
+    private fun startBackgroundLoad(parent: String, load: FolderLoad, notifyUri: Uri) {
+        loaderExecutor.execute {
+            val api = apiClient(op = "queryChildDocuments[bg]")
+            if (api == null) {
+                finishLoad(load, notifyUri, LoadState.ERROR, "Not authenticated")
+                return@execute
+            }
+            try {
+                streamPages({ offset, size -> api.listFolderFolders(parent, offset, size) }) { page ->
+                    appendRows(load, notifyUri, page.map { DocumentRowBuilder.folderRow(it) })
+                }
+                streamPages({ offset, size -> api.listFolderFiles(parent, offset, size) }) { page ->
+                    appendRows(load, notifyUri, page.map { DocumentRowBuilder.fileRow(it) })
+                }
+                finishLoad(load, notifyUri, LoadState.DONE, null)
+                Log.d(TAG, "queryChildDocuments parent=$parent loaded rows=${load.rows.size}")
+            } catch (e: InternxtApiException) {
+                Log.w(TAG, "queryChildDocuments parent=$parent failed: ${e.javaClass.simpleName}: ${e.message}")
+                finishLoad(load, notifyUri, LoadState.ERROR, e.message)
+            }
+        }
+    }
+
+    private fun appendRows(load: FolderLoad, notifyUri: Uri, rows: List<Map<String, Any?>>) {
+        if (rows.isEmpty()) return
+        synchronized(load) { load.rows.addAll(rows) }
+        context?.contentResolver?.notifyChange(notifyUri, null)
+    }
+
+    private fun finishLoad(load: FolderLoad, notifyUri: Uri, state: LoadState, errorMessage: String?) {
+        synchronized(load) {
+            load.state = state
+            load.errorMessage = errorMessage
+        }
+        context?.contentResolver?.notifyChange(notifyUri, null)
     }
 
     private fun apiClient(op: String): InternxtApiClient? {
@@ -110,12 +184,12 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         return InternxtApiClient(cfg)
     }
 
-    private inline fun <T> paginate(fetch: (offset: Int, size: Int) -> List<T>, onItem: (T) -> Unit) {
+    private inline fun <T> streamPages(fetch: (offset: Int, size: Int) -> List<T>, onPage: (List<T>) -> Unit) {
         val pageSize = InternxtApiClient.DEFAULT_PAGE_SIZE
         var offset = 0
         while (true) {
             val page = fetch(offset, pageSize)
-            page.forEach(onItem)
+            onPage(page)
             if (page.size < pageSize) break
             offset += pageSize
         }

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -14,29 +14,13 @@ import android.util.Log
 import com.internxt.cloud.R
 import com.internxt.cloud.documents.api.InternxtApiClient
 import com.internxt.cloud.documents.api.InternxtApiException
-import com.internxt.cloud.documents.api.model.TrashItem
 import com.internxt.cloud.documents.auth.InternxtAuthManager
-import java.io.FileNotFoundException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 
 class InternxtDocumentsProvider : DocumentsProvider() {
 
     private var authManager: InternxtAuthManager? = null
-
-    private val loaderExecutor = Executors.newSingleThreadExecutor { r ->
-        Thread(r, "InternxtDocsProvider-loader").apply { isDaemon = true }
-    }
-
-    private val folderLoads = ConcurrentHashMap<String, FolderLoad>()
-
-    private enum class LoadState { LOADING, DONE, ERROR }
-
-    private class FolderLoad {
-        @Volatile var state: LoadState = LoadState.LOADING
-        @Volatile var errorMessage: String? = null
-        val rows = mutableListOf<Map<String, Any?>>()
-    }
 
     private val loaderExecutor = Executors.newSingleThreadExecutor { r ->
         Thread(r, "InternxtDocsProvider-loader").apply { isDaemon = true }
@@ -97,7 +81,12 @@ class InternxtDocumentsProvider : DocumentsProvider() {
 
         val api = apiClient(op = "queryDocument")
         val row = if (api == null) null else try {
-            fetchDocumentRow(api, decoded?.kind, uuid)
+            when (decoded?.kind) {
+                DocumentId.Kind.FOLDER -> api.getFolder(uuid)?.let { DocumentRowBuilder.folderRow(it) }
+                DocumentId.Kind.FILE -> api.getFile(uuid)?.let { DocumentRowBuilder.fileRow(it) }
+                null -> api.getFolder(uuid)?.let { DocumentRowBuilder.folderRow(it) }
+                    ?: api.getFile(uuid)?.let { DocumentRowBuilder.fileRow(it) }
+            }
         } catch (e: InternxtApiException) {
             Log.w(TAG, "queryDocument id=$id failed: ${e.javaClass.simpleName}: ${e.message}")
             null
@@ -105,17 +94,6 @@ class InternxtDocumentsProvider : DocumentsProvider() {
 
         cursor.addDocumentRow(row ?: DocumentRowBuilder.folderRow(uuid = uuid, displayName = uuid))
         return cursor
-    }
-
-    private fun fetchDocumentRow(
-        api: InternxtApiClient,
-        kind: DocumentId.Kind?,
-        uuid: String,
-    ): Map<String, Any?>? = when (kind) {
-        DocumentId.Kind.FOLDER -> api.getFolder(uuid)?.let(DocumentRowBuilder::folderRow)
-        DocumentId.Kind.FILE -> api.getFile(uuid)?.let(DocumentRowBuilder::fileRow)
-        null -> api.getFolder(uuid)?.let(DocumentRowBuilder::folderRow)
-            ?: api.getFile(uuid)?.let(DocumentRowBuilder::fileRow)
     }
 
     override fun queryChildDocuments(
@@ -220,131 +198,6 @@ class InternxtDocumentsProvider : DocumentsProvider() {
     private fun MatrixCursor.addDocumentRow(row: Map<String, Any?>) {
         val builder = newRow()
         row.forEach { (column, value) -> builder.add(column, value) }
-    }
-
-    override fun renameDocument(documentId: String, displayName: String): String? =
-        mutate("renameDocument", documentId) { api, kind, uuid ->
-            val parent = parentUuidOf(api, kind, uuid)
-            when (kind) {
-                DocumentId.Kind.FILE -> api.renameFile(uuid, displayName)
-                DocumentId.Kind.FOLDER -> api.renameFolder(uuid, displayName)
-            }
-            notifyEncodedParent(parent) { encoded ->
-                patchRowDisplayName(encoded, documentId, displayName)
-            }
-            null
-        }
-
-    override fun moveDocument(
-        sourceDocumentId: String,
-        sourceParentDocumentId: String?,
-        targetParentDocumentId: String,
-    ): String? = mutate("moveDocument", sourceDocumentId) { api, kind, uuid ->
-        val targetUuid = rawUuid(targetParentDocumentId)
-        when (kind) {
-            DocumentId.Kind.FILE -> api.moveFile(uuid, targetUuid)
-            DocumentId.Kind.FOLDER -> api.moveFolder(uuid, targetUuid)
-        }
-        sourceParentDocumentId?.let {
-            removeRow(it, sourceDocumentId)
-            notifyChildren(it)
-        }
-        invalidateChildren(targetParentDocumentId)
-        null
-    }
-
-    override fun deleteDocument(documentId: String) {
-        mutate("deleteDocument", documentId) { api, kind, uuid ->
-            val parent = parentUuidOf(api, kind, uuid)
-            api.sendToTrash(listOf(TrashItem(uuid, trashTypeOf(kind))))
-            notifyEncodedParent(parent) { encoded ->
-                removeRow(encoded, documentId)
-            }
-        }
-    }
-
-    private inline fun <R> mutate(
-        op: String,
-        documentId: String,
-        block: (api: InternxtApiClient, kind: DocumentId.Kind, uuid: String) -> R,
-    ): R {
-        val api = apiClient(op) ?: throw FileNotFoundException("No auth")
-        val kind = resolveKind(api, documentId) ?: throw FileNotFoundException("Not found: $documentId")
-        return try {
-            block(api, kind, rawUuid(documentId))
-        } catch (e: InternxtApiException) {
-            Log.w(TAG, "$op $documentId failed: ${e.javaClass.simpleName}: ${e.message}")
-            throw FileNotFoundException(e.message)
-        }
-    }
-
-    private fun parentUuidOf(api: InternxtApiClient, kind: DocumentId.Kind, uuid: String): String? =
-        when (kind) {
-            DocumentId.Kind.FILE -> api.getFile(uuid)?.folderUuid
-            DocumentId.Kind.FOLDER -> api.getFolder(uuid)?.parentUuid
-        }
-
-    private fun trashTypeOf(kind: DocumentId.Kind): TrashItem.Type = when (kind) {
-        DocumentId.Kind.FILE -> TrashItem.Type.FILE
-        DocumentId.Kind.FOLDER -> TrashItem.Type.FOLDER
-    }
-
-    private inline fun notifyEncodedParent(rawParentUuid: String?, mutateCache: (encodedParent: String) -> Unit) {
-        rawParentUuid?.let {
-            val encoded = DocumentId.encodeFolder(it)
-            mutateCache(encoded)
-            notifyChildren(encoded)
-        }
-    }
-
-    private fun rawUuid(documentId: String): String =
-        DocumentId.decode(documentId)?.uuid ?: documentId
-
-    private fun resolveKind(api: InternxtApiClient, documentId: String): DocumentId.Kind? {
-        DocumentId.decode(documentId)?.kind?.let { return it }
-        return api.getFolder(documentId)?.let { DocumentId.Kind.FOLDER }
-            ?: api.getFile(documentId)?.let { DocumentId.Kind.FILE }
-    }
-
-    private fun notifyChildren(parentDocumentId: String) {
-        context?.contentResolver?.notifyChange(
-            DocumentsContract.buildChildDocumentsUri(AUTHORITY, parentDocumentId),
-            null,
-        )
-    }
-
-    private fun invalidateChildren(parentDocumentId: String) {
-        folderLoads.remove(parentDocumentId)
-        notifyChildren(parentDocumentId)
-    }
-
-    private fun patchRowDisplayName(parentDocumentId: String, documentId: String, displayName: String) {
-        updateRows(parentDocumentId) { rows ->
-            val idx = rows.indexOfFirst { it[Document.COLUMN_DOCUMENT_ID] == documentId }
-            if (idx >= 0) rows[idx] = rows[idx] + (Document.COLUMN_DISPLAY_NAME to displayName)
-        }
-    }
-
-    private fun removeRow(parentDocumentId: String, documentId: String) {
-        updateRows(parentDocumentId) { rows ->
-            rows.removeAll { it[Document.COLUMN_DOCUMENT_ID] == documentId }
-        }
-    }
-
-    private inline fun updateRows(
-        parentDocumentId: String,
-        action: (MutableList<Map<String, Any?>>) -> Unit,
-    ) {
-        val load = folderLoads[parentDocumentId] ?: return
-        synchronized(load) { action(load.rows) }
-    }
-
-    override fun refresh(uri: Uri, args: Bundle?, cancellationSignal: CancellationSignal?): Boolean {
-        val documentId = try { DocumentsContract.getDocumentId(uri) } catch (_: Exception) { null }
-        Log.d(TAG, "refresh uri=$uri documentId=$documentId")
-        if (documentId == null) return false
-        invalidateChildren(documentId)
-        return true
     }
 
     override fun openDocument(

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -16,7 +16,8 @@ class InternxtDocumentsProvider : DocumentsProvider() {
     private lateinit var authManager: InternxtAuthManager
 
     override fun onCreate(): Boolean {
-        authManager = InternxtAuthManager.create(context!!.applicationContext)
+        val ctx = context ?: return false
+        authManager = InternxtAuthManager.create(ctx.applicationContext) ?: return false
         return true
     }
 

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -13,7 +13,7 @@ import com.internxt.cloud.documents.auth.InternxtAuthManager
 
 class InternxtDocumentsProvider : DocumentsProvider() {
 
-    private lateinit var authManager: InternxtAuthManager
+    private var authManager: InternxtAuthManager? = null
 
     override fun onCreate(): Boolean {
         val ctx = context ?: return false
@@ -26,13 +26,13 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         val ctx = context ?: return cursor
         cursor.setNotificationUri(ctx.contentResolver, DocumentsContract.buildRootsUri(AUTHORITY))
 
-        val rootUuid = authManager.authenticatedRootUuid() ?: return cursor
+        val rootUuid = authManager?.authenticatedRootUuid() ?: return cursor
 
         cursor.newRow().apply {
             add(Root.COLUMN_ROOT_ID, ROOT_ID)
             add(Root.COLUMN_DOCUMENT_ID, rootUuid)
             add(Root.COLUMN_TITLE, ctx.getString(R.string.documents_provider_label))
-            authManager.userEmail()?.let { add(Root.COLUMN_SUMMARY, it) }
+            authManager?.userEmail()?.let { add(Root.COLUMN_SUMMARY, it) }
             add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_CREATE or Root.FLAG_SUPPORTS_IS_CHILD)
             add(Root.COLUMN_ICON, R.mipmap.ic_launcher)
         }

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -21,14 +21,14 @@ import com.internxt.cloud.documents.api.model.TrashItem
 import com.internxt.cloud.documents.auth.InternxtAuthManager
 import com.internxt.cloud.documents.cache.DocumentCache
 import com.internxt.cloud.documents.crypto.FileKeyDeriver
+import com.internxt.cloud.documents.crypto.toHex
 import com.internxt.cloud.documents.download.EncryptedFileDownloader
+import com.internxt.cloud.documents.http.HttpClients
 import com.rncrypto.util.CryptoService
-import okhttp3.OkHttpClient
 import java.io.File
 import java.io.FileNotFoundException
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.Executors
 
 class InternxtDocumentsProvider : DocumentsProvider() {
@@ -54,20 +54,13 @@ class InternxtDocumentsProvider : DocumentsProvider() {
     }
     private val itemKinds = ConcurrentHashMap<String, ItemKind>()
     private lateinit var closeHandler: Handler
-    private val downloadClient: OkHttpClient by lazy {
-        OkHttpClient.Builder()
-            .connectTimeout(30, TimeUnit.SECONDS)
-            .readTimeout(2, TimeUnit.MINUTES)
-            .writeTimeout(2, TimeUnit.MINUTES)
-            .callTimeout(0, TimeUnit.MILLISECONDS)
-            .build()
-    }
 
     private enum class ItemKind { FILE, FOLDER }
 
     override fun onCreate(): Boolean {
         val ctx = context ?: return false
         authManager = InternxtAuthManager.create(ctx.applicationContext) ?: return false
+        // Process-scoped: ContentProvider has no shutdown hook, so the thread lives until the process dies.
         closeHandler = Handler(HandlerThread("InternxtDocsClose").apply { start() }.looper)
         return true
     }
@@ -403,56 +396,82 @@ class InternxtDocumentsProvider : DocumentsProvider() {
             throw FileNotFoundException("Stored credentials have no mnemonic; sign out and back in")
         }
         val api = InternxtApiClient(cfg)
+        val file = requireFileMetadata(api, fileUuid)
 
+        val cacheFile = DocumentCache.cacheFileFor(ctx, id, file.updatedAt)
+        if (cacheFile.exists() && cacheFile.length() > 0) {
+            return openCached(ctx, id, cacheFile)
+        }
+        materializeIntoCache(ctx, id, api, cfg.mnemonic, file, cacheFile, signal)
+        return openCached(ctx, id, cacheFile)
+    }
+
+    private data class FileMetadata(
+        val bucket: String,
+        val fileId: String,
+        val updatedAt: String,
+    )
+
+    private fun requireFileMetadata(api: InternxtApiClient, fileUuid: String): FileMetadata {
         val file = try {
             api.getFile(fileUuid) ?: throw FileNotFoundException("File not found: $fileUuid")
         } catch (e: InternxtApiException) {
             throw FileNotFoundException("getFile $fileUuid failed: ${e.message}")
         }
-        val bucket = file.bucket ?: throw FileNotFoundException("File $fileUuid has no bucket")
-        val fileId = file.fileId ?: throw FileNotFoundException("File $fileUuid has no fileId")
-        val updatedAt = file.updatedAt ?: throw FileNotFoundException("File $fileUuid has no updatedAt")
+        return FileMetadata(
+            bucket = file.bucket ?: throw FileNotFoundException("File $fileUuid has no bucket"),
+            fileId = file.fileId ?: throw FileNotFoundException("File $fileUuid has no fileId"),
+            updatedAt = file.updatedAt ?: throw FileNotFoundException("File $fileUuid has no updatedAt"),
+        )
+    }
 
-        val cacheFile = DocumentCache.cacheFileFor(ctx, id, updatedAt)
-        if (cacheFile.exists() && cacheFile.length() > 0) {
-            return ParcelFileDescriptor.open(cacheFile, ParcelFileDescriptor.MODE_READ_ONLY)
-        }
-
+    private fun materializeIntoCache(
+        ctx: android.content.Context,
+        id: String,
+        api: InternxtApiClient,
+        mnemonic: String,
+        file: FileMetadata,
+        cacheFile: File,
+        signal: CancellationSignal?,
+    ) {
         val (tempEnc, tempDec) = DocumentCache.tempPaths(ctx, id)
         try {
             signal?.throwIfCanceled()
-            val links = api.getDownloadLinks(bucket, fileId)
-            EncryptedFileDownloader.download(downloadClient, links.shards, tempEnc, signal)
+            val links = api.getDownloadLinks(file.bucket, file.fileId)
+            EncryptedFileDownloader.download(HttpClients.download, links.shards, tempEnc, signal)
 
             signal?.throwIfCanceled()
-            val key = FileKeyDeriver.deriveFileKey(cfg.mnemonic, bucket, links.index)
+            val key = FileKeyDeriver.deriveFileKey(mnemonic, file.bucket, links.index)
             val iv = FileKeyDeriver.deriveIv(links.index)
-            decryptBlocking(tempEnc, tempDec, FileKeyDeriver.toHex(key), FileKeyDeriver.toHex(iv))
+            decryptBlocking(tempEnc, tempDec, key.toHex(), iv.toHex())
 
             if (!tempDec.renameTo(cacheFile)) {
                 throw FileNotFoundException("Failed to promote temp file to cache for $id")
             }
             tempEnc.delete()
             DocumentCache.pruneSiblings(ctx, id, cacheFile)
-
-            return ParcelFileDescriptor.open(
-                cacheFile,
-                ParcelFileDescriptor.MODE_READ_ONLY,
-                closeHandler,
-            ) { DocumentCache.deleteTempsFor(ctx, id) }
-        } catch (e: OperationCanceledException) {
-            tempEnc.delete(); tempDec.delete()
-            throw FileNotFoundException("openDocument $id cancelled").apply { initCause(e) }
         } catch (e: Exception) {
-            tempEnc.delete(); tempDec.delete()
-            if (e is FileNotFoundException) throw e
-            throw FileNotFoundException("openDocument $id failed: ${e.message}").apply { initCause(e) }
+            tempEnc.delete()
+            tempDec.delete()
+            throw when (e) {
+                is FileNotFoundException -> e
+                is OperationCanceledException ->
+                    FileNotFoundException("openDocument $id cancelled").apply { initCause(e) }
+                else ->
+                    FileNotFoundException("openDocument $id failed: ${e.message}").apply { initCause(e) }
+            }
         }
     }
 
+    private fun openCached(ctx: android.content.Context, id: String, cacheFile: File): ParcelFileDescriptor =
+        ParcelFileDescriptor.open(
+            cacheFile,
+            ParcelFileDescriptor.MODE_READ_ONLY,
+            closeHandler,
+        ) { DocumentCache.deleteTempsFor(ctx, id) }
+
     private fun decryptBlocking(src: File, dst: File, hexKey: String, hexIv: String) {
-        val latch = CountDownLatch(1)
-        val errorRef = arrayOfNulls<Exception>(1)
+        val done = CompletableFuture<Unit>()
         CryptoService.getInstance().decryptFile(
             src.absolutePath,
             dst.absolutePath,
@@ -460,11 +479,13 @@ class InternxtDocumentsProvider : DocumentsProvider() {
             hexIv,
             /* runInBackground = */ true,
         ) { err ->
-            errorRef[0] = err
-            latch.countDown()
+            if (err != null) done.completeExceptionally(err) else done.complete(Unit)
         }
-        latch.await()
-        errorRef[0]?.let { throw it }
+        try {
+            done.get()
+        } catch (e: java.util.concurrent.ExecutionException) {
+            throw e.cause ?: e
+        }
     }
 
     private fun resolveRootProjection(projection: Array<String>?): Array<String> =

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -543,9 +543,9 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         } catch (e: Exception) {
             tempEnc.delete()
             tempDec.delete()
-            throw when (e) {
-                is FileNotFoundException -> e
-                is CancellationException -> e
+            throw when {
+                e is FileNotFoundException -> e
+                isCancellation(e) -> e
                 else ->
                     FileNotFoundException("openDocument $id failed: ${e.message}").apply { initCause(e) }
             }

--- a/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/InternxtDocumentsProvider.kt
@@ -43,6 +43,14 @@ import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlin.coroutines.coroutineContext
 
 class InternxtDocumentsProvider : DocumentsProvider() {
 
@@ -52,9 +60,7 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         Thread(r, "InternxtDocsProvider-loader").apply { isDaemon = true }
     }
 
-    private val openExecutor = Executors.newCachedThreadPool { r ->
-        Thread(r, "InternxtDocsProvider-open").apply { isDaemon = true }
-    }
+    private val uploadScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     private val folderLoads = ConcurrentHashMap<String, FolderLoad>()
     private val pendingUploads = ConcurrentHashMap<String, PendingUpload>()
@@ -64,6 +70,7 @@ class InternxtDocumentsProvider : DocumentsProvider() {
     private class FolderLoad {
         @Volatile var state: LoadState = LoadState.LOADING
         @Volatile var errorMessage: String? = null
+        @Volatile var isRevalidating: Boolean = false
         val rows = mutableListOf<Map<String, Any?>>()
     }
     private val itemKinds = ConcurrentHashMap<String, ItemKind>()
@@ -82,6 +89,7 @@ class InternxtDocumentsProvider : DocumentsProvider() {
 
     override fun shutdown() {
         if (activeInstance === this) activeInstance = null
+        uploadScope.cancel()
         super.shutdown()
     }
 
@@ -377,8 +385,57 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         val documentId = try { DocumentsContract.getDocumentId(uri) } catch (_: Exception) { null }
         Log.d(TAG, "refresh uri=$uri documentId=$documentId")
         if (documentId == null) return false
-        invalidateChildren(documentId)
+        revalidateChildren(documentId)
         return true
+    }
+
+    private fun revalidateChildren(parentDocumentId: String) {
+        val load = folderLoads[parentDocumentId]
+        if (load == null) {
+            notifyChildren(parentDocumentId)
+            return
+        }
+        synchronized(load) {
+            if (load.state == LoadState.LOADING || load.isRevalidating) return
+            load.isRevalidating = true
+        }
+        val parentUuid = rawUuid(parentDocumentId)
+        val notifyUri = DocumentsContract.buildChildDocumentsUri(AUTHORITY, parentDocumentId)
+        loaderExecutor.execute { revalidate(parentUuid, load, notifyUri) }
+    }
+
+    private fun revalidate(parentUuid: String, load: FolderLoad, notifyUri: Uri) {
+        val api = apiClient(op = "refresh[bg]")
+        if (api == null) {
+            synchronized(load) { load.isRevalidating = false }
+            return
+        }
+        try {
+            val fresh = fetchAllRows(api, parentUuid)
+            synchronized(load) {
+                load.rows.clear()
+                load.rows.addAll(fresh)
+                load.state = LoadState.DONE
+                load.errorMessage = null
+                load.isRevalidating = false
+            }
+            context?.contentResolver?.notifyChange(notifyUri, null)
+            Log.d(TAG, "refresh parent=$parentUuid revalidated rows=${fresh.size}")
+        } catch (e: InternxtApiException) {
+            synchronized(load) { load.isRevalidating = false }
+            Log.w(TAG, "refresh parent=$parentUuid revalidation failed: ${e.javaClass.simpleName}: ${e.message}")
+        }
+    }
+
+    private fun fetchAllRows(api: InternxtApiClient, parentUuid: String): List<Map<String, Any?>> {
+        val rows = mutableListOf<Map<String, Any?>>()
+        streamPages({ offset, size -> api.listFolderFolders(parentUuid, offset, size) }) { page ->
+            rows.addAll(page.map { DocumentRowBuilder.folderRow(it) })
+        }
+        streamPages({ offset, size -> api.listFolderFiles(parentUuid, offset, size) }) { page ->
+            rows.addAll(page.map { DocumentRowBuilder.fileRow(it) })
+        }
+        return rows
     }
 
     override fun openDocument(
@@ -402,24 +459,24 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         }
         val fileUuid = decoded.uuid
 
-        val future = openExecutor.submit<ParcelFileDescriptor> {
-            openDocumentBlocking(ctx, id, signal, fileUuid)
-        }
         return try {
-            future.get()
-        } catch (e: java.util.concurrent.ExecutionException) {
-            val cause = e.cause
-            if (cause is FileNotFoundException) throw cause
-            throw FileNotFoundException("openDocument failed: ${cause?.message ?: e.message}").apply {
-                if (cause != null) initCause(cause)
+            runBlockingIo {
+                signal?.setOnCancelListener { coroutineContext.cancel() }
+                openDocumentSuspending(ctx, id, fileUuid)
             }
+        } catch (e: FileNotFoundException) {
+            throw e
+        } catch (e: CancellationException) {
+            throw FileNotFoundException("openDocument $id cancelled").apply { initCause(e) }
+        } catch (e: Exception) {
+            Log.w(TAG, "openDocument $id failed", e)
+            throw FileNotFoundException("openDocument failed: ${e.message}").apply { initCause(e) }
         }
     }
 
-    private fun openDocumentBlocking(
+    private suspend fun openDocumentSuspending(
         ctx: Context,
         id: String,
-        signal: CancellationSignal?,
         fileUuid: String,
     ): ParcelFileDescriptor {
         val cfg = authManager?.loadAuthConfig() ?: throw FileNotFoundException(NOT_AUTHENTICATED)
@@ -438,7 +495,7 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         if (cacheFile.exists() && cacheFile.length() > 0) {
             return openCached(ctx, id, cacheFile)
         }
-        materializeIntoCache(ctx, id, api, cfg.mnemonic, file, cacheFile, signal)
+        materializeIntoCache(ctx, id, api, cfg.mnemonic, file, cacheFile)
         return openCached(ctx, id, cacheFile)
     }
 
@@ -461,25 +518,22 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         )
     }
 
-    private fun materializeIntoCache(
+    private suspend fun materializeIntoCache(
         ctx: Context,
         id: String,
         api: InternxtApiClient,
         mnemonic: String,
         file: FileMetadata,
         cacheFile: File,
-        signal: CancellationSignal?,
     ) {
         val (tempEnc, tempDec) = DocumentCache.tempPaths(ctx, id)
         try {
-            signal?.throwIfCanceled()
             val links = api.getDownloadLinks(file.bucket, file.fileId)
-            EncryptedFileDownloader.download(HttpClients.download, links.shards, tempEnc, signal)
+            EncryptedFileDownloader.download(HttpClients.download, links.shards, tempEnc)
 
-            signal?.throwIfCanceled()
             val key = FileKeyDeriver.deriveFileKey(mnemonic, file.bucket, links.index)
             val iv = FileKeyDeriver.deriveIv(links.index)
-            decryptBlocking(tempEnc, tempDec, key.toHex(), iv.toHex())
+            decryptFile(tempEnc, tempDec, key.toHex(), iv.toHex())
 
             if (!tempDec.renameTo(cacheFile)) {
                 throw FileNotFoundException("Failed to promote temp file to cache for $id")
@@ -491,8 +545,7 @@ class InternxtDocumentsProvider : DocumentsProvider() {
             tempDec.delete()
             throw when (e) {
                 is FileNotFoundException -> e
-                is OperationCanceledException ->
-                    FileNotFoundException("openDocument $id cancelled").apply { initCause(e) }
+                is CancellationException -> e
                 else ->
                     FileNotFoundException("openDocument $id failed: ${e.message}").apply { initCause(e) }
             }
@@ -619,9 +672,10 @@ class InternxtDocumentsProvider : DocumentsProvider() {
             val pipe = ParcelFileDescriptor.createReliablePipe()
             val readEnd = pipe[0]
             val writeEnd = pipe[1]
-            openExecutor.execute {
-                runUpload(ctx, token, pending, cfg, readEnd, signal)
+            val job: Job = uploadScope.launch {
+                runUpload(ctx, token, pending, cfg, readEnd)
             }
+            signal?.setOnCancelListener { job.cancel() }
             return writeEnd
         } catch (t: Throwable) {
             pendingUploads.remove(token)
@@ -629,17 +683,17 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         }
     }
 
-    private fun runUpload(
+    private suspend fun runUpload(
         ctx: Context,
         token: String,
         pending: PendingUpload,
         cfg: AuthConfig,
         readEnd: ParcelFileDescriptor,
-        signal: CancellationSignal?,
     ) {
         val temps = uploadTempsFor(ctx, token)
+        val uploadJob = coroutineContext[Job]
         val uploadSignal = CancellationSignal()
-        signal?.setOnCancelListener { uploadSignal.cancel() }
+        uploadSignal.setOnCancelListener { uploadJob?.cancel() }
         UploadForegroundService.start(ctx, token, pending.plainName, uploadSignal)
 
         var failure: Throwable? = null
@@ -648,11 +702,11 @@ class InternxtDocumentsProvider : DocumentsProvider() {
             val bucketId = resolveBucket(api, pending.parentUuid)
             val crypto = prepareEncryption(cfg.mnemonic, bucketId)
             val encrypted = encryptInputToTemp(token, temps, readEnd, crypto, uploadSignal)
-            val outcome = uploadEncryptedFile(token, api, temps.enc, bucketId, encrypted, uploadSignal)
+            val outcome = uploadEncryptedFile(token, api, temps.enc, bucketId, encrypted)
             finalizeAndRecordFile(api, pending, bucketId, crypto.indexHex, encrypted.size, outcome)
             invalidateChildren(DocumentId.encodeFolder(pending.parentUuid))
         } catch (t: Throwable) {
-            if (t !is OperationCanceledException) {
+            if (!isCancellation(t)) {
                 Log.w(TAG, "upload failed token=$token: ${t.javaClass.simpleName}: ${t.message}")
             }
             failure = t
@@ -664,6 +718,9 @@ class InternxtDocumentsProvider : DocumentsProvider() {
             notifyServiceOfOutcome(ctx, token, failure)
         }
     }
+
+    private fun isCancellation(t: Throwable): Boolean =
+        t is OperationCanceledException || t is CancellationException
 
     /** `tempEnc` holds the ciphertext PUT to bridge; `plain` holds the pipe's plaintext
      *  while we hand it to CryptoService (which only accepts file paths). */
@@ -690,7 +747,7 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         )
     }
 
-    private fun encryptInputToTemp(
+    private suspend fun encryptInputToTemp(
         token: String,
         temps: UploadTemps,
         readEnd: ParcelFileDescriptor,
@@ -739,13 +796,12 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         }
     }
 
-    private fun uploadEncryptedFile(
+    private suspend fun uploadEncryptedFile(
         token: String,
         api: InternxtApiClient,
         tempEnc: File,
         bucketId: String,
         encrypted: EncryptedFileUploader.Encrypted,
-        signal: CancellationSignal,
     ): UploadOutcome {
         val partsCount = if (encrypted.size >= MULTIPART_THRESHOLD) {
             ((encrypted.size + MULTIPART_PART_SIZE - 1) / MULTIPART_PART_SIZE).toInt().coerceAtLeast(1)
@@ -763,14 +819,14 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         return when (slot) {
             is UploadSlot.Single -> {
                 EncryptedFileUploader.uploadSingle(
-                    HttpClients.upload, tempEnc, slot.url, signal, onProgress,
+                    HttpClients.upload, tempEnc, slot.url, onProgress,
                 )
                 UploadOutcome.Single(slot.uuid, listOf(encrypted.wholeSha256Hex))
             }
             is UploadSlot.Multipart -> {
                 val partHashes = EncryptedFileUploader.computePartSha256(tempEnc, MULTIPART_PART_SIZE)
                 val parts = EncryptedFileUploader.uploadMultipart(
-                    HttpClients.upload, tempEnc, slot.urls, MULTIPART_PART_SIZE, signal, onProgress,
+                    HttpClients.upload, tempEnc, slot.urls, MULTIPART_PART_SIZE, onProgress,
                 )
                 UploadOutcome.Multipart(slot.uuid, partHashes, parts, slot.uploadId)
             }
@@ -834,7 +890,7 @@ class InternxtDocumentsProvider : DocumentsProvider() {
     private fun notifyServiceOfOutcome(ctx: Context, token: String, failure: Throwable?) {
         when {
             failure == null -> UploadForegroundService.complete(token)
-            failure is OperationCanceledException -> UploadForegroundService.complete(token)
+            isCancellation(failure) -> UploadForegroundService.complete(token)
             else -> UploadForegroundService.fail(token, friendlyUploadError(ctx, failure))
         }
     }
@@ -902,7 +958,7 @@ class InternxtDocumentsProvider : DocumentsProvider() {
         Document.COLUMN_SIZE to null,
     )
 
-    private fun decryptBlocking(src: File, dst: File, hexKey: String, hexIv: String) {
+    private suspend fun decryptFile(src: File, dst: File, hexKey: String, hexIv: String) {
         awaitCryptoService("Decryption failed") { cb ->
             CryptoService.getInstance().decryptFile(
                 src.absolutePath,

--- a/android/app/src/main/java/com/internxt/cloud/documents/MimeTypes.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/MimeTypes.kt
@@ -1,0 +1,45 @@
+package com.internxt.cloud.documents
+
+import android.webkit.MimeTypeMap
+
+object MimeTypes {
+
+    const val DEFAULT = "application/octet-stream"
+
+    private val TABLE = mapOf(
+        "pdf" to "application/pdf",
+        "png" to "image/png",
+        "jpg" to "image/jpeg",
+        "jpeg" to "image/jpeg",
+        "gif" to "image/gif",
+        "webp" to "image/webp",
+        "mp4" to "video/mp4",
+        "mov" to "video/quicktime",
+        "mp3" to "audio/mpeg",
+        "wav" to "audio/wav",
+        "txt" to "text/plain",
+        "csv" to "text/csv",
+        "json" to "application/json",
+        "xml" to "application/xml",
+        "html" to "text/html",
+        "zip" to "application/zip",
+        "doc" to "application/msword",
+        "docx" to "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "xls" to "application/vnd.ms-excel",
+        "xlsx" to "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "ppt" to "application/vnd.ms-powerpoint",
+        "pptx" to "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    )
+
+    fun fromExtension(type: String?): String {
+        val key = type?.trim()?.lowercase().orEmpty()
+        if (key.isEmpty()) return DEFAULT
+        return TABLE[key] ?: lookupSystem(key) ?: DEFAULT
+    }
+
+    private fun lookupSystem(extension: String): String? = try {
+        MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
+    } catch (_: Throwable) {
+        null
+    }
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/AuthConfig.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/AuthConfig.kt
@@ -6,7 +6,7 @@ data class AuthConfig(
     val bearerToken: String,
     val bridgeUser: String,
     val userId: String,
-    val clientName: String = "drive-mobile",
-    val clientVersion: String = "v1.9.0",
+    val clientName: String,
+    val clientVersion: String,
     val desktopToken: String? = null
 )

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/AuthConfig.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/AuthConfig.kt
@@ -1,0 +1,12 @@
+package com.internxt.cloud.documents.api
+
+data class AuthConfig(
+    val driveBaseUrl: String,
+    val bridgeBaseUrl: String,
+    val bearerToken: String,
+    val bridgeUser: String,
+    val userId: String,
+    val clientName: String = "drive-mobile",
+    val clientVersion: String = "v1.9.0",
+    val desktopToken: String? = null
+)

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/AuthConfig.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/AuthConfig.kt
@@ -6,6 +6,7 @@ data class AuthConfig(
     val bearerToken: String,
     val bridgeUser: String,
     val userId: String,
+    val mnemonic: String,
     val clientName: String,
     val clientVersion: String,
     val desktopToken: String? = null

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
@@ -192,8 +192,7 @@ class InternxtApiClient(
         private val JSON = "application/json; charset=utf-8".toMediaType()
 
         private fun defaultClient(): OkHttpClient = OkHttpClient.Builder()
-            .connectTimeout(30, TimeUnit.SECONDS)
-            .readTimeout(30, TimeUnit.SECONDS)
+            .callTimeout(30, TimeUnit.SECONDS)
             .build()
     }
 }

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
@@ -29,6 +29,16 @@ class InternxtApiClient(
     fun listFolderFiles(parentUuid: String, offset: Int = 0, limit: Int = DEFAULT_PAGE_SIZE): List<DriveFile> =
         listChildren(parentUuid, kind = "files", jsonKey = "files", offset, limit, ::parseFile)
 
+    fun getFolder(uuid: String): DriveFolder? = getMetaOrNull("folders/$uuid/meta", ::parseFolder)
+
+    fun getFile(uuid: String): DriveFile? = getMetaOrNull("files/$uuid/meta", ::parseFile)
+
+    private fun <T> getMetaOrNull(path: String, parse: (JSONObject) -> T): T? = try {
+        parse(executeApiRequest(driveRequest(driveUrl(path)).get().build()))
+    } catch (_: InternxtApiException.NotFoundException) {
+        null
+    }
+
     private fun <T> listChildren(
         parentUuid: String,
         kind: String,

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
@@ -44,7 +44,7 @@ class InternxtApiClient(
             .addQueryParameter("sort", "plainName")
             .addQueryParameter("order", "ASC")
             .build()
-        val body = execute(driveRequest(url).get().build())
+        val body = executeApiRequest(driveRequest(url).get().build())
         return body.optJSONArray(jsonKey).orEmpty().map(parse)
     }
 
@@ -55,7 +55,7 @@ class InternxtApiClient(
         val req = driveRequest(driveUrl("folders"))
             .post(payload.toString().toRequestBody(JSON))
             .build()
-        return parseFolder(execute(req))
+        return parseFolder(executeApiRequest(req))
     }
 
     fun renameFile(fileUuid: String, newName: String): DriveFile {
@@ -63,7 +63,7 @@ class InternxtApiClient(
         val req = driveRequest(driveUrl("files/$fileUuid"))
             .patch(payload.toString().toRequestBody(JSON))
             .build()
-        return parseFile(execute(req))
+        return parseFile(executeApiRequest(req))
     }
 
     fun renameFolder(folderUuid: String, newName: String): DriveFolder {
@@ -71,7 +71,7 @@ class InternxtApiClient(
         val req = driveRequest(driveUrl("folders/$folderUuid"))
             .put(payload.toString().toRequestBody(JSON))
             .build()
-        return parseFolder(execute(req))
+        return parseFolder(executeApiRequest(req))
     }
 
     fun moveFile(fileUuid: String, destinationFolderUuid: String): DriveFile {
@@ -79,7 +79,7 @@ class InternxtApiClient(
         val req = driveRequest(driveUrl("files/$fileUuid"))
             .patch(payload.toString().toRequestBody(JSON))
             .build()
-        return parseFile(execute(req))
+        return parseFile(executeApiRequest(req))
     }
 
     fun moveFolder(folderUuid: String, destinationFolderUuid: String): DriveFolder {
@@ -87,7 +87,7 @@ class InternxtApiClient(
         val req = driveRequest(driveUrl("folders/$folderUuid"))
             .patch(payload.toString().toRequestBody(JSON))
             .build()
-        return parseFolder(execute(req))
+        return parseFolder(executeApiRequest(req))
     }
 
     fun sendToTrash(items: List<TrashItem>) {
@@ -99,12 +99,12 @@ class InternxtApiClient(
         val req = driveRequest(driveUrl("storage/trash/add"))
             .post(payload.toString().toRequestBody(JSON))
             .build()
-        execute(req)
+        executeApiRequest(req)
     }
 
     fun getDownloadLinks(bucketId: String, fileId: String): DownloadLinks {
         val url = bridgeUrl("buckets/$bucketId/files/$fileId/mirrors")
-        val body = execute(bridgeRequest(url).get().build())
+        val body = executeApiRequest(bridgeRequest(url).get().build())
         return parseDownloadLinks(body)
     }
 
@@ -129,7 +129,7 @@ class InternxtApiClient(
     private fun driveUrl(path: String) = "${config.driveBaseUrl.trimEnd('/')}/$path".toHttpUrl()
     private fun bridgeUrl(path: String) = "${config.bridgeBaseUrl.trimEnd('/')}/$path".toHttpUrl()
 
-    private fun execute(request: Request): JSONObject {
+    private fun executeApiRequest(request: Request): JSONObject {
         val response: Response = try {
             client.newCall(request).execute()
         } catch (e: IOException) {
@@ -196,21 +196,4 @@ class InternxtApiClient(
             .readTimeout(30, TimeUnit.SECONDS)
             .build()
     }
-}
-
-private fun JSONArray?.orEmpty(): JSONArray = this ?: JSONArray()
-
-private inline fun <T> JSONArray.map(transform: (JSONObject) -> T): List<T> {
-    val out = ArrayList<T>(length())
-    for (i in 0 until length()) out.add(transform(getJSONObject(i)))
-    return out
-}
-
-private fun JSONObject.optStringOrNull(key: String): String? =
-    if (isNull(key)) null else optString(key).takeIf { it.isNotEmpty() }
-
-private fun JSONObject.optLongFlexible(key: String): Long = when (val v = opt(key)) {
-    is Number -> v.toLong()
-    is String -> v.toLongOrNull() ?: 0L
-    else -> 0L
 }

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
@@ -1,0 +1,216 @@
+package com.internxt.cloud.documents.api
+
+import com.internxt.cloud.documents.api.model.DownloadLinks
+import com.internxt.cloud.documents.api.model.DriveFile
+import com.internxt.cloud.documents.api.model.DriveFolder
+import com.internxt.cloud.documents.api.model.Shard
+import com.internxt.cloud.documents.api.model.TrashItem
+import com.internxt.cloud.documents.crypto.HashUtil
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.IOException
+import java.util.Base64
+import java.util.concurrent.TimeUnit
+
+class InternxtApiClient(
+    private val config: AuthConfig,
+    private val client: OkHttpClient = defaultClient()
+) {
+
+    fun listFolderFolders(parentUuid: String, offset: Int = 0, limit: Int = DEFAULT_PAGE_SIZE): List<DriveFolder> =
+        listChildren(parentUuid, kind = "folders", jsonKey = "folders", offset, limit, ::parseFolder)
+
+    fun listFolderFiles(parentUuid: String, offset: Int = 0, limit: Int = DEFAULT_PAGE_SIZE): List<DriveFile> =
+        listChildren(parentUuid, kind = "files", jsonKey = "files", offset, limit, ::parseFile)
+
+    private fun <T> listChildren(
+        parentUuid: String,
+        kind: String,
+        jsonKey: String,
+        offset: Int,
+        limit: Int,
+        parse: (JSONObject) -> T
+    ): List<T> {
+        val url = driveUrl("folders/content/$parentUuid/$kind")
+            .newBuilder()
+            .addQueryParameter("offset", offset.toString())
+            .addQueryParameter("limit", limit.toString())
+            .addQueryParameter("sort", "plainName")
+            .addQueryParameter("order", "ASC")
+            .build()
+        val body = execute(driveRequest(url).get().build())
+        return body.optJSONArray(jsonKey).orEmpty().map(parse)
+    }
+
+    fun createFolder(parentUuid: String, plainName: String): DriveFolder {
+        val payload = JSONObject()
+            .put("plainName", plainName)
+            .put("parentFolderUuid", parentUuid)
+        val req = driveRequest(driveUrl("folders"))
+            .post(payload.toString().toRequestBody(JSON))
+            .build()
+        return parseFolder(execute(req))
+    }
+
+    fun renameFile(fileUuid: String, newName: String): DriveFile {
+        val payload = JSONObject().put("name", newName)
+        val req = driveRequest(driveUrl("files/$fileUuid"))
+            .patch(payload.toString().toRequestBody(JSON))
+            .build()
+        return parseFile(execute(req))
+    }
+
+    fun renameFolder(folderUuid: String, newName: String): DriveFolder {
+        val payload = JSONObject().put("name", newName)
+        val req = driveRequest(driveUrl("folders/$folderUuid"))
+            .put(payload.toString().toRequestBody(JSON))
+            .build()
+        return parseFolder(execute(req))
+    }
+
+    fun moveFile(fileUuid: String, destinationFolderUuid: String): DriveFile {
+        val payload = JSONObject().put("destinationFolder", destinationFolderUuid)
+        val req = driveRequest(driveUrl("files/$fileUuid"))
+            .patch(payload.toString().toRequestBody(JSON))
+            .build()
+        return parseFile(execute(req))
+    }
+
+    fun moveFolder(folderUuid: String, destinationFolderUuid: String): DriveFolder {
+        val payload = JSONObject().put("destinationFolder", destinationFolderUuid)
+        val req = driveRequest(driveUrl("folders/$folderUuid"))
+            .patch(payload.toString().toRequestBody(JSON))
+            .build()
+        return parseFolder(execute(req))
+    }
+
+    fun sendToTrash(items: List<TrashItem>) {
+        val jsonItems = JSONArray()
+        for (item in items) {
+            jsonItems.put(JSONObject().put("uuid", item.uuid).put("type", item.type.wire))
+        }
+        val payload = JSONObject().put("items", jsonItems)
+        val req = driveRequest(driveUrl("storage/trash/add"))
+            .post(payload.toString().toRequestBody(JSON))
+            .build()
+        execute(req)
+    }
+
+    fun getDownloadLinks(bucketId: String, fileId: String): DownloadLinks {
+        val url = bridgeUrl("buckets/$bucketId/files/$fileId/mirrors")
+        val body = execute(bridgeRequest(url).get().build())
+        return parseDownloadLinks(body)
+    }
+
+    private fun driveRequest(url: okhttp3.HttpUrl): Request.Builder =
+        baseRequest(url).header("Authorization", "Bearer ${config.bearerToken}")
+
+    private fun bridgeRequest(url: okhttp3.HttpUrl): Request.Builder {
+        val pass = HashUtil.deriveBridgePass(config.userId)
+        val basic = Base64.getEncoder().encodeToString("${config.bridgeUser}:$pass".toByteArray(Charsets.UTF_8))
+        return baseRequest(url).header("Authorization", "Basic $basic")
+    }
+
+    private fun baseRequest(url: okhttp3.HttpUrl): Request.Builder {
+        val builder = Request.Builder()
+            .url(url)
+            .header("internxt-client", config.clientName)
+            .header("internxt-version", config.clientVersion)
+        config.desktopToken?.let { builder.header("x-internxt-desktop-header", it) }
+        return builder
+    }
+
+    private fun driveUrl(path: String) = "${config.driveBaseUrl.trimEnd('/')}/$path".toHttpUrl()
+    private fun bridgeUrl(path: String) = "${config.bridgeBaseUrl.trimEnd('/')}/$path".toHttpUrl()
+
+    private fun execute(request: Request): JSONObject {
+        val response: Response = try {
+            client.newCall(request).execute()
+        } catch (e: IOException) {
+            throw InternxtApiException.NetworkException(e)
+        }
+        response.use { resp ->
+            val bodyStr = resp.body?.string().orEmpty()
+            when (resp.code) {
+                in 200..299 -> return if (bodyStr.isBlank()) JSONObject() else JSONObject(bodyStr)
+                401 -> throw InternxtApiException.UnauthorizedException()
+                404 -> throw InternxtApiException.NotFoundException()
+                else -> throw InternxtApiException.ApiError(resp.code, bodyStr)
+            }
+        }
+    }
+
+    private fun parseFolder(obj: JSONObject): DriveFolder = DriveFolder(
+        uuid = obj.getString("uuid"),
+        plainName = obj.optString("plainName"),
+        parentUuid = obj.optStringOrNull("parentUuid"),
+        bucket = obj.optStringOrNull("bucket"),
+        createdAt = obj.optStringOrNull("createdAt"),
+        updatedAt = obj.optStringOrNull("updatedAt")
+    )
+
+    private fun parseFile(obj: JSONObject): DriveFile = DriveFile(
+        uuid = obj.getString("uuid"),
+        plainName = obj.optString("plainName"),
+        type = obj.optStringOrNull("type"),
+        size = obj.optLongFlexible("size"),
+        bucket = obj.optStringOrNull("bucket"),
+        folderUuid = obj.optStringOrNull("folderUuid"),
+        createdAt = obj.optStringOrNull("createdAt"),
+        updatedAt = obj.optStringOrNull("updatedAt"),
+        fileId = obj.optStringOrNull("fileId")
+    )
+
+    private fun parseDownloadLinks(obj: JSONObject): DownloadLinks {
+        val shardsJson = obj.optJSONArray("shards") ?: JSONArray()
+        val shards = shardsJson.map {
+            Shard(
+                index = it.optInt("index"),
+                size = it.optLongFlexible("size"),
+                hash = it.optString("hash"),
+                url = it.optString("url")
+            )
+        }
+        return DownloadLinks(
+            bucket = obj.optString("bucket"),
+            index = obj.optString("index"),
+            size = obj.optLongFlexible("size"),
+            version = obj.optInt("version", 1),
+            shards = shards
+        )
+    }
+
+    companion object {
+        const val DEFAULT_PAGE_SIZE = 50
+
+        private val JSON = "application/json; charset=utf-8".toMediaType()
+
+        private fun defaultClient(): OkHttpClient = OkHttpClient.Builder()
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .build()
+    }
+}
+
+private fun JSONArray?.orEmpty(): JSONArray = this ?: JSONArray()
+
+private inline fun <T> JSONArray.map(transform: (JSONObject) -> T): List<T> {
+    val out = ArrayList<T>(length())
+    for (i in 0 until length()) out.add(transform(getJSONObject(i)))
+    return out
+}
+
+private fun JSONObject.optStringOrNull(key: String): String? =
+    if (isNull(key)) null else optString(key).takeIf { it.isNotEmpty() }
+
+private fun JSONObject.optLongFlexible(key: String): Long = when (val v = opt(key)) {
+    is Number -> v.toLong()
+    is String -> v.toLongOrNull() ?: 0L
+    else -> 0L
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
@@ -68,20 +68,20 @@ class InternxtApiClient(
         return parseFolder(executeApiRequest(req))
     }
 
-    fun renameFile(fileUuid: String, newName: String): DriveFile {
-        val payload = JSONObject().put("name", newName)
-        val req = driveRequest(driveUrl("files/$fileUuid"))
-            .patch(payload.toString().toRequestBody(JSON))
-            .build()
-        return parseFile(executeApiRequest(req))
-    }
-
-    fun renameFolder(folderUuid: String, newName: String): DriveFolder {
-        val payload = JSONObject().put("name", newName)
-        val req = driveRequest(driveUrl("folders/$folderUuid"))
+    fun renameFile(fileUuid: String, newName: String) {
+        val payload = JSONObject().put("plainName", newName)
+        val req = driveRequest(driveUrl("files/$fileUuid/meta"))
             .put(payload.toString().toRequestBody(JSON))
             .build()
-        return parseFolder(executeApiRequest(req))
+        executeApiRequest(req)
+    }
+
+    fun renameFolder(folderUuid: String, newName: String) {
+        val payload = JSONObject().put("plainName", newName)
+        val req = driveRequest(driveUrl("folders/$folderUuid/meta"))
+            .put(payload.toString().toRequestBody(JSON))
+            .build()
+        executeApiRequest(req)
     }
 
     fun moveFile(fileUuid: String, destinationFolderUuid: String): DriveFile {

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
@@ -29,11 +29,11 @@ class InternxtApiClient(
     fun listFolderFiles(parentUuid: String, offset: Int = 0, limit: Int = DEFAULT_PAGE_SIZE): List<DriveFile> =
         listChildren(parentUuid, kind = "files", jsonKey = "files", offset, limit, ::parseFile)
 
-    fun getFolder(uuid: String): DriveFolder? = getMetaOrNull("folders/$uuid/meta", ::parseFolder)
+    fun getFolder(uuid: String): DriveFolder? = getMeta("folders/$uuid/meta", ::parseFolder)
 
-    fun getFile(uuid: String): DriveFile? = getMetaOrNull("files/$uuid/meta", ::parseFile)
+    fun getFile(uuid: String): DriveFile? = getMeta("files/$uuid/meta", ::parseFile)
 
-    private fun <T> getMetaOrNull(path: String, parse: (JSONObject) -> T): T? = try {
+    private fun <T> getMeta(path: String, parse: (JSONObject) -> T): T? = try {
         parse(executeApiRequest(driveRequest(driveUrl(path)).get().build()))
     } catch (_: InternxtApiException.NotFoundException) {
         null

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
@@ -113,9 +113,37 @@ class InternxtApiClient(
     }
 
     fun getDownloadLinks(bucketId: String, fileId: String): DownloadLinks {
-        val url = bridgeUrl("buckets/$bucketId/files/$fileId/mirrors")
-        val body = executeApiRequest(bridgeRequest(url).get().build())
-        return parseDownloadLinks(body)
+        val url = bridgeUrl("buckets/$bucketId/files/$fileId/info")
+        val request = bridgeRequest(url).header("x-api-version", "2").get().build()
+        val body = executeApiRequest(request)
+
+        val index = body.optStringOrNull("index")
+            ?: throw InternxtApiException.ApiError(500, "Bridge /info response missing 'index'")
+        val version = body.optInt("version", 1)
+        if (version != 2) {
+            throw InternxtApiException.ApiError(409, "File version=$version is not supported (V2 only)")
+        }
+
+        val shardsJson = body.optJSONArray("shards") ?: JSONArray()
+        if (shardsJson.length() == 0) {
+            throw InternxtApiException.ApiError(404, "No shards returned for file $fileId")
+        }
+        val shards = shardsJson.map { obj ->
+            Shard(
+                index = obj.optInt("index"),
+                size = obj.optLongFlexible("size"),
+                hash = obj.optString("hash"),
+                url = obj.optString("url")
+            )
+        }
+
+        return DownloadLinks(
+            bucket = bucketId,
+            index = index,
+            size = body.optLongFlexible("size"),
+            version = version,
+            shards = shards
+        )
     }
 
     private fun driveRequest(url: okhttp3.HttpUrl): Request.Builder =
@@ -140,6 +168,16 @@ class InternxtApiClient(
     private fun bridgeUrl(path: String) = "${config.bridgeBaseUrl.trimEnd('/')}/$path".toHttpUrl()
 
     private fun executeApiRequest(request: Request): JSONObject {
+        val bodyStr = executeRaw(request)
+        return if (bodyStr.isBlank()) JSONObject() else JSONObject(bodyStr)
+    }
+
+    private fun executeApiRequestArray(request: Request): JSONArray {
+        val bodyStr = executeRaw(request)
+        return if (bodyStr.isBlank()) JSONArray() else JSONArray(bodyStr)
+    }
+
+    private fun executeRaw(request: Request): String {
         val response: Response = try {
             client.newCall(request).execute()
         } catch (e: IOException) {
@@ -148,7 +186,7 @@ class InternxtApiClient(
         response.use { resp ->
             val bodyStr = resp.body?.string().orEmpty()
             when (resp.code) {
-                in 200..299 -> return if (bodyStr.isBlank()) JSONObject() else JSONObject(bodyStr)
+                in 200..299 -> return bodyStr
                 401 -> throw InternxtApiException.UnauthorizedException()
                 404 -> throw InternxtApiException.NotFoundException()
                 else -> throw InternxtApiException.ApiError(resp.code, bodyStr)
@@ -177,32 +215,19 @@ class InternxtApiClient(
         fileId = obj.optStringOrNull("fileId")
     )
 
-    private fun parseDownloadLinks(obj: JSONObject): DownloadLinks {
-        val shardsJson = obj.optJSONArray("shards") ?: JSONArray()
-        val shards = shardsJson.map {
-            Shard(
-                index = it.optInt("index"),
-                size = it.optLongFlexible("size"),
-                hash = it.optString("hash"),
-                url = it.optString("url")
-            )
-        }
-        return DownloadLinks(
-            bucket = obj.optString("bucket"),
-            index = obj.optString("index"),
-            size = obj.optLongFlexible("size"),
-            version = obj.optInt("version", 1),
-            shards = shards
-        )
-    }
-
     companion object {
         const val DEFAULT_PAGE_SIZE = 50
 
         private val JSON = "application/json; charset=utf-8".toMediaType()
 
-        private fun defaultClient(): OkHttpClient = OkHttpClient.Builder()
-            .callTimeout(30, TimeUnit.SECONDS)
-            .build()
+        private val sharedClient: OkHttpClient by lazy {
+            OkHttpClient.Builder()
+                .connectTimeout(15, TimeUnit.SECONDS)
+                .readTimeout(15, TimeUnit.SECONDS)
+                .callTimeout(30, TimeUnit.SECONDS)
+                .build()
+        }
+
+        private fun defaultClient(): OkHttpClient = sharedClient
     }
 }

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
@@ -1,10 +1,15 @@
 package com.internxt.cloud.documents.api
 
+import com.internxt.cloud.documents.api.model.CreateFileEntry
 import com.internxt.cloud.documents.api.model.DownloadLinks
 import com.internxt.cloud.documents.api.model.DriveFile
 import com.internxt.cloud.documents.api.model.DriveFolder
+import com.internxt.cloud.documents.api.model.FinishUploadShard
 import com.internxt.cloud.documents.api.model.Shard
 import com.internxt.cloud.documents.api.model.TrashItem
+import com.internxt.cloud.documents.api.model.UploadFinishResponse
+import com.internxt.cloud.documents.api.model.UploadSlot
+import com.internxt.cloud.documents.api.model.UploadStartResponse
 import com.internxt.cloud.documents.crypto.HashUtil
 import com.internxt.cloud.documents.http.HttpClients
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -110,6 +115,104 @@ class InternxtApiClient(
             .post(payload.toString().toRequestBody(JSON))
             .build()
         executeApiRequest(req)
+    }
+
+    fun startUpload(bucketId: String, encryptedSize: Long, parts: Int = 1): UploadStartResponse {
+        require(parts >= 1) { "parts must be >= 1" }
+        val payload = JSONObject().put(
+            "uploads",
+            JSONArray().put(
+                JSONObject()
+                    .put("index", 0)
+                    .put("size", encryptedSize)
+            )
+        )
+        val url = bridgeUrl("v2/buckets/$bucketId/files/start")
+            .newBuilder()
+            .addQueryParameter("multiparts", parts.toString())
+            .build()
+        val req = bridgeRequest(url)
+            .post(payload.toString().toRequestBody(JSON))
+            .build()
+        return parseUploadStart(executeApiRequest(req))
+    }
+
+    fun finishUpload(
+        bucketId: String,
+        indexHex: String,
+        shards: List<FinishUploadShard>,
+    ): UploadFinishResponse {
+        require(shards.isNotEmpty()) { "shards cannot be empty" }
+        val shardsJson = JSONArray()
+        for (shard in shards) {
+            val obj = JSONObject()
+                .put("uuid", shard.uuid)
+                .put("hash", shard.hash)
+            if (shard.uploadId != null) obj.put("UploadId", shard.uploadId)
+            if (shard.parts != null) {
+                val parts = JSONArray()
+                shard.parts.sortedBy { it.partNumber }.forEach { part ->
+                    parts.put(
+                        JSONObject()
+                            .put("PartNumber", part.partNumber)
+                            .put("ETag", part.etag)
+                    )
+                }
+                obj.put("parts", parts)
+            }
+            shardsJson.put(obj)
+        }
+        val payload = JSONObject()
+            .put("index", indexHex)
+            .put("shards", shardsJson)
+        val req = bridgeRequest(bridgeUrl("v2/buckets/$bucketId/files/finish"))
+            .post(payload.toString().toRequestBody(JSON))
+            .build()
+        val body = executeApiRequest(req)
+        val id = body.optStringOrNull("id")
+            ?: throw InternxtApiException.MalformedResponse("Bridge /finish missing 'id'")
+        return UploadFinishResponse(id = id, bucket = body.optStringOrNull("bucket"))
+    }
+
+    fun createFileEntry(entry: CreateFileEntry): DriveFile {
+        val payload = JSONObject()
+            .put("fileId", entry.fileId)
+            .put("type", entry.type)
+            .put("size", entry.size)
+            .put("plainName", entry.plainName)
+            .put("bucket", entry.bucket)
+            .put("folderUuid", entry.folderUuid)
+            .put("encryptVersion", entry.encryptVersion)
+        entry.modificationTime?.let { payload.put("modificationTime", it) }
+        entry.creationTime?.let { payload.put("creationTime", it) }
+        val req = driveRequest(driveUrl("files"))
+            .post(payload.toString().toRequestBody(JSON))
+            .build()
+        return parseFile(executeApiRequest(req))
+    }
+
+    private fun parseUploadStart(body: JSONObject): UploadStartResponse {
+        val uploadsJson = body.optJSONArray("uploads")
+            ?: throw InternxtApiException.MalformedResponse("Bridge /start missing 'uploads'")
+        return UploadStartResponse(uploads = uploadsJson.map(::parseUploadSlot))
+    }
+
+    private fun parseUploadSlot(obj: JSONObject): UploadSlot {
+        val index = obj.optInt("index")
+        val uuid = obj.requireString("uuid")
+        return when (val urlsArr = obj.optJSONArray("urls")) {
+            null -> UploadSlot.Single(
+                index = index,
+                uuid = uuid,
+                url = obj.requireString("url"),
+            )
+            else -> UploadSlot.Multipart(
+                index = index,
+                uuid = uuid,
+                urls = urlsArr.toStringList(),
+                uploadId = obj.requireString("UploadId"),
+            )
+        }
     }
 
     fun getDownloadLinks(bucketId: String, fileId: String): DownloadLinks {

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit
 
 class InternxtApiClient(
     private val config: AuthConfig,
-    private val client: OkHttpClient = defaultClient()
+    private val client: OkHttpClient = sharedClient
 ) {
 
     fun listFolderFolders(parentUuid: String, offset: Int = 0, limit: Int = DEFAULT_PAGE_SIZE): List<DriveFolder> =
@@ -168,16 +168,6 @@ class InternxtApiClient(
     private fun bridgeUrl(path: String) = "${config.bridgeBaseUrl.trimEnd('/')}/$path".toHttpUrl()
 
     private fun executeApiRequest(request: Request): JSONObject {
-        val bodyStr = executeRaw(request)
-        return if (bodyStr.isBlank()) JSONObject() else JSONObject(bodyStr)
-    }
-
-    private fun executeApiRequestArray(request: Request): JSONArray {
-        val bodyStr = executeRaw(request)
-        return if (bodyStr.isBlank()) JSONArray() else JSONArray(bodyStr)
-    }
-
-    private fun executeRaw(request: Request): String {
         val response: Response = try {
             client.newCall(request).execute()
         } catch (e: IOException) {
@@ -185,8 +175,8 @@ class InternxtApiClient(
         }
         response.use { resp ->
             val bodyStr = resp.body?.string().orEmpty()
-            when (resp.code) {
-                in 200..299 -> return bodyStr
+            return when (resp.code) {
+                in 200..299 -> if (bodyStr.isBlank()) JSONObject() else JSONObject(bodyStr)
                 401 -> throw InternxtApiException.UnauthorizedException()
                 404 -> throw InternxtApiException.NotFoundException()
                 else -> throw InternxtApiException.ApiError(resp.code, bodyStr)
@@ -220,14 +210,12 @@ class InternxtApiClient(
 
         private val JSON = "application/json; charset=utf-8".toMediaType()
 
-        private val sharedClient: OkHttpClient by lazy {
+        internal val sharedClient: OkHttpClient by lazy {
             OkHttpClient.Builder()
                 .connectTimeout(15, TimeUnit.SECONDS)
                 .readTimeout(15, TimeUnit.SECONDS)
                 .callTimeout(30, TimeUnit.SECONDS)
                 .build()
         }
-
-        private fun defaultClient(): OkHttpClient = sharedClient
     }
 }

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiClient.kt
@@ -6,6 +6,7 @@ import com.internxt.cloud.documents.api.model.DriveFolder
 import com.internxt.cloud.documents.api.model.Shard
 import com.internxt.cloud.documents.api.model.TrashItem
 import com.internxt.cloud.documents.crypto.HashUtil
+import com.internxt.cloud.documents.http.HttpClients
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -16,11 +17,10 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.io.IOException
 import java.util.Base64
-import java.util.concurrent.TimeUnit
 
 class InternxtApiClient(
     private val config: AuthConfig,
-    private val client: OkHttpClient = sharedClient
+    private val client: OkHttpClient = HttpClients.api
 ) {
 
     fun listFolderFolders(parentUuid: String, offset: Int = 0, limit: Int = DEFAULT_PAGE_SIZE): List<DriveFolder> =
@@ -115,34 +115,34 @@ class InternxtApiClient(
     fun getDownloadLinks(bucketId: String, fileId: String): DownloadLinks {
         val url = bridgeUrl("buckets/$bucketId/files/$fileId/info")
         val request = bridgeRequest(url).header("x-api-version", "2").get().build()
-        val body = executeApiRequest(request)
+        return parseDownloadLinks(executeApiRequest(request), bucketId, fileId)
+    }
 
+    private fun parseDownloadLinks(body: JSONObject, bucketId: String, fileId: String): DownloadLinks {
         val index = body.optStringOrNull("index")
-            ?: throw InternxtApiException.ApiError(500, "Bridge /info response missing 'index'")
+            ?: throw InternxtApiException.MalformedResponse("Bridge /info missing 'index'")
         val version = body.optInt("version", 1)
         if (version != 2) {
-            throw InternxtApiException.ApiError(409, "File version=$version is not supported (V2 only)")
+            throw InternxtApiException.MalformedResponse("File version=$version is not supported (V2 only)")
         }
-
         val shardsJson = body.optJSONArray("shards") ?: JSONArray()
         if (shardsJson.length() == 0) {
-            throw InternxtApiException.ApiError(404, "No shards returned for file $fileId")
+            throw InternxtApiException.MalformedResponse("No shards returned for file $fileId")
         }
         val shards = shardsJson.map { obj ->
             Shard(
                 index = obj.optInt("index"),
                 size = obj.optLongFlexible("size"),
                 hash = obj.optString("hash"),
-                url = obj.optString("url")
+                url = obj.optString("url"),
             )
         }
-
         return DownloadLinks(
             bucket = bucketId,
             index = index,
             size = body.optLongFlexible("size"),
             version = version,
-            shards = shards
+            shards = shards,
         )
     }
 
@@ -209,13 +209,5 @@ class InternxtApiClient(
         const val DEFAULT_PAGE_SIZE = 50
 
         private val JSON = "application/json; charset=utf-8".toMediaType()
-
-        internal val sharedClient: OkHttpClient by lazy {
-            OkHttpClient.Builder()
-                .connectTimeout(15, TimeUnit.SECONDS)
-                .readTimeout(15, TimeUnit.SECONDS)
-                .callTimeout(30, TimeUnit.SECONDS)
-                .build()
-        }
     }
 }

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiException.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiException.kt
@@ -1,0 +1,10 @@
+package com.internxt.cloud.documents.api
+
+import java.io.IOException
+
+sealed class InternxtApiException(message: String, cause: Throwable? = null) : IOException(message, cause) {
+    class UnauthorizedException(message: String = "401 Unauthorized") : InternxtApiException(message)
+    class NotFoundException(message: String = "404 Not Found") : InternxtApiException(message)
+    class ApiError(val code: Int, val body: String?) : InternxtApiException("HTTP $code: ${body ?: ""}")
+    class NetworkException(cause: Throwable) : InternxtApiException("Network error", cause)
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiException.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/InternxtApiException.kt
@@ -7,4 +7,5 @@ sealed class InternxtApiException(message: String, cause: Throwable? = null) : I
     class NotFoundException(message: String = "404 Not Found") : InternxtApiException(message)
     class ApiError(val code: Int, val body: String?) : InternxtApiException("HTTP $code: ${body ?: ""}")
     class NetworkException(cause: Throwable) : InternxtApiException("Network error", cause)
+    class MalformedResponse(message: String) : InternxtApiException("Malformed response: $message")
 }

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/JsonExtensions.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/JsonExtensions.kt
@@ -1,0 +1,21 @@
+package com.internxt.cloud.documents.api
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+internal fun JSONArray?.orEmpty(): JSONArray = this ?: JSONArray()
+
+internal inline fun <T> JSONArray.map(transform: (JSONObject) -> T): List<T> {
+    val out = ArrayList<T>(length())
+    for (i in 0 until length()) out.add(transform(getJSONObject(i)))
+    return out
+}
+
+internal fun JSONObject.optStringOrNull(key: String): String? =
+    if (isNull(key)) null else optString(key).takeIf { it.isNotEmpty() }
+
+internal fun JSONObject.optLongFlexible(key: String): Long = when (val v = opt(key)) {
+    is Number -> v.toLong()
+    is String -> v.toLongOrNull() ?: 0L
+    else -> 0L
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/JsonExtensions.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/JsonExtensions.kt
@@ -14,6 +14,13 @@ internal inline fun <T> JSONArray.map(transform: (JSONObject) -> T): List<T> {
 internal fun JSONObject.optStringOrNull(key: String): String? =
     if (isNull(key)) null else optString(key).takeIf { it.isNotEmpty() }
 
+internal fun JSONObject.requireString(
+    key: String,
+    error: String = "Missing required field: $key",
+): String = optStringOrNull(key) ?: throw InternxtApiException.MalformedResponse(error)
+
+internal fun JSONArray.toStringList(): List<String> = List(length()) { getString(it) }
+
 internal fun JSONObject.optLongFlexible(key: String): Long = when (val v = opt(key)) {
     is Number -> v.toLong()
     is String -> v.toLongOrNull() ?: 0L

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/model/CreateFileEntry.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/model/CreateFileEntry.kt
@@ -1,0 +1,15 @@
+package com.internxt.cloud.documents.api.model
+
+const val ENCRYPT_VERSION_AES03 = "Aes03"
+
+data class CreateFileEntry(
+    val fileId: String,
+    val type: String,
+    val size: Long,
+    val plainName: String,
+    val bucket: String,
+    val folderUuid: String,
+    val encryptVersion: String = ENCRYPT_VERSION_AES03,
+    val modificationTime: String? = null,
+    val creationTime: String? = null,
+)

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/model/CreateFileEntry.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/model/CreateFileEntry.kt
@@ -1,6 +1,6 @@
 package com.internxt.cloud.documents.api.model
 
-const val ENCRYPT_VERSION_AES03 = "Aes03"
+const val ENCRYPT_VERSION_AES03 = "03-aes"
 
 data class CreateFileEntry(
     val fileId: String,

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/model/DownloadLinks.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/model/DownloadLinks.kt
@@ -1,0 +1,9 @@
+package com.internxt.cloud.documents.api.model
+
+data class DownloadLinks(
+    val bucket: String,
+    val index: String,
+    val size: Long,
+    val version: Int,
+    val shards: List<Shard>
+)

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/model/DriveFile.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/model/DriveFile.kt
@@ -1,0 +1,13 @@
+package com.internxt.cloud.documents.api.model
+
+data class DriveFile(
+    val uuid: String,
+    val plainName: String,
+    val type: String?,
+    val size: Long,
+    val bucket: String?,
+    val folderUuid: String?,
+    val createdAt: String?,
+    val updatedAt: String?,
+    val fileId: String?
+)

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/model/DriveFolder.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/model/DriveFolder.kt
@@ -1,0 +1,10 @@
+package com.internxt.cloud.documents.api.model
+
+data class DriveFolder(
+    val uuid: String,
+    val plainName: String,
+    val parentUuid: String?,
+    val bucket: String?,
+    val createdAt: String?,
+    val updatedAt: String?
+)

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/model/FinishUploadShard.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/model/FinishUploadShard.kt
@@ -1,0 +1,8 @@
+package com.internxt.cloud.documents.api.model
+
+data class FinishUploadShard(
+    val uuid: String,
+    val hash: String,
+    val uploadId: String? = null,
+    val parts: List<UploadedPart>? = null,
+)

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/model/Shard.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/model/Shard.kt
@@ -1,0 +1,8 @@
+package com.internxt.cloud.documents.api.model
+
+data class Shard(
+    val index: Int,
+    val size: Long,
+    val hash: String,
+    val url: String
+)

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/model/TrashItem.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/model/TrashItem.kt
@@ -1,0 +1,11 @@
+package com.internxt.cloud.documents.api.model
+
+data class TrashItem(
+    val uuid: String,
+    val type: Type
+) {
+    enum class Type(val wire: String) {
+        FILE("file"),
+        FOLDER("folder");
+    }
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/model/UploadFinishResponse.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/model/UploadFinishResponse.kt
@@ -1,0 +1,6 @@
+package com.internxt.cloud.documents.api.model
+
+data class UploadFinishResponse(
+    val id: String,
+    val bucket: String?,
+)

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/model/UploadStartResponse.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/model/UploadStartResponse.kt
@@ -1,0 +1,23 @@
+package com.internxt.cloud.documents.api.model
+
+data class UploadStartResponse(
+    val uploads: List<UploadSlot>,
+)
+
+sealed class UploadSlot {
+    abstract val index: Int
+    abstract val uuid: String
+
+    data class Single(
+        override val index: Int,
+        override val uuid: String,
+        val url: String,
+    ) : UploadSlot()
+
+    data class Multipart(
+        override val index: Int,
+        override val uuid: String,
+        val urls: List<String>,
+        val uploadId: String,
+    ) : UploadSlot()
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/api/model/UploadedPart.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/api/model/UploadedPart.kt
@@ -1,0 +1,6 @@
+package com.internxt.cloud.documents.api.model
+
+data class UploadedPart(
+    val partNumber: Int,
+    val etag: String,
+)

--- a/android/app/src/main/java/com/internxt/cloud/documents/auth/InternxtAuthManager.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/auth/InternxtAuthManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import com.internxt.cloud.BuildConfig
 import com.internxt.cloud.documents.api.AuthConfig
 
 class InternxtAuthManager(private val prefs: SharedPreferences) {
@@ -36,6 +37,8 @@ class InternxtAuthManager(private val prefs: SharedPreferences) {
             bearerToken = required(KEY_BEARER_TOKEN),
             bridgeUser = required(KEY_BRIDGE_USER),
             userId = required(KEY_USER_ID),
+            clientName = BuildConfig.INTERNXT_CLIENT_NAME,
+            clientVersion = BuildConfig.INTERNXT_CLIENT_VERSION,
             desktopToken = prefs.getString(KEY_DESKTOP_TOKEN, null)?.takeIf { it.isNotBlank() },
         )
     }

--- a/android/app/src/main/java/com/internxt/cloud/documents/auth/InternxtAuthManager.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/auth/InternxtAuthManager.kt
@@ -1,0 +1,98 @@
+package com.internxt.cloud.documents.auth
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import com.internxt.cloud.documents.api.AuthConfig
+
+class InternxtAuthManager(private val prefs: SharedPreferences) {
+
+    data class Credentials(
+        val bearerToken: String,
+        val userId: String,
+        val bridgeUser: String,
+        val rootFolderUuid: String,
+        val email: String?,
+        val driveBaseUrl: String,
+        val bridgeBaseUrl: String,
+        val desktopToken: String?,
+    )
+
+    fun isLoggedIn(): Boolean =
+        REQUIRED_KEYS.all { !prefs.getString(it, null).isNullOrBlank() }
+
+    fun rootFolderUuid(): String? = prefs.getString(KEY_ROOT_FOLDER_UUID, null)?.takeIf { it.isNotBlank() }
+
+    fun authenticatedRootUuid(): String? = if (isLoggedIn()) rootFolderUuid() else null
+
+    fun userEmail(): String? = prefs.getString(KEY_EMAIL, null)?.takeIf { it.isNotBlank() }
+
+    fun loadAuthConfig(): AuthConfig? {
+        if (!isLoggedIn()) return null
+        return AuthConfig(
+            driveBaseUrl = required(KEY_DRIVE_BASE_URL),
+            bridgeBaseUrl = required(KEY_BRIDGE_BASE_URL),
+            bearerToken = required(KEY_BEARER_TOKEN),
+            bridgeUser = required(KEY_BRIDGE_USER),
+            userId = required(KEY_USER_ID),
+            desktopToken = prefs.getString(KEY_DESKTOP_TOKEN, null)?.takeIf { it.isNotBlank() },
+        )
+    }
+
+    private fun required(key: String): String =
+        prefs.getString(key, null) ?: error("$key missing after isLoggedIn() returned true")
+
+    fun saveCredentials(creds: Credentials) {
+        prefs.edit()
+            .putString(KEY_BEARER_TOKEN, creds.bearerToken)
+            .putString(KEY_USER_ID, creds.userId)
+            .putString(KEY_BRIDGE_USER, creds.bridgeUser)
+            .putString(KEY_ROOT_FOLDER_UUID, creds.rootFolderUuid)
+            .putString(KEY_EMAIL, creds.email)
+            .putString(KEY_DRIVE_BASE_URL, creds.driveBaseUrl)
+            .putString(KEY_BRIDGE_BASE_URL, creds.bridgeBaseUrl)
+            .putString(KEY_DESKTOP_TOKEN, creds.desktopToken)
+            .apply()
+    }
+
+    fun clear() {
+        prefs.edit().clear().apply()
+    }
+
+    companion object {
+        private const val PREFS_FILE = "internxt_documents_auth"
+
+        private const val KEY_BEARER_TOKEN = "bearerToken"
+        private const val KEY_USER_ID = "userId"
+        private const val KEY_BRIDGE_USER = "bridgeUser"
+        private const val KEY_ROOT_FOLDER_UUID = "rootFolderUuid"
+        private const val KEY_EMAIL = "email"
+        private const val KEY_DRIVE_BASE_URL = "driveBaseUrl"
+        private const val KEY_BRIDGE_BASE_URL = "bridgeBaseUrl"
+        private const val KEY_DESKTOP_TOKEN = "desktopToken"
+
+        private val REQUIRED_KEYS = listOf(
+            KEY_BEARER_TOKEN,
+            KEY_USER_ID,
+            KEY_BRIDGE_USER,
+            KEY_ROOT_FOLDER_UUID,
+            KEY_DRIVE_BASE_URL,
+            KEY_BRIDGE_BASE_URL,
+        )
+
+        fun create(context: Context): InternxtAuthManager {
+            val masterKey = MasterKey.Builder(context)
+                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                .build()
+            val prefs = EncryptedSharedPreferences.create(
+                context,
+                PREFS_FILE,
+                masterKey,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+            )
+            return InternxtAuthManager(prefs)
+        }
+    }
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/auth/InternxtAuthManager.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/auth/InternxtAuthManager.kt
@@ -16,6 +16,7 @@ class InternxtAuthManager(private val prefs: SharedPreferences) {
         val bearerToken: String,
         val userId: String,
         val bridgeUser: String,
+        val mnemonic: String,
         val rootFolderUuid: String,
         val email: String?,
         val driveBaseUrl: String,
@@ -40,6 +41,7 @@ class InternxtAuthManager(private val prefs: SharedPreferences) {
             bearerToken = required(KEY_BEARER_TOKEN),
             bridgeUser = required(KEY_BRIDGE_USER),
             userId = required(KEY_USER_ID),
+            mnemonic = required(KEY_MNEMONIC),
             clientName = BuildConfig.INTERNXT_CLIENT_NAME,
             clientVersion = BuildConfig.INTERNXT_CLIENT_VERSION,
             desktopToken = prefs.getString(KEY_DESKTOP_TOKEN, null)?.takeIf { it.isNotBlank() },
@@ -54,6 +56,7 @@ class InternxtAuthManager(private val prefs: SharedPreferences) {
             .putString(KEY_BEARER_TOKEN, creds.bearerToken)
             .putString(KEY_USER_ID, creds.userId)
             .putString(KEY_BRIDGE_USER, creds.bridgeUser)
+            .putString(KEY_MNEMONIC, creds.mnemonic)
             .putString(KEY_ROOT_FOLDER_UUID, creds.rootFolderUuid)
             .putString(KEY_EMAIL, creds.email)
             .putString(KEY_DRIVE_BASE_URL, creds.driveBaseUrl)
@@ -70,6 +73,7 @@ class InternxtAuthManager(private val prefs: SharedPreferences) {
         private const val KEY_BEARER_TOKEN = "bearerToken"
         private const val KEY_USER_ID = "userId"
         private const val KEY_BRIDGE_USER = "bridgeUser"
+        private const val KEY_MNEMONIC = "mnemonic"
         private const val KEY_ROOT_FOLDER_UUID = "rootFolderUuid"
         private const val KEY_EMAIL = "email"
         private const val KEY_DRIVE_BASE_URL = "driveBaseUrl"
@@ -80,6 +84,7 @@ class InternxtAuthManager(private val prefs: SharedPreferences) {
             KEY_BEARER_TOKEN,
             KEY_USER_ID,
             KEY_BRIDGE_USER,
+            KEY_MNEMONIC,
             KEY_ROOT_FOLDER_UUID,
             KEY_DRIVE_BASE_URL,
             KEY_BRIDGE_BASE_URL,

--- a/android/app/src/main/java/com/internxt/cloud/documents/auth/InternxtAuthManager.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/auth/InternxtAuthManager.kt
@@ -2,10 +2,13 @@ package com.internxt.cloud.documents.auth
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.util.Log
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import com.internxt.cloud.BuildConfig
 import com.internxt.cloud.documents.api.AuthConfig
+import java.io.IOException
+import java.security.GeneralSecurityException
 
 class InternxtAuthManager(private val prefs: SharedPreferences) {
 
@@ -46,7 +49,7 @@ class InternxtAuthManager(private val prefs: SharedPreferences) {
     private fun required(key: String): String =
         prefs.getString(key, null) ?: error("$key missing after isLoggedIn() returned true")
 
-    fun saveCredentials(creds: Credentials) {
+    fun saveCredentials(creds: Credentials): Boolean =
         prefs.edit()
             .putString(KEY_BEARER_TOKEN, creds.bearerToken)
             .putString(KEY_USER_ID, creds.userId)
@@ -56,14 +59,12 @@ class InternxtAuthManager(private val prefs: SharedPreferences) {
             .putString(KEY_DRIVE_BASE_URL, creds.driveBaseUrl)
             .putString(KEY_BRIDGE_BASE_URL, creds.bridgeBaseUrl)
             .putString(KEY_DESKTOP_TOKEN, creds.desktopToken)
-            .apply()
-    }
+            .commit()
 
-    fun clear() {
-        prefs.edit().clear().apply()
-    }
+    fun clear(): Boolean = prefs.edit().clear().commit()
 
     companion object {
+        private const val TAG = "InternxtAuthManager"
         private const val PREFS_FILE = "internxt_documents_auth"
 
         private const val KEY_BEARER_TOKEN = "bearerToken"
@@ -84,18 +85,26 @@ class InternxtAuthManager(private val prefs: SharedPreferences) {
             KEY_BRIDGE_BASE_URL,
         )
 
-        fun create(context: Context): InternxtAuthManager {
-            val masterKey = MasterKey.Builder(context)
-                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-                .build()
-            val prefs = EncryptedSharedPreferences.create(
-                context,
-                PREFS_FILE,
-                masterKey,
-                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
-            )
-            return InternxtAuthManager(prefs)
+        fun create(context: Context): InternxtAuthManager? {
+            return try {
+                val masterKey = MasterKey.Builder(context)
+                    .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                    .build()
+                val prefs = EncryptedSharedPreferences.create(
+                    context,
+                    PREFS_FILE,
+                    masterKey,
+                    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+                )
+                InternxtAuthManager(prefs)
+            } catch (e: GeneralSecurityException) {
+                Log.e(TAG, "Keystore unavailable, SAF auth disabled", e)
+                null
+            } catch (e: IOException) {
+                Log.e(TAG, "Could not open encrypted prefs, SAF auth disabled", e)
+                null
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/internxt/cloud/documents/cache/DocumentCache.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/cache/DocumentCache.kt
@@ -11,41 +11,35 @@ object DocumentCache {
     private const val DEC_SUFFIX = ".dec"
     private const val ENC_SUFFIX = ".enc"
 
-    fun cacheFileFor(context: Context, uuid: String, updatedAt: String): File {
-        val dir = File(context.cacheDir, "$ROOT_DIR/$CACHE_DIR").apply { mkdirs() }
-        return File(dir, "${uuid}_${slugFromUpdatedAt(updatedAt)}$DEC_SUFFIX")
-    }
+    fun cacheFileFor(context: Context, uuid: String, updatedAt: String): File =
+        File(cacheDir(context), "${uuid}_${slugFromUpdatedAt(updatedAt)}$DEC_SUFFIX")
 
     fun tempPaths(context: Context, uuid: String): Pair<File, File> {
-        val dir = File(context.cacheDir, "$ROOT_DIR/$TMP_DIR").apply { mkdirs() }
+        val dir = tmpDir(context)
         val token = "${uuid}_${System.nanoTime()}"
         return File(dir, "$token$ENC_SUFFIX") to File(dir, "$token$DEC_SUFFIX")
     }
 
     fun pruneSiblings(context: Context, uuid: String, keep: File) {
-        val dir = File(context.cacheDir, "$ROOT_DIR/$CACHE_DIR")
-        val children = dir.listFiles() ?: return
-        for (file in children) {
-            if (file == keep) continue
-            if (file.name.startsWith("${uuid}_") && file.name.endsWith(DEC_SUFFIX)) {
-                file.delete()
-            }
+        deleteMatching(cacheDir(context)) {
+            it != keep && it.name.startsWith("${uuid}_") && it.name.endsWith(DEC_SUFFIX)
         }
     }
 
     fun deleteTempsFor(context: Context, uuid: String) {
-        val dir = File(context.cacheDir, "$ROOT_DIR/$TMP_DIR")
-        val children = dir.listFiles() ?: return
-        for (file in children) {
-            if (file.name.startsWith("${uuid}_")) file.delete()
-        }
+        deleteMatching(tmpDir(context)) { it.name.startsWith("${uuid}_") }
     }
 
-    fun slugFromUpdatedAt(updatedAt: String): String {
-        val sb = StringBuilder(updatedAt.length)
-        for (c in updatedAt) {
-            if (c.isLetterOrDigit()) sb.append(c)
-        }
-        return if (sb.isEmpty()) "0" else sb.toString()
+    private fun cacheDir(context: Context): File =
+        File(context.cacheDir, "$ROOT_DIR/$CACHE_DIR").apply { mkdirs() }
+
+    private fun tmpDir(context: Context): File =
+        File(context.cacheDir, "$ROOT_DIR/$TMP_DIR").apply { mkdirs() }
+
+    private inline fun deleteMatching(dir: File, predicate: (File) -> Boolean) {
+        dir.listFiles()?.forEach { if (predicate(it)) it.delete() }
     }
+
+    private fun slugFromUpdatedAt(updatedAt: String): String =
+        updatedAt.filter { it.isLetterOrDigit() }.ifEmpty { "0" }
 }

--- a/android/app/src/main/java/com/internxt/cloud/documents/cache/DocumentCache.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/cache/DocumentCache.kt
@@ -14,6 +14,11 @@ object DocumentCache {
     fun cacheFileFor(context: Context, uuid: String, updatedAt: String): File =
         File(cacheDir(context), "${uuid}_${slugFromUpdatedAt(updatedAt)}$DEC_SUFFIX")
 
+    fun existingCacheFor(context: Context, uuid: String): File? =
+        cacheDir(context).listFiles()
+            ?.filter { it.name.startsWith("${uuid}_") && it.name.endsWith(DEC_SUFFIX) && it.length() > 0 }
+            ?.maxByOrNull { it.lastModified() }
+
     fun tempPaths(context: Context, uuid: String): Pair<File, File> {
         val dir = tmpDir(context)
         val token = "${uuid}_${System.nanoTime()}"

--- a/android/app/src/main/java/com/internxt/cloud/documents/cache/DocumentCache.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/cache/DocumentCache.kt
@@ -1,0 +1,51 @@
+package com.internxt.cloud.documents.cache
+
+import android.content.Context
+import java.io.File
+
+object DocumentCache {
+
+    private const val ROOT_DIR = "internxt_documents"
+    private const val CACHE_DIR = "cache"
+    private const val TMP_DIR = "tmp"
+    private const val DEC_SUFFIX = ".dec"
+    private const val ENC_SUFFIX = ".enc"
+
+    fun cacheFileFor(context: Context, uuid: String, updatedAt: String): File {
+        val dir = File(context.cacheDir, "$ROOT_DIR/$CACHE_DIR").apply { mkdirs() }
+        return File(dir, "${uuid}_${slugFromUpdatedAt(updatedAt)}$DEC_SUFFIX")
+    }
+
+    fun tempPaths(context: Context, uuid: String): Pair<File, File> {
+        val dir = File(context.cacheDir, "$ROOT_DIR/$TMP_DIR").apply { mkdirs() }
+        val token = "${uuid}_${System.nanoTime()}"
+        return File(dir, "$token$ENC_SUFFIX") to File(dir, "$token$DEC_SUFFIX")
+    }
+
+    fun pruneSiblings(context: Context, uuid: String, keep: File) {
+        val dir = File(context.cacheDir, "$ROOT_DIR/$CACHE_DIR")
+        val children = dir.listFiles() ?: return
+        for (file in children) {
+            if (file == keep) continue
+            if (file.name.startsWith("${uuid}_") && file.name.endsWith(DEC_SUFFIX)) {
+                file.delete()
+            }
+        }
+    }
+
+    fun deleteTempsFor(context: Context, uuid: String) {
+        val dir = File(context.cacheDir, "$ROOT_DIR/$TMP_DIR")
+        val children = dir.listFiles() ?: return
+        for (file in children) {
+            if (file.name.startsWith("${uuid}_")) file.delete()
+        }
+    }
+
+    fun slugFromUpdatedAt(updatedAt: String): String {
+        val sb = StringBuilder(updatedAt.length)
+        for (c in updatedAt) {
+            if (c.isLetterOrDigit()) sb.append(c)
+        }
+        return if (sb.isEmpty()) "0" else sb.toString()
+    }
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/crypto/CryptoServiceAwait.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/crypto/CryptoServiceAwait.kt
@@ -2,25 +2,25 @@ package com.internxt.cloud.documents.crypto
 
 import com.rncrypto.util.OnlyErrorCallback
 import java.io.IOException
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ExecutionException
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.suspendCancellableCoroutine
 
 /**
- * Bridges `CryptoService.encryptFile` / `decryptFile` (callback-based) to a blocking call.
- * Pass `runInBackground = false` to those methods — the caller is already on a background
- * executor thread, so there's no point bouncing onto the rn-crypto thread pool just to
- * block on it. Any [Throwable] surfaced by the callback is rethrown as [IOException]
- * preserving the original cause.
+ * Suspends until `CryptoService.encryptFile` / `decryptFile` (callback-based) reports an
+ * outcome via [OnlyErrorCallback]. No thread is blocked waiting for the callback: the rn-crypto
+ * callback resumes the coroutine. Any non-null error is surfaced as [IOException] preserving the
+ * original cause.
  */
-internal inline fun awaitCryptoService(
+internal suspend inline fun awaitCryptoService(
     failureMessage: String,
-    invoke: (OnlyErrorCallback) -> Unit,
-) {
-    val done = CompletableFuture<Unit>()
-    invoke { err -> if (err != null) done.completeExceptionally(err) else done.complete(Unit) }
-    try {
-        done.get()
-    } catch (e: ExecutionException) {
-        throw (e.cause as? IOException) ?: IOException(failureMessage, e.cause)
+    crossinline invoke: (OnlyErrorCallback) -> Unit,
+) = suspendCancellableCoroutine { continuation ->
+    invoke { err ->
+        if (err != null) {
+            continuation.resumeWithException((err as? IOException) ?: IOException(failureMessage, err))
+        } else {
+            continuation.resume(Unit)
+        }
     }
 }

--- a/android/app/src/main/java/com/internxt/cloud/documents/crypto/CryptoServiceAwait.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/crypto/CryptoServiceAwait.kt
@@ -1,0 +1,26 @@
+package com.internxt.cloud.documents.crypto
+
+import com.rncrypto.util.OnlyErrorCallback
+import java.io.IOException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
+
+/**
+ * Bridges `CryptoService.encryptFile` / `decryptFile` (callback-based) to a blocking call.
+ * Pass `runInBackground = false` to those methods — the caller is already on a background
+ * executor thread, so there's no point bouncing onto the rn-crypto thread pool just to
+ * block on it. Any [Throwable] surfaced by the callback is rethrown as [IOException]
+ * preserving the original cause.
+ */
+internal inline fun awaitCryptoService(
+    failureMessage: String,
+    invoke: (OnlyErrorCallback) -> Unit,
+) {
+    val done = CompletableFuture<Unit>()
+    invoke { err -> if (err != null) done.completeExceptionally(err) else done.complete(Unit) }
+    try {
+        done.get()
+    } catch (e: ExecutionException) {
+        throw (e.cause as? IOException) ?: IOException(failureMessage, e.cause)
+    }
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/crypto/FileKeyDeriver.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/crypto/FileKeyDeriver.kt
@@ -1,8 +1,17 @@
 package com.internxt.cloud.documents.crypto
 
+import com.facebook.common.util.Hex
 import com.rncrypto.util.CryptoService
-import java.security.MessageDigest
 
+/**
+ * Derives the AES-CTR key/IV used to decrypt files from Internxt's network shards.
+ * Matches src/network/crypto.ts: generateFileKey.
+ *
+ *   seed      = PBKDF2(mnemonic, "mnemonic", 2048, 64)
+ *   bucketKey = SHA-512( seed || bucketId )
+ *   fileKey   = SHA-512( bucketKey[0..32] || index )[0..32]
+ *   iv        = index[0..16]
+ */
 object FileKeyDeriver {
 
     private const val PBKDF2_SALT = "mnemonic"
@@ -12,47 +21,14 @@ object FileKeyDeriver {
     private const val IV_LENGTH = 16
 
     fun deriveFileKey(mnemonic: String, bucketIdHex: String, indexHex: String): ByteArray {
-        val seed = pbkdf2Seed(mnemonic)
-        val bucketKey = sha512(seed, hexDecode(bucketIdHex))
-        val fileKey = sha512(bucketKey.copyOf(FILE_KEY_LENGTH), hexDecode(indexHex))
+        val crypto = CryptoService.getInstance()
+        val seed = crypto.pbkdf2(mnemonic, PBKDF2_SALT.toByteArray(Charsets.UTF_8), PBKDF2_ROUNDS, SEED_LENGTH)
+        val bucketKey = crypto.sha512(listOf(seed, Hex.decodeHex(bucketIdHex)))
+        val fileKey = crypto.sha512(listOf(bucketKey.copyOf(FILE_KEY_LENGTH), Hex.decodeHex(indexHex)))
         return fileKey.copyOf(FILE_KEY_LENGTH)
     }
 
-    fun deriveIv(indexHex: String): ByteArray = hexDecode(indexHex).copyOf(IV_LENGTH)
+    fun deriveIv(indexHex: String): ByteArray = Hex.decodeHex(indexHex).copyOf(IV_LENGTH)
 
-    fun toHex(bytes: ByteArray): String {
-        val sb = StringBuilder(bytes.size * 2)
-        for (b in bytes) {
-            val v = b.toInt() and 0xff
-            sb.append(HEX[v ushr 4])
-            sb.append(HEX[v and 0x0f])
-        }
-        return sb.toString()
-    }
-
-    private fun pbkdf2Seed(mnemonic: String): ByteArray =
-        CryptoService.getInstance().pbkdf2(mnemonic, PBKDF2_SALT.toByteArray(Charsets.UTF_8), PBKDF2_ROUNDS, SEED_LENGTH)
-
-    private fun sha512(key: ByteArray, data: ByteArray): ByteArray {
-        val md = MessageDigest.getInstance("SHA-512")
-        md.update(key)
-        md.update(data)
-        return md.digest()
-    }
-
-    private fun hexDecode(hex: String): ByteArray {
-        require(hex.length % 2 == 0) { "Hex string must have even length" }
-        val out = ByteArray(hex.length / 2)
-        var i = 0
-        while (i < hex.length) {
-            val hi = Character.digit(hex[i], 16)
-            val lo = Character.digit(hex[i + 1], 16)
-            require(hi >= 0 && lo >= 0) { "Invalid hex character at position $i" }
-            out[i / 2] = ((hi shl 4) or lo).toByte()
-            i += 2
-        }
-        return out
-    }
-
-    private val HEX = "0123456789abcdef".toCharArray()
+    fun toHex(bytes: ByteArray): String = Hex.encodeHex(bytes, /* truncateAtFirstZero = */ false)
 }

--- a/android/app/src/main/java/com/internxt/cloud/documents/crypto/FileKeyDeriver.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/crypto/FileKeyDeriver.kt
@@ -29,6 +29,6 @@ object FileKeyDeriver {
     }
 
     fun deriveIv(indexHex: String): ByteArray = Hex.decodeHex(indexHex).copyOf(IV_LENGTH)
-
-    fun toHex(bytes: ByteArray): String = Hex.encodeHex(bytes, /* truncateAtFirstZero = */ false)
 }
+
+fun ByteArray.toHex(): String = Hex.encodeHex(this, /* truncateAtFirstZero = */ false)

--- a/android/app/src/main/java/com/internxt/cloud/documents/crypto/FileKeyDeriver.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/crypto/FileKeyDeriver.kt
@@ -1,0 +1,58 @@
+package com.internxt.cloud.documents.crypto
+
+import com.rncrypto.util.CryptoService
+import java.security.MessageDigest
+
+object FileKeyDeriver {
+
+    private const val PBKDF2_SALT = "mnemonic"
+    private const val PBKDF2_ROUNDS = 2048
+    private const val SEED_LENGTH = 64
+    private const val FILE_KEY_LENGTH = 32
+    private const val IV_LENGTH = 16
+
+    fun deriveFileKey(mnemonic: String, bucketIdHex: String, indexHex: String): ByteArray {
+        val seed = pbkdf2Seed(mnemonic)
+        val bucketKey = sha512(seed, hexDecode(bucketIdHex))
+        val fileKey = sha512(bucketKey.copyOf(FILE_KEY_LENGTH), hexDecode(indexHex))
+        return fileKey.copyOf(FILE_KEY_LENGTH)
+    }
+
+    fun deriveIv(indexHex: String): ByteArray = hexDecode(indexHex).copyOf(IV_LENGTH)
+
+    fun toHex(bytes: ByteArray): String {
+        val sb = StringBuilder(bytes.size * 2)
+        for (b in bytes) {
+            val v = b.toInt() and 0xff
+            sb.append(HEX[v ushr 4])
+            sb.append(HEX[v and 0x0f])
+        }
+        return sb.toString()
+    }
+
+    private fun pbkdf2Seed(mnemonic: String): ByteArray =
+        CryptoService.getInstance().pbkdf2(mnemonic, PBKDF2_SALT.toByteArray(Charsets.UTF_8), PBKDF2_ROUNDS, SEED_LENGTH)
+
+    private fun sha512(key: ByteArray, data: ByteArray): ByteArray {
+        val md = MessageDigest.getInstance("SHA-512")
+        md.update(key)
+        md.update(data)
+        return md.digest()
+    }
+
+    private fun hexDecode(hex: String): ByteArray {
+        require(hex.length % 2 == 0) { "Hex string must have even length" }
+        val out = ByteArray(hex.length / 2)
+        var i = 0
+        while (i < hex.length) {
+            val hi = Character.digit(hex[i], 16)
+            val lo = Character.digit(hex[i + 1], 16)
+            require(hi >= 0 && lo >= 0) { "Invalid hex character at position $i" }
+            out[i / 2] = ((hi shl 4) or lo).toByte()
+            i += 2
+        }
+        return out
+    }
+
+    private val HEX = "0123456789abcdef".toCharArray()
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/crypto/HashUtil.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/crypto/HashUtil.kt
@@ -1,0 +1,21 @@
+package com.internxt.cloud.documents.crypto
+
+import java.security.MessageDigest
+
+object HashUtil {
+
+    fun deriveBridgePass(userId: String): String = sha256Hex(userId.toByteArray(Charsets.UTF_8))
+
+    fun sha256Hex(bytes: ByteArray): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(bytes)
+        val sb = StringBuilder(digest.size * 2)
+        for (b in digest) {
+            val v = b.toInt() and 0xff
+            sb.append(HEX[v ushr 4])
+            sb.append(HEX[v and 0x0f])
+        }
+        return sb.toString()
+    }
+
+    private val HEX = "0123456789abcdef".toCharArray()
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/crypto/Ripemd160.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/crypto/Ripemd160.kt
@@ -1,0 +1,14 @@
+package com.internxt.cloud.documents.crypto
+
+import org.bouncycastle.crypto.digests.RIPEMD160Digest
+
+object Ripemd160 {
+
+    fun digest(input: ByteArray): ByteArray {
+        val md = RIPEMD160Digest()
+        md.update(input, 0, input.size)
+        val out = ByteArray(md.digestSize)
+        md.doFinal(out, 0)
+        return out
+    }
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/download/EncryptedFileDownloader.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/download/EncryptedFileDownloader.kt
@@ -1,0 +1,67 @@
+package com.internxt.cloud.documents.download
+
+import android.os.CancellationSignal
+import android.os.OperationCanceledException
+import com.internxt.cloud.documents.api.model.Shard
+import okhttp3.Call
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicReference
+
+object EncryptedFileDownloader {
+
+    private const val COPY_BUFFER_SIZE = 16 * 1024
+
+    @Throws(IOException::class, OperationCanceledException::class)
+    fun download(
+        client: OkHttpClient,
+        shards: List<Shard>,
+        target: File,
+        signal: CancellationSignal?
+    ) {
+        require(shards.isNotEmpty()) { "No shards to download" }
+        target.parentFile?.mkdirs()
+        if (target.exists()) target.delete()
+
+        val activeCall = AtomicReference<Call?>(null)
+        signal?.setOnCancelListener { activeCall.get()?.cancel() }
+
+        FileOutputStream(target, /* append = */ true).use { out ->
+            for (shard in shards.sortedBy { it.index }) {
+                signal?.throwIfCanceled()
+
+                val request = Request.Builder().url(shard.url).get().build()
+                val call = client.newCall(request)
+                activeCall.set(call)
+
+                try {
+                    call.execute().use { response ->
+                        if (!response.isSuccessful) {
+                            throw IOException("Shard ${shard.index} HTTP ${response.code}")
+                        }
+                        val body = response.body ?: throw IOException("Shard ${shard.index} empty body")
+                        val buffer = ByteArray(COPY_BUFFER_SIZE)
+                        body.byteStream().use { input ->
+                            while (true) {
+                                val read = input.read(buffer)
+                                if (read == -1) break
+                                out.write(buffer, 0, read)
+                            }
+                        }
+                    }
+                } catch (e: IOException) {
+                    if (signal?.isCanceled == true) {
+                        throw OperationCanceledException("Download cancelled").apply { initCause(e) }
+                    }
+                    throw e
+                } finally {
+                    activeCall.set(null)
+                }
+            }
+            out.flush()
+        }
+    }
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/download/EncryptedFileDownloader.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/download/EncryptedFileDownloader.kt
@@ -1,37 +1,31 @@
 package com.internxt.cloud.documents.download
 
-import android.os.CancellationSignal
-import android.os.OperationCanceledException
 import com.internxt.cloud.documents.api.model.Shard
-import okhttp3.Call
+import com.internxt.cloud.documents.http.await
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
-import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.ensureActive
+import kotlin.coroutines.coroutineContext
 
 object EncryptedFileDownloader {
 
     private const val COPY_BUFFER_SIZE = 16 * 1024
 
-    @Throws(IOException::class, OperationCanceledException::class)
-    fun download(
+    suspend fun download(
         client: OkHttpClient,
         shards: List<Shard>,
         target: File,
-        signal: CancellationSignal?
     ) {
         require(shards.isNotEmpty()) { "No shards to download" }
         prepareTarget(target)
 
-        val activeCall = AtomicReference<Call?>(null)
-        signal?.setOnCancelListener { activeCall.get()?.cancel() }
-
         FileOutputStream(target, /* append = */ true).use { out ->
             shards.sortedBy { it.index }.forEach { shard ->
-                signal?.throwIfCanceled()
-                downloadShard(client, shard, out, activeCall, signal)
+                coroutineContext.ensureActive()
+                downloadShard(client, shard, out)
             }
             out.flush()
         }
@@ -44,27 +38,13 @@ object EncryptedFileDownloader {
         }
     }
 
-    private fun downloadShard(
+    private suspend fun downloadShard(
         client: OkHttpClient,
         shard: Shard,
         out: FileOutputStream,
-        activeCall: AtomicReference<Call?>,
-        signal: CancellationSignal?
     ) {
         val request = Request.Builder().url(shard.url).get().build()
-        val call = client.newCall(request)
-        activeCall.set(call)
-
-        try {
-            call.execute().use { response -> writeShardResponse(shard, response, out) }
-        } catch (e: IOException) {
-            if (signal != null && signal.isCanceled) {
-                throw OperationCanceledException("Download cancelled").apply { initCause(e) }
-            }
-            throw e
-        } finally {
-            activeCall.set(null)
-        }
+        client.newCall(request).await().use { response -> writeShardResponse(shard, response, out) }
     }
 
     private fun writeShardResponse(shard: Shard, response: okhttp3.Response, out: FileOutputStream) {

--- a/android/app/src/main/java/com/internxt/cloud/documents/download/EncryptedFileDownloader.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/download/EncryptedFileDownloader.kt
@@ -23,45 +23,62 @@ object EncryptedFileDownloader {
         signal: CancellationSignal?
     ) {
         require(shards.isNotEmpty()) { "No shards to download" }
-        target.parentFile?.mkdirs()
-        if (target.exists()) target.delete()
+        prepareTarget(target)
 
         val activeCall = AtomicReference<Call?>(null)
         signal?.setOnCancelListener { activeCall.get()?.cancel() }
 
         FileOutputStream(target, /* append = */ true).use { out ->
-            for (shard in shards.sortedBy { it.index }) {
+            shards.sortedBy { it.index }.forEach { shard ->
                 signal?.throwIfCanceled()
-
-                val request = Request.Builder().url(shard.url).get().build()
-                val call = client.newCall(request)
-                activeCall.set(call)
-
-                try {
-                    call.execute().use { response ->
-                        if (!response.isSuccessful) {
-                            throw IOException("Shard ${shard.index} HTTP ${response.code}")
-                        }
-                        val body = response.body ?: throw IOException("Shard ${shard.index} empty body")
-                        val buffer = ByteArray(COPY_BUFFER_SIZE)
-                        body.byteStream().use { input ->
-                            while (true) {
-                                val read = input.read(buffer)
-                                if (read == -1) break
-                                out.write(buffer, 0, read)
-                            }
-                        }
-                    }
-                } catch (e: IOException) {
-                    if (signal?.isCanceled == true) {
-                        throw OperationCanceledException("Download cancelled").apply { initCause(e) }
-                    }
-                    throw e
-                } finally {
-                    activeCall.set(null)
-                }
+                downloadShard(client, shard, out, activeCall, signal)
             }
             out.flush()
+        }
+    }
+
+    private fun prepareTarget(target: File) {
+        target.parentFile?.mkdirs()
+        if (target.exists() && !target.delete()) {
+            throw IOException("Failed to delete existing target file: ${target.absolutePath}")
+        }
+    }
+
+    private fun downloadShard(
+        client: OkHttpClient,
+        shard: Shard,
+        out: FileOutputStream,
+        activeCall: AtomicReference<Call?>,
+        signal: CancellationSignal?
+    ) {
+        val request = Request.Builder().url(shard.url).get().build()
+        val call = client.newCall(request)
+        activeCall.set(call)
+
+        try {
+            call.execute().use { response -> writeShardResponse(shard, response, out) }
+        } catch (e: IOException) {
+            if (signal?.isCanceled == true) {
+                throw OperationCanceledException("Download cancelled").apply { initCause(e) }
+            }
+            throw e
+        } finally {
+            activeCall.set(null)
+        }
+    }
+
+    private fun writeShardResponse(shard: Shard, response: okhttp3.Response, out: FileOutputStream) {
+        if (!response.isSuccessful) {
+            throw IOException("Shard ${shard.index} HTTP ${response.code}")
+        }
+        val body = response.body ?: throw IOException("Shard ${shard.index} empty body")
+        val buffer = ByteArray(COPY_BUFFER_SIZE)
+        body.byteStream().use { input ->
+            var read = input.read(buffer)
+            while (read != -1) {
+                out.write(buffer, 0, read)
+                read = input.read(buffer)
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/internxt/cloud/documents/download/EncryptedFileDownloader.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/download/EncryptedFileDownloader.kt
@@ -58,7 +58,7 @@ object EncryptedFileDownloader {
         try {
             call.execute().use { response -> writeShardResponse(shard, response, out) }
         } catch (e: IOException) {
-            if (signal?.isCanceled == true) {
+            if (signal != null && signal.isCanceled) {
                 throw OperationCanceledException("Download cancelled").apply { initCause(e) }
             }
             throw e

--- a/android/app/src/main/java/com/internxt/cloud/documents/http/CallAwait.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/http/CallAwait.kt
@@ -1,0 +1,28 @@
+package com.internxt.cloud.documents.http
+
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.Response
+import java.io.IOException
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+suspend fun Call.await(): Response = suspendCancellableCoroutine { continuation ->
+    enqueue(object : Callback {
+        override fun onResponse(call: Call, response: Response) {
+            continuation.resume(response) { response.closeQuietly() }
+        }
+
+        override fun onFailure(call: Call, e: IOException) {
+            continuation.resumeWithException(e)
+        }
+    })
+    continuation.invokeOnCancellation { cancel() }
+}
+
+private fun Response.closeQuietly() {
+    try {
+        close()
+    } catch (_: Throwable) {
+    }
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/http/HttpClients.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/http/HttpClients.kt
@@ -1,0 +1,24 @@
+package com.internxt.cloud.documents.http
+
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
+
+object HttpClients {
+
+    val api: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(15, TimeUnit.SECONDS)
+            .callTimeout(30, TimeUnit.SECONDS)
+            .build()
+    }
+
+    val download: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(2, TimeUnit.MINUTES)
+            .writeTimeout(2, TimeUnit.MINUTES)
+            .callTimeout(0, TimeUnit.MILLISECONDS)
+            .build()
+    }
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/http/HttpClients.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/http/HttpClients.kt
@@ -13,12 +13,14 @@ object HttpClients {
             .build()
     }
 
-    val download: OkHttpClient by lazy {
+    val download: OkHttpClient by lazy { largeTransferClient(writeTimeoutMinutes = 2L) }
+    val upload: OkHttpClient by lazy { largeTransferClient(writeTimeoutMinutes = 0L) }
+
+    private fun largeTransferClient(writeTimeoutMinutes: Long): OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(2, TimeUnit.MINUTES)
-            .writeTimeout(2, TimeUnit.MINUTES)
+            .writeTimeout(writeTimeoutMinutes, TimeUnit.MINUTES)
             .callTimeout(0, TimeUnit.MILLISECONDS)
             .build()
-    }
 }

--- a/android/app/src/main/java/com/internxt/cloud/documents/signaling/InternxtSignalingModule.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/signaling/InternxtSignalingModule.kt
@@ -1,0 +1,35 @@
+package com.internxt.cloud.documents.signaling
+
+import android.util.Log
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.internxt.cloud.documents.InternxtDocumentsProvider
+
+class InternxtSignalingModule(ctx: ReactApplicationContext) :
+    ReactContextBaseJavaModule(ctx) {
+
+    override fun getName() = MODULE_NAME
+
+    @ReactMethod
+    fun notifyParentChanged(parentFolderUuid: String?, promise: Promise) {
+        val folderUuid = parentFolderUuid?.takeIf { it.isNotBlank() } ?: run {
+            promise.reject("E_INVALID_FOLDER", "parentFolderUuid must be a non-empty string")
+            return
+        }
+        try {
+            InternxtDocumentsProvider.signalParentChanged(folderUuid)
+            promise.resolve(null)
+        } catch (e: Exception) {
+            // Best-effort signal: never let a failed refresh break the JS caller.
+            Log.w(TAG, "notifyParentChanged failed for $folderUuid", e)
+            promise.resolve(null)
+        }
+    }
+
+    companion object {
+        const val MODULE_NAME = "InternxtSignalingModule"
+        private const val TAG = "InternxtSignaling"
+    }
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/signaling/InternxtSignalingModule.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/signaling/InternxtSignalingModule.kt
@@ -18,12 +18,16 @@ class InternxtSignalingModule(ctx: ReactApplicationContext) :
             promise.reject("E_INVALID_FOLDER", "parentFolderUuid must be a non-empty string")
             return
         }
+        signalParent(folderUuid, promise)
+    }
+
+    private fun signalParent(folderUuid: String, promise: Promise) {
         try {
             InternxtDocumentsProvider.signalParentChanged(folderUuid)
             promise.resolve(null)
         } catch (e: Exception) {
             // Best-effort signal: never let a failed refresh break the JS caller.
-            Log.w(TAG, "notifyParentChanged failed for $folderUuid", e)
+            Log.w(TAG, "signalParent failed for $folderUuid", e)
             promise.resolve(null)
         }
     }

--- a/android/app/src/main/java/com/internxt/cloud/documents/signaling/InternxtSignalingPackage.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/signaling/InternxtSignalingPackage.kt
@@ -1,0 +1,14 @@
+package com.internxt.cloud.documents.signaling
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class InternxtSignalingPackage : ReactPackage {
+    override fun createNativeModules(context: ReactApplicationContext): List<NativeModule> =
+        listOf(InternxtSignalingModule(context))
+
+    override fun createViewManagers(context: ReactApplicationContext): List<ViewManager<*, *>> =
+        emptyList()
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/upload/CancelUploadReceiver.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/upload/CancelUploadReceiver.kt
@@ -1,0 +1,17 @@
+package com.internxt.cloud.documents.upload
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.ContextCompat
+
+class CancelUploadReceiver : BroadcastReceiver() {
+
+    override fun onReceive(ctx: Context, intent: Intent) {
+        val token = intent.getStringExtra(UploadForegroundService.EXTRA_TOKEN) ?: return
+        val forward = Intent(ctx, UploadForegroundService::class.java)
+            .setAction(UploadForegroundService.ACTION_CANCEL)
+            .putExtra(UploadForegroundService.EXTRA_TOKEN, token)
+        ContextCompat.startForegroundService(ctx, forward)
+    }
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/upload/EncryptedFileUploader.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/upload/EncryptedFileUploader.kt
@@ -1,13 +1,11 @@
 package com.internxt.cloud.documents.upload
 
-import android.os.CancellationSignal
-import android.os.OperationCanceledException
 import com.internxt.cloud.documents.api.model.UploadedPart
 import com.internxt.cloud.documents.crypto.Ripemd160
 import com.internxt.cloud.documents.crypto.awaitCryptoService
 import com.internxt.cloud.documents.crypto.toHex
+import com.internxt.cloud.documents.http.await
 import com.rncrypto.util.CryptoService
-import okhttp3.Call
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -19,7 +17,8 @@ import java.io.IOException
 import java.io.InputStream
 import java.io.RandomAccessFile
 import java.security.MessageDigest
-import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.ensureActive
+import kotlin.coroutines.coroutineContext
 
 object EncryptedFileUploader {
 
@@ -37,7 +36,7 @@ object EncryptedFileUploader {
      * package does not return a digest, so SHA-256 over the ciphertext is computed here
      * by streaming the produced file back through MessageDigest.
      */
-    fun encryptFile(plain: File, tempEnc: File, key: ByteArray, iv: ByteArray): Encrypted {
+    suspend fun encryptFile(plain: File, tempEnc: File, key: ByteArray, iv: ByteArray): Encrypted {
         prepareTarget(tempEnc)
         awaitCryptoService("Encryption failed") { cb ->
             CryptoService.getInstance().encryptFile(
@@ -91,42 +90,36 @@ object EncryptedFileUploader {
         return hashes
     }
 
-    fun uploadSingle(
+    suspend fun uploadSingle(
         client: OkHttpClient,
         tempEnc: File,
         url: String,
-        signal: CancellationSignal?,
         onProgress: ((Long) -> Unit)? = null,
     ) {
-        val active = AtomicReference<Call?>(null)
-        signal?.setOnCancelListener { active.get()?.cancel() }
         val body = fileRangeBody(tempEnc, 0L, tempEnc.length(), onProgress, baseSent = 0L)
         val request = Request.Builder().url(url).put(body).build()
-        runCall(client, request, signal, active) { /* ETag not needed for single */ }
+        runCall(client, request) { /* ETag not needed for single */ }
     }
 
-    fun uploadMultipart(
+    suspend fun uploadMultipart(
         client: OkHttpClient,
         tempEnc: File,
         urls: List<String>,
         partSize: Long,
-        signal: CancellationSignal?,
         onProgress: ((Long) -> Unit)? = null,
     ): List<UploadedPart> {
         require(urls.isNotEmpty()) { "urls cannot be empty" }
         val total = tempEnc.length()
-        val active = AtomicReference<Call?>(null)
-        signal?.setOnCancelListener { active.get()?.cancel() }
 
         val parts = ArrayList<UploadedPart>(urls.size)
         var offset = 0L
         urls.forEachIndexed { index, url ->
-            signal?.throwIfCanceled()
+            coroutineContext.ensureActive()
             val length = (total - offset).coerceAtMost(partSize)
             require(length > 0) { "Computed empty part for index $index" }
             val body = fileRangeBody(tempEnc, offset, length, onProgress, baseSent = offset)
             val request = Request.Builder().url(url).put(body).build()
-            val etag = runCall(client, request, signal, active) { response ->
+            val etag = runCall(client, request) { response ->
                 response.header("ETag") ?: response.header("Etag")
                     ?: throw IOException("Part ${index + 1} missing ETag in response")
             }
@@ -146,30 +139,15 @@ object EncryptedFileUploader {
         return Ripemd160.digest(hexDecode(concatenated)).toHex()
     }
 
-    private inline fun <T> runCall(
+    private suspend fun <T> runCall(
         client: OkHttpClient,
         request: Request,
-        signal: CancellationSignal?,
-        active: AtomicReference<Call?>,
         onResponse: (okhttp3.Response) -> T,
-    ): T {
-        val call = client.newCall(request)
-        active.set(call)
-        try {
-            return call.execute().use { response ->
-                if (!response.isSuccessful) {
-                    throw IOException("PUT failed HTTP ${response.code}")
-                }
-                onResponse(response)
-            }
-        } catch (e: IOException) {
-            if (signal != null && signal.isCanceled) {
-                throw OperationCanceledException("Upload cancelled").apply { initCause(e) }
-            }
-            throw e
-        } finally {
-            active.set(null)
+    ): T = client.newCall(request).await().use { response ->
+        if (!response.isSuccessful) {
+            throw IOException("PUT failed HTTP ${response.code}")
         }
+        onResponse(response)
     }
 
     private fun fileRangeBody(

--- a/android/app/src/main/java/com/internxt/cloud/documents/upload/EncryptedFileUploader.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/upload/EncryptedFileUploader.kt
@@ -1,0 +1,257 @@
+package com.internxt.cloud.documents.upload
+
+import android.os.CancellationSignal
+import android.os.OperationCanceledException
+import com.internxt.cloud.documents.api.model.UploadedPart
+import com.internxt.cloud.documents.crypto.Ripemd160
+import com.internxt.cloud.documents.crypto.awaitCryptoService
+import com.internxt.cloud.documents.crypto.toHex
+import com.rncrypto.util.CryptoService
+import okhttp3.Call
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
+import okio.BufferedSink
+import okio.source
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import java.io.RandomAccessFile
+import java.security.MessageDigest
+import java.util.concurrent.atomic.AtomicReference
+
+object EncryptedFileUploader {
+
+    internal const val COPY_BUFFER_SIZE = 16 * 1024
+    private val OCTET_STREAM = "application/octet-stream".toMediaType()
+
+    data class Encrypted(
+        val size: Long,
+        val wholeSha256Hex: String,
+    )
+
+    /**
+     * Encrypt [plain] → [tempEnc] using the official `@internxt/rn-crypto` CryptoService —
+     * the same code path the RN side calls into (NetworkFacade.ts -> encryptFile). The
+     * package does not return a digest, so SHA-256 over the ciphertext is computed here
+     * by streaming the produced file back through MessageDigest.
+     */
+    fun encryptFile(plain: File, tempEnc: File, key: ByteArray, iv: ByteArray): Encrypted {
+        prepareTarget(tempEnc)
+        awaitCryptoService("Encryption failed") { cb ->
+            CryptoService.getInstance().encryptFile(
+                plain.absolutePath,
+                tempEnc.absolutePath,
+                key.toHex(),
+                iv.toHex(),
+                /* runInBackground = */ false,
+                cb,
+            )
+        }
+        return Encrypted(size = tempEnc.length(), wholeSha256Hex = computeSha256Hex(tempEnc))
+    }
+
+    private fun computeSha256Hex(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val buffer = ByteArray(COPY_BUFFER_SIZE)
+        file.inputStream().use { input ->
+            while (true) {
+                val n = input.read(buffer)
+                if (n == -1) break
+                digest.update(buffer, 0, n)
+            }
+        }
+        return digest.digest().toHex()
+    }
+
+    fun computePartSha256(tempEnc: File, partSize: Long): List<String> {
+        require(partSize > 0) { "partSize must be > 0" }
+        val total = tempEnc.length()
+        if (total == 0L) return emptyList()
+        val hashes = mutableListOf<String>()
+        val buffer = ByteArray(COPY_BUFFER_SIZE)
+        RandomAccessFile(tempEnc, "r").use { raf ->
+            var consumed = 0L
+            while (consumed < total) {
+                val partEnd = (consumed + partSize).coerceAtMost(total)
+                val digest = MessageDigest.getInstance("SHA-256")
+                var partRemaining = partEnd - consumed
+                while (partRemaining > 0) {
+                    val toRead = partRemaining.coerceAtMost(buffer.size.toLong()).toInt()
+                    val n = raf.read(buffer, 0, toRead)
+                    if (n == -1) throw IOException("Unexpected EOF computing part hashes")
+                    digest.update(buffer, 0, n)
+                    partRemaining -= n
+                    consumed += n
+                }
+                hashes.add(digest.digest().toHex())
+            }
+        }
+        return hashes
+    }
+
+    fun uploadSingle(
+        client: OkHttpClient,
+        tempEnc: File,
+        url: String,
+        signal: CancellationSignal?,
+        onProgress: ((Long) -> Unit)? = null,
+    ) {
+        val active = AtomicReference<Call?>(null)
+        signal?.setOnCancelListener { active.get()?.cancel() }
+        val body = fileRangeBody(tempEnc, 0L, tempEnc.length(), onProgress, baseSent = 0L)
+        val request = Request.Builder().url(url).put(body).build()
+        runCall(client, request, signal, active) { /* ETag not needed for single */ }
+    }
+
+    fun uploadMultipart(
+        client: OkHttpClient,
+        tempEnc: File,
+        urls: List<String>,
+        partSize: Long,
+        signal: CancellationSignal?,
+        onProgress: ((Long) -> Unit)? = null,
+    ): List<UploadedPart> {
+        require(urls.isNotEmpty()) { "urls cannot be empty" }
+        val total = tempEnc.length()
+        val active = AtomicReference<Call?>(null)
+        signal?.setOnCancelListener { active.get()?.cancel() }
+
+        val parts = ArrayList<UploadedPart>(urls.size)
+        var offset = 0L
+        urls.forEachIndexed { index, url ->
+            signal?.throwIfCanceled()
+            val length = (total - offset).coerceAtMost(partSize)
+            require(length > 0) { "Computed empty part for index $index" }
+            val body = fileRangeBody(tempEnc, offset, length, onProgress, baseSent = offset)
+            val request = Request.Builder().url(url).put(body).build()
+            var etag: String? = null
+            runCall(client, request, signal, active) { response ->
+                etag = response.header("ETag") ?: response.header("Etag")
+                    ?: throw IOException("Part ${index + 1} missing ETag in response")
+            }
+            parts.add(UploadedPart(partNumber = index + 1, etag = etag!!))
+            offset += length
+        }
+        return parts
+    }
+
+    /**
+     * `ripemd160(hex_decode(concat(sha256_hex_per_part)))`. For single-part upload,
+     * pass a 1-element list with the whole-file SHA-256.
+     */
+    fun computeShardHash(partHashesHex: List<String>): String {
+        require(partHashesHex.isNotEmpty()) { "no part hashes" }
+        val concatenated = partHashesHex.joinToString(separator = "")
+        return Ripemd160.digest(hexDecode(concatenated)).toHex()
+    }
+
+    private inline fun runCall(
+        client: OkHttpClient,
+        request: Request,
+        signal: CancellationSignal?,
+        active: AtomicReference<Call?>,
+        onResponse: (okhttp3.Response) -> Unit,
+    ) {
+        val call = client.newCall(request)
+        active.set(call)
+        try {
+            call.execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IOException("PUT failed HTTP ${response.code}")
+                }
+                onResponse(response)
+            }
+        } catch (e: IOException) {
+            if (signal != null && signal.isCanceled) {
+                throw OperationCanceledException("Upload cancelled").apply { initCause(e) }
+            }
+            throw e
+        } finally {
+            active.set(null)
+        }
+    }
+
+    private fun fileRangeBody(
+        file: File,
+        offset: Long,
+        length: Long,
+        onProgress: ((Long) -> Unit)? = null,
+        baseSent: Long = 0L,
+    ): RequestBody =
+        object : RequestBody() {
+            override fun contentType() = OCTET_STREAM
+            override fun contentLength(): Long = length
+            override fun writeTo(sink: BufferedSink) {
+                RandomAccessFile(file, "r").use { raf ->
+                    raf.seek(offset)
+                    if (onProgress == null) {
+                        val limited = LimitedInputStream(raf, length)
+                        limited.source().use { sink.writeAll(it) }
+                    } else {
+                        val buffer = ByteArray(COPY_BUFFER_SIZE)
+                        var remaining = length
+                        var sent = 0L
+                        while (remaining > 0) {
+                            val toRead = remaining.coerceAtMost(buffer.size.toLong()).toInt()
+                            val n = raf.read(buffer, 0, toRead)
+                            if (n == -1) throw IOException("Unexpected EOF reading upload body")
+                            sink.write(buffer, 0, n)
+                            remaining -= n
+                            sent += n
+                            onProgress(baseSent + sent)
+                        }
+                    }
+                }
+            }
+        }
+
+    private fun prepareTarget(target: File) {
+        target.parentFile?.mkdirs()
+        if (target.exists() && !target.delete()) {
+            throw IOException("Failed to delete existing temp file: ${target.absolutePath}")
+        }
+    }
+
+    private fun hexDecode(hex: String): ByteArray {
+        require(hex.length % 2 == 0) { "Invalid hex length" }
+        val out = ByteArray(hex.length / 2)
+        for (i in out.indices) {
+            val hi = Character.digit(hex[i * 2], 16)
+            val lo = Character.digit(hex[i * 2 + 1], 16)
+            require(hi >= 0 && lo >= 0) { "Invalid hex char" }
+            out[i] = ((hi shl 4) or lo).toByte()
+        }
+        return out
+    }
+
+    private class LimitedInputStream(
+        private val raf: RandomAccessFile,
+        private var remaining: Long,
+    ) : InputStream() {
+
+        override fun read(): Int {
+            if (remaining <= 0) return -1
+            val b = raf.read()
+            if (b == -1) {
+                remaining = 0
+                return -1
+            }
+            remaining--
+            return b
+        }
+
+        override fun read(b: ByteArray, off: Int, len: Int): Int {
+            if (remaining <= 0) return -1
+            val toRead = remaining.coerceAtMost(len.toLong()).toInt()
+            val n = raf.read(b, off, toRead)
+            if (n == -1) {
+                remaining = 0
+                return -1
+            }
+            remaining -= n
+            return n
+        }
+    }
+}

--- a/android/app/src/main/java/com/internxt/cloud/documents/upload/EncryptedFileUploader.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/upload/EncryptedFileUploader.kt
@@ -126,12 +126,11 @@ object EncryptedFileUploader {
             require(length > 0) { "Computed empty part for index $index" }
             val body = fileRangeBody(tempEnc, offset, length, onProgress, baseSent = offset)
             val request = Request.Builder().url(url).put(body).build()
-            var etag: String? = null
-            runCall(client, request, signal, active) { response ->
-                etag = response.header("ETag") ?: response.header("Etag")
+            val etag = runCall(client, request, signal, active) { response ->
+                response.header("ETag") ?: response.header("Etag")
                     ?: throw IOException("Part ${index + 1} missing ETag in response")
             }
-            parts.add(UploadedPart(partNumber = index + 1, etag = etag!!))
+            parts.add(UploadedPart(partNumber = index + 1, etag = etag))
             offset += length
         }
         return parts
@@ -147,17 +146,17 @@ object EncryptedFileUploader {
         return Ripemd160.digest(hexDecode(concatenated)).toHex()
     }
 
-    private inline fun runCall(
+    private inline fun <T> runCall(
         client: OkHttpClient,
         request: Request,
         signal: CancellationSignal?,
         active: AtomicReference<Call?>,
-        onResponse: (okhttp3.Response) -> Unit,
-    ) {
+        onResponse: (okhttp3.Response) -> T,
+    ): T {
         val call = client.newCall(request)
         active.set(call)
         try {
-            call.execute().use { response ->
+            return call.execute().use { response ->
                 if (!response.isSuccessful) {
                     throw IOException("PUT failed HTTP ${response.code}")
                 }

--- a/android/app/src/main/java/com/internxt/cloud/documents/upload/PendingUpload.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/upload/PendingUpload.kt
@@ -1,0 +1,8 @@
+package com.internxt.cloud.documents.upload
+
+data class PendingUpload(
+    val parentUuid: String,
+    val plainName: String,
+    val mimeType: String,
+    val createdAtMillis: Long = System.currentTimeMillis(),
+)

--- a/android/app/src/main/java/com/internxt/cloud/documents/upload/UploadForegroundService.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/upload/UploadForegroundService.kt
@@ -1,0 +1,245 @@
+package com.internxt.cloud.documents.upload
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.CancellationSignal
+import android.os.IBinder
+import android.text.format.Formatter
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+import com.internxt.cloud.R
+import java.util.concurrent.ConcurrentHashMap
+
+class UploadForegroundService : Service() {
+
+    private val notificationManager: NotificationManager by lazy {
+        getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        instance = this
+        ensureChannel(this)
+        cancelOrphanedNotifications()
+    }
+
+    /**
+     * After process death, the static `uploads` map is empty but any in-flight foreground
+     * notification posted by a previous incarnation survives. Cancel anything in our channel
+     * that isn't backed by a live upload state so the tray doesn't show ghost progress bars.
+     */
+    private fun cancelOrphanedNotifications() {
+        val live = uploads.values
+            .flatMap { listOf(it.notificationId, it.errorNotificationId) }
+            .toHashSet()
+        notificationManager.activeNotifications
+            .filter { it.notification.channelId == CHANNEL_ID && it.id !in live }
+            .forEach { notificationManager.cancel(it.id) }
+    }
+
+    override fun onDestroy() {
+        if (instance === this) instance = null
+        isForeground = false
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val action = intent?.action
+        val token = intent?.getStringExtra(EXTRA_TOKEN)
+        when (action) {
+            ACTION_START -> {
+                val state = token?.let { uploads[it] }
+                if (state != null) {
+                    intent.getStringExtra(EXTRA_DISPLAY_NAME)?.takeIf { it.isNotEmpty() }
+                        ?.let { state.displayName = it }
+                    postNotification(state, foregroundOnFirst = true)
+                } else {
+                    ensureForeground()
+                    maybeStop()
+                }
+            }
+            ACTION_CANCEL -> {
+                token?.let { signals[it]?.cancel() }
+                ensureForeground()
+                maybeStop()
+            }
+            else -> {
+                ensureForeground()
+                maybeStop()
+            }
+        }
+        return START_NOT_STICKY
+    }
+
+    private fun ensureForeground() {
+        if (isForeground) return
+        val state = uploads.values.firstOrNull() ?: UploadState("placeholder", "")
+        postNotification(state, foregroundOnFirst = true)
+    }
+
+    private fun postNotification(state: UploadState, foregroundOnFirst: Boolean) {
+        val notification = buildProgressNotification(state)
+        if (foregroundOnFirst && !isForeground) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                startForeground(
+                    state.notificationId,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+                )
+            } else {
+                startForeground(state.notificationId, notification)
+            }
+            isForeground = true
+        } else {
+            notificationManager.notify(state.notificationId, notification)
+        }
+    }
+
+    private fun postFailure(state: UploadState, message: String) {
+        // Use a distinct id so stopForeground(STOP_FOREGROUND_REMOVE) doesn't tear this down.
+        notificationManager.notify(state.errorNotificationId, buildErrorNotification(state, message))
+    }
+
+    private fun buildProgressNotification(state: UploadState): Notification {
+        val cancelPi = PendingIntent.getBroadcast(
+            this,
+            state.notificationId,
+            Intent(this, CancelUploadReceiver::class.java)
+                .setAction(ACTION_CANCEL)
+                .putExtra(EXTRA_TOKEN, state.token),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val title = when (state.phase) {
+            Phase.ENCRYPTING -> getString(R.string.upload_notification_encrypting, state.displayName)
+            Phase.UPLOADING -> getString(R.string.upload_notification_uploading, state.displayName)
+        }
+
+        val builder = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle(title)
+            .setContentText(formatProgressText(state))
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+            .addAction(0, getString(R.string.upload_notification_cancel), cancelPi)
+
+        if (state.phase == Phase.UPLOADING && state.total > 0) {
+            val pct = ((state.bytes * 100L) / state.total).toInt().coerceIn(0, 100)
+            builder.setProgress(100, pct, false)
+        } else {
+            builder.setProgress(0, 0, true)
+        }
+        return builder.build()
+    }
+
+    private fun buildErrorNotification(state: UploadState, message: String): Notification {
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle(getString(R.string.upload_notification_failed, state.displayName))
+            .setContentText(message)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(message))
+            .setOngoing(false)
+            .setAutoCancel(true)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .build()
+    }
+
+    private fun formatProgressText(state: UploadState): String = when {
+        state.phase == Phase.UPLOADING && state.total > 0 ->
+            "${Formatter.formatShortFileSize(this, state.bytes)} / " +
+                Formatter.formatShortFileSize(this, state.total)
+        state.bytes > 0 -> Formatter.formatShortFileSize(this, state.bytes)
+        else -> ""
+    }
+
+    private fun maybeStop() {
+        if (uploads.isEmpty()) {
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            stopSelf()
+            isForeground = false
+        }
+    }
+
+    enum class Phase { ENCRYPTING, UPLOADING }
+
+    private class UploadState(val token: String, var displayName: String) {
+        @Volatile var bytes: Long = 0L
+        @Volatile var total: Long = 0L
+        @Volatile var phase: Phase = Phase.ENCRYPTING
+        val notificationId: Int = stableNotificationId(token)
+        val errorNotificationId: Int = stableNotificationId("err:$token")
+    }
+
+    companion object {
+        const val CHANNEL_ID = "internxt_uploads"
+
+        const val ACTION_START = "com.internxt.cloud.documents.upload.START"
+        const val ACTION_CANCEL = "com.internxt.cloud.documents.upload.CANCEL"
+        const val EXTRA_TOKEN = "token"
+        const val EXTRA_DISPLAY_NAME = "display_name"
+
+        @Volatile private var instance: UploadForegroundService? = null
+        @Volatile private var isForeground = false
+
+        private val signals = ConcurrentHashMap<String, CancellationSignal>()
+        private val uploads = ConcurrentHashMap<String, UploadState>()
+
+        fun start(ctx: Context, token: String, displayName: String, signal: CancellationSignal) {
+            signals[token] = signal
+            uploads.getOrPut(token) { UploadState(token, displayName) }
+            val intent = Intent(ctx, UploadForegroundService::class.java)
+                .setAction(ACTION_START)
+                .putExtra(EXTRA_TOKEN, token)
+                .putExtra(EXTRA_DISPLAY_NAME, displayName)
+            ContextCompat.startForegroundService(ctx, intent)
+        }
+
+        fun reportProgress(token: String, phase: Phase, bytes: Long, total: Long) {
+            val state = uploads[token] ?: return
+            state.phase = phase
+            state.bytes = bytes
+            state.total = total
+            instance?.postNotification(state, foregroundOnFirst = false)
+        }
+
+        fun complete(token: String) {
+            val state = uploads.remove(token) ?: run { signals.remove(token); return }
+            signals.remove(token)
+            instance?.notificationManager?.cancel(state.notificationId)
+            instance?.maybeStop()
+        }
+
+        fun fail(token: String, message: String) {
+            val state = uploads.remove(token) ?: run { signals.remove(token); return }
+            signals.remove(token)
+            instance?.postFailure(state, message)
+            instance?.maybeStop()
+        }
+
+        private fun ensureChannel(ctx: Context) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+            val nm = ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            if (nm.getNotificationChannel(CHANNEL_ID) != null) return
+            val name = ctx.getString(R.string.upload_notification_channel_name)
+            nm.createNotificationChannel(
+                NotificationChannel(CHANNEL_ID, name, NotificationManager.IMPORTANCE_LOW)
+            )
+        }
+
+        private fun stableNotificationId(token: String): Int {
+            val h = token.hashCode()
+            return if (h == Int.MIN_VALUE) 1 else (h and Int.MAX_VALUE).coerceAtLeast(1)
+        }
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -5,4 +5,15 @@
   <string name="expo_runtime_version">1.9.1</string>
   <string name="expo_splash_screen_resize_mode" translatable="false">contain</string>
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
+  <string name="upload_notification_channel_name">Internxt uploads</string>
+  <string name="upload_notification_encrypting">Encrypting %1$s</string>
+  <string name="upload_notification_uploading">Uploading %1$s</string>
+  <string name="upload_notification_failed">Upload failed: %1$s</string>
+  <string name="upload_notification_cancel">Cancel</string>
+  <string name="upload_error_storage_full">Your Internxt Drive is full. Free up space or upgrade your plan.</string>
+  <string name="upload_error_signed_out">You\'ve been signed out. Open Internxt to sign in again.</string>
+  <string name="upload_error_too_large">This file is too large to upload.</string>
+  <string name="upload_error_server">Internxt is having trouble right now. Please try again in a moment.</string>
+  <string name="upload_error_network">No internet connection. The upload will not complete until you reconnect.</string>
+  <string name="upload_error_generic">Couldn\'t upload the file. Please try again.</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
   <string name="app_name">Internxt</string>
+  <string name="documents_provider_label">Internxt Drive</string>
   <string name="expo_system_ui_user_interface_style" translatable="false">automatic</string>
   <string name="expo_runtime_version">1.9.1</string>
   <string name="expo_splash_screen_resize_mode" translatable="false">contain</string>

--- a/android/app/src/test/java/com/internxt/cloud/documents/BlockingIoTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/BlockingIoTest.kt
@@ -1,0 +1,33 @@
+package com.internxt.cloud.documents
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BlockingIoTest {
+
+    @Test
+    fun `when bridging from the caller thread, then the body runs on a different IO thread`() {
+        val callerThread = Thread.currentThread()
+
+        val bodyThread = runBlockingIo { Thread.currentThread() }
+
+        assertNotEquals(
+            "body must not run on the caller (binder) thread, otherwise blocking network trips StrictMode",
+            callerThread,
+            bodyThread,
+        )
+        assertTrue(
+            "expected an IO dispatcher thread but ran on ${bodyThread.name}",
+            bodyThread.name.contains("DefaultDispatcher") || bodyThread.name.contains("IO"),
+        )
+    }
+
+    @Test
+    fun `when the body returns a value, then it is propagated to the caller`() {
+        val result = runBlockingIo { 42 }
+
+        assertEquals(42, result)
+    }
+}

--- a/android/app/src/test/java/com/internxt/cloud/documents/DocumentNamingTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/DocumentNamingTest.kt
@@ -23,12 +23,12 @@ class DocumentNamingTest {
 
     @Test
     fun uniqueNamePreservesFileExtension() {
-        assertEquals("report (1).pdf", DocumentNaming.uniqueName("report.pdf", setOf("report.pdf")))
+        assertEquals("report (1).pdf", DocumentNaming.uniqueName(REPORT_PDF, setOf(REPORT_PDF)))
     }
 
     @Test
     fun uniqueNameForFolderHasNoExtension() {
-        assertEquals("My Folder (1)", DocumentNaming.uniqueName("My Folder", setOf("My Folder")))
+        assertEquals("$FOLDER_NAME (1)", DocumentNaming.uniqueName(FOLDER_NAME, setOf(FOLDER_NAME)))
     }
 
     @Test
@@ -38,7 +38,7 @@ class DocumentNamingTest {
 
     @Test
     fun splitNameExtNoExtension() {
-        assertEquals("My Folder" to "", DocumentNaming.splitNameExt("My Folder"))
+        assertEquals(FOLDER_NAME to "", DocumentNaming.splitNameExt(FOLDER_NAME))
     }
 
     @Test
@@ -53,12 +53,17 @@ class DocumentNamingTest {
 
     @Test
     fun joinNameTypeAppendsType() {
-        assertEquals("report.pdf", DocumentNaming.joinNameType("report", "pdf"))
+        assertEquals(REPORT_PDF, DocumentNaming.joinNameType("report", "pdf"))
     }
 
     @Test
     fun joinNameTypeWithoutTypeReturnsName() {
         assertEquals("report", DocumentNaming.joinNameType("report", null))
         assertEquals("report", DocumentNaming.joinNameType("report", ""))
+    }
+
+    companion object {
+        private const val FOLDER_NAME = "My Folder"
+        private const val REPORT_PDF = "report.pdf"
     }
 }

--- a/android/app/src/test/java/com/internxt/cloud/documents/DocumentNamingTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/DocumentNamingTest.kt
@@ -1,0 +1,64 @@
+package com.internxt.cloud.documents
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DocumentNamingTest {
+
+    @Test
+    fun uniqueNameReturnsRequestedWhenNoCollision() {
+        assertEquals("Reports", DocumentNaming.uniqueName("Reports", setOf("Photos", "Music")))
+    }
+
+    @Test
+    fun uniqueNameAppendsSuffixOnCollision() {
+        assertEquals("Reports (1)", DocumentNaming.uniqueName("Reports", setOf("Reports")))
+    }
+
+    @Test
+    fun uniqueNameSkipsTakenSuffixes() {
+        val existing = setOf("Reports", "Reports (1)", "Reports (2)")
+        assertEquals("Reports (3)", DocumentNaming.uniqueName("Reports", existing))
+    }
+
+    @Test
+    fun uniqueNamePreservesFileExtension() {
+        assertEquals("report (1).pdf", DocumentNaming.uniqueName("report.pdf", setOf("report.pdf")))
+    }
+
+    @Test
+    fun uniqueNameForFolderHasNoExtension() {
+        assertEquals("My Folder (1)", DocumentNaming.uniqueName("My Folder", setOf("My Folder")))
+    }
+
+    @Test
+    fun splitNameExtSplitsOnLastDot() {
+        assertEquals("archive.tar" to ".gz", DocumentNaming.splitNameExt("archive.tar.gz"))
+    }
+
+    @Test
+    fun splitNameExtNoExtension() {
+        assertEquals("My Folder" to "", DocumentNaming.splitNameExt("My Folder"))
+    }
+
+    @Test
+    fun splitNameExtLeadingDotIsNotAnExtension() {
+        assertEquals(".gitignore" to "", DocumentNaming.splitNameExt(".gitignore"))
+    }
+
+    @Test
+    fun splitNameExtTrailingDotIsNotAnExtension() {
+        assertEquals("name." to "", DocumentNaming.splitNameExt("name."))
+    }
+
+    @Test
+    fun joinNameTypeAppendsType() {
+        assertEquals("report.pdf", DocumentNaming.joinNameType("report", "pdf"))
+    }
+
+    @Test
+    fun joinNameTypeWithoutTypeReturnsName() {
+        assertEquals("report", DocumentNaming.joinNameType("report", null))
+        assertEquals("report", DocumentNaming.joinNameType("report", ""))
+    }
+}

--- a/android/app/src/test/java/com/internxt/cloud/documents/DocumentRowBuilderTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/DocumentRowBuilderTest.kt
@@ -26,7 +26,11 @@ class DocumentRowBuilderTest {
         assertEquals(Document.MIME_TYPE_DIR, row[Document.COLUMN_MIME_TYPE])
         assertEquals("Documents", row[Document.COLUMN_DISPLAY_NAME])
         assertEquals(1768089600000L, row[Document.COLUMN_LAST_MODIFIED])
-        assertEquals(Document.FLAG_DIR_SUPPORTS_CREATE, row[Document.COLUMN_FLAGS])
+        val expectedFolderFlags = Document.FLAG_DIR_SUPPORTS_CREATE or
+            Document.FLAG_SUPPORTS_RENAME or
+            Document.FLAG_SUPPORTS_DELETE or
+            Document.FLAG_SUPPORTS_MOVE
+        assertEquals(expectedFolderFlags, row[Document.COLUMN_FLAGS])
         assertNull(row[Document.COLUMN_SIZE])
     }
 
@@ -50,7 +54,10 @@ class DocumentRowBuilderTest {
         assertEquals("application/pdf", row[Document.COLUMN_MIME_TYPE])
         assertEquals("report.pdf", row[Document.COLUMN_DISPLAY_NAME])
         assertEquals(1768089600000L, row[Document.COLUMN_LAST_MODIFIED])
-        assertEquals(0, row[Document.COLUMN_FLAGS])
+        val expectedFileFlags = Document.FLAG_SUPPORTS_RENAME or
+            Document.FLAG_SUPPORTS_DELETE or
+            Document.FLAG_SUPPORTS_MOVE
+        assertEquals(expectedFileFlags, row[Document.COLUMN_FLAGS])
         assertEquals(102400L, row[Document.COLUMN_SIZE])
     }
 

--- a/android/app/src/test/java/com/internxt/cloud/documents/DocumentRowBuilderTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/DocumentRowBuilderTest.kt
@@ -1,0 +1,107 @@
+package com.internxt.cloud.documents
+
+import android.provider.DocumentsContract.Document
+import com.internxt.cloud.documents.api.model.DriveFile
+import com.internxt.cloud.documents.api.model.DriveFolder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class DocumentRowBuilderTest {
+
+    @Test
+    fun folderRowFields() {
+        val folder = DriveFolder(
+            uuid = "folder-uuid",
+            plainName = "Documents",
+            parentUuid = "parent-uuid",
+            bucket = null,
+            createdAt = null,
+            updatedAt = "2026-01-11T00:00:00.000Z",
+        )
+
+        val row = DocumentRowBuilder.folderRow(folder)
+
+        assertEquals("folder-uuid", row[Document.COLUMN_DOCUMENT_ID])
+        assertEquals(Document.MIME_TYPE_DIR, row[Document.COLUMN_MIME_TYPE])
+        assertEquals("Documents", row[Document.COLUMN_DISPLAY_NAME])
+        assertEquals(1768089600000L, row[Document.COLUMN_LAST_MODIFIED])
+        assertEquals(Document.FLAG_DIR_SUPPORTS_CREATE, row[Document.COLUMN_FLAGS])
+        assertNull(row[Document.COLUMN_SIZE])
+    }
+
+    @Test
+    fun fileRowFields() {
+        val file = DriveFile(
+            uuid = "file-uuid",
+            plainName = "report.pdf",
+            type = "pdf",
+            size = 102400L,
+            bucket = "bucket-id",
+            folderUuid = "parent-uuid",
+            createdAt = null,
+            updatedAt = "2026-01-11T00:00:00.000Z",
+            fileId = "file-id-1",
+        )
+
+        val row = DocumentRowBuilder.fileRow(file)
+
+        assertEquals("file-uuid", row[Document.COLUMN_DOCUMENT_ID])
+        assertEquals("application/pdf", row[Document.COLUMN_MIME_TYPE])
+        assertEquals("report.pdf", row[Document.COLUMN_DISPLAY_NAME])
+        assertEquals(1768089600000L, row[Document.COLUMN_LAST_MODIFIED])
+        assertEquals(0, row[Document.COLUMN_FLAGS])
+        assertEquals(102400L, row[Document.COLUMN_SIZE])
+    }
+
+    @Test
+    fun fileRowUnknownExtensionFallsBackToOctetStream() {
+        val file = DriveFile(
+            uuid = "file-uuid",
+            plainName = "weird.xyz",
+            type = "xyz",
+            size = 0L,
+            bucket = null,
+            folderUuid = null,
+            createdAt = null,
+            updatedAt = null,
+            fileId = null,
+        )
+
+        val row = DocumentRowBuilder.fileRow(file)
+
+        assertEquals("application/octet-stream", row[Document.COLUMN_MIME_TYPE])
+        assertEquals("weird.xyz", row[Document.COLUMN_DISPLAY_NAME])
+        assertNull(row[Document.COLUMN_LAST_MODIFIED])
+    }
+
+    @Test
+    fun folderRowOverloadFields() {
+        val row = DocumentRowBuilder.folderRow("root-uuid", "Internxt Drive")
+
+        assertEquals("root-uuid", row[Document.COLUMN_DOCUMENT_ID])
+        assertEquals(Document.MIME_TYPE_DIR, row[Document.COLUMN_MIME_TYPE])
+        assertEquals("Internxt Drive", row[Document.COLUMN_DISPLAY_NAME])
+        assertNull(row[Document.COLUMN_LAST_MODIFIED])
+        assertEquals(Document.FLAG_DIR_SUPPORTS_CREATE, row[Document.COLUMN_FLAGS])
+        assertNull(row[Document.COLUMN_SIZE])
+    }
+
+    @Test
+    fun parseIsoToMillisHandlesValidInput() {
+        assertEquals(1768089600000L, DocumentRowBuilder.parseIsoToMillis("2026-01-11T00:00:00.000Z"))
+    }
+
+    @Test
+    fun parseIsoToMillisHandlesNullAndBlank() {
+        assertNull(DocumentRowBuilder.parseIsoToMillis(null))
+        assertNull(DocumentRowBuilder.parseIsoToMillis(""))
+        assertNull(DocumentRowBuilder.parseIsoToMillis("   "))
+    }
+
+    @Test
+    fun parseIsoToMillisHandlesMalformed() {
+        assertNull(DocumentRowBuilder.parseIsoToMillis("not-a-date"))
+        assertNull(DocumentRowBuilder.parseIsoToMillis("2026-99-99"))
+    }
+}

--- a/android/app/src/test/java/com/internxt/cloud/documents/DocumentRowBuilderTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/DocumentRowBuilderTest.kt
@@ -22,7 +22,7 @@ class DocumentRowBuilderTest {
 
         val row = DocumentRowBuilder.folderRow(folder)
 
-        assertEquals("folder-uuid", row[Document.COLUMN_DOCUMENT_ID])
+        assertEquals("f:folder-uuid", row[Document.COLUMN_DOCUMENT_ID])
         assertEquals(Document.MIME_TYPE_DIR, row[Document.COLUMN_MIME_TYPE])
         assertEquals("Documents", row[Document.COLUMN_DISPLAY_NAME])
         assertEquals(1768089600000L, row[Document.COLUMN_LAST_MODIFIED])
@@ -46,7 +46,7 @@ class DocumentRowBuilderTest {
 
         val row = DocumentRowBuilder.fileRow(file)
 
-        assertEquals("file-uuid", row[Document.COLUMN_DOCUMENT_ID])
+        assertEquals("d:file-uuid", row[Document.COLUMN_DOCUMENT_ID])
         assertEquals("application/pdf", row[Document.COLUMN_MIME_TYPE])
         assertEquals("report.pdf", row[Document.COLUMN_DISPLAY_NAME])
         assertEquals(1768089600000L, row[Document.COLUMN_LAST_MODIFIED])
@@ -79,7 +79,7 @@ class DocumentRowBuilderTest {
     fun folderRowOverloadFields() {
         val row = DocumentRowBuilder.folderRow("root-uuid", "Internxt Drive")
 
-        assertEquals("root-uuid", row[Document.COLUMN_DOCUMENT_ID])
+        assertEquals("f:root-uuid", row[Document.COLUMN_DOCUMENT_ID])
         assertEquals(Document.MIME_TYPE_DIR, row[Document.COLUMN_MIME_TYPE])
         assertEquals("Internxt Drive", row[Document.COLUMN_DISPLAY_NAME])
         assertNull(row[Document.COLUMN_LAST_MODIFIED])

--- a/android/app/src/test/java/com/internxt/cloud/documents/MimeTypesTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/MimeTypesTest.kt
@@ -1,0 +1,47 @@
+package com.internxt.cloud.documents
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MimeTypesTest {
+
+    @Test
+    fun mapsKnownExtensions() {
+        assertEquals("application/pdf", MimeTypes.fromExtension("pdf"))
+        assertEquals("image/jpeg", MimeTypes.fromExtension("jpg"))
+        assertEquals("image/jpeg", MimeTypes.fromExtension("jpeg"))
+        assertEquals("image/png", MimeTypes.fromExtension("png"))
+        assertEquals("video/mp4", MimeTypes.fromExtension("mp4"))
+        assertEquals("audio/mpeg", MimeTypes.fromExtension("mp3"))
+        assertEquals("application/zip", MimeTypes.fromExtension("zip"))
+        assertEquals(
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            MimeTypes.fromExtension("xlsx")
+        )
+    }
+
+    @Test
+    fun isCaseInsensitive() {
+        assertEquals("application/pdf", MimeTypes.fromExtension("PDF"))
+        assertEquals("image/jpeg", MimeTypes.fromExtension("JPG"))
+        assertEquals("image/jpeg", MimeTypes.fromExtension("Jpeg"))
+    }
+
+    @Test
+    fun trimsWhitespace() {
+        assertEquals("application/pdf", MimeTypes.fromExtension("  pdf  "))
+    }
+
+    @Test
+    fun unknownExtensionFallsBackToOctetStream() {
+        assertEquals(MimeTypes.DEFAULT, MimeTypes.fromExtension("xyz"))
+        assertEquals("application/octet-stream", MimeTypes.fromExtension("xyz"))
+    }
+
+    @Test
+    fun nullAndBlankFallBackToOctetStream() {
+        assertEquals(MimeTypes.DEFAULT, MimeTypes.fromExtension(null))
+        assertEquals(MimeTypes.DEFAULT, MimeTypes.fromExtension(""))
+        assertEquals(MimeTypes.DEFAULT, MimeTypes.fromExtension("   "))
+    }
+}

--- a/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientTest.kt
@@ -14,6 +14,10 @@ class InternxtApiClientTest {
     private lateinit var server: MockWebServer
     private lateinit var client: InternxtApiClient
 
+    companion object {
+        private const val PARENT_UUID = "parent-uuid"
+    }
+
     @Before
     fun setUp() {
         server = MockWebServer().apply { start() }
@@ -48,7 +52,7 @@ class InternxtApiClientTest {
                       "type": "pdf",
                       "size": 102400,
                       "bucket": "bucket-id",
-                      "folderUuid": "parent-uuid",
+                      "folderUuid": "$PARENT_UUID",
                       "createdAt": "2026-01-10T00:00:00.000Z",
                       "updatedAt": "2026-01-11T00:00:00.000Z",
                       "fileId": "file-id-1"
@@ -59,7 +63,7 @@ class InternxtApiClientTest {
             )
         )
 
-        val files = client.listFolderFiles("parent-uuid")
+        val files = client.listFolderFiles(PARENT_UUID)
 
         assertEquals(1, files.size)
         val file = files[0]
@@ -68,7 +72,7 @@ class InternxtApiClientTest {
         assertEquals("pdf", file.type)
         assertEquals(102400L, file.size)
         assertEquals("bucket-id", file.bucket)
-        assertEquals("parent-uuid", file.folderUuid)
+        assertEquals(PARENT_UUID, file.folderUuid)
         assertEquals("2026-01-10T00:00:00.000Z", file.createdAt)
         assertEquals("file-id-1", file.fileId)
     }
@@ -77,12 +81,12 @@ class InternxtApiClientTest {
     fun listFolderFilesBuildsAuthenticatedDriveRequest() {
         server.enqueue(MockResponse().setResponseCode(200).setBody("""{"files":[]}"""))
 
-        client.listFolderFiles("parent-uuid")
+        client.listFolderFiles(PARENT_UUID)
 
         val recorded = server.takeRequest()
         assertEquals("GET", recorded.method)
         assertEquals(
-            "/folders/content/parent-uuid/files?offset=0&limit=50&sort=plainName&order=ASC",
+            "/folders/content/$PARENT_UUID/files?offset=0&limit=50&sort=plainName&order=ASC",
             recorded.path
         )
         assertEquals("Bearer test-token", recorded.getHeader("Authorization"))
@@ -96,7 +100,7 @@ class InternxtApiClientTest {
         server.enqueue(MockResponse().setResponseCode(401))
 
         assertThrows(InternxtApiException.UnauthorizedException::class.java) {
-            client.listFolderFiles("parent-uuid")
+            client.listFolderFiles(PARENT_UUID)
         }
     }
 
@@ -114,7 +118,7 @@ class InternxtApiClientTest {
         server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
 
         assertThrows(InternxtApiException.NetworkException::class.java) {
-            client.listFolderFiles("parent-uuid")
+            client.listFolderFiles(PARENT_UUID)
         }
     }
 

--- a/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientTest.kt
@@ -5,7 +5,6 @@ import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.SocketPolicy
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Test
@@ -25,7 +24,8 @@ class InternxtApiClientTest {
                 bridgeBaseUrl = base,
                 bearerToken = "test-token",
                 bridgeUser = "user@example.com",
-                userId = "1234567890"
+                userId = "1234567890",
+                desktopToken = "desktop-token-xyz"
             )
         )
     }
@@ -36,7 +36,7 @@ class InternxtApiClientTest {
     }
 
     @Test
-    fun listFolderFilesParsesResponseAndSendsBearerAndQuery() {
+    fun listFolderFilesParsesResponseFields() {
         server.enqueue(
             MockResponse().setResponseCode(200).setBody(
                 """
@@ -52,17 +52,6 @@ class InternxtApiClientTest {
                       "createdAt": "2026-01-10T00:00:00.000Z",
                       "updatedAt": "2026-01-11T00:00:00.000Z",
                       "fileId": "file-id-1"
-                    },
-                    {
-                      "uuid": "file-uuid-2",
-                      "plainName": "photo.jpg",
-                      "type": "jpg",
-                      "size": 2048,
-                      "bucket": "bucket-id",
-                      "folderUuid": "parent-uuid",
-                      "createdAt": "2026-01-12T00:00:00.000Z",
-                      "updatedAt": "2026-01-12T00:00:00.000Z",
-                      "fileId": "file-id-2"
                     }
                   ]
                 }
@@ -72,39 +61,48 @@ class InternxtApiClientTest {
 
         val files = client.listFolderFiles("parent-uuid")
 
-        assertEquals(2, files.size)
-        val first = files[0]
-        assertEquals("file-uuid-1", first.uuid)
-        assertEquals("report.pdf", first.plainName)
-        assertEquals("pdf", first.type)
-        assertEquals(102400L, first.size)
-        assertEquals("bucket-id", first.bucket)
-        assertEquals("parent-uuid", first.folderUuid)
-        assertEquals("2026-01-10T00:00:00.000Z", first.createdAt)
-        assertEquals("file-id-1", first.fileId)
+        assertEquals(1, files.size)
+        val file = files[0]
+        assertEquals("file-uuid-1", file.uuid)
+        assertEquals("report.pdf", file.plainName)
+        assertEquals("pdf", file.type)
+        assertEquals(102400L, file.size)
+        assertEquals("bucket-id", file.bucket)
+        assertEquals("parent-uuid", file.folderUuid)
+        assertEquals("2026-01-10T00:00:00.000Z", file.createdAt)
+        assertEquals("file-id-1", file.fileId)
+    }
+
+    @Test
+    fun listFolderFilesBuildsAuthenticatedDriveRequest() {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"files":[]}"""))
+
+        client.listFolderFiles("parent-uuid")
 
         val recorded = server.takeRequest()
         assertEquals("GET", recorded.method)
-        assertEquals("Bearer test-token", recorded.getHeader("Authorization"))
         assertEquals(
             "/folders/content/parent-uuid/files?offset=0&limit=50&sort=plainName&order=ASC",
             recorded.path
         )
+        assertEquals("Bearer test-token", recorded.getHeader("Authorization"))
+        assertEquals("drive-mobile", recorded.getHeader("internxt-client"))
+        assertEquals("v1.9.0", recorded.getHeader("internxt-version"))
+        assertEquals("desktop-token-xyz", recorded.getHeader("x-internxt-desktop-header"))
     }
 
     @Test
     fun unauthorizedResponseSurfacesAsUnauthorizedException() {
-        server.enqueue(MockResponse().setResponseCode(401).setBody("""{"error":"Invalid token"}"""))
+        server.enqueue(MockResponse().setResponseCode(401))
 
-        val ex = assertThrows(InternxtApiException.UnauthorizedException::class.java) {
+        assertThrows(InternxtApiException.UnauthorizedException::class.java) {
             client.listFolderFiles("parent-uuid")
         }
-        assertNotNull(ex.message)
     }
 
     @Test
     fun notFoundResponseSurfacesAsNotFoundException() {
-        server.enqueue(MockResponse().setResponseCode(404).setBody(""))
+        server.enqueue(MockResponse().setResponseCode(404))
 
         assertThrows(InternxtApiException.NotFoundException::class.java) {
             client.listFolderFiles("missing-uuid")
@@ -121,31 +119,6 @@ class InternxtApiClientTest {
     }
 
     @Test
-    fun driveRequestsIncludeGatewayHeaders() {
-        val base = server.url("/").toString().trimEnd('/')
-        val clientWithHeaders = InternxtApiClient(
-            AuthConfig(
-                driveBaseUrl = base,
-                bridgeBaseUrl = base,
-                bearerToken = "test-token",
-                bridgeUser = "user@example.com",
-                userId = "1234567890",
-                clientName = "drive-mobile",
-                clientVersion = "v1.9.0",
-                desktopToken = "desktop-token-xyz"
-            )
-        )
-        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"files":[]}"""))
-
-        clientWithHeaders.listFolderFiles("parent-uuid")
-
-        val recorded = server.takeRequest()
-        assertEquals("drive-mobile", recorded.getHeader("internxt-client"))
-        assertEquals("v1.9.0", recorded.getHeader("internxt-version"))
-        assertEquals("desktop-token-xyz", recorded.getHeader("x-internxt-desktop-header"))
-    }
-
-    @Test
     fun getDownloadLinksUsesBasicAuthWithDerivedBridgePass() {
         server.enqueue(
             MockResponse().setResponseCode(200).setBody(
@@ -156,8 +129,7 @@ class InternxtApiClientTest {
                   "size": 1024,
                   "version": 2,
                   "shards": [
-                    {"index":0,"size":512,"hash":"aa","url":"https://shard/0"},
-                    {"index":1,"size":512,"hash":"bb","url":"https://shard/1"}
+                    {"index":0,"size":512,"hash":"aa","url":"https://shard/0"}
                   ]
                 }
                 """.trimIndent()
@@ -166,18 +138,14 @@ class InternxtApiClientTest {
 
         val links = client.getDownloadLinks("bucket-id", "file-id-1")
 
-        assertEquals(2, links.shards.size)
+        assertEquals(1, links.shards.size)
         assertEquals("https://shard/0", links.shards[0].url)
         assertEquals(512L, links.shards[0].size)
 
         val recorded = server.takeRequest()
-        val auth = recorded.getHeader("Authorization") ?: error("missing auth")
-        assertEquals(
-            "Basic " + java.util.Base64.getEncoder().encodeToString(
-                "user@example.com:c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646"
-                    .toByteArray(Charsets.UTF_8)
-            ),
-            auth
-        )
+        val expectedPass = "c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646"
+        val expectedAuth = "Basic " + java.util.Base64.getEncoder()
+            .encodeToString("user@example.com:$expectedPass".toByteArray(Charsets.UTF_8))
+        assertEquals(expectedAuth, recorded.getHeader("Authorization"))
     }
 }

--- a/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientTest.kt
@@ -1,5 +1,6 @@
 package com.internxt.cloud.documents.api
 
+import com.internxt.cloud.documents.api.model.TrashItem
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.SocketPolicy
@@ -304,6 +305,76 @@ class InternxtApiClientTest {
         enqueueJson("", code = 404)
 
         assertNull(client.getFile("missing-uuid"))
+    }
+
+    @Test
+    fun renameFilePutsPlainNameToMetaEndpoint() {
+        enqueueJson("")
+
+        client.renameFile("file-uuid-1", "renamed.pdf")
+
+        val recorded = server.takeRequest()
+        assertEquals("PUT", recorded.method)
+        assertEquals("/files/file-uuid-1/meta", recorded.path)
+        assertEquals("renamed.pdf", JSONObject(recorded.body.readUtf8()).getString("plainName"))
+    }
+
+    @Test
+    fun renameFolderPutsPlainNameToMetaEndpoint() {
+        enqueueJson("")
+
+        client.renameFolder("folder-uuid-1", "Renamed")
+
+        val recorded = server.takeRequest()
+        assertEquals("PUT", recorded.method)
+        assertEquals("/folders/folder-uuid-1/meta", recorded.path)
+        assertEquals("Renamed", JSONObject(recorded.body.readUtf8()).getString("plainName"))
+    }
+
+    @Test
+    fun moveFilePatchesDestinationPayload() {
+        enqueueJson("""{"uuid":"file-uuid-1","folderUuid":"$PARENT_UUID"}""")
+
+        client.moveFile("file-uuid-1", PARENT_UUID)
+
+        val recorded = server.takeRequest()
+        assertEquals("PATCH", recorded.method)
+        assertEquals("/files/file-uuid-1", recorded.path)
+        assertEquals(PARENT_UUID, JSONObject(recorded.body.readUtf8()).getString("destinationFolder"))
+    }
+
+    @Test
+    fun moveFolderPatchesDestinationPayload() {
+        enqueueJson("""{"uuid":"folder-uuid-1","parentUuid":"$PARENT_UUID"}""")
+
+        client.moveFolder("folder-uuid-1", PARENT_UUID)
+
+        val recorded = server.takeRequest()
+        assertEquals("PATCH", recorded.method)
+        assertEquals("/folders/folder-uuid-1", recorded.path)
+        assertEquals(PARENT_UUID, JSONObject(recorded.body.readUtf8()).getString("destinationFolder"))
+    }
+
+    @Test
+    fun sendToTrashPostsItemsPayload() {
+        enqueueJson("")
+
+        client.sendToTrash(
+            listOf(
+                TrashItem("file-uuid-1", TrashItem.Type.FILE),
+                TrashItem("folder-uuid-1", TrashItem.Type.FOLDER),
+            )
+        )
+
+        val recorded = server.takeRequest()
+        assertEquals("POST", recorded.method)
+        assertEquals("/storage/trash/add", recorded.path)
+        val items = JSONObject(recorded.body.readUtf8()).getJSONArray("items")
+        assertEquals(2, items.length())
+        assertEquals("file-uuid-1", items.getJSONObject(0).getString("uuid"))
+        assertEquals("file", items.getJSONObject(0).getString("type"))
+        assertEquals("folder-uuid-1", items.getJSONObject(1).getString("uuid"))
+        assertEquals("folder", items.getJSONObject(1).getString("type"))
     }
 
     @Test

--- a/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientTest.kt
@@ -1,0 +1,183 @@
+package com.internxt.cloud.documents.api
+
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertThrows
+import org.junit.Before
+import org.junit.Test
+
+class InternxtApiClientTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: InternxtApiClient
+
+    @Before
+    fun setUp() {
+        server = MockWebServer().apply { start() }
+        val base = server.url("/").toString().trimEnd('/')
+        client = InternxtApiClient(
+            AuthConfig(
+                driveBaseUrl = base,
+                bridgeBaseUrl = base,
+                bearerToken = "test-token",
+                bridgeUser = "user@example.com",
+                userId = "1234567890"
+            )
+        )
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun listFolderFilesParsesResponseAndSendsBearerAndQuery() {
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """
+                {
+                  "files": [
+                    {
+                      "uuid": "file-uuid-1",
+                      "plainName": "report.pdf",
+                      "type": "pdf",
+                      "size": 102400,
+                      "bucket": "bucket-id",
+                      "folderUuid": "parent-uuid",
+                      "createdAt": "2026-01-10T00:00:00.000Z",
+                      "updatedAt": "2026-01-11T00:00:00.000Z",
+                      "fileId": "file-id-1"
+                    },
+                    {
+                      "uuid": "file-uuid-2",
+                      "plainName": "photo.jpg",
+                      "type": "jpg",
+                      "size": 2048,
+                      "bucket": "bucket-id",
+                      "folderUuid": "parent-uuid",
+                      "createdAt": "2026-01-12T00:00:00.000Z",
+                      "updatedAt": "2026-01-12T00:00:00.000Z",
+                      "fileId": "file-id-2"
+                    }
+                  ]
+                }
+                """.trimIndent()
+            )
+        )
+
+        val files = client.listFolderFiles("parent-uuid")
+
+        assertEquals(2, files.size)
+        val first = files[0]
+        assertEquals("file-uuid-1", first.uuid)
+        assertEquals("report.pdf", first.plainName)
+        assertEquals("pdf", first.type)
+        assertEquals(102400L, first.size)
+        assertEquals("bucket-id", first.bucket)
+        assertEquals("parent-uuid", first.folderUuid)
+        assertEquals("2026-01-10T00:00:00.000Z", first.createdAt)
+        assertEquals("file-id-1", first.fileId)
+
+        val recorded = server.takeRequest()
+        assertEquals("GET", recorded.method)
+        assertEquals("Bearer test-token", recorded.getHeader("Authorization"))
+        assertEquals(
+            "/folders/content/parent-uuid/files?offset=0&limit=50&sort=plainName&order=ASC",
+            recorded.path
+        )
+    }
+
+    @Test
+    fun unauthorizedResponseSurfacesAsUnauthorizedException() {
+        server.enqueue(MockResponse().setResponseCode(401).setBody("""{"error":"Invalid token"}"""))
+
+        val ex = assertThrows(InternxtApiException.UnauthorizedException::class.java) {
+            client.listFolderFiles("parent-uuid")
+        }
+        assertNotNull(ex.message)
+    }
+
+    @Test
+    fun notFoundResponseSurfacesAsNotFoundException() {
+        server.enqueue(MockResponse().setResponseCode(404).setBody(""))
+
+        assertThrows(InternxtApiException.NotFoundException::class.java) {
+            client.listFolderFiles("missing-uuid")
+        }
+    }
+
+    @Test
+    fun socketDisconnectSurfacesAsNetworkException() {
+        server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
+
+        assertThrows(InternxtApiException.NetworkException::class.java) {
+            client.listFolderFiles("parent-uuid")
+        }
+    }
+
+    @Test
+    fun driveRequestsIncludeGatewayHeaders() {
+        val base = server.url("/").toString().trimEnd('/')
+        val clientWithHeaders = InternxtApiClient(
+            AuthConfig(
+                driveBaseUrl = base,
+                bridgeBaseUrl = base,
+                bearerToken = "test-token",
+                bridgeUser = "user@example.com",
+                userId = "1234567890",
+                clientName = "drive-mobile",
+                clientVersion = "v1.9.0",
+                desktopToken = "desktop-token-xyz"
+            )
+        )
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"files":[]}"""))
+
+        clientWithHeaders.listFolderFiles("parent-uuid")
+
+        val recorded = server.takeRequest()
+        assertEquals("drive-mobile", recorded.getHeader("internxt-client"))
+        assertEquals("v1.9.0", recorded.getHeader("internxt-version"))
+        assertEquals("desktop-token-xyz", recorded.getHeader("x-internxt-desktop-header"))
+    }
+
+    @Test
+    fun getDownloadLinksUsesBasicAuthWithDerivedBridgePass() {
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """
+                {
+                  "bucket": "bucket-id",
+                  "index": "idx",
+                  "size": 1024,
+                  "version": 2,
+                  "shards": [
+                    {"index":0,"size":512,"hash":"aa","url":"https://shard/0"},
+                    {"index":1,"size":512,"hash":"bb","url":"https://shard/1"}
+                  ]
+                }
+                """.trimIndent()
+            )
+        )
+
+        val links = client.getDownloadLinks("bucket-id", "file-id-1")
+
+        assertEquals(2, links.shards.size)
+        assertEquals("https://shard/0", links.shards[0].url)
+        assertEquals(512L, links.shards[0].size)
+
+        val recorded = server.takeRequest()
+        val auth = recorded.getHeader("Authorization") ?: error("missing auth")
+        assertEquals(
+            "Basic " + java.util.Base64.getEncoder().encodeToString(
+                "user@example.com:c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646"
+                    .toByteArray(Charsets.UTF_8)
+            ),
+            auth
+        )
+    }
+}

--- a/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientTest.kt
@@ -5,9 +5,11 @@ import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.SocketPolicy
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Test
+import org.json.JSONObject
 
 class InternxtApiClientTest {
 
@@ -29,6 +31,8 @@ class InternxtApiClientTest {
                 bearerToken = "test-token",
                 bridgeUser = "user@example.com",
                 userId = "1234567890",
+                clientName = "drive-mobile",
+                clientVersion = "v1.9.0",
                 desktopToken = "desktop-token-xyz"
             )
         )
@@ -39,28 +43,29 @@ class InternxtApiClientTest {
         server.shutdown()
     }
 
+    private fun enqueueJson(body: String, code: Int = 200) {
+        server.enqueue(MockResponse().setResponseCode(code).setBody(body))
+    }
+
     @Test
     fun listFolderFilesParsesResponseFields() {
-        server.enqueue(
-            MockResponse().setResponseCode(200).setBody(
-                """
+        enqueueJson(
+            """
+            {
+              "files": [
                 {
-                  "files": [
-                    {
-                      "uuid": "file-uuid-1",
-                      "plainName": "report.pdf",
-                      "type": "pdf",
-                      "size": 102400,
-                      "bucket": "bucket-id",
-                      "folderUuid": "$PARENT_UUID",
-                      "createdAt": "2026-01-10T00:00:00.000Z",
-                      "updatedAt": "2026-01-11T00:00:00.000Z",
-                      "fileId": "file-id-1"
-                    }
-                  ]
+                  "uuid": "file-uuid-1",
+                  "plainName": "report.pdf",
+                  "type": "pdf",
+                  "size": 102400,
+                  "bucket": "bucket-id",
+                  "folderUuid": "$PARENT_UUID",
+                  "createdAt": "2026-01-10T00:00:00.000Z",
+                  "fileId": "file-id-1"
                 }
-                """.trimIndent()
-            )
+              ]
+            }
+            """.trimIndent()
         )
 
         val files = client.listFolderFiles(PARENT_UUID)
@@ -79,7 +84,7 @@ class InternxtApiClientTest {
 
     @Test
     fun listFolderFilesBuildsAuthenticatedDriveRequest() {
-        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"files":[]}"""))
+        enqueueJson("""{"files":[]}""")
 
         client.listFolderFiles(PARENT_UUID)
 
@@ -96,8 +101,8 @@ class InternxtApiClientTest {
     }
 
     @Test
-    fun unauthorizedResponseSurfacesAsUnauthorizedException() {
-        server.enqueue(MockResponse().setResponseCode(401))
+    fun unauthorizedResponseSurfacesAsUnauthorized() {
+        enqueueJson("", code = 401)
 
         assertThrows(InternxtApiException.UnauthorizedException::class.java) {
             client.listFolderFiles(PARENT_UUID)
@@ -105,8 +110,8 @@ class InternxtApiClientTest {
     }
 
     @Test
-    fun notFoundResponseSurfacesAsNotFoundException() {
-        server.enqueue(MockResponse().setResponseCode(404))
+    fun notFoundResponseSurfacesAsNotFound() {
+        enqueueJson("", code = 404)
 
         assertThrows(InternxtApiException.NotFoundException::class.java) {
             client.listFolderFiles("missing-uuid")
@@ -114,7 +119,7 @@ class InternxtApiClientTest {
     }
 
     @Test
-    fun socketDisconnectSurfacesAsNetworkException() {
+    fun socketDisconnectSurfacesAsNetworkError() {
         server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
 
         assertThrows(InternxtApiException.NetworkException::class.java) {
@@ -124,20 +129,18 @@ class InternxtApiClientTest {
 
     @Test
     fun getDownloadLinksUsesBasicAuthWithDerivedBridgePass() {
-        server.enqueue(
-            MockResponse().setResponseCode(200).setBody(
-                """
-                {
-                  "bucket": "bucket-id",
-                  "index": "idx",
-                  "size": 1024,
-                  "version": 2,
-                  "shards": [
-                    {"index":0,"size":512,"hash":"aa","url":"https://shard/0"}
-                  ]
-                }
-                """.trimIndent()
-            )
+        enqueueJson(
+            """
+            {
+              "bucket": "bucket-id",
+              "index": "idx",
+              "size": 1024,
+              "version": 2,
+              "shards": [
+                {"index":0,"size":512,"hash":"aa","url":"https://shard/0"}
+              ]
+            }
+            """.trimIndent()
         )
 
         val links = client.getDownloadLinks("bucket-id", "file-id-1")
@@ -151,5 +154,121 @@ class InternxtApiClientTest {
         val expectedAuth = "Basic " + java.util.Base64.getEncoder()
             .encodeToString("user@example.com:$expectedPass".toByteArray(Charsets.UTF_8))
         assertEquals(expectedAuth, recorded.getHeader("Authorization"))
+    }
+
+    @Test
+    fun listFolderFoldersParsesResponseFields() {
+        enqueueJson(
+            """
+            {
+              "folders": [
+                {
+                  "uuid": "folder-uuid-1",
+                  "plainName": "Documents",
+                  "parentUuid": "$PARENT_UUID",
+                  "bucket": "bucket-id",
+                  "createdAt": "2026-01-10T00:00:00.000Z",
+                  "updatedAt": "2026-01-11T00:00:00.000Z"
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        val folders = client.listFolderFolders(PARENT_UUID)
+
+        assertEquals(1, folders.size)
+        val folder = folders[0]
+        assertEquals("folder-uuid-1", folder.uuid)
+        assertEquals("Documents", folder.plainName)
+        assertEquals(PARENT_UUID, folder.parentUuid)
+        assertEquals("bucket-id", folder.bucket)
+
+        val recorded = server.takeRequest()
+        assertEquals(
+            "/folders/content/$PARENT_UUID/folders?offset=0&limit=50&sort=plainName&order=ASC",
+            recorded.path
+        )
+    }
+
+    @Test
+    fun createFolderPostsPayloadAndReturnsFolder() {
+        enqueueJson("""{"uuid":"new-folder-uuid","plainName":"New Folder","parentUuid":"$PARENT_UUID"}""")
+
+        val created = client.createFolder(PARENT_UUID, "New Folder")
+
+        assertEquals("new-folder-uuid", created.uuid)
+        assertEquals("New Folder", created.plainName)
+        assertEquals(PARENT_UUID, created.parentUuid)
+
+        val recorded = server.takeRequest()
+        assertEquals("POST", recorded.method)
+        assertEquals("/folders", recorded.path)
+        val sentBody = JSONObject(recorded.body.readUtf8())
+        assertEquals("New Folder", sentBody.getString("plainName"))
+        assertEquals(PARENT_UUID, sentBody.getString("parentFolderUuid"))
+    }
+
+    @Test
+    fun listFolderFilesMapsNullOptionalFieldsToNull() {
+        enqueueJson(
+            """
+            {
+              "files": [
+                {
+                  "uuid": "file-uuid-1",
+                  "plainName": "report.pdf",
+                  "type": null,
+                  "bucket": null,
+                  "folderUuid": null,
+                  "createdAt": null,
+                  "updatedAt": null,
+                  "fileId": null
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        val file = client.listFolderFiles(PARENT_UUID).single()
+
+        assertNull(file.type)
+        assertNull(file.bucket)
+        assertNull(file.folderUuid)
+        assertNull(file.createdAt)
+        assertNull(file.updatedAt)
+        assertNull(file.fileId)
+    }
+
+    @Test
+    fun listFolderFilesParsesSizeGivenAsString() {
+        enqueueJson(
+            """
+            {
+              "files": [
+                {
+                  "uuid": "file-uuid-1",
+                  "plainName": "big.bin",
+                  "size": "9999999999"
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        val file = client.listFolderFiles(PARENT_UUID).single()
+
+        assertEquals(9999999999L, file.size)
+    }
+
+    @Test
+    fun serverErrorSurfacesAsApiError() {
+        enqueueJson("""{"error":"boom"}""", code = 500)
+
+        val thrown = assertThrows(InternxtApiException.ApiError::class.java) {
+            client.listFolderFiles(PARENT_UUID)
+        }
+        assertEquals(500, thrown.code)
+        assertEquals("""{"error":"boom"}""", thrown.body)
     }
 }

--- a/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientTest.kt
@@ -18,6 +18,8 @@ class InternxtApiClientTest {
 
     companion object {
         private const val PARENT_UUID = "parent-uuid"
+        private const val BUCKET_ID = "bucket-id"
+        private const val NEW_FOLDER_NAME = "New Folder"
     }
 
     @Before
@@ -58,7 +60,7 @@ class InternxtApiClientTest {
                   "plainName": "report.pdf",
                   "type": "pdf",
                   "size": 102400,
-                  "bucket": "bucket-id",
+                  "bucket": "$BUCKET_ID",
                   "folderUuid": "$PARENT_UUID",
                   "createdAt": "2026-01-10T00:00:00.000Z",
                   "fileId": "file-id-1"
@@ -76,7 +78,7 @@ class InternxtApiClientTest {
         assertEquals("report.pdf", file.plainName)
         assertEquals("pdf", file.type)
         assertEquals(102400L, file.size)
-        assertEquals("bucket-id", file.bucket)
+        assertEquals(BUCKET_ID, file.bucket)
         assertEquals(PARENT_UUID, file.folderUuid)
         assertEquals("2026-01-10T00:00:00.000Z", file.createdAt)
         assertEquals("file-id-1", file.fileId)
@@ -132,7 +134,7 @@ class InternxtApiClientTest {
         enqueueJson(
             """
             {
-              "bucket": "bucket-id",
+              "bucket": "$BUCKET_ID",
               "index": "idx",
               "size": 1024,
               "version": 2,
@@ -143,7 +145,7 @@ class InternxtApiClientTest {
             """.trimIndent()
         )
 
-        val links = client.getDownloadLinks("bucket-id", "file-id-1")
+        val links = client.getDownloadLinks(BUCKET_ID, "file-id-1")
 
         assertEquals(1, links.shards.size)
         assertEquals("https://shard/0", links.shards[0].url)
@@ -166,7 +168,7 @@ class InternxtApiClientTest {
                   "uuid": "folder-uuid-1",
                   "plainName": "Documents",
                   "parentUuid": "$PARENT_UUID",
-                  "bucket": "bucket-id",
+                  "bucket": "$BUCKET_ID",
                   "createdAt": "2026-01-10T00:00:00.000Z",
                   "updatedAt": "2026-01-11T00:00:00.000Z"
                 }
@@ -182,7 +184,7 @@ class InternxtApiClientTest {
         assertEquals("folder-uuid-1", folder.uuid)
         assertEquals("Documents", folder.plainName)
         assertEquals(PARENT_UUID, folder.parentUuid)
-        assertEquals("bucket-id", folder.bucket)
+        assertEquals(BUCKET_ID, folder.bucket)
 
         val recorded = server.takeRequest()
         assertEquals(
@@ -193,19 +195,19 @@ class InternxtApiClientTest {
 
     @Test
     fun createFolderPostsPayloadAndReturnsFolder() {
-        enqueueJson("""{"uuid":"new-folder-uuid","plainName":"New Folder","parentUuid":"$PARENT_UUID"}""")
+        enqueueJson("""{"uuid":"new-folder-uuid","plainName":"$NEW_FOLDER_NAME","parentUuid":"$PARENT_UUID"}""")
 
-        val created = client.createFolder(PARENT_UUID, "New Folder")
+        val created = client.createFolder(PARENT_UUID, NEW_FOLDER_NAME)
 
         assertEquals("new-folder-uuid", created.uuid)
-        assertEquals("New Folder", created.plainName)
+        assertEquals(NEW_FOLDER_NAME, created.plainName)
         assertEquals(PARENT_UUID, created.parentUuid)
 
         val recorded = server.takeRequest()
         assertEquals("POST", recorded.method)
         assertEquals("/folders", recorded.path)
         val sentBody = JSONObject(recorded.body.readUtf8())
-        assertEquals("New Folder", sentBody.getString("plainName"))
+        assertEquals(NEW_FOLDER_NAME, sentBody.getString("plainName"))
         assertEquals(PARENT_UUID, sentBody.getString("parentFolderUuid"))
     }
 

--- a/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientTest.kt
@@ -264,6 +264,49 @@ class InternxtApiClientTest {
     }
 
     @Test
+    fun getFolderHitsMetaEndpointAndReturnsParsedFolder() {
+        enqueueJson("""{"uuid":"folder-uuid-1","plainName":"Documents"}""")
+
+        val folder = client.getFolder("folder-uuid-1")
+
+        assertEquals("folder-uuid-1", folder?.uuid)
+        assertEquals("Documents", folder?.plainName)
+
+        val recorded = server.takeRequest()
+        assertEquals("GET", recorded.method)
+        assertEquals("/folders/folder-uuid-1/meta", recorded.path)
+    }
+
+    @Test
+    fun getFolderReturnsNullWhenNotFound() {
+        enqueueJson("", code = 404)
+
+        assertNull(client.getFolder("missing-uuid"))
+    }
+
+    @Test
+    fun getFileHitsMetaEndpointAndReturnsParsedFile() {
+        enqueueJson("""{"uuid":"file-uuid-1","plainName":"report.pdf","type":"pdf","size":102400}""")
+
+        val file = client.getFile("file-uuid-1")
+
+        assertEquals("file-uuid-1", file?.uuid)
+        assertEquals("report.pdf", file?.plainName)
+        assertEquals(102400L, file?.size)
+
+        val recorded = server.takeRequest()
+        assertEquals("GET", recorded.method)
+        assertEquals("/files/file-uuid-1/meta", recorded.path)
+    }
+
+    @Test
+    fun getFileReturnsNullWhenNotFound() {
+        enqueueJson("", code = 404)
+
+        assertNull(client.getFile("missing-uuid"))
+    }
+
+    @Test
     fun serverErrorSurfacesAsApiError() {
         enqueueJson("""{"error":"boom"}""", code = 500)
 

--- a/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientTest.kt
@@ -34,6 +34,7 @@ class InternxtApiClientTest {
                 bearerToken = "test-token",
                 bridgeUser = "user@example.com",
                 userId = "1234567890",
+                mnemonic = "test mnemonic phrase",
                 clientName = "drive-mobile",
                 clientVersion = "v1.9.0",
                 desktopToken = "desktop-token-xyz"
@@ -148,15 +149,22 @@ class InternxtApiClientTest {
 
         val links = client.getDownloadLinks(BUCKET_ID, "file-id-1")
 
+        assertEquals(BUCKET_ID, links.bucket)
+        assertEquals("idx", links.index)
+        assertEquals(1024L, links.size)
+        assertEquals(2, links.version)
         assertEquals(1, links.shards.size)
         assertEquals("https://shard/0", links.shards[0].url)
         assertEquals(512L, links.shards[0].size)
 
-        val recorded = server.takeRequest()
+        val infoRequest = server.takeRequest()
+        assertEquals("/buckets/$BUCKET_ID/files/file-id-1/info", infoRequest.path)
+        assertEquals("2", infoRequest.getHeader("x-api-version"))
+
         val expectedPass = "c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646"
         val expectedAuth = "Basic " + java.util.Base64.getEncoder()
             .encodeToString("user@example.com:$expectedPass".toByteArray(Charsets.UTF_8))
-        assertEquals(expectedAuth, recorded.getHeader("Authorization"))
+        assertEquals(expectedAuth, infoRequest.getHeader("Authorization"))
     }
 
     @Test

--- a/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientTest.kt
@@ -1,6 +1,5 @@
 package com.internxt.cloud.documents.api
 
-import com.internxt.cloud.documents.api.model.TrashItem
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.SocketPolicy
@@ -305,76 +304,6 @@ class InternxtApiClientTest {
         enqueueJson("", code = 404)
 
         assertNull(client.getFile("missing-uuid"))
-    }
-
-    @Test
-    fun renameFilePutsPlainNameToMetaEndpoint() {
-        enqueueJson("")
-
-        client.renameFile("file-uuid-1", "renamed.pdf")
-
-        val recorded = server.takeRequest()
-        assertEquals("PUT", recorded.method)
-        assertEquals("/files/file-uuid-1/meta", recorded.path)
-        assertEquals("renamed.pdf", JSONObject(recorded.body.readUtf8()).getString("plainName"))
-    }
-
-    @Test
-    fun renameFolderPutsPlainNameToMetaEndpoint() {
-        enqueueJson("")
-
-        client.renameFolder("folder-uuid-1", "Renamed")
-
-        val recorded = server.takeRequest()
-        assertEquals("PUT", recorded.method)
-        assertEquals("/folders/folder-uuid-1/meta", recorded.path)
-        assertEquals("Renamed", JSONObject(recorded.body.readUtf8()).getString("plainName"))
-    }
-
-    @Test
-    fun moveFilePatchesDestinationPayload() {
-        enqueueJson("""{"uuid":"file-uuid-1","folderUuid":"$PARENT_UUID"}""")
-
-        client.moveFile("file-uuid-1", PARENT_UUID)
-
-        val recorded = server.takeRequest()
-        assertEquals("PATCH", recorded.method)
-        assertEquals("/files/file-uuid-1", recorded.path)
-        assertEquals(PARENT_UUID, JSONObject(recorded.body.readUtf8()).getString("destinationFolder"))
-    }
-
-    @Test
-    fun moveFolderPatchesDestinationPayload() {
-        enqueueJson("""{"uuid":"folder-uuid-1","parentUuid":"$PARENT_UUID"}""")
-
-        client.moveFolder("folder-uuid-1", PARENT_UUID)
-
-        val recorded = server.takeRequest()
-        assertEquals("PATCH", recorded.method)
-        assertEquals("/folders/folder-uuid-1", recorded.path)
-        assertEquals(PARENT_UUID, JSONObject(recorded.body.readUtf8()).getString("destinationFolder"))
-    }
-
-    @Test
-    fun sendToTrashPostsItemsPayload() {
-        enqueueJson("")
-
-        client.sendToTrash(
-            listOf(
-                TrashItem("file-uuid-1", TrashItem.Type.FILE),
-                TrashItem("folder-uuid-1", TrashItem.Type.FOLDER),
-            )
-        )
-
-        val recorded = server.takeRequest()
-        assertEquals("POST", recorded.method)
-        assertEquals("/storage/trash/add", recorded.path)
-        val items = JSONObject(recorded.body.readUtf8()).getJSONArray("items")
-        assertEquals(2, items.length())
-        assertEquals("file-uuid-1", items.getJSONObject(0).getString("uuid"))
-        assertEquals("file", items.getJSONObject(0).getString("type"))
-        assertEquals("folder-uuid-1", items.getJSONObject(1).getString("uuid"))
-        assertEquals("folder", items.getJSONObject(1).getString("type"))
     }
 
     @Test

--- a/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientUploadTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientUploadTest.kt
@@ -1,0 +1,196 @@
+package com.internxt.cloud.documents.api
+
+import com.internxt.cloud.documents.api.model.CreateFileEntry
+import com.internxt.cloud.documents.api.model.ENCRYPT_VERSION_AES03
+import com.internxt.cloud.documents.api.model.FinishUploadShard
+import com.internxt.cloud.documents.api.model.UploadSlot
+import com.internxt.cloud.documents.api.model.UploadedPart
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class InternxtApiClientUploadTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: InternxtApiClient
+
+    companion object {
+        private const val BUCKET_ID = "bucket-123"
+        private const val PARENT_UUID = "parent-uuid-1"
+        private const val SLOT_UUID = "slot-uuid"
+        private const val BUCKET_FILE_ID = "bucket-file-id"
+        private const val TIMESTAMP = "2026-05-25T00:00:00Z"
+    }
+
+    @Before
+    fun setUp() {
+        server = MockWebServer().apply { start() }
+        val base = server.url("/").toString().trimEnd('/')
+        client = InternxtApiClient(
+            AuthConfig(
+                driveBaseUrl = base,
+                bridgeBaseUrl = base,
+                bearerToken = "test-token",
+                bridgeUser = "user@example.com",
+                userId = "1234567890",
+                mnemonic = "test mnemonic phrase",
+                clientName = "drive-mobile",
+                clientVersion = "v1.9.0",
+                desktopToken = null,
+            )
+        )
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun enqueue(body: String, code: Int = 200) {
+        server.enqueue(MockResponse().setResponseCode(code).setBody(body))
+    }
+
+    @Test
+    fun startUploadSinglePostsExpectedBodyAndParsesSlot() {
+        enqueue(
+            """{"uploads":[{"index":0,"uuid":"$SLOT_UUID","url":"https://shard/up"}]}"""
+        )
+
+        val response = client.startUpload(BUCKET_ID, encryptedSize = 4096, parts = 1)
+
+        assertEquals(1, response.uploads.size)
+        val slot = response.uploads[0]
+        assertTrue("expected Single slot, got ${slot::class.simpleName}", slot is UploadSlot.Single)
+        slot as UploadSlot.Single
+        assertEquals(SLOT_UUID, slot.uuid)
+        assertEquals("https://shard/up", slot.url)
+
+        val recorded = server.takeRequest()
+        assertEquals("POST", recorded.method)
+        assertEquals("/v2/buckets/$BUCKET_ID/files/start?multiparts=1", recorded.path)
+        val sent = JSONObject(recorded.body.readUtf8())
+        val uploads = sent.getJSONArray("uploads")
+        assertEquals(1, uploads.length())
+        assertEquals(0, uploads.getJSONObject(0).getInt("index"))
+        assertEquals(4096L, uploads.getJSONObject(0).getLong("size"))
+        assertNotNull(recorded.getHeader("Authorization"))
+        assertEquals(true, recorded.getHeader("Authorization")!!.startsWith("Basic "))
+    }
+
+    @Test
+    fun startUploadMultipartPassesPartsCountAndParsesUrls() {
+        enqueue(
+            """{"uploads":[{"index":0,"uuid":"$SLOT_UUID","urls":["https://p/1","https://p/2","https://p/3"],"UploadId":"up-1"}]}"""
+        )
+
+        val response = client.startUpload(BUCKET_ID, encryptedSize = 300L * 1024L * 1024L, parts = 4)
+
+        val slot = response.uploads.single()
+        assertTrue("expected Multipart slot, got ${slot::class.simpleName}", slot is UploadSlot.Multipart)
+        slot as UploadSlot.Multipart
+        assertEquals(listOf("https://p/1", "https://p/2", "https://p/3"), slot.urls)
+        assertEquals("up-1", slot.uploadId)
+
+        val recorded = server.takeRequest()
+        assertEquals("/v2/buckets/$BUCKET_ID/files/start?multiparts=4", recorded.path)
+    }
+
+    @Test
+    fun finishUploadSingleShardBody() {
+        enqueue("""{"id":"$BUCKET_FILE_ID","bucket":"$BUCKET_ID"}""")
+
+        val finish = client.finishUpload(
+            BUCKET_ID,
+            indexHex = "ab".repeat(32),
+            shards = listOf(FinishUploadShard(uuid = SLOT_UUID, hash = "deadbeef")),
+        )
+
+        assertEquals(BUCKET_FILE_ID, finish.id)
+        assertEquals(BUCKET_ID, finish.bucket)
+
+        val recorded = server.takeRequest()
+        assertEquals("POST", recorded.method)
+        assertEquals("/v2/buckets/$BUCKET_ID/files/finish", recorded.path)
+        val sent = JSONObject(recorded.body.readUtf8())
+        assertEquals("ab".repeat(32), sent.getString("index"))
+        val shards = sent.getJSONArray("shards")
+        assertEquals(1, shards.length())
+        val shard = shards.getJSONObject(0)
+        assertEquals(SLOT_UUID, shard.getString("uuid"))
+        assertEquals("deadbeef", shard.getString("hash"))
+        assertEquals(false, shard.has("UploadId"))
+        assertEquals(false, shard.has("parts"))
+    }
+
+    @Test
+    fun finishUploadMultipartIncludesUploadIdAndParts() {
+        enqueue("""{"id":"$BUCKET_FILE_ID"}""")
+
+        client.finishUpload(
+            BUCKET_ID,
+            indexHex = "cd".repeat(32),
+            shards = listOf(
+                FinishUploadShard(
+                    uuid = SLOT_UUID,
+                    hash = "deadbeef",
+                    uploadId = "up-1",
+                    parts = listOf(
+                        UploadedPart(partNumber = 2, etag = "etag-2"),
+                        UploadedPart(partNumber = 1, etag = "etag-1"),
+                    ),
+                )
+            ),
+        )
+
+        val recorded = server.takeRequest()
+        val shard = JSONObject(recorded.body.readUtf8()).getJSONArray("shards").getJSONObject(0)
+        assertEquals("up-1", shard.getString("UploadId"))
+        val parts = shard.getJSONArray("parts")
+        assertEquals(2, parts.length())
+        assertEquals(1, parts.getJSONObject(0).getInt("PartNumber"))
+        assertEquals("etag-1", parts.getJSONObject(0).getString("ETag"))
+        assertEquals(2, parts.getJSONObject(1).getInt("PartNumber"))
+        assertEquals("etag-2", parts.getJSONObject(1).getString("ETag"))
+    }
+
+    @Test
+    fun createFileEntryPostsToDriveFilesWithBearer() {
+        enqueue("""{"uuid":"new-file-uuid","plainName":"report.pdf","type":"pdf","size":4096}""")
+
+        val created = client.createFileEntry(
+            CreateFileEntry(
+                fileId = BUCKET_FILE_ID,
+                type = "pdf",
+                size = 4096L,
+                plainName = "report.pdf",
+                bucket = BUCKET_ID,
+                folderUuid = PARENT_UUID,
+                modificationTime = TIMESTAMP,
+                creationTime = TIMESTAMP,
+            )
+        )
+
+        assertEquals("new-file-uuid", created.uuid)
+
+        val recorded = server.takeRequest()
+        assertEquals("POST", recorded.method)
+        assertEquals("/files", recorded.path)
+        assertEquals("Bearer test-token", recorded.getHeader("Authorization"))
+        val sent = JSONObject(recorded.body.readUtf8())
+        assertEquals(BUCKET_FILE_ID, sent.getString("fileId"))
+        assertEquals("pdf", sent.getString("type"))
+        assertEquals(4096L, sent.getLong("size"))
+        assertEquals("report.pdf", sent.getString("plainName"))
+        assertEquals(BUCKET_ID, sent.getString("bucket"))
+        assertEquals(PARENT_UUID, sent.getString("folderUuid"))
+        assertEquals(ENCRYPT_VERSION_AES03, sent.getString("encryptVersion"))
+        assertEquals(TIMESTAMP, sent.getString("modificationTime"))
+        assertEquals(TIMESTAMP, sent.getString("creationTime"))
+    }
+}

--- a/android/app/src/test/java/com/internxt/cloud/documents/api/JsonExtensionsTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/api/JsonExtensionsTest.kt
@@ -1,0 +1,90 @@
+package com.internxt.cloud.documents.api
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class JsonExtensionsTest {
+
+    @Test
+    fun orEmptyReturnsEmptyArrayWhenNull() {
+        val result = (null as JSONArray?).orEmpty()
+        assertNotNull(result)
+        assertEquals(0, result.length())
+    }
+
+    @Test
+    fun orEmptyReturnsSameInstanceWhenNotNull() {
+        val array = JSONArray().put("a")
+        assertSame(array, array.orEmpty())
+    }
+
+    @Test
+    fun mapTransformsEachElementPreservingOrder() {
+        val array = JSONArray()
+            .put(JSONObject().put("n", 1))
+            .put(JSONObject().put("n", 2))
+            .put(JSONObject().put("n", 3))
+
+        val result = array.map { it.getInt("n") }
+
+        assertEquals(listOf(1, 2, 3), result)
+    }
+
+    @Test
+    fun mapReturnsEmptyListForEmptyArray() {
+        val result = JSONArray().map { it.toString() }
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun optStringOrNullReturnsNullForMissingKey() {
+        assertNull(JSONObject().optStringOrNull("missing"))
+    }
+
+    @Test
+    fun optStringOrNullReturnsNullForJsonNullValue() {
+        val obj = JSONObject().put("key", JSONObject.NULL)
+        assertNull(obj.optStringOrNull("key"))
+    }
+
+    @Test
+    fun optStringOrNullReturnsNullForEmptyString() {
+        val obj = JSONObject().put("key", "")
+        assertNull(obj.optStringOrNull("key"))
+    }
+
+    @Test
+    fun optStringOrNullReturnsValueForNonEmptyString() {
+        val obj = JSONObject().put("key", "hello")
+        assertEquals("hello", obj.optStringOrNull("key"))
+    }
+
+    @Test
+    fun optLongFlexibleConvertsNumericValueToLong() {
+        val obj = JSONObject().put("key", 42)
+        assertEquals(42L, obj.optLongFlexible("key"))
+    }
+
+    @Test
+    fun optLongFlexibleParsesNumericString() {
+        val obj = JSONObject().put("key", "1024")
+        assertEquals(1024L, obj.optLongFlexible("key"))
+    }
+
+    @Test
+    fun optLongFlexibleReturnsZeroForNonNumericString() {
+        val obj = JSONObject().put("key", "not-a-number")
+        assertEquals(0L, obj.optLongFlexible("key"))
+    }
+
+    @Test
+    fun optLongFlexibleReturnsZeroForMissingKey() {
+        assertEquals(0L, JSONObject().optLongFlexible("missing"))
+    }
+}

--- a/android/app/src/test/java/com/internxt/cloud/documents/auth/InternxtAuthManagerTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/auth/InternxtAuthManagerTest.kt
@@ -14,12 +14,13 @@ class InternxtAuthManagerTest {
     private lateinit var manager: InternxtAuthManager
 
     companion object {
+        private const val USER_EMAIL = "user@example.com"
         private val FULL_CREDS = InternxtAuthManager.Credentials(
             bearerToken = "bearer-xyz",
             userId = "user-1",
-            bridgeUser = "user@example.com",
+            bridgeUser = USER_EMAIL,
             rootFolderUuid = "root-uuid",
-            email = "user@example.com",
+            email = USER_EMAIL,
             driveBaseUrl = "https://drive.test/api",
             bridgeBaseUrl = "https://bridge.test",
             desktopToken = "desktop-tok",
@@ -46,7 +47,7 @@ class InternxtAuthManagerTest {
 
         assertTrue(manager.isLoggedIn())
         assertEquals("root-uuid", manager.rootFolderUuid())
-        assertEquals("user@example.com", manager.userEmail())
+        assertEquals(USER_EMAIL, manager.userEmail())
     }
 
     @Test
@@ -57,7 +58,7 @@ class InternxtAuthManagerTest {
         assertEquals("https://drive.test/api", config.driveBaseUrl)
         assertEquals("https://bridge.test", config.bridgeBaseUrl)
         assertEquals("bearer-xyz", config.bearerToken)
-        assertEquals("user@example.com", config.bridgeUser)
+        assertEquals(USER_EMAIL, config.bridgeUser)
         assertEquals("user-1", config.userId)
         assertEquals("desktop-tok", config.desktopToken)
     }

--- a/android/app/src/test/java/com/internxt/cloud/documents/auth/InternxtAuthManagerTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/auth/InternxtAuthManagerTest.kt
@@ -1,0 +1,167 @@
+package com.internxt.cloud.documents.auth
+
+import android.content.SharedPreferences
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class InternxtAuthManagerTest {
+
+    private lateinit var prefs: FakeSharedPreferences
+    private lateinit var manager: InternxtAuthManager
+
+    companion object {
+        private val FULL_CREDS = InternxtAuthManager.Credentials(
+            bearerToken = "bearer-xyz",
+            userId = "user-1",
+            bridgeUser = "user@example.com",
+            rootFolderUuid = "root-uuid",
+            email = "user@example.com",
+            driveBaseUrl = "https://drive.test/api",
+            bridgeBaseUrl = "https://bridge.test",
+            desktopToken = "desktop-tok",
+        )
+    }
+
+    @Before
+    fun setUp() {
+        prefs = FakeSharedPreferences()
+        manager = InternxtAuthManager(prefs)
+    }
+
+    @Test
+    fun isLoggedInFalseWhenPrefsEmpty() {
+        assertFalse(manager.isLoggedIn())
+        assertNull(manager.rootFolderUuid())
+        assertNull(manager.userEmail())
+        assertNull(manager.loadAuthConfig())
+    }
+
+    @Test
+    fun isLoggedInTrueAfterSavingFullCredentials() {
+        manager.saveCredentials(FULL_CREDS)
+
+        assertTrue(manager.isLoggedIn())
+        assertEquals("root-uuid", manager.rootFolderUuid())
+        assertEquals("user@example.com", manager.userEmail())
+    }
+
+    @Test
+    fun loadAuthConfigReturnsExpectedFields() {
+        manager.saveCredentials(FULL_CREDS)
+
+        val config = manager.loadAuthConfig()!!
+        assertEquals("https://drive.test/api", config.driveBaseUrl)
+        assertEquals("https://bridge.test", config.bridgeBaseUrl)
+        assertEquals("bearer-xyz", config.bearerToken)
+        assertEquals("user@example.com", config.bridgeUser)
+        assertEquals("user-1", config.userId)
+        assertEquals("desktop-tok", config.desktopToken)
+    }
+
+    @Test
+    fun loadAuthConfigOmitsDesktopTokenWhenBlank() {
+        manager.saveCredentials(FULL_CREDS.copy(desktopToken = null))
+
+        val config = manager.loadAuthConfig()!!
+        assertNull(config.desktopToken)
+    }
+
+    @Test
+    fun isLoggedInFalseWhenAnyRequiredFieldMissing() {
+        val requiredMissing = listOf(
+            FULL_CREDS.copy(bearerToken = ""),
+            FULL_CREDS.copy(userId = ""),
+            FULL_CREDS.copy(bridgeUser = ""),
+            FULL_CREDS.copy(rootFolderUuid = ""),
+            FULL_CREDS.copy(driveBaseUrl = ""),
+            FULL_CREDS.copy(bridgeBaseUrl = ""),
+        )
+        for (creds in requiredMissing) {
+            prefs = FakeSharedPreferences()
+            manager = InternxtAuthManager(prefs)
+            manager.saveCredentials(creds)
+
+            assertFalse("should be logged out when field blank: $creds", manager.isLoggedIn())
+            assertNull(manager.loadAuthConfig())
+        }
+    }
+
+    @Test
+    fun clearRemovesAllCredentials() {
+        manager.saveCredentials(FULL_CREDS)
+        assertTrue(manager.isLoggedIn())
+
+        manager.clear()
+
+        assertFalse(manager.isLoggedIn())
+        assertNull(manager.rootFolderUuid())
+        assertNull(manager.userEmail())
+        assertNull(manager.loadAuthConfig())
+    }
+
+    @Test
+    fun savingOverwritesPreviousCredentials() {
+        manager.saveCredentials(FULL_CREDS)
+        manager.saveCredentials(FULL_CREDS.copy(bearerToken = "new-token", rootFolderUuid = "new-root"))
+
+        assertEquals("new-token", manager.loadAuthConfig()!!.bearerToken)
+        assertEquals("new-root", manager.rootFolderUuid())
+    }
+}
+
+private class FakeSharedPreferences : SharedPreferences {
+    private val store = HashMap<String, Any?>()
+
+    override fun getAll(): MutableMap<String, *> = HashMap(store)
+    override fun getString(key: String?, defValue: String?): String? =
+        store[key] as? String ?: defValue
+
+    override fun getStringSet(key: String?, defValues: MutableSet<String>?): MutableSet<String>? =
+        @Suppress("UNCHECKED_CAST") (store[key] as? MutableSet<String>) ?: defValues
+
+    override fun getInt(key: String?, defValue: Int): Int = (store[key] as? Int) ?: defValue
+    override fun getLong(key: String?, defValue: Long): Long = (store[key] as? Long) ?: defValue
+    override fun getFloat(key: String?, defValue: Float): Float = (store[key] as? Float) ?: defValue
+    override fun getBoolean(key: String?, defValue: Boolean): Boolean = (store[key] as? Boolean) ?: defValue
+    override fun contains(key: String?): Boolean = store.containsKey(key)
+    override fun registerOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) = Unit
+    override fun unregisterOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) = Unit
+
+    override fun edit(): SharedPreferences.Editor = FakeEditor(store)
+
+    private class FakeEditor(private val store: HashMap<String, Any?>) : SharedPreferences.Editor {
+        private val pending = HashMap<String, Any?>()
+        private val removed = HashSet<String>()
+        private var clearPending = false
+
+        override fun putString(key: String, value: String?) = apply { pending[key] = value }
+        override fun putStringSet(key: String, values: MutableSet<String>?) = apply { pending[key] = values }
+        override fun putInt(key: String, value: Int) = apply { pending[key] = value }
+        override fun putLong(key: String, value: Long) = apply { pending[key] = value }
+        override fun putFloat(key: String, value: Float) = apply { pending[key] = value }
+        override fun putBoolean(key: String, value: Boolean) = apply { pending[key] = value }
+        override fun remove(key: String) = apply { removed.add(key) }
+        override fun clear() = apply { clearPending = true }
+
+        override fun commit(): Boolean {
+            applyChanges()
+            return true
+        }
+
+        override fun apply() {
+            applyChanges()
+        }
+
+        private fun applyChanges() {
+            if (clearPending) store.clear()
+            for (k in removed) store.remove(k)
+            for ((k, v) in pending) {
+                if (v == null) store.remove(k) else store[k] = v
+            }
+        }
+    }
+}

--- a/android/app/src/test/java/com/internxt/cloud/documents/auth/InternxtAuthManagerTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/auth/InternxtAuthManagerTest.kt
@@ -19,6 +19,7 @@ class InternxtAuthManagerTest {
             bearerToken = "bearer-xyz",
             userId = "user-1",
             bridgeUser = USER_EMAIL,
+            mnemonic = "test mnemonic phrase",
             rootFolderUuid = "root-uuid",
             email = USER_EMAIL,
             driveBaseUrl = "https://drive.test/api",

--- a/android/app/src/test/java/com/internxt/cloud/documents/crypto/CryptoServiceAwaitTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/crypto/CryptoServiceAwaitTest.kt
@@ -19,7 +19,7 @@ class CryptoServiceAwaitTest {
         val original = IOException("boom")
 
         val thrown = runCatching {
-            awaitCryptoService("crypto failed") { cb -> cb.onComplete(original) }
+            awaitCryptoService(CRYPTO_FAILED_MESSAGE) { cb -> cb.onComplete(original) }
         }.exceptionOrNull()
 
         val io = thrown as? IOException ?: return@runTest fail("expected IOException but got $thrown")
@@ -31,11 +31,11 @@ class CryptoServiceAwaitTest {
         val original = IllegalStateException("nope")
 
         val thrown = runCatching {
-            awaitCryptoService("crypto failed") { cb -> cb.onComplete(original) }
+            awaitCryptoService(CRYPTO_FAILED_MESSAGE) { cb -> cb.onComplete(original) }
         }.exceptionOrNull()
 
         val io = thrown as? IOException ?: return@runTest fail("expected IOException but got $thrown")
-        assertEquals("crypto failed", io.message)
+        assertEquals(CRYPTO_FAILED_MESSAGE, io.message)
         assertTrue("original cause not preserved in chain", io.hasCauseWithMessage("nope"))
     }
 
@@ -46,5 +46,9 @@ class CryptoServiceAwaitTest {
             current = current.cause
         }
         return false
+    }
+
+    companion object {
+        private const val CRYPTO_FAILED_MESSAGE = "crypto failed"
     }
 }

--- a/android/app/src/test/java/com/internxt/cloud/documents/crypto/CryptoServiceAwaitTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/crypto/CryptoServiceAwaitTest.kt
@@ -1,0 +1,50 @@
+package com.internxt.cloud.documents.crypto
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import java.io.IOException
+
+class CryptoServiceAwaitTest {
+
+    @Test
+    fun `when the callback reports no error, then it resumes without throwing`() = runTest {
+        awaitCryptoService("should not surface") { cb -> cb.onComplete(null) }
+    }
+
+    @Test
+    fun `when the callback reports an IOException, then it surfaces it as an IOException`() = runTest {
+        val original = IOException("boom")
+
+        val thrown = runCatching {
+            awaitCryptoService("crypto failed") { cb -> cb.onComplete(original) }
+        }.exceptionOrNull()
+
+        val io = thrown as? IOException ?: return@runTest fail("expected IOException but got $thrown")
+        assertEquals("boom", io.message)
+    }
+
+    @Test
+    fun `when the callback reports a non-IO error, then it wraps it in an IOException keeping the cause`() = runTest {
+        val original = IllegalStateException("nope")
+
+        val thrown = runCatching {
+            awaitCryptoService("crypto failed") { cb -> cb.onComplete(original) }
+        }.exceptionOrNull()
+
+        val io = thrown as? IOException ?: return@runTest fail("expected IOException but got $thrown")
+        assertEquals("crypto failed", io.message)
+        assertTrue("original cause not preserved in chain", io.hasCauseWithMessage("nope"))
+    }
+
+    private fun Throwable.hasCauseWithMessage(message: String): Boolean {
+        var current: Throwable? = cause
+        while (current != null) {
+            if (current.message == message) return true
+            current = current.cause
+        }
+        return false
+    }
+}

--- a/android/app/src/test/java/com/internxt/cloud/documents/crypto/FileKeyDeriverTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/crypto/FileKeyDeriverTest.kt
@@ -1,0 +1,31 @@
+package com.internxt.cloud.documents.crypto
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FileKeyDeriverTest {
+
+    @Test
+    fun deriveFileKeyMatchesDriveWebForCanonicalTriple() {
+        val fileKey = FileKeyDeriver.deriveFileKey(MNEMONIC, BUCKET_ID, INDEX_HEX)
+        assertEquals(EXPECTED_FILE_KEY_HEX, fileKey.toHex().lowercase())
+    }
+
+    @Test
+    fun deriveIvMatchesFirst16BytesOfIndex() {
+        val iv = FileKeyDeriver.deriveIv(INDEX_HEX)
+        assertEquals(EXPECTED_IV_HEX, iv.toHex().lowercase())
+    }
+
+    companion object {
+        private const val MNEMONIC =
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+        private const val BUCKET_ID = "a1b2c3d4e5f6a1b2c1d2e3f4a5b6c7d8"
+        private const val INDEX_HEX =
+            "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+
+        private const val EXPECTED_FILE_KEY_HEX =
+            "186473ae7deaa32c1b5b9b1c7708c2c29098f24664ece11abfff56839c630fbb"
+        private const val EXPECTED_IV_HEX = "abcdef1234567890abcdef1234567890"
+    }
+}

--- a/android/app/src/test/java/com/internxt/cloud/documents/crypto/HashUtilTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/crypto/HashUtilTest.kt
@@ -1,0 +1,30 @@
+package com.internxt.cloud.documents.crypto
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HashUtilTest {
+
+    @Test
+    fun derivesSha256HexMatchingJsReference() {
+        assertEquals(
+            "c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646",
+            HashUtil.deriveBridgePass("1234567890")
+        )
+    }
+
+    @Test
+    fun derivesSha256HexForUuidShapedUserId() {
+        assertEquals(
+            "70f333dce10c05a12f6b6f372aa31a182d1e6a8d38d2041c94c9814606a653fe",
+            HashUtil.deriveBridgePass("79a88429-b45a-4ae7-90f1-c351b6882670")
+        )
+    }
+
+    @Test
+    fun producesLowercaseHex() {
+        val hex = HashUtil.deriveBridgePass("abc")
+        assertEquals(hex.lowercase(), hex)
+        assertEquals(64, hex.length)
+    }
+}

--- a/android/app/src/test/java/com/internxt/cloud/documents/download/EncryptedFileDownloaderTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/download/EncryptedFileDownloaderTest.kt
@@ -1,0 +1,92 @@
+package com.internxt.cloud.documents.download
+
+import com.internxt.cloud.documents.api.model.Shard
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.nio.file.Files
+import kotlin.coroutines.cancellation.CancellationException
+
+class EncryptedFileDownloaderTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: OkHttpClient
+    private lateinit var tempDir: File
+
+    @Before
+    fun setUp() {
+        server = MockWebServer().apply { start() }
+        client = OkHttpClient()
+        tempDir = Files.createTempDirectory("downloader-test").toFile()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+        tempDir.deleteRecursively()
+    }
+
+    private fun shard(index: Int, path: String, size: Int): Shard =
+        Shard(index = index, size = size.toLong(), hash = "h$index", url = server.url(path).toString())
+
+    @Test
+    fun `when shards are served out of order, then bytes are written in index order`() = runTest {
+        val part0 = ByteArray(2_000) { it.toByte() }
+        val part1 = ByteArray(1_500) { (it + 7).toByte() }
+        server.enqueue(MockResponse().setResponseCode(200).setBody(okio.Buffer().write(part0)))
+        server.enqueue(MockResponse().setResponseCode(200).setBody(okio.Buffer().write(part1)))
+        val target = File(tempDir, "out.bin")
+
+        val shards = listOf(shard(1, "/p1", part1.size), shard(0, "/p0", part0.size))
+        EncryptedFileDownloader.download(client, shards, target)
+
+        assertArrayEquals(part0 + part1, target.readBytes())
+    }
+
+    @Test
+    fun `when the coroutine is cancelled mid transfer, then it raises cancellation not a network error`() {
+        val requestReceived = CompletableDeferred<Unit>()
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                requestReceived.complete(Unit)
+                Thread.sleep(2_000)
+                return MockResponse().setResponseCode(200).setBody("late")
+            }
+        }
+        val target = File(tempDir, "cancel.bin")
+        val shards = listOf(shard(0, "/slow", 4))
+        val thrown = CompletableDeferred<Throwable>()
+
+        runBlocking {
+            val job = launch(Dispatchers.IO) {
+                try {
+                    EncryptedFileDownloader.download(client, shards, target)
+                } catch (t: Throwable) {
+                    thrown.complete(t)
+                    throw t
+                }
+            }
+            requestReceived.await()
+            job.cancel()
+            job.join()
+        }
+
+        assertTrue(
+            "expected cancellation but got ${thrown.getCompleted().javaClass.name}",
+            thrown.getCompleted() is CancellationException,
+        )
+    }
+}

--- a/android/app/src/test/java/com/internxt/cloud/documents/upload/EncryptedFileUploaderTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/upload/EncryptedFileUploaderTest.kt
@@ -2,13 +2,20 @@ package com.internxt.cloud.documents.upload
 
 import com.internxt.cloud.documents.crypto.Ripemd160
 import com.internxt.cloud.documents.crypto.toHex
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 import org.junit.After
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.io.File
@@ -17,6 +24,7 @@ import java.security.MessageDigest
 import javax.crypto.Cipher
 import javax.crypto.spec.IvParameterSpec
 import javax.crypto.spec.SecretKeySpec
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Encryption itself is exercised by the `@internxt/rn-crypto` package's own test suite
@@ -60,7 +68,7 @@ class EncryptedFileUploaderTest {
         File(tempDir, name).apply { writeBytes(controlEncrypt(plain)) }
 
     @Test
-    fun uploadSinglePutsTempFileContentsAndReportsCorrectHash() {
+    fun uploadSinglePutsTempFileContentsAndReportsCorrectHash() = runTest {
         val plain = ByteArray(8_000) { it.toByte() }
         val tempEnc = writeEncrypted("single.enc", plain)
         val encBytes = tempEnc.readBytes()
@@ -68,7 +76,7 @@ class EncryptedFileUploaderTest {
 
         server.enqueue(MockResponse().setResponseCode(200))
         val url = server.url("/upload").toString()
-        EncryptedFileUploader.uploadSingle(client, tempEnc, url, signal = null)
+        EncryptedFileUploader.uploadSingle(client, tempEnc, url)
 
         val recorded = server.takeRequest()
         assertEquals("PUT", recorded.method)
@@ -81,7 +89,7 @@ class EncryptedFileUploaderTest {
     }
 
     @Test
-    fun uploadMultipartCollectsEtagsAndPartHashesMatchSlices() {
+    fun uploadMultipartCollectsEtagsAndPartHashesMatchSlices() = runTest {
         val partSize = 4_000L
         val plain = ByteArray(13_000) { it.toByte() }
         val tempEnc = writeEncrypted("multi.enc", plain)
@@ -97,7 +105,6 @@ class EncryptedFileUploaderTest {
             tempEnc = tempEnc,
             urls = urls,
             partSize = partSize,
-            signal = null,
         )
 
         assertEquals(listOf(1, 2, 3, 4), parts.map { it.partNumber })
@@ -129,6 +136,40 @@ class EncryptedFileUploaderTest {
         val computed = EncryptedFileUploader.computeShardHash(expected)
         val expectedHash = Ripemd160.digest(hexDecode(expected.joinToString(""))).toHex()
         assertEquals(expectedHash, computed)
+    }
+
+    @Test
+    fun `when the upload coroutine is cancelled mid PUT, then it raises cancellation not a failure`() {
+        val requestReceived = CompletableDeferred<Unit>()
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                requestReceived.complete(Unit)
+                Thread.sleep(2_000)
+                return MockResponse().setResponseCode(200)
+            }
+        }
+        val tempEnc = writeEncrypted("cancel.enc", ByteArray(8_000) { it.toByte() })
+        val url = server.url("/slow").toString()
+        val thrown = CompletableDeferred<Throwable>()
+
+        runBlocking {
+            val job = launch(Dispatchers.IO) {
+                try {
+                    EncryptedFileUploader.uploadSingle(client, tempEnc, url)
+                } catch (t: Throwable) {
+                    thrown.complete(t)
+                    throw t
+                }
+            }
+            requestReceived.await()
+            job.cancel()
+            job.join()
+        }
+
+        assertTrue(
+            "expected cancellation but got ${thrown.getCompleted().javaClass.name}",
+            thrown.getCompleted() is CancellationException,
+        )
     }
 
     private fun hexDecode(hex: String): ByteArray {

--- a/android/app/src/test/java/com/internxt/cloud/documents/upload/EncryptedFileUploaderTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/upload/EncryptedFileUploaderTest.kt
@@ -1,0 +1,143 @@
+package com.internxt.cloud.documents.upload
+
+import com.internxt.cloud.documents.crypto.Ripemd160
+import com.internxt.cloud.documents.crypto.toHex
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.nio.file.Files
+import java.security.MessageDigest
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Encryption itself is exercised by the `@internxt/rn-crypto` package's own test suite
+ * (`EncryptFileRepositoryTest`) — we don't re-verify the cipher here. These tests cover
+ * the upload + hashing logic, building the encrypted input with a control AES-CTR call
+ * so we know exactly what bytes the uploader is meant to PUT.
+ */
+class EncryptedFileUploaderTest {
+
+    companion object {
+        private const val SHA_256 = "SHA-256"
+    }
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: OkHttpClient
+    private lateinit var tempDir: File
+
+    private val key = ByteArray(32) { it.toByte() }
+    private val iv = ByteArray(16) { (it + 1).toByte() }
+
+    @Before
+    fun setUp() {
+        server = MockWebServer().apply { start() }
+        client = OkHttpClient()
+        tempDir = Files.createTempDirectory("uploader-test").toFile()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+        tempDir.deleteRecursively()
+    }
+
+    private fun controlEncrypt(plain: ByteArray): ByteArray {
+        val cipher = Cipher.getInstance("AES/CTR/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, SecretKeySpec(key, "AES"), IvParameterSpec(iv))
+        return cipher.doFinal(plain)
+    }
+
+    private fun writeEncrypted(name: String, plain: ByteArray): File =
+        File(tempDir, name).apply { writeBytes(controlEncrypt(plain)) }
+
+    @Test
+    fun uploadSinglePutsTempFileContentsAndReportsCorrectHash() {
+        val plain = ByteArray(8_000) { it.toByte() }
+        val tempEnc = writeEncrypted("single.enc", plain)
+        val encBytes = tempEnc.readBytes()
+        val sha = MessageDigest.getInstance(SHA_256).digest(encBytes)
+
+        server.enqueue(MockResponse().setResponseCode(200))
+        val url = server.url("/upload").toString()
+        EncryptedFileUploader.uploadSingle(client, tempEnc, url, signal = null)
+
+        val recorded = server.takeRequest()
+        assertEquals("PUT", recorded.method)
+        assertEquals("/upload", recorded.path)
+        assertArrayEquals(encBytes, recorded.body.readByteArray())
+
+        val computed = EncryptedFileUploader.computeShardHash(listOf(sha.toHex()))
+        val expected = Ripemd160.digest(sha).toHex()
+        assertEquals(expected, computed)
+    }
+
+    @Test
+    fun uploadMultipartCollectsEtagsAndPartHashesMatchSlices() {
+        val partSize = 4_000L
+        val plain = ByteArray(13_000) { it.toByte() }
+        val tempEnc = writeEncrypted("multi.enc", plain)
+        val totalSize = tempEnc.length()
+
+        val urls = (1..4).map { idx ->
+            server.enqueue(MockResponse().setResponseCode(200).setHeader("ETag", "etag-$idx"))
+            server.url("/part-$idx").toString()
+        }
+
+        val parts = EncryptedFileUploader.uploadMultipart(
+            client = client,
+            tempEnc = tempEnc,
+            urls = urls,
+            partSize = partSize,
+            signal = null,
+        )
+
+        assertEquals(listOf(1, 2, 3, 4), parts.map { it.partNumber })
+        assertEquals(listOf("etag-1", "etag-2", "etag-3", "etag-4"), parts.map { it.etag })
+
+        val sentParts = (1..4).map { server.takeRequest() }
+        var offset = 0
+        sentParts.forEachIndexed { i, req: RecordedRequest ->
+            val expectedLength = ((offset + partSize).coerceAtMost(totalSize) - offset).toInt()
+            val body = req.body.readByteArray()
+            assertEquals("part ${i + 1} length", expectedLength, body.size)
+            assertArrayEquals(
+                "part ${i + 1} bytes",
+                tempEnc.readBytes().copyOfRange(offset, offset + expectedLength),
+                body,
+            )
+            offset += expectedLength
+        }
+
+        // hash parity with the RN multipart formula
+        val partHashes = EncryptedFileUploader.computePartSha256(tempEnc, partSize)
+        val bytes = tempEnc.readBytes()
+        val expected = partHashes.mapIndexed { i, h ->
+            val start = (i * partSize).toInt()
+            val end = (start + partSize.toInt()).coerceAtMost(bytes.size)
+            assertEquals(MessageDigest.getInstance(SHA_256).digest(bytes.copyOfRange(start, end)).toHex(), h)
+            h
+        }
+        val computed = EncryptedFileUploader.computeShardHash(expected)
+        val expectedHash = Ripemd160.digest(hexDecode(expected.joinToString(""))).toHex()
+        assertEquals(expectedHash, computed)
+    }
+
+    private fun hexDecode(hex: String): ByteArray {
+        val out = ByteArray(hex.length / 2)
+        for (i in out.indices) {
+            val hi = Character.digit(hex[i * 2], 16)
+            val lo = Character.digit(hex[i * 2 + 1], 16)
+            out[i] = ((hi shl 4) or lo).toByte()
+        }
+        return out
+    }
+}

--- a/ios/Internxt.xcodeproj/project.pbxproj
+++ b/ios/Internxt.xcodeproj/project.pbxproj
@@ -35,6 +35,9 @@
 		DEBEAEC02F72E65B00A6E6D5 /* AppGroupPendingShareModule.m in Sources */ = {isa = PBXBuildFile; fileRef = DEBEAEBD2F72E65B00A6E6D5 /* AppGroupPendingShareModule.m */; };
 		F11748422D0307B40044C1D9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11748412D0307B40044C1D9 /* AppDelegate.swift */; };
 		F2C595E5ECBAD697016C9410 /* libPods-InternxtShareExtension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D0A0CA179360CA52F0B5054A /* libPods-InternxtShareExtension.a */; };
+		FB1D480012F87A94000E14783 /* FileProviderErrorMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1D480112F87A94000E14783 /* FileProviderErrorMapperTests.swift */; };
+		FB1D480212F87A94000E14783 /* FileProviderErrorMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47912F87A94000E14783 /* FileProviderErrorMapper.swift */; };
+		FB1D480312F87A94000E14783 /* InternxtSwiftCore in Frameworks */ = {isa = PBXBuildFile; productRef = FB1D480412F87A94000E14783 /* InternxtSwiftCore */; };
 		FEB260B2B281D37EEABD1ECA /* libPods-InternxtFileProvider.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 20957EE3E4797FBBC2BD3192 /* libPods-InternxtFileProvider.a */; };
 /* End PBXBuildFile section */
 
@@ -127,6 +130,8 @@
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		F11748412D0307B40044C1D9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = Internxt/AppDelegate.swift; sourceTree = "<group>"; };
 		F11748442D0722820044C1D9 /* Internxt-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "Internxt-Bridging-Header.h"; path = "Internxt/Internxt-Bridging-Header.h"; sourceTree = "<group>"; };
+		FB1D480112F87A94000E14783 /* FileProviderErrorMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderErrorMapperTests.swift; sourceTree = "<group>"; };
+		FB1D480512F87A94000E14783 /* InternxtFileProviderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = InternxtFileProviderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FDEA9EEAEC8CE666D14877B2 /* Pods-Internxt.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.debug.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -144,6 +149,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				7A61A118D20D0540EF70FE74 /* libPods-InternxtShareExtension.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FB1D480612F87A94000E14783 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FB1D480312F87A94000E14783 /* InternxtSwiftCore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -222,6 +235,7 @@
 				13B07FAE1A68108700A75B9A /* Internxt */,
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
 				DE1D47442F87A94000E14783 /* InternxtFileProvider */,
+				FB1D480712F87A94000E14783 /* InternxtFileProviderTests */,
 				83CBBA001A601CBA00E9B192 /* Products */,
 				2D16E6871FA4F8E400B85C8A /* Frameworks */,
 				7151A997BCA04521BD294E7B /* InternxtShareExtension */,
@@ -239,6 +253,7 @@
 				13B07F961A680F5B00A75B9A /* Internxt.app */,
 				7F5486528A7D46DD91A7910F /* InternxtShareExtension.appex */,
 				DE1D47412F87A94000E14783 /* InternxtFileProvider.appex */,
+				FB1D480512F87A94000E14783 /* InternxtFileProviderTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -288,6 +303,14 @@
 				DE1D47682F87A94000E14783 /* InternxtFileProvider.plist */,
 			);
 			path = InternxtFileProvider;
+			sourceTree = "<group>";
+		};
+		FB1D480712F87A94000E14783 /* InternxtFileProviderTests */ = {
+			isa = PBXGroup;
+			children = (
+				FB1D480112F87A94000E14783 /* FileProviderErrorMapperTests.swift */,
+			);
+			path = InternxtFileProviderTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -362,6 +385,25 @@
 			productReference = DE1D47412F87A94000E14783 /* InternxtFileProvider.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
+		FB1D480812F87A94000E14783 /* InternxtFileProviderTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FB1D480912F87A94000E14783 /* Build configuration list for PBXNativeTarget "InternxtFileProviderTests" */;
+			buildPhases = (
+				FB1D480A12F87A94000E14783 /* Sources */,
+				FB1D480612F87A94000E14783 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = InternxtFileProviderTests;
+			packageProductDependencies = (
+				FB1D480412F87A94000E14783 /* InternxtSwiftCore */,
+			);
+			productName = InternxtFileProviderTests;
+			productReference = FB1D480512F87A94000E14783 /* InternxtFileProviderTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -381,6 +423,9 @@
 						ProvisioningStyle = Automatic;
 					};
 					DE1D47402F87A94000E14783 = {
+						CreatedOnToolsVersion = 26.4;
+					};
+					FB1D480812F87A94000E14783 = {
 						CreatedOnToolsVersion = 26.4;
 					};
 				};
@@ -404,6 +449,7 @@
 				13B07F861A680F5B00A75B9A /* Internxt */,
 				573EC8782D084646801534FA /* InternxtShareExtension */,
 				DE1D47402F87A94000E14783 /* InternxtFileProvider */,
+				FB1D480812F87A94000E14783 /* InternxtFileProviderTests */,
 			);
 		};
 /* End PBXProject section */
@@ -727,6 +773,15 @@
 				AB1D47802F87A94000E14783 /* NetworkFacadeFactory.swift in Sources */,
 				AB1D47812F87A94000E14783 /* SharedKeychainCredentials.swift in Sources */,
 				AA0100082F87A94000E14783 /* SharedAuthKeychain.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FB1D480A12F87A94000E14783 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FB1D480012F87A94000E14783 /* FileProviderErrorMapperTests.swift in Sources */,
+				FB1D480212F87A94000E14783 /* FileProviderErrorMapper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1090,6 +1145,57 @@
 			};
 			name = Release;
 		};
+		FB1D480B12F87A94000E14783 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
+				PRODUCT_BUNDLE_IDENTIFIER = com.internxt.snacks.InternxtFileProviderTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		FB1D480C12F87A94000E14783 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
+				PRODUCT_BUNDLE_IDENTIFIER = com.internxt.snacks.InternxtFileProviderTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1129,6 +1235,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		FB1D480912F87A94000E14783 /* Build configuration list for PBXNativeTarget "InternxtFileProviderTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FB1D480B12F87A94000E14783 /* Debug */,
+				FB1D480C12F87A94000E14783 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
@@ -1144,6 +1259,11 @@
 
 /* Begin XCSwiftPackageProductDependency section */
 		DE1D47552F87AB4000E14783 /* InternxtSwiftCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DE1D47542F87AB4000E14783 /* XCRemoteSwiftPackageReference "swift-core" */;
+			productName = InternxtSwiftCore;
+		};
+		FB1D480412F87A94000E14783 /* InternxtSwiftCore */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = DE1D47542F87AB4000E14783 /* XCRemoteSwiftPackageReference "swift-core" */;
 			productName = InternxtSwiftCore;

--- a/ios/Internxt.xcodeproj/project.pbxproj
+++ b/ios/Internxt.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		AA0100082F87A94000E14783 /* SharedAuthKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100002F87A94000E14783 /* SharedAuthKeychain.swift */; };
 		AB1D47702F87A94000E14783 /* FileProviderItemIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47722F87A94000E14783 /* FileProviderItemIdentifier.swift */; };
 		AB1D47712F87A94000E14783 /* DriveAPIFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47732F87A94000E14783 /* DriveAPIFactory.swift */; };
+		AB1D47802F87A94000E14783 /* NetworkFacadeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47822F87A94000E14783 /* NetworkFacadeFactory.swift */; };
+		AB1D47812F87A94000E14783 /* SharedKeychainCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47832F87A94000E14783 /* SharedKeychainCredentials.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
 		DEBEAEBF2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBEAEBE2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift */; };
 		DEBEAEC02F72E65B00A6E6D5 /* AppGroupPendingShareModule.m in Sources */ = {isa = PBXBuildFile; fileRef = DEBEAEBD2F72E65B00A6E6D5 /* AppGroupPendingShareModule.m */; };
@@ -98,6 +100,8 @@
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = Internxt/SplashScreen.storyboard; sourceTree = "<group>"; };
 		AB1D47722F87A94000E14783 /* FileProviderItemIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderItemIdentifier.swift; sourceTree = "<group>"; };
 		AB1D47732F87A94000E14783 /* DriveAPIFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DriveAPIFactory.swift; sourceTree = "<group>"; };
+		AB1D47822F87A94000E14783 /* NetworkFacadeFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkFacadeFactory.swift; sourceTree = "<group>"; };
+		AB1D47832F87A94000E14783 /* SharedKeychainCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedKeychainCredentials.swift; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
 		BD55E1E535AECF7719BDD772 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-Internxt/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 		D0A0CA179360CA52F0B5054A /* libPods-InternxtShareExtension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-InternxtShareExtension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -265,6 +269,8 @@
 				DE1D47652F87A94000E14783 /* FileProviderItem.swift */,
 				AB1D47722F87A94000E14783 /* FileProviderItemIdentifier.swift */,
 				AB1D47732F87A94000E14783 /* DriveAPIFactory.swift */,
+				AB1D47822F87A94000E14783 /* NetworkFacadeFactory.swift */,
+				AB1D47832F87A94000E14783 /* SharedKeychainCredentials.swift */,
 				DE1D47662F87A94000E14783 /* Info.plist */,
 				DE1D47672F87A94000E14783 /* InternxtFileProvider.entitlements */,
 				DE1D47682F87A94000E14783 /* InternxtFileProvider.plist */,
@@ -702,6 +708,8 @@
 				DE1D47622F87A94000E14783 /* FileProviderItem.swift in Sources */,
 				AB1D47702F87A94000E14783 /* FileProviderItemIdentifier.swift in Sources */,
 				AB1D47712F87A94000E14783 /* DriveAPIFactory.swift in Sources */,
+				AB1D47802F87A94000E14783 /* NetworkFacadeFactory.swift in Sources */,
+				AB1D47812F87A94000E14783 /* SharedKeychainCredentials.swift in Sources */,
 				AA0100082F87A94000E14783 /* SharedAuthKeychain.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/Internxt.xcodeproj/project.pbxproj
+++ b/ios/Internxt.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		AA0100052F87A94000E14783 /* InternxtAuthCredentialsModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100042F87A94000E14783 /* InternxtAuthCredentialsModule.swift */; };
 		AA0100072F87A94000E14783 /* InternxtAuthCredentialsModule.m in Sources */ = {isa = PBXBuildFile; fileRef = AA0100062F87A94000E14783 /* InternxtAuthCredentialsModule.m */; };
 		AA0100082F87A94000E14783 /* SharedAuthKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100002F87A94000E14783 /* SharedAuthKeychain.swift */; };
+		AB1D47702F87A94000E14783 /* FileProviderItemIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47722F87A94000E14783 /* FileProviderItemIdentifier.swift */; };
+		AB1D47712F87A94000E14783 /* DriveAPIFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47732F87A94000E14783 /* DriveAPIFactory.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
 		DEBEAEBF2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBEAEBE2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift */; };
 		DEBEAEC02F72E65B00A6E6D5 /* AppGroupPendingShareModule.m in Sources */ = {isa = PBXBuildFile; fileRef = DEBEAEBD2F72E65B00A6E6D5 /* AppGroupPendingShareModule.m */; };
@@ -94,6 +96,8 @@
 		AA0100062F87A94000E14783 /* InternxtAuthCredentialsModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = InternxtAuthCredentialsModule.m; path = Internxt/InternxtAuthCredentialsModule.m; sourceTree = "<group>"; };
 		A7EBA4C496DAF1149115FA8A /* Pods-Internxt.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.debug.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.debug.xcconfig"; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = Internxt/SplashScreen.storyboard; sourceTree = "<group>"; };
+		AB1D47722F87A94000E14783 /* FileProviderItemIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderItemIdentifier.swift; sourceTree = "<group>"; };
+		AB1D47732F87A94000E14783 /* DriveAPIFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DriveAPIFactory.swift; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
 		BD55E1E535AECF7719BDD772 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-Internxt/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 		D0A0CA179360CA52F0B5054A /* libPods-InternxtShareExtension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-InternxtShareExtension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -259,6 +263,8 @@
 				DE1D47632F87A94000E14783 /* FileProviderExtension.swift */,
 				DE1D47642F87A94000E14783 /* FileProviderEnumerator.swift */,
 				DE1D47652F87A94000E14783 /* FileProviderItem.swift */,
+				AB1D47722F87A94000E14783 /* FileProviderItemIdentifier.swift */,
+				AB1D47732F87A94000E14783 /* DriveAPIFactory.swift */,
 				DE1D47662F87A94000E14783 /* Info.plist */,
 				DE1D47672F87A94000E14783 /* InternxtFileProvider.entitlements */,
 				DE1D47682F87A94000E14783 /* InternxtFileProvider.plist */,
@@ -694,6 +700,8 @@
 				DE1D47602F87A94000E14783 /* FileProviderExtension.swift in Sources */,
 				DE1D47612F87A94000E14783 /* FileProviderEnumerator.swift in Sources */,
 				DE1D47622F87A94000E14783 /* FileProviderItem.swift in Sources */,
+				AB1D47702F87A94000E14783 /* FileProviderItemIdentifier.swift in Sources */,
+				AB1D47712F87A94000E14783 /* DriveAPIFactory.swift in Sources */,
 				AA0100082F87A94000E14783 /* SharedAuthKeychain.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/Internxt.xcodeproj/project.pbxproj
+++ b/ios/Internxt.xcodeproj/project.pbxproj
@@ -18,6 +18,13 @@
 		7D373856C83A43879BFBE604 /* InternxtShareExtension.appex in Copy Files */ = {isa = PBXBuildFile; fileRef = 7F5486528A7D46DD91A7910F /* InternxtShareExtension.appex */; };
 		8F8148045BC14A539BD1917D /* ShareExtensionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6F72E1B98D469883DAFB30 /* ShareExtensionViewController.swift */; };
 		AA0100012F87A94000E14783 /* SharedAuthKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100002F87A94000E14783 /* SharedAuthKeychain.swift */; };
+		FF2010002F90000000E14783 /* FileProviderModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1010002F90000000E14783 /* FileProviderModule.swift */; };
+		FF2010012F90000000E14783 /* FileProviderModule.m in Sources */ = {isa = PBXBuildFile; fileRef = FF1010012F90000000E14783 /* FileProviderModule.m */; };
+		FF2010062F90000000E14783 /* FileProviderItemIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47722F87A94000E14783 /* FileProviderItemIdentifier.swift */; };
+		FF2010022F90000000E14783 /* SyncAnchorStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1010022F90000000E14783 /* SyncAnchorStore.swift */; };
+		FF2010032F90000000E14783 /* SyncAnchorStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1010022F90000000E14783 /* SyncAnchorStore.swift */; };
+		FF2010042F90000000E14783 /* SyncAnchorStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1010022F90000000E14783 /* SyncAnchorStore.swift */; };
+		FF2010052F90000000E14783 /* SyncAnchorStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1010032F90000000E14783 /* SyncAnchorStoreTests.swift */; };
 		AA0100032F87A94000E14783 /* FileProviderDomainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100022F87A94000E14783 /* FileProviderDomainManager.swift */; };
 		AA0100052F87A94000E14783 /* InternxtAuthCredentialsModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100042F87A94000E14783 /* InternxtAuthCredentialsModule.swift */; };
 		AA0100072F87A94000E14783 /* InternxtAuthCredentialsModule.m in Sources */ = {isa = PBXBuildFile; fileRef = AA0100062F87A94000E14783 /* InternxtAuthCredentialsModule.m */; };
@@ -105,6 +112,10 @@
 		9616C09E46C26A3E032F9B0B /* Pods-InternxtShareExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtShareExtension.release.xcconfig"; path = "Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension.release.xcconfig"; sourceTree = "<group>"; };
 		A4921399A370F5CE6EE7EA0F /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-InternxtShareExtension/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 		AA0100002F87A94000E14783 /* SharedAuthKeychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SharedAuthKeychain.swift; path = Internxt/SharedAuthKeychain.swift; sourceTree = "<group>"; };
+		FF1010002F90000000E14783 /* FileProviderModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FileProviderModule.swift; path = Internxt/FileProviderModule.swift; sourceTree = "<group>"; };
+		FF1010012F90000000E14783 /* FileProviderModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = FileProviderModule.m; path = Internxt/FileProviderModule.m; sourceTree = "<group>"; };
+		FF1010022F90000000E14783 /* SyncAnchorStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncAnchorStore.swift; sourceTree = "<group>"; };
+		FF1010032F90000000E14783 /* SyncAnchorStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncAnchorStoreTests.swift; sourceTree = "<group>"; };
 		AA0100022F87A94000E14783 /* FileProviderDomainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FileProviderDomainManager.swift; path = Internxt/FileProviderDomainManager.swift; sourceTree = "<group>"; };
 		AA0100042F87A94000E14783 /* InternxtAuthCredentialsModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = InternxtAuthCredentialsModule.swift; path = Internxt/InternxtAuthCredentialsModule.swift; sourceTree = "<group>"; };
 		AA0100062F87A94000E14783 /* InternxtAuthCredentialsModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = InternxtAuthCredentialsModule.m; path = Internxt/InternxtAuthCredentialsModule.m; sourceTree = "<group>"; };
@@ -178,6 +189,8 @@
 				AA0100022F87A94000E14783 /* FileProviderDomainManager.swift */,
 				AA0100042F87A94000E14783 /* InternxtAuthCredentialsModule.swift */,
 				AA0100062F87A94000E14783 /* InternxtAuthCredentialsModule.m */,
+				FF1010002F90000000E14783 /* FileProviderModule.swift */,
+				FF1010012F90000000E14783 /* FileProviderModule.m */,
 				F11748412D0307B40044C1D9 /* AppDelegate.swift */,
 				F11748442D0722820044C1D9 /* Internxt-Bridging-Header.h */,
 				BB2F792B24A3F905000567C9 /* Supporting */,
@@ -294,6 +307,7 @@
 			isa = PBXGroup;
 			children = (
 				DE1D47632F87A94000E14783 /* FileProviderExtension.swift */,
+				FF1010022F90000000E14783 /* SyncAnchorStore.swift */,
 				DE1D47642F87A94000E14783 /* FileProviderEnumerator.swift */,
 				DE1D47652F87A94000E14783 /* FileProviderItem.swift */,
 				AB1D47912F87A94000E14783 /* FileProviderErrorMapper.swift */,
@@ -316,6 +330,7 @@
 			children = (
 				FB1D480112F87A94000E14783 /* FileProviderErrorMapperTests.swift */,
 				FB1D481112F87A94000E14783 /* FileProviderMutationTests.swift */,
+				FF1010032F90000000E14783 /* SyncAnchorStoreTests.swift */,
 			);
 			path = InternxtFileProviderTests;
 			sourceTree = "<group>";
@@ -752,6 +767,10 @@
 				AA0100032F87A94000E14783 /* FileProviderDomainManager.swift in Sources */,
 				AA0100052F87A94000E14783 /* InternxtAuthCredentialsModule.swift in Sources */,
 				AA0100072F87A94000E14783 /* InternxtAuthCredentialsModule.m in Sources */,
+				FF2010002F90000000E14783 /* FileProviderModule.swift in Sources */,
+				FF2010012F90000000E14783 /* FileProviderModule.m in Sources */,
+				FF2010032F90000000E14783 /* SyncAnchorStore.swift in Sources */,
+				FF2010062F90000000E14783 /* FileProviderItemIdentifier.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -769,6 +788,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DE1D47602F87A94000E14783 /* FileProviderExtension.swift in Sources */,
+				FF2010022F90000000E14783 /* SyncAnchorStore.swift in Sources */,
 				DE1D47612F87A94000E14783 /* FileProviderEnumerator.swift in Sources */,
 				DE1D47622F87A94000E14783 /* FileProviderItem.swift in Sources */,
 				AB1D47902F87A94000E14783 /* FileProviderErrorMapper.swift in Sources */,
@@ -790,6 +810,8 @@
 				FB1D480012F87A94000E14783 /* FileProviderErrorMapperTests.swift in Sources */,
 				FB1D480212F87A94000E14783 /* FileProviderErrorMapper.swift in Sources */,
 				FB1D481012F87A94000E14783 /* FileProviderMutationTests.swift in Sources */,
+				FF2010042F90000000E14783 /* SyncAnchorStore.swift in Sources */,
+				FF2010052F90000000E14783 /* SyncAnchorStoreTests.swift in Sources */,
 				FB1D481212F87A94000E14783 /* FileProviderItem.swift in Sources */,
 				FB1D481312F87A94000E14783 /* FileProviderItemIdentifier.swift in Sources */,
 				FB1D481412F87A94000E14783 /* FileProviderMutationService.swift in Sources */,

--- a/ios/Internxt.xcodeproj/project.pbxproj
+++ b/ios/Internxt.xcodeproj/project.pbxproj
@@ -26,6 +26,10 @@
 		AB1D47712F87A94000E14783 /* DriveAPIFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47732F87A94000E14783 /* DriveAPIFactory.swift */; };
 		AB1D47802F87A94000E14783 /* NetworkFacadeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47822F87A94000E14783 /* NetworkFacadeFactory.swift */; };
 		AB1D47812F87A94000E14783 /* SharedKeychainCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47832F87A94000E14783 /* SharedKeychainCredentials.swift */; };
+		AB1D47902F87A94000E14783 /* FileProviderErrorMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47912F87A94000E14783 /* FileProviderErrorMapper.swift */; };
+		AB1D47922F87A94000E14783 /* FileProviderUploadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47932F87A94000E14783 /* FileProviderUploadService.swift */; };
+		AB1D47942F87A94000E14783 /* FileProviderDownloadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47952F87A94000E14783 /* FileProviderDownloadService.swift */; };
+		AB1D47962F87A94000E14783 /* FileProviderMutationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47972F87A94000E14783 /* FileProviderMutationService.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
 		DEBEAEBF2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBEAEBE2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift */; };
 		DEBEAEC02F72E65B00A6E6D5 /* AppGroupPendingShareModule.m in Sources */ = {isa = PBXBuildFile; fileRef = DEBEAEBD2F72E65B00A6E6D5 /* AppGroupPendingShareModule.m */; };
@@ -102,6 +106,10 @@
 		AB1D47732F87A94000E14783 /* DriveAPIFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DriveAPIFactory.swift; sourceTree = "<group>"; };
 		AB1D47822F87A94000E14783 /* NetworkFacadeFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkFacadeFactory.swift; sourceTree = "<group>"; };
 		AB1D47832F87A94000E14783 /* SharedKeychainCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedKeychainCredentials.swift; sourceTree = "<group>"; };
+		AB1D47912F87A94000E14783 /* FileProviderErrorMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderErrorMapper.swift; sourceTree = "<group>"; };
+		AB1D47932F87A94000E14783 /* FileProviderUploadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderUploadService.swift; sourceTree = "<group>"; };
+		AB1D47952F87A94000E14783 /* FileProviderDownloadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderDownloadService.swift; sourceTree = "<group>"; };
+		AB1D47972F87A94000E14783 /* FileProviderMutationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderMutationService.swift; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
 		BD55E1E535AECF7719BDD772 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-Internxt/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 		D0A0CA179360CA52F0B5054A /* libPods-InternxtShareExtension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-InternxtShareExtension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -267,6 +275,10 @@
 				DE1D47632F87A94000E14783 /* FileProviderExtension.swift */,
 				DE1D47642F87A94000E14783 /* FileProviderEnumerator.swift */,
 				DE1D47652F87A94000E14783 /* FileProviderItem.swift */,
+				AB1D47912F87A94000E14783 /* FileProviderErrorMapper.swift */,
+				AB1D47932F87A94000E14783 /* FileProviderUploadService.swift */,
+				AB1D47952F87A94000E14783 /* FileProviderDownloadService.swift */,
+				AB1D47972F87A94000E14783 /* FileProviderMutationService.swift */,
 				AB1D47722F87A94000E14783 /* FileProviderItemIdentifier.swift */,
 				AB1D47732F87A94000E14783 /* DriveAPIFactory.swift */,
 				AB1D47822F87A94000E14783 /* NetworkFacadeFactory.swift */,
@@ -706,6 +718,10 @@
 				DE1D47602F87A94000E14783 /* FileProviderExtension.swift in Sources */,
 				DE1D47612F87A94000E14783 /* FileProviderEnumerator.swift in Sources */,
 				DE1D47622F87A94000E14783 /* FileProviderItem.swift in Sources */,
+				AB1D47902F87A94000E14783 /* FileProviderErrorMapper.swift in Sources */,
+				AB1D47922F87A94000E14783 /* FileProviderUploadService.swift in Sources */,
+				AB1D47942F87A94000E14783 /* FileProviderDownloadService.swift in Sources */,
+				AB1D47962F87A94000E14783 /* FileProviderMutationService.swift in Sources */,
 				AB1D47702F87A94000E14783 /* FileProviderItemIdentifier.swift in Sources */,
 				AB1D47712F87A94000E14783 /* DriveAPIFactory.swift in Sources */,
 				AB1D47802F87A94000E14783 /* NetworkFacadeFactory.swift in Sources */,

--- a/ios/Internxt.xcodeproj/project.pbxproj
+++ b/ios/Internxt.xcodeproj/project.pbxproj
@@ -37,6 +37,11 @@
 		F2C595E5ECBAD697016C9410 /* libPods-InternxtShareExtension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D0A0CA179360CA52F0B5054A /* libPods-InternxtShareExtension.a */; };
 		FB1D480012F87A94000E14783 /* FileProviderErrorMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1D480112F87A94000E14783 /* FileProviderErrorMapperTests.swift */; };
 		FB1D480212F87A94000E14783 /* FileProviderErrorMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47912F87A94000E14783 /* FileProviderErrorMapper.swift */; };
+		FB1D481012F87A94000E14783 /* FileProviderMutationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1D481112F87A94000E14783 /* FileProviderMutationTests.swift */; };
+		FB1D481212F87A94000E14783 /* FileProviderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1D47652F87A94000E14783 /* FileProviderItem.swift */; };
+		FB1D481312F87A94000E14783 /* FileProviderItemIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47722F87A94000E14783 /* FileProviderItemIdentifier.swift */; };
+		FB1D481412F87A94000E14783 /* FileProviderMutationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47972F87A94000E14783 /* FileProviderMutationService.swift */; };
+		FB1D481512F87A94000E14783 /* SharedAuthKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100002F87A94000E14783 /* SharedAuthKeychain.swift */; };
 		FB1D480312F87A94000E14783 /* InternxtSwiftCore in Frameworks */ = {isa = PBXBuildFile; productRef = FB1D480412F87A94000E14783 /* InternxtSwiftCore */; };
 		FEB260B2B281D37EEABD1ECA /* libPods-InternxtFileProvider.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 20957EE3E4797FBBC2BD3192 /* libPods-InternxtFileProvider.a */; };
 /* End PBXBuildFile section */
@@ -131,6 +136,7 @@
 		F11748412D0307B40044C1D9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = Internxt/AppDelegate.swift; sourceTree = "<group>"; };
 		F11748442D0722820044C1D9 /* Internxt-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "Internxt-Bridging-Header.h"; path = "Internxt/Internxt-Bridging-Header.h"; sourceTree = "<group>"; };
 		FB1D480112F87A94000E14783 /* FileProviderErrorMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderErrorMapperTests.swift; sourceTree = "<group>"; };
+		FB1D481112F87A94000E14783 /* FileProviderMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderMutationTests.swift; sourceTree = "<group>"; };
 		FB1D480512F87A94000E14783 /* InternxtFileProviderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = InternxtFileProviderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FDEA9EEAEC8CE666D14877B2 /* Pods-Internxt.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.debug.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -309,6 +315,7 @@
 			isa = PBXGroup;
 			children = (
 				FB1D480112F87A94000E14783 /* FileProviderErrorMapperTests.swift */,
+				FB1D481112F87A94000E14783 /* FileProviderMutationTests.swift */,
 			);
 			path = InternxtFileProviderTests;
 			sourceTree = "<group>";
@@ -782,6 +789,11 @@
 			files = (
 				FB1D480012F87A94000E14783 /* FileProviderErrorMapperTests.swift in Sources */,
 				FB1D480212F87A94000E14783 /* FileProviderErrorMapper.swift in Sources */,
+				FB1D481012F87A94000E14783 /* FileProviderMutationTests.swift in Sources */,
+				FB1D481212F87A94000E14783 /* FileProviderItem.swift in Sources */,
+				FB1D481312F87A94000E14783 /* FileProviderItemIdentifier.swift in Sources */,
+				FB1D481412F87A94000E14783 /* FileProviderMutationService.swift in Sources */,
+				FB1D481512F87A94000E14783 /* SharedAuthKeychain.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Internxt.xcodeproj/project.pbxproj
+++ b/ios/Internxt.xcodeproj/project.pbxproj
@@ -17,6 +17,11 @@
 		7A61A118D20D0540EF70FE74 /* libPods-InternxtShareExtension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 546A3CDB7E733C0B5DA4C994 /* libPods-InternxtShareExtension.a */; };
 		7D373856C83A43879BFBE604 /* InternxtShareExtension.appex in Copy Files */ = {isa = PBXBuildFile; fileRef = 7F5486528A7D46DD91A7910F /* InternxtShareExtension.appex */; };
 		8F8148045BC14A539BD1917D /* ShareExtensionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6F72E1B98D469883DAFB30 /* ShareExtensionViewController.swift */; };
+		AA0100012F87A94000E14783 /* SharedAuthKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100002F87A94000E14783 /* SharedAuthKeychain.swift */; };
+		AA0100032F87A94000E14783 /* FileProviderDomainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100022F87A94000E14783 /* FileProviderDomainManager.swift */; };
+		AA0100052F87A94000E14783 /* InternxtAuthCredentialsModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100042F87A94000E14783 /* InternxtAuthCredentialsModule.swift */; };
+		AA0100072F87A94000E14783 /* InternxtAuthCredentialsModule.m in Sources */ = {isa = PBXBuildFile; fileRef = AA0100062F87A94000E14783 /* InternxtAuthCredentialsModule.m */; };
+		AA0100082F87A94000E14783 /* SharedAuthKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100002F87A94000E14783 /* SharedAuthKeychain.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
 		DEBEAEBF2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBEAEBE2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift */; };
 		DEBEAEC02F72E65B00A6E6D5 /* AppGroupPendingShareModule.m in Sources */ = {isa = PBXBuildFile; fileRef = DEBEAEBD2F72E65B00A6E6D5 /* AppGroupPendingShareModule.m */; };
@@ -83,6 +88,10 @@
 		944651400FAC80AAD61017EE /* libPods-Internxt.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Internxt.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9616C09E46C26A3E032F9B0B /* Pods-InternxtShareExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtShareExtension.release.xcconfig"; path = "Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension.release.xcconfig"; sourceTree = "<group>"; };
 		A4921399A370F5CE6EE7EA0F /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-InternxtShareExtension/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
+		AA0100002F87A94000E14783 /* SharedAuthKeychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SharedAuthKeychain.swift; path = Internxt/SharedAuthKeychain.swift; sourceTree = "<group>"; };
+		AA0100022F87A94000E14783 /* FileProviderDomainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FileProviderDomainManager.swift; path = Internxt/FileProviderDomainManager.swift; sourceTree = "<group>"; };
+		AA0100042F87A94000E14783 /* InternxtAuthCredentialsModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = InternxtAuthCredentialsModule.swift; path = Internxt/InternxtAuthCredentialsModule.swift; sourceTree = "<group>"; };
+		AA0100062F87A94000E14783 /* InternxtAuthCredentialsModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = InternxtAuthCredentialsModule.m; path = Internxt/InternxtAuthCredentialsModule.m; sourceTree = "<group>"; };
 		A7EBA4C496DAF1149115FA8A /* Pods-Internxt.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.debug.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.debug.xcconfig"; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = Internxt/SplashScreen.storyboard; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
@@ -130,6 +139,10 @@
 			children = (
 				DEBEAEBD2F72E65B00A6E6D5 /* AppGroupPendingShareModule.m */,
 				DEBEAEBE2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift */,
+				AA0100002F87A94000E14783 /* SharedAuthKeychain.swift */,
+				AA0100022F87A94000E14783 /* FileProviderDomainManager.swift */,
+				AA0100042F87A94000E14783 /* InternxtAuthCredentialsModule.swift */,
+				AA0100062F87A94000E14783 /* InternxtAuthCredentialsModule.m */,
 				F11748412D0307B40044C1D9 /* AppDelegate.swift */,
 				F11748442D0722820044C1D9 /* Internxt-Bridging-Header.h */,
 				BB2F792B24A3F905000567C9 /* Supporting */,
@@ -335,7 +348,6 @@
 				LastUpgradeCheck = 1130;
 				TargetAttributes = {
 					13B07F861A680F5B00A75B9A = {
-						DevelopmentTeam = JR4S3SY396;
 						LastSwiftMigration = 1250;
 						ProvisioningStyle = Automatic;
 					};
@@ -659,6 +671,10 @@
 				1818AB341F31CC033FFF750B /* ExpoModulesProvider.swift in Sources */,
 				DEBEAEBF2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift in Sources */,
 				DEBEAEC02F72E65B00A6E6D5 /* AppGroupPendingShareModule.m in Sources */,
+				AA0100012F87A94000E14783 /* SharedAuthKeychain.swift in Sources */,
+				AA0100032F87A94000E14783 /* FileProviderDomainManager.swift in Sources */,
+				AA0100052F87A94000E14783 /* InternxtAuthCredentialsModule.swift in Sources */,
+				AA0100072F87A94000E14783 /* InternxtAuthCredentialsModule.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -678,6 +694,7 @@
 				DE1D47602F87A94000E14783 /* FileProviderExtension.swift in Sources */,
 				DE1D47612F87A94000E14783 /* FileProviderEnumerator.swift in Sources */,
 				DE1D47622F87A94000E14783 /* FileProviderItem.swift in Sources */,
+				AA0100082F87A94000E14783 /* SharedAuthKeychain.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -975,7 +992,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.9.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
@@ -1025,7 +1042,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.9.0;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.internxt.snacks.InternxtFileProvider;

--- a/ios/Internxt.xcodeproj/project.pbxproj
+++ b/ios/Internxt.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0BF8BD03596D167E534E4B02 /* libPods-Internxt.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 55EA068F694B454131066FDC /* libPods-Internxt.a */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		1818AB341F31CC033FFF750B /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD55E1E535AECF7719BDD772 /* ExpoModulesProvider.swift */; };
 		18D7DE9587FA2B2314575ED6 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4921399A370F5CE6EE7EA0F /* ExpoModulesProvider.swift */; };
@@ -20,9 +21,18 @@
 		DEBEAEBF2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBEAEBE2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift */; };
 		DEBEAEC02F72E65B00A6E6D5 /* AppGroupPendingShareModule.m in Sources */ = {isa = PBXBuildFile; fileRef = DEBEAEBD2F72E65B00A6E6D5 /* AppGroupPendingShareModule.m */; };
 		F11748422D0307B40044C1D9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11748412D0307B40044C1D9 /* AppDelegate.swift */; };
+		F2C595E5ECBAD697016C9410 /* libPods-InternxtShareExtension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D0A0CA179360CA52F0B5054A /* libPods-InternxtShareExtension.a */; };
+		FEB260B2B281D37EEABD1ECA /* libPods-InternxtFileProvider.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 20957EE3E4797FBBC2BD3192 /* libPods-InternxtFileProvider.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		DE1D474D2F87A94000E14783 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 83CBB9F71A601CBA00E9B192 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DE1D47402F87A94000E14783;
+			remoteInfo = InternxtFileProvider;
+		};
 		DEA227B339134920AF95B704 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 83CBB9F71A601CBA00E9B192 /* Project object */;
@@ -39,6 +49,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 13;
 			files = (
+				DE1D474F2F87A94000E14783 /* InternxtFileProvider.appex in Embed Foundation Extensions */,
 			);
 			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -57,9 +68,11 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0512BC474AAE3164D3544B18 /* Pods-InternxtShareExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtShareExtension.debug.xcconfig"; path = "Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* Internxt.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Internxt.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Internxt/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Internxt/Info.plist; sourceTree = "<group>"; };
+		20957EE3E4797FBBC2BD3192 /* libPods-InternxtFileProvider.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-InternxtFileProvider.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		30C3C55FF8AE435F8A82A9BC /* InternxtShareExtension.entitlements */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; path = InternxtShareExtension.entitlements; sourceTree = "<group>"; };
 		37A2C3A4643426D3F429F041 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = Internxt/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		3A6F72E1B98D469883DAFB30 /* ShareExtensionViewController.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; path = ShareExtensionViewController.swift; sourceTree = "<group>"; };
@@ -74,12 +87,22 @@
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = Internxt/SplashScreen.storyboard; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
 		BD55E1E535AECF7719BDD772 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-Internxt/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
+		D0A0CA179360CA52F0B5054A /* libPods-InternxtShareExtension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-InternxtShareExtension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DAE15E8DB4DF4E048E04B0E0 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DE1D47412F87A94000E14783 /* InternxtFileProvider.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = InternxtFileProvider.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		DE1D47422F87A94000E14783 /* UniformTypeIdentifiers.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UniformTypeIdentifiers.framework; path = System/Library/Frameworks/UniformTypeIdentifiers.framework; sourceTree = SDKROOT; };
+		DE1D47632F87A94000E14783 /* FileProviderExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderExtension.swift; sourceTree = "<group>"; };
+		DE1D47642F87A94000E14783 /* FileProviderEnumerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderEnumerator.swift; sourceTree = "<group>"; };
+		DE1D47652F87A94000E14783 /* FileProviderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderItem.swift; sourceTree = "<group>"; };
+		DE1D47662F87A94000E14783 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DE1D47672F87A94000E14783 /* InternxtFileProvider.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = InternxtFileProvider.entitlements; sourceTree = "<group>"; };
+		DE1D47682F87A94000E14783 /* InternxtFileProvider.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = InternxtFileProvider.plist; sourceTree = "<group>"; };
 		DEBEAEBD2F72E65B00A6E6D5 /* AppGroupPendingShareModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = AppGroupPendingShareModule.m; path = Internxt/AppGroupPendingShareModule.m; sourceTree = "<group>"; };
 		DEBEAEBE2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppGroupPendingShareModule.swift; path = Internxt/AppGroupPendingShareModule.swift; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		F11748412D0307B40044C1D9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = Internxt/AppDelegate.swift; sourceTree = "<group>"; };
 		F11748442D0722820044C1D9 /* Internxt-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "Internxt-Bridging-Header.h"; path = "Internxt/Internxt-Bridging-Header.h"; sourceTree = "<group>"; };
+		FDEA9EEAEC8CE666D14877B2 /* Pods-Internxt.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.debug.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -169,6 +192,7 @@
 			children = (
 				13B07FAE1A68108700A75B9A /* Internxt */,
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
+				DE1D47442F87A94000E14783 /* InternxtFileProvider */,
 				83CBBA001A601CBA00E9B192 /* Products */,
 				2D16E6871FA4F8E400B85C8A /* Frameworks */,
 				7151A997BCA04521BD294E7B /* InternxtShareExtension */,
@@ -185,6 +209,7 @@
 			children = (
 				13B07F961A680F5B00A75B9A /* Internxt.app */,
 				7F5486528A7D46DD91A7910F /* InternxtShareExtension.appex */,
+				DE1D47412F87A94000E14783 /* InternxtFileProvider.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -215,6 +240,19 @@
 			name = InternxtShareExtension;
 			sourceTree = "<group>";
 		};
+		DE1D47442F87A94000E14783 /* InternxtFileProvider */ = {
+			isa = PBXGroup;
+			children = (
+				DE1D47632F87A94000E14783 /* FileProviderExtension.swift */,
+				DE1D47642F87A94000E14783 /* FileProviderEnumerator.swift */,
+				DE1D47652F87A94000E14783 /* FileProviderItem.swift */,
+				DE1D47662F87A94000E14783 /* Info.plist */,
+				DE1D47672F87A94000E14783 /* InternxtFileProvider.entitlements */,
+				DE1D47682F87A94000E14783 /* InternxtFileProvider.plist */,
+			);
+			path = InternxtFileProvider;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -237,6 +275,7 @@
 			);
 			dependencies = (
 				03ED76FE58CE4782913172E7 /* PBXTargetDependency */,
+				DE1D474E2F87A94000E14783 /* PBXTargetDependency */,
 			);
 			name = Internxt;
 			productName = Internxt;
@@ -265,12 +304,34 @@
 			productReference = 7F5486528A7D46DD91A7910F /* InternxtShareExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
+		DE1D47402F87A94000E14783 /* InternxtFileProvider */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DE1D47532F87A94000E14783 /* Build configuration list for PBXNativeTarget "InternxtFileProvider" */;
+			buildPhases = (
+				04C47D43FAB17BFF5826C486 /* [CP] Check Pods Manifest.lock */,
+				DE1D473D2F87A94000E14783 /* Sources */,
+				DE1D473E2F87A94000E14783 /* Frameworks */,
+				DE1D473F2F87A94000E14783 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = InternxtFileProvider;
+			packageProductDependencies = (
+				DE1D47552F87AB4000E14783 /* InternxtSwiftCore */,
+			);
+			productName = InternxtFileProvider;
+			productReference = DE1D47412F87A94000E14783 /* InternxtFileProvider.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		83CBB9F71A601CBA00E9B192 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 2640;
 				LastUpgradeCheck = 1130;
 				TargetAttributes = {
 					13B07F861A680F5B00A75B9A = {
@@ -283,6 +344,9 @@
 						LastSwiftMigration = 1250;
 						ProvisioningStyle = Automatic;
 					};
+					DE1D47402F87A94000E14783 = {
+						CreatedOnToolsVersion = 26.4;
+					};
 				};
 			};
 			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "Internxt" */;
@@ -294,12 +358,16 @@
 				Base,
 			);
 			mainGroup = 83CBB9F61A601CBA00E9B192;
+			packageReferences = (
+				DE1D47542F87AB4000E14783 /* XCRemoteSwiftPackageReference "swift-core" */,
+			);
 			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
 				13B07F861A680F5B00A75B9A /* Internxt */,
 				573EC8782D084646801534FA /* InternxtShareExtension */,
+				DE1D47402F87A94000E14783 /* InternxtFileProvider */,
 			);
 		};
 /* End PBXProject section */
@@ -317,6 +385,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		2F5766E756C84914803E7082 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DE1D473F2F87A94000E14783 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -596,6 +671,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DE1D473D2F87A94000E14783 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DE1D47602F87A94000E14783 /* FileProviderExtension.swift in Sources */,
+				DE1D47612F87A94000E14783 /* FileProviderEnumerator.swift in Sources */,
+				DE1D47622F87A94000E14783 /* FileProviderItem.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -603,6 +688,11 @@
 			isa = PBXTargetDependency;
 			target = 573EC8782D084646801534FA /* InternxtShareExtension */;
 			targetProxy = DEA227B339134920AF95B704 /* PBXContainerItemProxy */;
+		};
+		DE1D474E2F87A94000E14783 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DE1D47402F87A94000E14783 /* InternxtFileProvider */;
+			targetProxy = DE1D474D2F87A94000E14783 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -854,6 +944,103 @@
 			};
 			name = Release;
 		};
+		DE1D47502F87A94000E14783 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AC8B28CC3C9A8FDF21A8C1E7 /* Pods-InternxtFileProvider.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = InternxtFileProvider/InternxtFileProvider.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = JR4S3SY396;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = InternxtFileProvider/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = InternxtFileProvider;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
+				PRODUCT_BUNDLE_IDENTIFIER = com.internxt.snacks.InternxtFileProvider;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		DE1D47512F87A94000E14783 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8C48FB43821216C363EBF3FC /* Pods-InternxtFileProvider.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = InternxtFileProvider/InternxtFileProvider.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = JR4S3SY396;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = InternxtFileProvider/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = InternxtFileProvider;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
+				PRODUCT_BUNDLE_IDENTIFIER = com.internxt.snacks.InternxtFileProvider;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -884,7 +1071,35 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		DE1D47532F87A94000E14783 /* Build configuration list for PBXNativeTarget "InternxtFileProvider" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DE1D47502F87A94000E14783 /* Debug */,
+				DE1D47512F87A94000E14783 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		DE1D47542F87AB4000E14783 /* XCRemoteSwiftPackageReference "swift-core" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/internxt/swift-core";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		DE1D47552F87AB4000E14783 /* InternxtSwiftCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DE1D47542F87AB4000E14783 /* XCRemoteSwiftPackageReference "swift-core" */;
+			productName = InternxtSwiftCore;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 83CBB9F71A601CBA00E9B192 /* Project object */;
 }

--- a/ios/Internxt.xcodeproj/project.pbxproj
+++ b/ios/Internxt.xcodeproj/project.pbxproj
@@ -7,24 +7,18 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0BF8BD03596D167E534E4B02 /* libPods-Internxt.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 55EA068F694B454131066FDC /* libPods-Internxt.a */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		1818AB341F31CC033FFF750B /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD55E1E535AECF7719BDD772 /* ExpoModulesProvider.swift */; };
 		18D7DE9587FA2B2314575ED6 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4921399A370F5CE6EE7EA0F /* ExpoModulesProvider.swift */; };
 		2F8E878CDCAC7D5C07B5C670 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 37A2C3A4643426D3F429F041 /* PrivacyInfo.xcprivacy */; };
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
+		512CF1042062583CD79DC618 /* InternxtSwiftCore in Frameworks */ = {isa = PBXBuildFile; productRef = DE1D47552F87AB4000E14783 /* InternxtSwiftCore */; };
+		517593AA71C926C43E076321 /* FileProviderExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1D47632F87A94000E14783 /* FileProviderExtension.swift */; };
 		7677A9D0CC2D34CF895A907E /* libPods-Internxt.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 944651400FAC80AAD61017EE /* libPods-Internxt.a */; };
 		7A61A118D20D0540EF70FE74 /* libPods-InternxtShareExtension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 546A3CDB7E733C0B5DA4C994 /* libPods-InternxtShareExtension.a */; };
 		7D373856C83A43879BFBE604 /* InternxtShareExtension.appex in Copy Files */ = {isa = PBXBuildFile; fileRef = 7F5486528A7D46DD91A7910F /* InternxtShareExtension.appex */; };
 		8F8148045BC14A539BD1917D /* ShareExtensionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6F72E1B98D469883DAFB30 /* ShareExtensionViewController.swift */; };
 		AA0100012F87A94000E14783 /* SharedAuthKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100002F87A94000E14783 /* SharedAuthKeychain.swift */; };
-		FF2010002F90000000E14783 /* FileProviderModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1010002F90000000E14783 /* FileProviderModule.swift */; };
-		FF2010012F90000000E14783 /* FileProviderModule.m in Sources */ = {isa = PBXBuildFile; fileRef = FF1010012F90000000E14783 /* FileProviderModule.m */; };
-		FF2010062F90000000E14783 /* FileProviderItemIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47722F87A94000E14783 /* FileProviderItemIdentifier.swift */; };
-		FF2010022F90000000E14783 /* SyncAnchorStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1010022F90000000E14783 /* SyncAnchorStore.swift */; };
-		FF2010032F90000000E14783 /* SyncAnchorStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1010022F90000000E14783 /* SyncAnchorStore.swift */; };
-		FF2010042F90000000E14783 /* SyncAnchorStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1010022F90000000E14783 /* SyncAnchorStore.swift */; };
-		FF2010052F90000000E14783 /* SyncAnchorStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1010032F90000000E14783 /* SyncAnchorStoreTests.swift */; };
 		AA0100032F87A94000E14783 /* FileProviderDomainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100022F87A94000E14783 /* FileProviderDomainManager.swift */; };
 		AA0100052F87A94000E14783 /* InternxtAuthCredentialsModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100042F87A94000E14783 /* InternxtAuthCredentialsModule.swift */; };
 		AA0100072F87A94000E14783 /* InternxtAuthCredentialsModule.m in Sources */ = {isa = PBXBuildFile; fileRef = AA0100062F87A94000E14783 /* InternxtAuthCredentialsModule.m */; };
@@ -38,19 +32,26 @@
 		AB1D47942F87A94000E14783 /* FileProviderDownloadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47952F87A94000E14783 /* FileProviderDownloadService.swift */; };
 		AB1D47962F87A94000E14783 /* FileProviderMutationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47972F87A94000E14783 /* FileProviderMutationService.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
+		CEF3BECD880147688CACD8B5 /* FileProviderEnumerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1D47642F87A94000E14783 /* FileProviderEnumerator.swift */; };
 		DEBEAEBF2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBEAEBE2F72E65B00A6E6D5 /* AppGroupPendingShareModule.swift */; };
 		DEBEAEC02F72E65B00A6E6D5 /* AppGroupPendingShareModule.m in Sources */ = {isa = PBXBuildFile; fileRef = DEBEAEBD2F72E65B00A6E6D5 /* AppGroupPendingShareModule.m */; };
 		F11748422D0307B40044C1D9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11748412D0307B40044C1D9 /* AppDelegate.swift */; };
-		F2C595E5ECBAD697016C9410 /* libPods-InternxtShareExtension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D0A0CA179360CA52F0B5054A /* libPods-InternxtShareExtension.a */; };
+		F603918B0E78918549FB9494 /* FileProviderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1D47652F87A94000E14783 /* FileProviderItem.swift */; };
 		FB1D480012F87A94000E14783 /* FileProviderErrorMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1D480112F87A94000E14783 /* FileProviderErrorMapperTests.swift */; };
 		FB1D480212F87A94000E14783 /* FileProviderErrorMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47912F87A94000E14783 /* FileProviderErrorMapper.swift */; };
+		FB1D480312F87A94000E14783 /* InternxtSwiftCore in Frameworks */ = {isa = PBXBuildFile; productRef = FB1D480412F87A94000E14783 /* InternxtSwiftCore */; };
 		FB1D481012F87A94000E14783 /* FileProviderMutationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1D481112F87A94000E14783 /* FileProviderMutationTests.swift */; };
 		FB1D481212F87A94000E14783 /* FileProviderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1D47652F87A94000E14783 /* FileProviderItem.swift */; };
 		FB1D481312F87A94000E14783 /* FileProviderItemIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47722F87A94000E14783 /* FileProviderItemIdentifier.swift */; };
 		FB1D481412F87A94000E14783 /* FileProviderMutationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47972F87A94000E14783 /* FileProviderMutationService.swift */; };
 		FB1D481512F87A94000E14783 /* SharedAuthKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100002F87A94000E14783 /* SharedAuthKeychain.swift */; };
-		FB1D480312F87A94000E14783 /* InternxtSwiftCore in Frameworks */ = {isa = PBXBuildFile; productRef = FB1D480412F87A94000E14783 /* InternxtSwiftCore */; };
-		FEB260B2B281D37EEABD1ECA /* libPods-InternxtFileProvider.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 20957EE3E4797FBBC2BD3192 /* libPods-InternxtFileProvider.a */; };
+		FF2010002F90000000E14783 /* FileProviderModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1010002F90000000E14783 /* FileProviderModule.swift */; };
+		FF2010012F90000000E14783 /* FileProviderModule.m in Sources */ = {isa = PBXBuildFile; fileRef = FF1010012F90000000E14783 /* FileProviderModule.m */; };
+		FF2010022F90000000E14783 /* SyncAnchorStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1010022F90000000E14783 /* SyncAnchorStore.swift */; };
+		FF2010032F90000000E14783 /* SyncAnchorStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1010022F90000000E14783 /* SyncAnchorStore.swift */; };
+		FF2010042F90000000E14783 /* SyncAnchorStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1010022F90000000E14783 /* SyncAnchorStore.swift */; };
+		FF2010052F90000000E14783 /* SyncAnchorStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1010032F90000000E14783 /* SyncAnchorStoreTests.swift */; };
+		FF2010062F90000000E14783 /* FileProviderItemIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1D47722F87A94000E14783 /* FileProviderItemIdentifier.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -77,7 +78,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 13;
 			files = (
-				DE1D474F2F87A94000E14783 /* InternxtFileProvider.appex in Embed Foundation Extensions */,
 			);
 			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -96,11 +96,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		0512BC474AAE3164D3544B18 /* Pods-InternxtShareExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtShareExtension.debug.xcconfig"; path = "Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* Internxt.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Internxt.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Internxt/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Internxt/Info.plist; sourceTree = "<group>"; };
-		20957EE3E4797FBBC2BD3192 /* libPods-InternxtFileProvider.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-InternxtFileProvider.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		30C3C55FF8AE435F8A82A9BC /* InternxtShareExtension.entitlements */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; path = InternxtShareExtension.entitlements; sourceTree = "<group>"; };
 		37A2C3A4643426D3F429F041 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = Internxt/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		3A6F72E1B98D469883DAFB30 /* ShareExtensionViewController.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; path = ShareExtensionViewController.swift; sourceTree = "<group>"; };
@@ -111,15 +109,11 @@
 		944651400FAC80AAD61017EE /* libPods-Internxt.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Internxt.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9616C09E46C26A3E032F9B0B /* Pods-InternxtShareExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InternxtShareExtension.release.xcconfig"; path = "Target Support Files/Pods-InternxtShareExtension/Pods-InternxtShareExtension.release.xcconfig"; sourceTree = "<group>"; };
 		A4921399A370F5CE6EE7EA0F /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-InternxtShareExtension/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
+		A7EBA4C496DAF1149115FA8A /* Pods-Internxt.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.debug.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.debug.xcconfig"; sourceTree = "<group>"; };
 		AA0100002F87A94000E14783 /* SharedAuthKeychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SharedAuthKeychain.swift; path = Internxt/SharedAuthKeychain.swift; sourceTree = "<group>"; };
-		FF1010002F90000000E14783 /* FileProviderModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FileProviderModule.swift; path = Internxt/FileProviderModule.swift; sourceTree = "<group>"; };
-		FF1010012F90000000E14783 /* FileProviderModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = FileProviderModule.m; path = Internxt/FileProviderModule.m; sourceTree = "<group>"; };
-		FF1010022F90000000E14783 /* SyncAnchorStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncAnchorStore.swift; sourceTree = "<group>"; };
-		FF1010032F90000000E14783 /* SyncAnchorStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncAnchorStoreTests.swift; sourceTree = "<group>"; };
 		AA0100022F87A94000E14783 /* FileProviderDomainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FileProviderDomainManager.swift; path = Internxt/FileProviderDomainManager.swift; sourceTree = "<group>"; };
 		AA0100042F87A94000E14783 /* InternxtAuthCredentialsModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = InternxtAuthCredentialsModule.swift; path = Internxt/InternxtAuthCredentialsModule.swift; sourceTree = "<group>"; };
 		AA0100062F87A94000E14783 /* InternxtAuthCredentialsModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = InternxtAuthCredentialsModule.m; path = Internxt/InternxtAuthCredentialsModule.m; sourceTree = "<group>"; };
-		A7EBA4C496DAF1149115FA8A /* Pods-Internxt.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.debug.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.debug.xcconfig"; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = Internxt/SplashScreen.storyboard; sourceTree = "<group>"; };
 		AB1D47722F87A94000E14783 /* FileProviderItemIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderItemIdentifier.swift; sourceTree = "<group>"; };
 		AB1D47732F87A94000E14783 /* DriveAPIFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DriveAPIFactory.swift; sourceTree = "<group>"; };
@@ -131,10 +125,8 @@
 		AB1D47972F87A94000E14783 /* FileProviderMutationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderMutationService.swift; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
 		BD55E1E535AECF7719BDD772 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-Internxt/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
-		D0A0CA179360CA52F0B5054A /* libPods-InternxtShareExtension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-InternxtShareExtension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DAE15E8DB4DF4E048E04B0E0 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DE1D47412F87A94000E14783 /* InternxtFileProvider.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = InternxtFileProvider.appex; sourceTree = BUILT_PRODUCTS_DIR; };
-		DE1D47422F87A94000E14783 /* UniformTypeIdentifiers.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UniformTypeIdentifiers.framework; path = System/Library/Frameworks/UniformTypeIdentifiers.framework; sourceTree = SDKROOT; };
 		DE1D47632F87A94000E14783 /* FileProviderExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderExtension.swift; sourceTree = "<group>"; };
 		DE1D47642F87A94000E14783 /* FileProviderEnumerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderEnumerator.swift; sourceTree = "<group>"; };
 		DE1D47652F87A94000E14783 /* FileProviderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderItem.swift; sourceTree = "<group>"; };
@@ -147,9 +139,12 @@
 		F11748412D0307B40044C1D9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = Internxt/AppDelegate.swift; sourceTree = "<group>"; };
 		F11748442D0722820044C1D9 /* Internxt-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "Internxt-Bridging-Header.h"; path = "Internxt/Internxt-Bridging-Header.h"; sourceTree = "<group>"; };
 		FB1D480112F87A94000E14783 /* FileProviderErrorMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderErrorMapperTests.swift; sourceTree = "<group>"; };
-		FB1D481112F87A94000E14783 /* FileProviderMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderMutationTests.swift; sourceTree = "<group>"; };
 		FB1D480512F87A94000E14783 /* InternxtFileProviderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = InternxtFileProviderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		FDEA9EEAEC8CE666D14877B2 /* Pods-Internxt.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Internxt.debug.xcconfig"; path = "Target Support Files/Pods-Internxt/Pods-Internxt.debug.xcconfig"; sourceTree = "<group>"; };
+		FB1D481112F87A94000E14783 /* FileProviderMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderMutationTests.swift; sourceTree = "<group>"; };
+		FF1010002F90000000E14783 /* FileProviderModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FileProviderModule.swift; path = Internxt/FileProviderModule.swift; sourceTree = "<group>"; };
+		FF1010012F90000000E14783 /* FileProviderModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = FileProviderModule.m; path = Internxt/FileProviderModule.m; sourceTree = "<group>"; };
+		FF1010022F90000000E14783 /* SyncAnchorStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncAnchorStore.swift; sourceTree = "<group>"; };
+		FF1010032F90000000E14783 /* SyncAnchorStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncAnchorStoreTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -158,6 +153,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				7677A9D0CC2D34CF895A907E /* libPods-Internxt.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2A04AF4D95A14473303BAABA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				512CF1042062583CD79DC618 /* InternxtSwiftCore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -390,10 +393,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DE1D47532F87A94000E14783 /* Build configuration list for PBXNativeTarget "InternxtFileProvider" */;
 			buildPhases = (
-				04C47D43FAB17BFF5826C486 /* [CP] Check Pods Manifest.lock */,
 				DE1D473D2F87A94000E14783 /* Sources */,
-				DE1D473E2F87A94000E14783 /* Frameworks */,
 				DE1D473F2F87A94000E14783 /* Resources */,
+				2A04AF4D95A14473303BAABA /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -787,10 +789,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DE1D47602F87A94000E14783 /* FileProviderExtension.swift in Sources */,
 				FF2010022F90000000E14783 /* SyncAnchorStore.swift in Sources */,
-				DE1D47612F87A94000E14783 /* FileProviderEnumerator.swift in Sources */,
-				DE1D47622F87A94000E14783 /* FileProviderItem.swift in Sources */,
 				AB1D47902F87A94000E14783 /* FileProviderErrorMapper.swift in Sources */,
 				AB1D47922F87A94000E14783 /* FileProviderUploadService.swift in Sources */,
 				AB1D47942F87A94000E14783 /* FileProviderDownloadService.swift in Sources */,
@@ -800,6 +799,9 @@
 				AB1D47802F87A94000E14783 /* NetworkFacadeFactory.swift in Sources */,
 				AB1D47812F87A94000E14783 /* SharedKeychainCredentials.swift in Sources */,
 				AA0100082F87A94000E14783 /* SharedAuthKeychain.swift in Sources */,
+				F603918B0E78918549FB9494 /* FileProviderItem.swift in Sources */,
+				517593AA71C926C43E076321 /* FileProviderExtension.swift in Sources */,
+				CEF3BECD880147688CACD8B5 /* FileProviderEnumerator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1084,7 +1086,6 @@
 		};
 		DE1D47502F87A94000E14783 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AC8B28CC3C9A8FDF21A8C1E7 /* Pods-InternxtFileProvider.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1133,7 +1134,6 @@
 		};
 		DE1D47512F87A94000E14783 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8C48FB43821216C363EBF3FC /* Pods-InternxtFileProvider.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/ios/Internxt.xcodeproj/xcshareddata/xcschemes/InternxtFileProvider.xcscheme
+++ b/ios/Internxt.xcodeproj/xcshareddata/xcschemes/InternxtFileProvider.xcscheme
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2640"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DE1D47402F87A94000E14783"
+               BuildableName = "InternxtFileProvider.appex"
+               BlueprintName = "InternxtFileProvider"
+               ReferencedContainer = "container:Internxt.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+               BuildableName = "Internxt.app"
+               BlueprintName = "Internxt"
+               ReferencedContainer = "container:Internxt.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      askForAppToLaunch = "Yes"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2"
+      queueDebuggingEnableBacktraceRecording = "Yes">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+            BuildableName = "Internxt.app"
+            BlueprintName = "Internxt"
+            ReferencedContainer = "container:Internxt.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      askForAppToLaunch = "Yes"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+            BuildableName = "Internxt.app"
+            BlueprintName = "Internxt"
+            ReferencedContainer = "container:Internxt.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/Internxt.xcodeproj/xcshareddata/xcschemes/InternxtFileProviderTests.xcscheme
+++ b/ios/Internxt.xcodeproj/xcshareddata/xcschemes/InternxtFileProviderTests.xcscheme
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FB1D480812F87A94000E14783"
+               BuildableName = "InternxtFileProviderTests.xctest"
+               BlueprintName = "InternxtFileProviderTests"
+               ReferencedContainer = "container:Internxt.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FB1D480812F87A94000E14783"
+               BuildableName = "InternxtFileProviderTests.xctest"
+               BlueprintName = "InternxtFileProviderTests"
+               ReferencedContainer = "container:Internxt.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/Internxt.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Internxt.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "f8d6cbc56ef3d7b4288ed213a329a2171e922e22cab926463add5c4d1f99c732",
+  "pins" : [
+    {
+      "identity" : "idzswiftcommoncrypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/iosdevzone/IDZSwiftCommonCrypto.git",
+      "state" : {
+        "revision" : "47f9747d12137cd59d783ab376e3ccab7206319b",
+        "version" : "0.16.1"
+      }
+    },
+    {
+      "identity" : "swift-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/internxt/swift-core",
+      "state" : {
+        "branch" : "main",
+        "revision" : "ab849424b8e12641207184fe3695de0c69a0de80"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/ios/Internxt/AppDelegate.swift
+++ b/ios/Internxt/AppDelegate.swift
@@ -1,7 +1,6 @@
 import Expo
 import React
 import ReactAppDependencyProvider
-import Security
 
 @UIApplicationMain
 public class AppDelegate: ExpoAppDelegate {
@@ -44,81 +43,7 @@ public class AppDelegate: ExpoAppDelegate {
   // MARK: - App Group auth sync
 
   private func syncAuthStatusToAppGroup() {
-    guard let sharedGroup = Bundle.main.object(forInfoDictionaryKey: "SharedKeychainGroup") as? String
-    else { return }
-
-    let isAuthenticated = privateKeychainItemExists(key: "photosToken")
-
-    if isAuthenticated {
-      copyToSharedKeychain(privateKey: "photosToken",        sharedKey: "shared_photosToken",   accessGroup: sharedGroup)
-      copyToSharedKeychain(privateKey: "xUser_mnemonic",     sharedKey: "shared_mnemonic",      accessGroup: sharedGroup)
-      copyToSharedKeychain(privateKey: "xUser_rootFolderId", sharedKey: "shared_rootFolderId",  accessGroup: sharedGroup)
-      copyToSharedKeychain(privateKey: "xUser_bucket",       sharedKey: "shared_bucket",        accessGroup: sharedGroup)
-      copyToSharedKeychain(privateKey: "xUser_bridgeUser",   sharedKey: "shared_bridgeUser",    accessGroup: sharedGroup)
-      copyToSharedKeychain(privateKey: "xUser_userId",       sharedKey: "shared_userId",        accessGroup: sharedGroup)
-    } else {
-      deleteFromSharedKeychain(key: "shared_photosToken",  accessGroup: sharedGroup)
-      deleteFromSharedKeychain(key: "shared_mnemonic",     accessGroup: sharedGroup)
-      deleteFromSharedKeychain(key: "shared_rootFolderId", accessGroup: sharedGroup)
-      deleteFromSharedKeychain(key: "shared_bucket",       accessGroup: sharedGroup)
-      deleteFromSharedKeychain(key: "shared_bridgeUser",   accessGroup: sharedGroup)
-      deleteFromSharedKeychain(key: "shared_userId",       accessGroup: sharedGroup)
-    }
-
-    if privateKeychainItemExists(key: "themePreference") {
-      copyToSharedKeychain(privateKey: "themePreference", sharedKey: "shared_themePreference", accessGroup: sharedGroup)
-    } else {
-      deleteFromSharedKeychain(key: "shared_themePreference", accessGroup: sharedGroup)
-    }
-  }
-
-  private func privateKeychainItemExists(key: String) -> Bool {
-    return readFromPrivateKeychain(key: key) != nil
-  }
-
-  private func copyToSharedKeychain(privateKey: String, sharedKey: String, accessGroup: String) {
-    guard let data = readFromPrivateKeychain(key: privateKey) else { return }
-    writeToSharedKeychain(data: data, key: sharedKey, accessGroup: accessGroup)
-  }
-
-  private func readFromPrivateKeychain(key: String) -> Data? {
-    var result: AnyObject?
-    let query: [String: Any] = [
-      kSecClass as String: kSecClassGenericPassword,
-      kSecAttrService as String: "app:no-auth",
-      kSecAttrGeneric as String: Data(key.utf8),
-      kSecAttrAccount as String: Data(key.utf8),
-      kSecMatchLimit as String: kSecMatchLimitOne,
-      kSecReturnData as String: true,
-    ]
-    guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
-          let data = result as? Data else { return nil }
-    return data
-  }
-
-  private func writeToSharedKeychain(data: Data, key: String, accessGroup: String) {
-    deleteFromSharedKeychain(key: key, accessGroup: accessGroup)
-    let query: [String: Any] = [
-      kSecClass as String: kSecClassGenericPassword,
-      kSecAttrService as String: "app:no-auth",
-      kSecAttrGeneric as String: Data(key.utf8),
-      kSecAttrAccount as String: Data(key.utf8),
-      kSecAttrAccessGroup as String: accessGroup,
-      kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked,
-      kSecValueData as String: data,
-    ]
-    SecItemAdd(query as CFDictionary, nil)
-  }
-
-  private func deleteFromSharedKeychain(key: String, accessGroup: String) {
-    let query: [String: Any] = [
-      kSecClass as String: kSecClassGenericPassword,
-      kSecAttrService as String: "app:no-auth",
-      kSecAttrGeneric as String: Data(key.utf8),
-      kSecAttrAccount as String: Data(key.utf8),
-      kSecAttrAccessGroup as String: accessGroup,
-    ]
-    SecItemDelete(query as CFDictionary)
+    SharedAuthKeychain.syncFromPrivateKeychain()
   }
 
   // Linking API

--- a/ios/Internxt/FileProviderDomainManager.swift
+++ b/ios/Internxt/FileProviderDomainManager.swift
@@ -23,6 +23,13 @@ enum FileProviderDomainManager {
   }
 
   static func signalEnumeration(completion: @escaping (Error?) -> Void) {
+    signalEnumeration(for: .workingSet, completion: completion)
+  }
+
+  static func signalEnumeration(
+    for container: NSFileProviderItemIdentifier,
+    completion: @escaping (Error?) -> Void
+  ) {
     guard let manager = NSFileProviderManager(for: domain) else {
       completion(NSError(
         domain: "FileProviderDomainManager",
@@ -31,7 +38,7 @@ enum FileProviderDomainManager {
       ))
       return
     }
-    manager.signalEnumerator(for: .workingSet) { error in
+    manager.signalEnumerator(for: container) { error in
       completion(error)
     }
   }

--- a/ios/Internxt/FileProviderDomainManager.swift
+++ b/ios/Internxt/FileProviderDomainManager.swift
@@ -1,0 +1,34 @@
+import FileProvider
+import Foundation
+
+@available(iOS 16.0, *)
+enum FileProviderDomainManager {
+  static let domainIdentifier = NSFileProviderDomainIdentifier("com.internxt.drive")
+  static let displayName = "Internxt Drive"
+
+  private static var domain: NSFileProviderDomain {
+    NSFileProviderDomain(identifier: domainIdentifier, displayName: displayName)
+  }
+
+  static func registerDomain(completion: @escaping (Error?) -> Void) {
+    NSFileProviderManager.add(domain) { error in
+      completion(isAlreadyExists(error) ? nil : error)
+    }
+  }
+
+  static func unregisterDomain(completion: @escaping (Error?) -> Void) {
+    NSFileProviderManager.removeAllDomains { removeError in
+      completion(isNotFound(removeError) ? nil : removeError)
+    }
+  }
+
+  private static func isAlreadyExists(_ error: Error?) -> Bool {
+    guard let error = error as NSError? else { return false }
+    return error.domain == NSCocoaErrorDomain && error.code == NSFileWriteFileExistsError
+  }
+
+  private static func isNotFound(_ error: Error?) -> Bool {
+    guard let error = error as NSError? else { return false }
+    return error.domain == NSCocoaErrorDomain && error.code == NSFileNoSuchFileError
+  }
+}

--- a/ios/Internxt/FileProviderDomainManager.swift
+++ b/ios/Internxt/FileProviderDomainManager.swift
@@ -22,6 +22,20 @@ enum FileProviderDomainManager {
     }
   }
 
+  static func signalEnumeration(completion: @escaping (Error?) -> Void) {
+    guard let manager = NSFileProviderManager(for: domain) else {
+      completion(NSError(
+        domain: "FileProviderDomainManager",
+        code: -1,
+        userInfo: [NSLocalizedDescriptionKey: "No NSFileProviderManager for domain \(domainIdentifier.rawValue)"]
+      ))
+      return
+    }
+    manager.signalEnumerator(for: .workingSet) { error in
+      completion(error)
+    }
+  }
+
   private static func isAlreadyExists(_ error: Error?) -> Bool {
     guard let error = error as NSError? else { return false }
     return error.domain == NSCocoaErrorDomain && error.code == NSFileWriteFileExistsError

--- a/ios/Internxt/FileProviderModule.m
+++ b/ios/Internxt/FileProviderModule.m
@@ -1,0 +1,7 @@
+#import <React/RCTBridgeModule.h>
+
+@interface RCT_EXTERN_MODULE(InternxtSignalingModule, NSObject)
+RCT_EXTERN_METHOD(notifyParentChanged:(NSString *)parentFolderUuid
+                  resolver:(RCTPromiseResolveBlock)resolver
+                  rejecter:(RCTPromiseRejectBlock)rejecter)
+@end

--- a/ios/Internxt/FileProviderModule.swift
+++ b/ios/Internxt/FileProviderModule.swift
@@ -1,0 +1,35 @@
+import FileProvider
+import Foundation
+import React
+
+@objc(InternxtSignalingModule)
+class FileProviderModule: NSObject {
+
+  @objc static func requiresMainQueueSetup() -> Bool { false }
+
+  @objc func notifyParentChanged(
+    _ parentFolderUuid: String,
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter _: @escaping RCTPromiseRejectBlock
+  ) {
+    guard #available(iOS 16.0, *) else {
+      resolver(nil)
+      return
+    }
+
+    let store = SyncAnchorStore()
+    _ = store?.recordChange(parentUuid: parentFolderUuid)
+
+    signalParent(parentFolderUuid, resolver: resolver)
+  }
+
+  @available(iOS 16.0, *)
+  private func signalParent(_ parentFolderUuid: String, resolver: @escaping RCTPromiseResolveBlock) {
+    let container = FileProviderItemID.parentIdentifier(folderUuid: parentFolderUuid)
+    FileProviderDomainManager.signalEnumeration(for: container) { _ in
+      FileProviderDomainManager.signalEnumeration { _ in
+        resolver(nil)
+      }
+    }
+  }
+}

--- a/ios/Internxt/InternxtAuthCredentialsModule.m
+++ b/ios/Internxt/InternxtAuthCredentialsModule.m
@@ -1,0 +1,9 @@
+#import <React/RCTBridgeModule.h>
+
+@interface RCT_EXTERN_MODULE(InternxtAuthCredentialsModule, NSObject)
+RCT_EXTERN_METHOD(setCredentials:(NSDictionary *)creds
+                  resolver:(RCTPromiseResolveBlock)resolver
+                  rejecter:(RCTPromiseRejectBlock)rejecter)
+RCT_EXTERN_METHOD(clearCredentials:(RCTPromiseResolveBlock)resolver
+                  rejecter:(RCTPromiseRejectBlock)rejecter)
+@end

--- a/ios/Internxt/InternxtAuthCredentialsModule.swift
+++ b/ios/Internxt/InternxtAuthCredentialsModule.swift
@@ -62,6 +62,7 @@ class InternxtAuthCredentialsModule: NSObject {
     writeIfPresent(creds["bridgeUser"], to: SharedAuthKeychain.bridgeUserKey)
     writeIfPresent(creds["userId"], to: SharedAuthKeychain.userIdKey)
     writeIfPresent(creds["driveBaseUrl"], to: SharedAuthKeychain.driveBaseUrlKey)
+    writeIfPresent(creds["bridgeBaseUrl"], to: SharedAuthKeychain.bridgeBaseUrlKey)
   }
 
   private func writeIfPresent(_ value: Any?, to sharedKey: String) {

--- a/ios/Internxt/InternxtAuthCredentialsModule.swift
+++ b/ios/Internxt/InternxtAuthCredentialsModule.swift
@@ -56,6 +56,7 @@ class InternxtAuthCredentialsModule: NSObject {
     writeIfPresent(creds["rootFolderUuid"], to: SharedAuthKeychain.rootFolderIdKey)
     writeIfPresent(creds["bridgeUser"], to: SharedAuthKeychain.bridgeUserKey)
     writeIfPresent(creds["userId"], to: SharedAuthKeychain.userIdKey)
+    writeIfPresent(creds["driveBaseUrl"], to: SharedAuthKeychain.driveBaseUrlKey)
   }
 
   private func writeIfPresent(_ value: Any?, to sharedKey: String) {

--- a/ios/Internxt/InternxtAuthCredentialsModule.swift
+++ b/ios/Internxt/InternxtAuthCredentialsModule.swift
@@ -26,7 +26,12 @@ class InternxtAuthCredentialsModule: NSObject {
         rejecter("E_REGISTER_DOMAIN", error.localizedDescription, error as NSError)
         return
       }
-      resolver(nil)
+      FileProviderDomainManager.signalEnumeration { signalError in
+        if let signalError = signalError {
+          NSLog("InternxtAuthCredentialsModule: signalEnumeration failed (ignored): \(signalError.localizedDescription)")
+        }
+        resolver(nil)
+      }
     }
   }
 

--- a/ios/Internxt/InternxtAuthCredentialsModule.swift
+++ b/ios/Internxt/InternxtAuthCredentialsModule.swift
@@ -1,0 +1,65 @@
+import Foundation
+import React
+
+/// Bridges the RN auth lifecycle to iOS. On login the host app writes the auth
+/// credentials into the shared Keychain (read by the File Provider extension) and
+/// registers the File Provider domain; on logout it clears them and removes the
+/// domain. iOS counterpart of the Android `InternxtAuthCredentialsModule`
+/// (`setCredentials` + `notifyChange(roots)` / `clearCredentials` + `notifyChange(roots)`).
+@objc(InternxtAuthCredentialsModule)
+class InternxtAuthCredentialsModule: NSObject {
+
+  @objc static func requiresMainQueueSetup() -> Bool { false }
+
+  @objc func setCredentials(
+    _ creds: NSDictionary,
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    writeSharedCredentials(creds)
+    guard #available(iOS 16.0, *) else {
+      resolver(nil)
+      return
+    }
+    FileProviderDomainManager.registerDomain { error in
+      if let error = error {
+        rejecter("E_REGISTER_DOMAIN", error.localizedDescription, error as NSError)
+        return
+      }
+      resolver(nil)
+    }
+  }
+
+  @objc func clearCredentials(
+    _ resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    guard #available(iOS 16.0, *) else {
+      SharedAuthKeychain.clearAll()
+      resolver(nil)
+      return
+    }
+
+    FileProviderDomainManager.unregisterDomain { error in
+      SharedAuthKeychain.clearAll()
+      if let error = error {
+        rejecter("E_UNREGISTER_DOMAIN", error.localizedDescription, error as NSError)
+        return
+      }
+      resolver(nil)
+    }
+  }
+
+  private func writeSharedCredentials(_ creds: NSDictionary) {
+    writeIfPresent(creds["bearerToken"], to: SharedAuthKeychain.photosTokenKey)
+    writeIfPresent(creds["mnemonic"], to: SharedAuthKeychain.mnemonicKey)
+    writeIfPresent(creds["rootFolderUuid"], to: SharedAuthKeychain.rootFolderIdKey)
+    writeIfPresent(creds["bridgeUser"], to: SharedAuthKeychain.bridgeUserKey)
+    writeIfPresent(creds["userId"], to: SharedAuthKeychain.userIdKey)
+  }
+
+  private func writeIfPresent(_ value: Any?, to sharedKey: String) {
+    guard let value = value as? String, !value.isEmpty else { return }
+    SharedAuthKeychain.write(value, for: sharedKey)
+  }
+}

--- a/ios/Internxt/SharedAuthKeychain.swift
+++ b/ios/Internxt/SharedAuthKeychain.swift
@@ -14,9 +14,11 @@ enum SharedAuthKeychain {
   static let bucketKey = "shared_bucket"
   static let bridgeUserKey = "shared_bridgeUser"
   static let userIdKey = "shared_userId"
+  static let driveBaseUrlKey = "shared_driveBaseUrl"
 
   static let allKeys = [
     photosTokenKey, mnemonicKey, rootFolderIdKey, bucketKey, bridgeUserKey, userIdKey,
+    driveBaseUrlKey,
   ]
 
   static var accessGroup: String? {

--- a/ios/Internxt/SharedAuthKeychain.swift
+++ b/ios/Internxt/SharedAuthKeychain.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Security
+
+/// Single source of truth for the shared Keychain access group used to hand off
+/// auth credentials from the host app to the share extension and the File
+/// Provider extension. Extracted from `AppDelegate` so the native module and the
+/// app-lifecycle sync write to the exact same items.
+enum SharedAuthKeychain {
+  static let service = "app:no-auth"
+
+  static let photosTokenKey = "shared_photosToken"
+  static let mnemonicKey = "shared_mnemonic"
+  static let rootFolderIdKey = "shared_rootFolderId"
+  static let bucketKey = "shared_bucket"
+  static let bridgeUserKey = "shared_bridgeUser"
+  static let userIdKey = "shared_userId"
+
+  static let allKeys = [
+    photosTokenKey, mnemonicKey, rootFolderIdKey, bucketKey, bridgeUserKey, userIdKey,
+  ]
+
+  static var accessGroup: String? {
+    Bundle.main.object(forInfoDictionaryKey: "SharedKeychainGroup") as? String
+  }
+
+  static func read(_ sharedKey: String) -> Data? {
+    guard let accessGroup = accessGroup else { return nil }
+    var result: AnyObject?
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrGeneric as String: Data(sharedKey.utf8),
+      kSecAttrAccount as String: Data(sharedKey.utf8),
+      kSecAttrAccessGroup as String: accessGroup,
+      kSecMatchLimit as String: kSecMatchLimitOne,
+      kSecReturnData as String: true,
+    ]
+    guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+          let data = result as? Data else { return nil }
+    return data
+  }
+
+  static func write(_ value: Data, for sharedKey: String) {
+    guard let accessGroup = accessGroup else { return }
+    delete(sharedKey)
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrGeneric as String: Data(sharedKey.utf8),
+      kSecAttrAccount as String: Data(sharedKey.utf8),
+      kSecAttrAccessGroup as String: accessGroup,
+      kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked,
+      kSecValueData as String: value,
+    ]
+    SecItemAdd(query as CFDictionary, nil)
+  }
+
+  static func write(_ value: String, for sharedKey: String) {
+    write(Data(value.utf8), for: sharedKey)
+  }
+
+  static func delete(_ sharedKey: String) {
+    guard let accessGroup = accessGroup else { return }
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrGeneric as String: Data(sharedKey.utf8),
+      kSecAttrAccount as String: Data(sharedKey.utf8),
+      kSecAttrAccessGroup as String: accessGroup,
+    ]
+    SecItemDelete(query as CFDictionary)
+  }
+
+  static func clearAll() {
+    allKeys.forEach(delete)
+  }
+
+  static func readPrivate(_ privateKey: String) -> Data? {
+    var result: AnyObject?
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrGeneric as String: Data(privateKey.utf8),
+      kSecAttrAccount as String: Data(privateKey.utf8),
+      kSecMatchLimit as String: kSecMatchLimitOne,
+      kSecReturnData as String: true,
+    ]
+    guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+          let data = result as? Data else { return nil }
+    return data
+  }
+
+  static func syncFromPrivateKeychain() {
+    guard accessGroup != nil else { return }
+
+    let isAuthenticated = readPrivate("photosToken") != nil
+    guard isAuthenticated else {
+      clearAll()
+      return
+    }
+
+    copyFromPrivate(privateKey: "photosToken", sharedKey: photosTokenKey)
+    copyFromPrivate(privateKey: "xUser_mnemonic", sharedKey: mnemonicKey)
+    copyFromPrivate(privateKey: "xUser_rootFolderId", sharedKey: rootFolderIdKey)
+    copyFromPrivate(privateKey: "xUser_bucket", sharedKey: bucketKey)
+    copyFromPrivate(privateKey: "xUser_bridgeUser", sharedKey: bridgeUserKey)
+    copyFromPrivate(privateKey: "xUser_userId", sharedKey: userIdKey)
+  }
+
+  private static func copyFromPrivate(privateKey: String, sharedKey: String) {
+    guard let data = readPrivate(privateKey) else { return }
+    write(data, for: sharedKey)
+  }
+}

--- a/ios/Internxt/SharedAuthKeychain.swift
+++ b/ios/Internxt/SharedAuthKeychain.swift
@@ -49,7 +49,13 @@ enum SharedAuthKeychain {
       kSecAttrGeneric as String: Data(sharedKey.utf8),
       kSecAttrAccount as String: Data(sharedKey.utf8),
       kSecAttrAccessGroup as String: accessGroup,
-      kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked,
+      // These credentials are read by the File Provider extension in the
+      // background with no UI, so a user-authentication gate (SecAccessControl /
+      // .userPresence) is intentionally NOT used — it would block every
+      // background read. `AfterFirstUnlock` keeps the item readable once the
+      // device has been unlocked after boot while still protecting it before
+      // first unlock at boot.
+      kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
       kSecValueData as String: value,
     ]
     SecItemAdd(query as CFDictionary, nil)
@@ -100,15 +106,28 @@ enum SharedAuthKeychain {
     }
 
     copyFromPrivate(privateKey: "photosToken", sharedKey: photosTokenKey)
-    copyFromPrivate(privateKey: "xUser_mnemonic", sharedKey: mnemonicKey)
-    copyFromPrivate(privateKey: "xUser_rootFolderId", sharedKey: rootFolderIdKey)
+    copyFromPrivate(privateKey: "xUser_mnemonic", sharedKey: mnemonicKey, isJSONEncoded: true)
+    copyFromPrivate(privateKey: "xUser_rootFolderId", sharedKey: rootFolderIdKey, isJSONEncoded: true)
     copyFromPrivate(privateKey: "xUser_bucket", sharedKey: bucketKey)
     copyFromPrivate(privateKey: "xUser_bridgeUser", sharedKey: bridgeUserKey)
     copyFromPrivate(privateKey: "xUser_userId", sharedKey: userIdKey)
   }
 
-  private static func copyFromPrivate(privateKey: String, sharedKey: String) {
+  private static func copyFromPrivate(privateKey: String, sharedKey: String, isJSONEncoded: Bool = false) {
     guard let data = readPrivate(privateKey) else { return }
-    write(data, for: sharedKey)
+    write(isJSONEncoded ? jsonDecoded(data) : data, for: sharedKey)
+  }
+
+  private static func jsonDecoded(_ data: Data) -> Data {
+    guard let object = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]) else {
+      return data
+    }
+    if let string = object as? String {
+      return Data(string.utf8)
+    }
+    if let number = object as? NSNumber {
+      return Data(number.stringValue.utf8)
+    }
+    return data
   }
 }

--- a/ios/Internxt/SharedAuthKeychain.swift
+++ b/ios/Internxt/SharedAuthKeychain.swift
@@ -15,10 +15,11 @@ enum SharedAuthKeychain {
   static let bridgeUserKey = "shared_bridgeUser"
   static let userIdKey = "shared_userId"
   static let driveBaseUrlKey = "shared_driveBaseUrl"
+  static let bridgeBaseUrlKey = "shared_bridgeBaseUrl"
 
   static let allKeys = [
     photosTokenKey, mnemonicKey, rootFolderIdKey, bucketKey, bridgeUserKey, userIdKey,
-    driveBaseUrlKey,
+    driveBaseUrlKey, bridgeBaseUrlKey,
   ]
 
   static var accessGroup: String? {
@@ -111,8 +112,8 @@ enum SharedAuthKeychain {
     copyFromPrivate(privateKey: "xUser_mnemonic", sharedKey: mnemonicKey, isJSONEncoded: true)
     copyFromPrivate(privateKey: "xUser_rootFolderId", sharedKey: rootFolderIdKey, isJSONEncoded: true)
     copyFromPrivate(privateKey: "xUser_bucket", sharedKey: bucketKey)
-    copyFromPrivate(privateKey: "xUser_bridgeUser", sharedKey: bridgeUserKey)
-    copyFromPrivate(privateKey: "xUser_userId", sharedKey: userIdKey)
+    copyFromPrivate(privateKey: "xUser_bridgeUser", sharedKey: bridgeUserKey, isJSONEncoded: true)
+    copyFromPrivate(privateKey: "xUser_userId", sharedKey: userIdKey, isJSONEncoded: true)
   }
 
   private static func copyFromPrivate(privateKey: String, sharedKey: String, isJSONEncoded: Bool = false) {

--- a/ios/Internxt/SharedAuthKeychain.swift
+++ b/ios/Internxt/SharedAuthKeychain.swift
@@ -16,6 +16,7 @@ enum SharedAuthKeychain {
   static let userIdKey = "shared_userId"
   static let driveBaseUrlKey = "shared_driveBaseUrl"
   static let bridgeBaseUrlKey = "shared_bridgeBaseUrl"
+  static let themePreferenceKey = "shared_themePreference"
 
   static let allKeys = [
     photosTokenKey, mnemonicKey, rootFolderIdKey, bucketKey, bridgeUserKey, userIdKey,
@@ -102,6 +103,8 @@ enum SharedAuthKeychain {
   static func syncFromPrivateKeychain() {
     guard accessGroup != nil else { return }
 
+    syncThemePreference()
+
     let isAuthenticated = readPrivate("photosToken") != nil
     guard isAuthenticated else {
       clearAll()
@@ -114,6 +117,15 @@ enum SharedAuthKeychain {
     copyFromPrivate(privateKey: "xUser_bucket", sharedKey: bucketKey)
     copyFromPrivate(privateKey: "xUser_bridgeUser", sharedKey: bridgeUserKey, isJSONEncoded: true)
     copyFromPrivate(privateKey: "xUser_userId", sharedKey: userIdKey, isJSONEncoded: true)
+  }
+
+  static func syncThemePreference() {
+    guard accessGroup != nil else { return }
+    if let data = readPrivate("themePreference") {
+      write(data, for: themePreferenceKey)
+    } else {
+      delete(themePreferenceKey)
+    }
   }
 
   private static func copyFromPrivate(privateKey: String, sharedKey: String, isJSONEncoded: Bool = false) {

--- a/ios/InternxtFileProvider/DriveAPIFactory.swift
+++ b/ios/InternxtFileProvider/DriveAPIFactory.swift
@@ -15,4 +15,18 @@ enum DriveAPIFactory {
       clientVersion: SharedKeychainCredentials.clientVersion
     )
   }
+
+  static func makeTrash() -> TrashAPI? {
+    guard let authToken = SharedKeychainCredentials.string(SharedAuthKeychain.photosTokenKey),
+          let baseUrl = SharedKeychainCredentials.string(SharedAuthKeychain.driveBaseUrlKey) else {
+      return nil
+    }
+
+    return TrashAPI(
+      baseUrl: baseUrl,
+      authToken: authToken,
+      clientName: SharedKeychainCredentials.clientName,
+      clientVersion: SharedKeychainCredentials.clientVersion
+    )
+  }
 }

--- a/ios/InternxtFileProvider/DriveAPIFactory.swift
+++ b/ios/InternxtFileProvider/DriveAPIFactory.swift
@@ -3,34 +3,16 @@ import InternxtSwiftCore
 
 enum DriveAPIFactory {
   static func make() -> DriveAPI? {
-    guard let authToken = sharedString(SharedAuthKeychain.photosTokenKey),
-          let baseUrl = sharedString(SharedAuthKeychain.driveBaseUrlKey) else {
+    guard let authToken = SharedKeychainCredentials.string(SharedAuthKeychain.photosTokenKey),
+          let baseUrl = SharedKeychainCredentials.string(SharedAuthKeychain.driveBaseUrlKey) else {
       return nil
     }
 
     return DriveAPI(
       baseUrl: baseUrl,
       authToken: authToken,
-      clientName: clientName,
-      clientVersion: clientVersion
+      clientName: SharedKeychainCredentials.clientName,
+      clientVersion: SharedKeychainCredentials.clientVersion
     )
-  }
-
-  private static func sharedString(_ key: String) -> String? {
-    guard let data = SharedAuthKeychain.read(key) else { return nil }
-    let value = String(decoding: data, as: UTF8.self)
-    return value.isEmpty ? nil : value
-  }
-
-  private static var clientName: String {
-    bundleString("CFBundleName") ?? "drive-mobile"
-  }
-
-  private static var clientVersion: String {
-    bundleString("CFBundleShortVersionString") ?? "0.0.0"
-  }
-
-  private static func bundleString(_ key: String) -> String? {
-    Bundle(for: FileProviderExtension.self).object(forInfoDictionaryKey: key) as? String
   }
 }

--- a/ios/InternxtFileProvider/DriveAPIFactory.swift
+++ b/ios/InternxtFileProvider/DriveAPIFactory.swift
@@ -1,0 +1,36 @@
+import Foundation
+import InternxtSwiftCore
+
+enum DriveAPIFactory {
+  static func make() -> DriveAPI? {
+    guard let authToken = sharedString(SharedAuthKeychain.photosTokenKey),
+          let baseUrl = sharedString(SharedAuthKeychain.driveBaseUrlKey) else {
+      return nil
+    }
+
+    return DriveAPI(
+      baseUrl: baseUrl,
+      authToken: authToken,
+      clientName: clientName,
+      clientVersion: clientVersion
+    )
+  }
+
+  private static func sharedString(_ key: String) -> String? {
+    guard let data = SharedAuthKeychain.read(key) else { return nil }
+    let value = String(decoding: data, as: UTF8.self)
+    return value.isEmpty ? nil : value
+  }
+
+  private static var clientName: String {
+    bundleString("CFBundleName") ?? "drive-mobile"
+  }
+
+  private static var clientVersion: String {
+    bundleString("CFBundleShortVersionString") ?? "0.0.0"
+  }
+
+  private static func bundleString(_ key: String) -> String? {
+    Bundle(for: FileProviderExtension.self).object(forInfoDictionaryKey: key) as? String
+  }
+}

--- a/ios/InternxtFileProvider/FileProviderDownloadService.swift
+++ b/ios/InternxtFileProvider/FileProviderDownloadService.swift
@@ -1,0 +1,37 @@
+//
+//  FileProviderDownloadService.swift
+//  InternxtFileProvider
+//
+//  Created by Ramon Candel on 9/4/26.
+//
+
+import FileProvider
+import InternxtSwiftCore
+
+struct FileProviderDownloadService {
+    let driveAPI: DriveAPI
+    let networkFacade: NetworkFacade
+
+    func fetchContents(
+        uuid: String,
+        progressHandler: @escaping (Double) -> Void
+    ) async throws -> (url: URL, meta: GetFileMetaByIdResponse) {
+        let encryptedTmp = Self.temporaryFileURL()
+        let plainTmp = Self.temporaryFileURL()
+        defer { try? FileManager.default.removeItem(at: encryptedTmp) }
+
+        let meta = try await driveAPI.getFileMetaByUuid(uuid: uuid)
+        _ = try await networkFacade.downloadFile(
+            bucketId: meta.bucket,
+            fileId: meta.fileId,
+            encryptedFileDestination: encryptedTmp,
+            destinationURL: plainTmp,
+            progressHandler: progressHandler
+        )
+        return (plainTmp, meta)
+    }
+
+    static func temporaryFileURL() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    }
+}

--- a/ios/InternxtFileProvider/FileProviderEnumerator.swift
+++ b/ios/InternxtFileProvider/FileProviderEnumerator.swift
@@ -1,0 +1,57 @@
+//
+//  FileProviderEnumerator.swift
+//  InternxtFileProvider
+//
+//  Created by Ramon Candel on 9/4/26.
+//
+
+import FileProvider
+
+class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
+    
+    private let enumeratedItemIdentifier: NSFileProviderItemIdentifier
+    private let anchor = NSFileProviderSyncAnchor("an anchor".data(using: .utf8)!)
+    
+    init(enumeratedItemIdentifier: NSFileProviderItemIdentifier) {
+        self.enumeratedItemIdentifier = enumeratedItemIdentifier
+        super.init()
+    }
+
+    func invalidate() {
+        // TODO: perform invalidation of server connection if necessary
+    }
+
+    func enumerateItems(for observer: NSFileProviderEnumerationObserver, startingAt page: NSFileProviderPage) {
+        /* TODO:
+         - inspect the page to determine whether this is an initial or a follow-up request
+         
+         If this is an enumerator for a directory, the root container or all directories:
+         - perform a server request to fetch directory contents
+         If this is an enumerator for the active set:
+         - perform a server request to update your local database
+         - fetch the active set from your local database
+         
+         - inform the observer about the items returned by the server (possibly multiple times)
+         - inform the observer that you are finished with this page
+         */
+        observer.didEnumerate([FileProviderItem(identifier: NSFileProviderItemIdentifier("a file"))])
+        observer.finishEnumerating(upTo: nil)
+    }
+    
+    func enumerateChanges(for observer: NSFileProviderChangeObserver, from anchor: NSFileProviderSyncAnchor) {
+        /* TODO:
+         - query the server for updates since the passed-in sync anchor
+         
+         If this is an enumerator for the active set:
+         - note the changes in your local database
+         
+         - inform the observer about item deletions and updates (modifications + insertions)
+         - inform the observer when you have finished enumerating up to a subsequent sync anchor
+         */
+        observer.finishEnumeratingChanges(upTo: anchor, moreComing: false)
+    }
+
+    func currentSyncAnchor(completionHandler: @escaping (NSFileProviderSyncAnchor?) -> Void) {
+        completionHandler(anchor)
+    }
+}

--- a/ios/InternxtFileProvider/FileProviderEnumerator.swift
+++ b/ios/InternxtFileProvider/FileProviderEnumerator.swift
@@ -6,52 +6,136 @@
 //
 
 import FileProvider
+import InternxtSwiftCore
 
 class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
-    
-    private let enumeratedItemIdentifier: NSFileProviderItemIdentifier
-    private let anchor = NSFileProviderSyncAnchor("an anchor".data(using: .utf8)!)
-    
-    init(enumeratedItemIdentifier: NSFileProviderItemIdentifier) {
-        self.enumeratedItemIdentifier = enumeratedItemIdentifier
-        super.init()
+
+  private static let pageSize = 50
+  private static let order = "ASC"
+
+  private enum Phase: String {
+    case folders
+    case files
+  }
+
+  private struct Cursor {
+    let phase: Phase
+    let offset: Int
+
+    static let initial = Cursor(phase: .folders, offset: 0)
+
+    func encoded() -> NSFileProviderPage {
+      NSFileProviderPage("\(phase.rawValue):\(offset)".data(using: .utf8)!)
     }
 
-    func invalidate() {
-        // TODO: perform invalidation of server connection if necessary
+    static func decode(_ page: NSFileProviderPage) -> Cursor {
+      guard let raw = String(data: page.rawValue, encoding: .utf8),
+            let separatorIndex = raw.firstIndex(of: ":"),
+            let phase = Phase(rawValue: String(raw[raw.startIndex..<separatorIndex])),
+            let offset = Int(raw[raw.index(after: separatorIndex)...]) else {
+        return .initial
+      }
+      return Cursor(phase: phase, offset: offset)
+    }
+  }
+
+  private let enumeratedItemIdentifier: NSFileProviderItemIdentifier
+  private let anchor = NSFileProviderSyncAnchor("an anchor".data(using: .utf8)!)
+
+  init(enumeratedItemIdentifier: NSFileProviderItemIdentifier) {
+    self.enumeratedItemIdentifier = enumeratedItemIdentifier
+    super.init()
+  }
+
+  func invalidate() {}
+
+  func enumerateItems(for observer: NSFileProviderEnumerationObserver, startingAt page: NSFileProviderPage) {
+    let cursor = Cursor.decode(page)
+
+    guard FileProviderItemID.isDriveFolderContainer(enumeratedItemIdentifier) else {
+      observer.didEnumerate([])
+      observer.finishEnumerating(upTo: nil)
+      return
     }
 
-    func enumerateItems(for observer: NSFileProviderEnumerationObserver, startingAt page: NSFileProviderPage) {
-        /* TODO:
-         - inspect the page to determine whether this is an initial or a follow-up request
-         
-         If this is an enumerator for a directory, the root container or all directories:
-         - perform a server request to fetch directory contents
-         If this is an enumerator for the active set:
-         - perform a server request to update your local database
-         - fetch the active set from your local database
-         
-         - inform the observer about the items returned by the server (possibly multiple times)
-         - inform the observer that you are finished with this page
-         */
-        observer.didEnumerate([FileProviderItem(identifier: NSFileProviderItemIdentifier("a file"))])
-        observer.finishEnumerating(upTo: nil)
-    }
-    
-    func enumerateChanges(for observer: NSFileProviderChangeObserver, from anchor: NSFileProviderSyncAnchor) {
-        /* TODO:
-         - query the server for updates since the passed-in sync anchor
-         
-         If this is an enumerator for the active set:
-         - note the changes in your local database
-         
-         - inform the observer about item deletions and updates (modifications + insertions)
-         - inform the observer when you have finished enumerating up to a subsequent sync anchor
-         */
-        observer.finishEnumeratingChanges(upTo: anchor, moreComing: false)
+    guard let folderUuid = FileProviderItemID.folderUuid(for: enumeratedItemIdentifier),
+          let driveAPI = DriveAPIFactory.make() else {
+      observer.finishEnumeratingWithError(notAuthenticatedError())
+      return
     }
 
-    func currentSyncAnchor(completionHandler: @escaping (NSFileProviderSyncAnchor?) -> Void) {
-        completionHandler(anchor)
+    Task {
+      do {
+        switch cursor.phase {
+        case .folders:
+          try await enumerateFolders(driveAPI, folderUuid: folderUuid, offset: cursor.offset, observer: observer)
+        case .files:
+          try await enumerateFiles(driveAPI, folderUuid: folderUuid, offset: cursor.offset, observer: observer)
+        }
+      } catch {
+        observer.finishEnumeratingWithError(enumerationError(from: error))
+      }
     }
+  }
+
+  private func enumerateFolders(
+    _ driveAPI: DriveAPI,
+    folderUuid: String,
+    offset: Int,
+    observer: NSFileProviderEnumerationObserver
+  ) async throws {
+    let response = try await driveAPI.getFolderFolders(
+      folderUuid: folderUuid, offset: offset, limit: Self.pageSize, order: Self.order
+    )
+    let items = response.folders.map {
+      FileProviderItem(folder: $0, parent: enumeratedItemIdentifier)
+    }
+    observer.didEnumerate(items)
+
+    if response.folders.count == Self.pageSize {
+      observer.finishEnumerating(upTo: Cursor(phase: .folders, offset: offset + Self.pageSize).encoded())
+    } else {
+      observer.finishEnumerating(upTo: Cursor(phase: .files, offset: 0).encoded())
+    }
+  }
+
+  private func enumerateFiles(
+    _ driveAPI: DriveAPI,
+    folderUuid: String,
+    offset: Int,
+    observer: NSFileProviderEnumerationObserver
+  ) async throws {
+    let response = try await driveAPI.getFolderFilesV2(
+      folderUuid: folderUuid, offset: offset, limit: Self.pageSize, order: Self.order
+    )
+    let items = response.files.map {
+      FileProviderItem(file: $0, parent: enumeratedItemIdentifier)
+    }
+    observer.didEnumerate(items)
+
+    if response.files.count == Self.pageSize {
+      observer.finishEnumerating(upTo: Cursor(phase: .files, offset: offset + Self.pageSize).encoded())
+    } else {
+      observer.finishEnumerating(upTo: nil)
+    }
+  }
+
+  private func notAuthenticatedError() -> Error {
+    NSFileProviderError(.notAuthenticated)
+  }
+
+  private func enumerationError(from error: Error) -> Error {
+    if let apiError = error as? APIClientError, apiError.statusCode == 401 {
+      return notAuthenticatedError()
+    }
+    return error
+  }
+
+  func enumerateChanges(for observer: NSFileProviderChangeObserver, from anchor: NSFileProviderSyncAnchor) {
+    observer.finishEnumeratingChanges(upTo: anchor, moreComing: false)
+  }
+
+  func currentSyncAnchor(completionHandler: @escaping (NSFileProviderSyncAnchor?) -> Void) {
+    completionHandler(anchor)
+  }
 }

--- a/ios/InternxtFileProvider/FileProviderEnumerator.swift
+++ b/ios/InternxtFileProvider/FileProviderEnumerator.swift
@@ -12,6 +12,7 @@ class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
 
   private static let pageSize = 50
   private static let order = "ASC"
+  private static let folderContainerAnchor = NSFileProviderSyncAnchor(SyncAnchorStore.encode(0))
 
   private enum Phase: String {
     case folders
@@ -40,7 +41,12 @@ class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
   }
 
   private let enumeratedItemIdentifier: NSFileProviderItemIdentifier
-  private let anchor = NSFileProviderSyncAnchor("an anchor".data(using: .utf8)!)
+  private let syncAnchorStore = SyncAnchorStore()
+  private var browsedChildIds: [String] = []
+
+  private var isWorkingSet: Bool {
+    enumeratedItemIdentifier == .workingSet
+  }
 
   init(enumeratedItemIdentifier: NSFileProviderItemIdentifier) {
     self.enumeratedItemIdentifier = enumeratedItemIdentifier
@@ -50,9 +56,7 @@ class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
   func invalidate() {}
 
   func enumerateItems(for observer: NSFileProviderEnumerationObserver, startingAt page: NSFileProviderPage) {
-    let cursor = Cursor.decode(page)
-
-    guard FileProviderItemID.isDriveFolderContainer(enumeratedItemIdentifier) else {
+    guard !isWorkingSet, FileProviderItemID.isDriveFolderContainer(enumeratedItemIdentifier) else {
       observer.didEnumerate([])
       observer.finishEnumerating(upTo: nil)
       return
@@ -64,6 +68,7 @@ class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
       return
     }
 
+    let cursor = Cursor.decode(page)
     Task {
       do {
         switch cursor.phase {
@@ -91,6 +96,7 @@ class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
       FileProviderItem(folder: $0, parent: enumeratedItemIdentifier)
     }
     observer.didEnumerate(items)
+    accumulate(items)
 
     if response.folders.count == Self.pageSize {
       observer.finishEnumerating(upTo: Cursor(phase: .folders, offset: offset + Self.pageSize).encoded())
@@ -112,12 +118,125 @@ class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
       FileProviderItem(file: $0, parent: enumeratedItemIdentifier)
     }
     observer.didEnumerate(items)
+    accumulate(items)
 
     if response.files.count == Self.pageSize {
       observer.finishEnumerating(upTo: Cursor(phase: .files, offset: offset + Self.pageSize).encoded())
     } else {
+      seedSnapshot(forFolderUuid: folderUuid)
       observer.finishEnumerating(upTo: nil)
     }
+  }
+
+  private func accumulate(_ items: [FileProviderItem]) {
+    browsedChildIds.append(contentsOf: items.map { $0.itemIdentifier.rawValue })
+  }
+
+  private func seedSnapshot(forFolderUuid folderUuid: String) {
+    syncAnchorStore?.saveSnapshot(browsedChildIds, forFolderUuid: folderUuid)
+  }
+
+  func currentSyncAnchor(completionHandler: @escaping (NSFileProviderSyncAnchor?) -> Void) {
+    completionHandler(isWorkingSet ? workingSetAnchor() : Self.folderContainerAnchor)
+  }
+
+  func enumerateChanges(for observer: NSFileProviderChangeObserver, from anchor: NSFileProviderSyncAnchor) {
+    guard isWorkingSet else {
+      observer.finishEnumeratingChanges(upTo: Self.folderContainerAnchor, moreComing: false)
+      return
+    }
+    enumerateWorkingSetChanges(for: observer, from: anchor)
+  }
+
+  private func enumerateWorkingSetChanges(for observer: NSFileProviderChangeObserver, from anchor: NSFileProviderSyncAnchor) {
+    let incoming = SyncAnchorStore.decode(anchor.rawValue) ?? 0
+    let current = workingSetAnchor()
+
+    guard let store = syncAnchorStore else {
+      observer.finishEnumeratingChanges(upTo: NSFileProviderSyncAnchor(SyncAnchorStore.encode(incoming)), moreComing: false)
+      return
+    }
+
+    let parents = store.changedParents(after: incoming)
+
+    guard !parents.isEmpty, let driveAPI = DriveAPIFactory.make() else {
+      observer.finishEnumeratingChanges(upTo: current, moreComing: false)
+      return
+    }
+
+    Task {
+      do {
+        for parentUuid in parents {
+          try await diffFolder(parentUuid, store: store, driveAPI: driveAPI, observer: observer)
+        }
+        observer.finishEnumeratingChanges(upTo: current, moreComing: false)
+      } catch {
+        observer.finishEnumeratingChanges(
+          upTo: NSFileProviderSyncAnchor(SyncAnchorStore.encode(incoming)),
+          moreComing: false
+        )
+      }
+    }
+  }
+
+  private func diffFolder(
+    _ parentUuid: String,
+    store: SyncAnchorStore,
+    driveAPI: DriveAPI,
+    observer: NSFileProviderChangeObserver
+  ) async throws {
+    let parent = FileProviderItemID.parentIdentifier(folderUuid: parentUuid)
+    let folderUuid = FileProviderItemID.folderUuid(for: parent) ?? parentUuid
+
+    let currentItems = try await currentChildren(of: folderUuid, parent: parent, driveAPI: driveAPI)
+    let currentIds = currentItems.map { $0.itemIdentifier.rawValue }
+    let prevIds = store.snapshot(forFolderUuid: parentUuid)
+    let deletedIds = Set(prevIds).subtracting(currentIds)
+
+    observer.didUpdate(currentItems)
+    if !deletedIds.isEmpty {
+      observer.didDeleteItems(withIdentifiers: deletedIds.map { NSFileProviderItemIdentifier($0) })
+    }
+    store.saveSnapshot(currentIds, forFolderUuid: parentUuid)
+  }
+
+  private func currentChildren(
+    of folderUuid: String,
+    parent: NSFileProviderItemIdentifier,
+    driveAPI: DriveAPI
+  ) async throws -> [FileProviderItem] {
+    var items: [FileProviderItem] = []
+    try await forEachPage { offset in
+      let response = try await driveAPI.getFolderFolders(
+        folderUuid: folderUuid, offset: offset, limit: Self.pageSize, order: Self.order
+      )
+      items.append(contentsOf: response.folders.map { FileProviderItem(folder: $0, parent: parent) })
+      return response.folders.count
+    }
+    try await forEachPage { offset in
+      let response = try await driveAPI.getFolderFilesV2(
+        folderUuid: folderUuid, offset: offset, limit: Self.pageSize, order: Self.order
+      )
+      items.append(contentsOf: response.files.map { FileProviderItem(file: $0, parent: parent) })
+      return response.files.count
+    }
+    return items
+  }
+
+  private func forEachPage(_ fetchPage: (_ offset: Int) async throws -> Int) async throws {
+    var offset = 0
+    while true {
+      let count = try await fetchPage(offset)
+      if count < Self.pageSize { break }
+      offset += Self.pageSize
+    }
+  }
+
+  private func workingSetAnchor() -> NSFileProviderSyncAnchor {
+    guard let store = syncAnchorStore else {
+      return NSFileProviderSyncAnchor(SyncAnchorStore.encode(0))
+    }
+    return NSFileProviderSyncAnchor(store.currentData)
   }
 
   private func notAuthenticatedError() -> Error {
@@ -129,13 +248,5 @@ class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
       return notAuthenticatedError()
     }
     return error
-  }
-
-  func enumerateChanges(for observer: NSFileProviderChangeObserver, from anchor: NSFileProviderSyncAnchor) {
-    observer.finishEnumeratingChanges(upTo: anchor, moreComing: false)
-  }
-
-  func currentSyncAnchor(completionHandler: @escaping (NSFileProviderSyncAnchor?) -> Void) {
-    completionHandler(anchor)
   }
 }

--- a/ios/InternxtFileProvider/FileProviderErrorMapper.swift
+++ b/ios/InternxtFileProvider/FileProviderErrorMapper.swift
@@ -1,0 +1,72 @@
+//
+//  FileProviderErrorMapper.swift
+//  InternxtFileProvider
+//
+//  Created by Ramon Candel on 9/4/26.
+//
+
+import FileProvider
+import InternxtSwiftCore
+
+enum FileProviderErrorMapper {
+    private static let offlineURLErrorCodes: Set<URLError.Code> = [
+        .notConnectedToInternet,
+        .networkConnectionLost,
+        .timedOut,
+        .cannotConnectToHost,
+        .dataNotAllowed,
+        .cannotFindHost
+    ]
+
+    private static let offlineErrorCodes: Set<ErrorCode> = [
+        .networkNoConnection,
+        .networkConnectionLost,
+        .networkTimeout,
+        .networkCannotConnect
+    ]
+
+    static func lookupError(from error: Error) -> Error {
+        if isUnauthorized(error) {
+            return NSFileProviderError(.notAuthenticated)
+        }
+        if isOffline(error) {
+            return NSFileProviderError(.serverUnreachable)
+        }
+        return NSFileProviderError(.noSuchItem)
+    }
+
+    static func isUnauthorized(_ error: Error) -> Bool {
+        if let enriched = error as? EnrichedError {
+            if enriched.code == .apiUnauthorized {
+                return true
+            }
+            if let cause = enriched.cause {
+                return isUnauthorized(cause)
+            }
+            return false
+        }
+        if let apiError = error as? APIClientError {
+            return apiError.statusCode == 401
+        }
+        return false
+    }
+
+    static func isOffline(_ error: Error) -> Bool {
+        if let enriched = error as? EnrichedError {
+            if offlineErrorCodes.contains(enriched.code) {
+                return true
+            }
+            if let cause = enriched.cause {
+                return isOffline(cause)
+            }
+            return false
+        }
+        if let urlError = error as? URLError {
+            return offlineURLErrorCodes.contains(urlError.code)
+        }
+        if let apiError = error as? APIClientError {
+            return apiError.statusCode <= 0
+        }
+        return false
+    }
+}

--- a/ios/InternxtFileProvider/FileProviderErrorMapper.swift
+++ b/ios/InternxtFileProvider/FileProviderErrorMapper.swift
@@ -26,13 +26,32 @@ enum FileProviderErrorMapper {
     ]
 
     static func lookupError(from error: Error) -> Error {
+        if let alreadyMapped = error as? NSFileProviderError {
+            return alreadyMapped
+        }
         if isUnauthorized(error) {
             return NSFileProviderError(.notAuthenticated)
         }
         if isOffline(error) {
             return NSFileProviderError(.serverUnreachable)
         }
+        if isNameCollision(error) {
+            return NSFileProviderError(.filenameCollision)
+        }
         return NSFileProviderError(.noSuchItem)
+    }
+
+    static func isNameCollision(_ error: Error) -> Bool {
+        if let enriched = error as? EnrichedError {
+            if let cause = enriched.cause {
+                return isNameCollision(cause)
+            }
+            return false
+        }
+        if let apiError = error as? APIClientError {
+            return apiError.statusCode == 409
+        }
+        return false
     }
 
     static func isUnauthorized(_ error: Error) -> Bool {

--- a/ios/InternxtFileProvider/FileProviderExtension.swift
+++ b/ios/InternxtFileProvider/FileProviderExtension.swift
@@ -1,0 +1,61 @@
+//
+//  FileProviderExtension.swift
+//  InternxtFileProvider
+//
+//  Created by Ramon Candel on 9/4/26.
+//
+
+import FileProvider
+import InternxtSwiftCore
+
+class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
+    required init(domain: NSFileProviderDomain) {
+        // TODO: The containing application must create a domain using `NSFileProviderManager.add(_:, completionHandler:)`. The system will then launch the application extension process, call `FileProviderExtension.init(domain:)` to instantiate the extension for that domain, and call methods on the instance.
+        super.init()
+    }
+    
+    func invalidate() {
+        // TODO: cleanup any resources
+    }
+    
+    func item(for identifier: NSFileProviderItemIdentifier, request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, Error?) -> Void) -> Progress {
+        // resolve the given identifier to a record in the model
+        
+        // TODO: implement the actual lookup
+
+        completionHandler(FileProviderItem(identifier: identifier), nil)
+        return Progress()
+    }
+    
+    func fetchContents(for itemIdentifier: NSFileProviderItemIdentifier, version requestedVersion: NSFileProviderItemVersion?, request: NSFileProviderRequest, completionHandler: @escaping (URL?, NSFileProviderItem?, Error?) -> Void) -> Progress {
+        // TODO: implement fetching of the contents for the itemIdentifier at the specified version
+        
+        completionHandler(nil, nil, NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError, userInfo:[:]))
+        return Progress()
+    }
+    
+    func createItem(basedOn itemTemplate: NSFileProviderItem, fields: NSFileProviderItemFields, contents url: URL?, options: NSFileProviderCreateItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) -> Progress {
+        // TODO: a new item was created on disk, process the item's creation
+        
+        completionHandler(itemTemplate, [], false, nil)
+        return Progress()
+    }
+    
+    func modifyItem(_ item: NSFileProviderItem, baseVersion version: NSFileProviderItemVersion, changedFields: NSFileProviderItemFields, contents newContents: URL?, options: NSFileProviderModifyItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) -> Progress {
+        // TODO: an item was modified on disk, process the item's modification
+        
+        completionHandler(nil, [], false, NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError, userInfo:[:]))
+        return Progress()
+    }
+    
+    func deleteItem(identifier: NSFileProviderItemIdentifier, baseVersion version: NSFileProviderItemVersion, options: NSFileProviderDeleteItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (Error?) -> Void) -> Progress {
+        // TODO: an item was deleted on disk, process the item's deletion
+        
+        completionHandler(NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError, userInfo:[:]))
+        return Progress()
+    }
+    
+    func enumerator(for containerItemIdentifier: NSFileProviderItemIdentifier, request: NSFileProviderRequest) throws -> NSFileProviderEnumerator {
+        return FileProviderEnumerator(enumeratedItemIdentifier: containerItemIdentifier)
+    }
+}

--- a/ios/InternxtFileProvider/FileProviderExtension.swift
+++ b/ios/InternxtFileProvider/FileProviderExtension.swift
@@ -7,13 +7,41 @@
 
 import FileProvider
 import InternxtSwiftCore
+import UniformTypeIdentifiers
 
 class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
     private let rootDisplayName: String
 
+    private enum FriendlyError {
+        static let offlineDescription = "No internet connection"
+        static let offlineReason = "Connect to the internet and try again to upload to Internxt Drive."
+        static let notAuthenticatedDescription = "Sign in required"
+        static let notAuthenticatedReason = "Open the Internxt app and sign in to continue."
+        static let genericDescription = "Couldn’t complete the operation"
+        static let genericReason = "Something went wrong with Internxt Drive. Please try again."
+    }
+
     required init(domain: NSFileProviderDomain) {
         self.rootDisplayName = domain.displayName
         super.init()
+    }
+
+    private static func fileProviderError(_ code: NSFileProviderError.Code, description: String, reason: String? = nil) -> NSError {
+        var userInfo: [String: Any] = [NSLocalizedDescriptionKey: description]
+        userInfo[NSLocalizedFailureReasonErrorKey] = reason ?? description
+        return NSError(domain: NSFileProviderError.errorDomain, code: code.rawValue, userInfo: userInfo)
+    }
+
+    private static var offlineError: NSError {
+        fileProviderError(.serverUnreachable, description: FriendlyError.offlineDescription, reason: FriendlyError.offlineReason)
+    }
+
+    private static var notAuthenticatedError: NSError {
+        fileProviderError(.notAuthenticated, description: FriendlyError.notAuthenticatedDescription, reason: FriendlyError.notAuthenticatedReason)
+    }
+
+    private static var noSuchItemError: NSError {
+        fileProviderError(.noSuchItem, description: FriendlyError.genericDescription, reason: FriendlyError.genericReason)
     }
 
     func invalidate() {
@@ -28,12 +56,12 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         }
 
         guard let decoded = FileProviderItemID.decode(identifier) else {
-            completionHandler(nil, NSFileProviderError(.noSuchItem))
+            completionHandler(nil, Self.noSuchItemError)
             return Progress()
         }
 
         guard let driveAPI = DriveAPIFactory.make() else {
-            completionHandler(nil, NSFileProviderError(.notAuthenticated))
+            completionHandler(nil, Self.notAuthenticatedError)
             return Progress()
         }
 
@@ -83,12 +111,12 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
 
     private func lookupError(from error: Error) -> Error {
         if isUnauthorized(error) {
-            return NSFileProviderError(.notAuthenticated)
+            return Self.notAuthenticatedError
         }
         if isOffline(error) {
-            return NSFileProviderError(.serverUnreachable)
+            return Self.offlineError
         }
-        return error
+        return Self.noSuchItemError
     }
 
     private func isUnauthorized(_ error: Error) -> Bool {
@@ -128,12 +156,12 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
 
     func fetchContents(for itemIdentifier: NSFileProviderItemIdentifier, version requestedVersion: NSFileProviderItemVersion?, request: NSFileProviderRequest, completionHandler: @escaping (URL?, NSFileProviderItem?, Error?) -> Void) -> Progress {
         guard let decoded = FileProviderItemID.decode(itemIdentifier), decoded.kind == .file else {
-            completionHandler(nil, nil, NSFileProviderError(.noSuchItem))
+            completionHandler(nil, nil, Self.noSuchItemError)
             return Progress()
         }
 
         guard let driveAPI = DriveAPIFactory.make(), let networkFacade = NetworkFacadeFactory.make() else {
-            completionHandler(nil, nil, NSFileProviderError(.notAuthenticated))
+            completionHandler(nil, nil, Self.notAuthenticatedError)
             return Progress()
         }
 
@@ -168,17 +196,198 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
     }
     
     func createItem(basedOn itemTemplate: NSFileProviderItem, fields: NSFileProviderItemFields, contents url: URL?, options: NSFileProviderCreateItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) -> Progress {
-        // TODO: a new item was created on disk, process the item's creation
-        
-        completionHandler(itemTemplate, [], false, nil)
-        return Progress()
+        guard let driveAPI = DriveAPIFactory.make(), let networkFacade = NetworkFacadeFactory.make() else {
+            completionHandler(nil, [], false, Self.notAuthenticatedError)
+            return Progress()
+        }
+
+        guard let parentUuid = FileProviderItemID.folderUuid(for: itemTemplate.parentItemIdentifier) else {
+            completionHandler(nil, [], false, Self.noSuchItemError)
+            return Progress()
+        }
+
+        let parentIdentifier = itemTemplate.parentItemIdentifier
+
+        if itemTemplate.contentType?.conforms(to: .folder) == true {
+            return createFolder(
+                name: itemTemplate.filename,
+                parentUuid: parentUuid,
+                parentIdentifier: parentIdentifier,
+                driveAPI: driveAPI,
+                completionHandler: completionHandler
+            )
+        }
+
+        guard let contentsURL = url else {
+            completionHandler(nil, [], false, Self.noSuchItemError)
+            return Progress()
+        }
+
+        return uploadFile(
+            filename: itemTemplate.filename,
+            contentsURL: contentsURL,
+            parentUuid: parentUuid,
+            parentIdentifier: parentIdentifier,
+            driveAPI: driveAPI,
+            networkFacade: networkFacade,
+            completionHandler: completionHandler
+        )
+    }
+
+    private func createFolder(
+        name: String,
+        parentUuid: String,
+        parentIdentifier: NSFileProviderItemIdentifier,
+        driveAPI: DriveAPI,
+        completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
+    ) -> Progress {
+        let progress = Progress(totalUnitCount: 1)
+        Task {
+            do {
+                let response = try await driveAPI.createFolderNew(parentFolderUuid: parentUuid, folderName: name)
+                progress.completedUnitCount = 1
+                let item = FileProviderItem(folder: response, parent: parentIdentifier)
+                completionHandler(item, [], false, nil)
+            } catch {
+                completionHandler(nil, [], false, lookupError(from: error))
+            }
+        }
+        return progress
+    }
+
+    private func uploadFile(
+        filename: String,
+        contentsURL: URL,
+        parentUuid: String,
+        parentIdentifier: NSFileProviderItemIdentifier,
+        driveAPI: DriveAPI,
+        networkFacade: NetworkFacade,
+        completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
+    ) -> Progress {
+        let progress = Progress(totalUnitCount: 100)
+        Task {
+            let encryptedTmp = Self.temporaryFileURL()
+            defer { try? FileManager.default.removeItem(at: encryptedTmp) }
+
+            do {
+                let meta = try await driveAPI.getFolderMetaByUuid(uuid: parentUuid)
+                guard let bucket = try await Self.resolveBucket(parentMeta: meta, driveAPI: driveAPI) else {
+                    completionHandler(nil, [], false, Self.notAuthenticatedError)
+                    return
+                }
+                guard let input = InputStream(url: contentsURL) else {
+                    completionHandler(nil, [], false, Self.noSuchItemError)
+                    return
+                }
+
+                let fileSize = Self.fileSize(of: contentsURL)
+                let finish = try await networkFacade.uploadFile(
+                    input: input,
+                    encryptedOutput: encryptedTmp,
+                    fileSize: fileSize,
+                    bucketId: bucket,
+                    progressHandler: { fraction in
+                        progress.completedUnitCount = Int64(fraction * 100)
+                    }
+                )
+
+                let (baseName, fileExtension) = Self.splitNameExtension(filename)
+                let created = try await driveAPI.createFileNew(createFile: CreateFileDataNew(
+                    fileId: finish.id,
+                    type: fileExtension,
+                    bucket: bucket,
+                    size: fileSize,
+                    folderId: meta.id,
+                    name: baseName,
+                    plainName: baseName,
+                    folderUuid: parentUuid
+                ))
+
+                let item = FileProviderItem(file: created, parent: parentIdentifier)
+                completionHandler(item, [], false, nil)
+            } catch {
+                completionHandler(nil, [], false, lookupError(from: error))
+            }
+        }
+        return progress
+    }
+
+    private static func resolveBucket(parentMeta: GetFolderMetaByIdResponse, driveAPI: DriveAPI) async throws -> String? {
+        if let bucket = parentMeta.bucket {
+            return bucket
+        }
+        guard let rootUuid = FileProviderItemID.rootFolderUuid() else {
+            return nil
+        }
+        let rootMeta = try await driveAPI.getFolderMetaByUuid(uuid: rootUuid)
+        return rootMeta.bucket
+    }
+
+    private static func fileSize(of url: URL) -> Int {
+        let values = try? url.resourceValues(forKeys: [.fileSizeKey])
+        return values?.fileSize ?? 0
+    }
+
+    private static func splitNameExtension(_ filename: String) -> (base: String, fileExtension: String?) {
+        FileProviderItem.splitNameExtension(filename, kind: .file)
     }
     
     func modifyItem(_ item: NSFileProviderItem, baseVersion version: NSFileProviderItemVersion, changedFields: NSFileProviderItemFields, contents newContents: URL?, options: NSFileProviderModifyItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) -> Progress {
-        // TODO: an item was modified on disk, process the item's modification
-        
-        completionHandler(nil, [], false, NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError, userInfo:[:]))
+        if changedFields.contains(.contents) || changedFields.contains(.parentItemIdentifier) {
+            completionHandler(item, [], false, nil)
+            return Progress()
+        }
+
+        if changedFields.contains(.filename) {
+            return renameItem(item, completionHandler: completionHandler)
+        }
+
+        completionHandler(item, [], false, nil)
         return Progress()
+    }
+
+    private func renameItem(
+        _ item: NSFileProviderItem,
+        completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
+    ) -> Progress {
+        guard let driveAPI = DriveAPIFactory.make() else {
+            completionHandler(nil, [], false, Self.notAuthenticatedError)
+            return Progress()
+        }
+
+        guard let decoded = FileProviderItemID.decode(item.itemIdentifier) else {
+            completionHandler(nil, [], false, Self.noSuchItemError)
+            return Progress()
+        }
+
+        let newFilename = item.filename
+        let progress = Progress(totalUnitCount: 1)
+        Task {
+            do {
+                try await rename(decoded, to: newFilename, driveAPI: driveAPI)
+                progress.completedUnitCount = 1
+                let renamed = FileProviderItem.renamed(from: item, newFilename: newFilename) ?? item
+                completionHandler(renamed, [], false, nil)
+            } catch {
+                completionHandler(nil, [], false, lookupError(from: error))
+            }
+        }
+        return progress
+    }
+
+    private func rename(
+        _ decoded: (kind: DriveItemKind, uuid: String),
+        to newFilename: String,
+        driveAPI: DriveAPI
+    ) async throws {
+        switch decoded.kind {
+        case .folder:
+            _ = try await driveAPI.updateFolderNew(folderUuid: decoded.uuid, folderName: newFilename)
+        case .file:
+            let meta = try await driveAPI.getFileMetaByUuid(uuid: decoded.uuid)
+            let (baseName, _) = Self.splitNameExtension(newFilename)
+            _ = try await driveAPI.updateFileNew(uuid: decoded.uuid, bucketId: meta.bucket, newFilename: baseName)
+        }
     }
     
     func deleteItem(identifier: NSFileProviderItemIdentifier, baseVersion version: NSFileProviderItemVersion, options: NSFileProviderDeleteItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (Error?) -> Void) -> Progress {

--- a/ios/InternxtFileProvider/FileProviderExtension.swift
+++ b/ios/InternxtFileProvider/FileProviderExtension.swift
@@ -93,7 +93,9 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         let parentIdentifier = itemTemplate.parentItemIdentifier
         let uploadService = FileProviderUploadService(driveAPI: driveAPI, networkFacade: networkFacade)
 
-        if itemTemplate.contentType?.conforms(to: .folder) == true {
+        let isFolder = itemTemplate.contentType?.conforms(to: .folder) == true
+
+        if isFolder {
             return createFolder(
                 name: itemTemplate.filename,
                 parentUuid: parentUuid,
@@ -180,23 +182,14 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
     }
 
     func modifyItem(_ item: NSFileProviderItem, baseVersion version: NSFileProviderItemVersion, changedFields: NSFileProviderItemFields, contents newContents: URL?, options: NSFileProviderModifyItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) -> Progress {
-        if changedFields.contains(.contents) || changedFields.contains(.parentItemIdentifier) {
+        let shouldRename = changedFields.contains(.filename)
+        let shouldMove = changedFields.contains(.parentItemIdentifier)
+
+        guard shouldRename || shouldMove else {
             completionHandler(item, [], false, nil)
             return Progress()
         }
 
-        if changedFields.contains(.filename) {
-            return renameItem(item, completionHandler: completionHandler)
-        }
-
-        completionHandler(item, [], false, nil)
-        return Progress()
-    }
-
-    private func renameItem(
-        _ item: NSFileProviderItem,
-        completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
-    ) -> Progress {
         guard let driveAPI = DriveAPIFactory.make() else {
             completionHandler(nil, [], false, NSFileProviderError(.notAuthenticated))
             return Progress()
@@ -207,15 +200,31 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
             return Progress()
         }
 
+        var destinationFolderUuid: String?
+        if shouldMove {
+            guard let resolved = FileProviderItemID.folderUuid(for: item.parentItemIdentifier) else {
+                completionHandler(nil, [], false, NSFileProviderError(.noSuchItem))
+                return Progress()
+            }
+            destinationFolderUuid = resolved
+        }
+
         let mutationService = FileProviderMutationService(driveAPI: driveAPI)
         let newFilename = item.filename
         let progress = Progress(totalUnitCount: 1)
         Task {
             do {
-                try await mutationService.rename(decoded, to: newFilename)
+                if shouldRename {
+                    try await mutationService.rename(decoded, to: newFilename)
+                }
+                if let destinationFolderUuid {
+                    try await mutationService.move(decoded, toParentUuid: destinationFolderUuid)
+                }
                 progress.completedUnitCount = 1
-                let renamed = FileProviderItem.renamed(from: item, newFilename: newFilename) ?? item
-                completionHandler(renamed, [], false, nil)
+                let modified = shouldRename
+                    ? (FileProviderItem.renamed(from: item, newFilename: newFilename) ?? item)
+                    : item
+                completionHandler(modified, [], false, nil)
             } catch {
                 completionHandler(nil, [], false, FileProviderErrorMapper.lookupError(from: error))
             }
@@ -224,10 +233,28 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
     }
 
     func deleteItem(identifier: NSFileProviderItemIdentifier, baseVersion version: NSFileProviderItemVersion, options: NSFileProviderDeleteItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (Error?) -> Void) -> Progress {
-        // TODO: an item was deleted on disk, process the item's deletion
+        guard let driveAPI = DriveAPIFactory.make(), let trashAPI = DriveAPIFactory.makeTrash() else {
+            completionHandler(NSFileProviderError(.notAuthenticated))
+            return Progress()
+        }
 
-        completionHandler(NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError, userInfo:[:]))
-        return Progress()
+        guard let decoded = FileProviderItemID.decode(identifier) else {
+            completionHandler(NSFileProviderError(.noSuchItem))
+            return Progress()
+        }
+
+        let mutationService = FileProviderMutationService(driveAPI: driveAPI, trashAPI: trashAPI)
+        let progress = Progress(totalUnitCount: 1)
+        Task {
+            do {
+                try await mutationService.trash(decoded)
+                progress.completedUnitCount = 1
+                completionHandler(nil)
+            } catch {
+                completionHandler(FileProviderErrorMapper.lookupError(from: error))
+            }
+        }
+        return progress
     }
 
     func enumerator(for containerItemIdentifier: NSFileProviderItemIdentifier, request: NSFileProviderRequest) throws -> NSFileProviderEnumerator {

--- a/ios/InternxtFileProvider/FileProviderExtension.swift
+++ b/ios/InternxtFileProvider/FileProviderExtension.swift
@@ -65,18 +65,106 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         }
     }
 
+    private static let offlineURLErrorCodes: Set<URLError.Code> = [
+        .notConnectedToInternet,
+        .networkConnectionLost,
+        .timedOut,
+        .cannotConnectToHost,
+        .dataNotAllowed,
+        .cannotFindHost
+    ]
+
+    private static let offlineErrorCodes: Set<ErrorCode> = [
+        .networkNoConnection,
+        .networkConnectionLost,
+        .networkTimeout,
+        .networkCannotConnect
+    ]
+
     private func lookupError(from error: Error) -> Error {
-        if let apiError = error as? APIClientError, apiError.statusCode == 401 {
+        if isUnauthorized(error) {
             return NSFileProviderError(.notAuthenticated)
+        }
+        if isOffline(error) {
+            return NSFileProviderError(.serverUnreachable)
         }
         return error
     }
 
-    func fetchContents(for itemIdentifier: NSFileProviderItemIdentifier, version requestedVersion: NSFileProviderItemVersion?, request: NSFileProviderRequest, completionHandler: @escaping (URL?, NSFileProviderItem?, Error?) -> Void) -> Progress {
-        // TODO: implement fetching of the contents for the itemIdentifier at the specified version
+    private func isUnauthorized(_ error: Error) -> Bool {
+        if let enriched = error as? EnrichedError {
+            if enriched.code == .apiUnauthorized {
+                return true
+            }
+            if let cause = enriched.cause {
+                return isUnauthorized(cause)
+            }
+            return false
+        }
+        if let apiError = error as? APIClientError {
+            return apiError.statusCode == 401
+        }
+        return false
+    }
 
-        completionHandler(nil, nil, NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError, userInfo:[:]))
-        return Progress()
+    private func isOffline(_ error: Error) -> Bool {
+        if let enriched = error as? EnrichedError {
+            if Self.offlineErrorCodes.contains(enriched.code) {
+                return true
+            }
+            if let cause = enriched.cause {
+                return isOffline(cause)
+            }
+            return false
+        }
+        if let urlError = error as? URLError {
+            return Self.offlineURLErrorCodes.contains(urlError.code)
+        }
+        if let apiError = error as? APIClientError {
+            return apiError.statusCode <= 0
+        }
+        return false
+    }
+
+    func fetchContents(for itemIdentifier: NSFileProviderItemIdentifier, version requestedVersion: NSFileProviderItemVersion?, request: NSFileProviderRequest, completionHandler: @escaping (URL?, NSFileProviderItem?, Error?) -> Void) -> Progress {
+        guard let decoded = FileProviderItemID.decode(itemIdentifier), decoded.kind == .file else {
+            completionHandler(nil, nil, NSFileProviderError(.noSuchItem))
+            return Progress()
+        }
+
+        guard let driveAPI = DriveAPIFactory.make(), let networkFacade = NetworkFacadeFactory.make() else {
+            completionHandler(nil, nil, NSFileProviderError(.notAuthenticated))
+            return Progress()
+        }
+
+        let progress = Progress(totalUnitCount: 100)
+        Task {
+            let encryptedTmp = Self.temporaryFileURL()
+            let plainTmp = Self.temporaryFileURL()
+            defer { try? FileManager.default.removeItem(at: encryptedTmp) }
+
+            do {
+                let meta = try await driveAPI.getFileMetaByUuid(uuid: decoded.uuid)
+                _ = try await networkFacade.downloadFile(
+                    bucketId: meta.bucket,
+                    fileId: meta.fileId,
+                    encryptedFileDestination: encryptedTmp,
+                    destinationURL: plainTmp,
+                    progressHandler: { fraction in
+                        progress.completedUnitCount = Int64(fraction * 100)
+                    }
+                )
+                let item = FileProviderItem(fileMeta: meta, identifier: itemIdentifier)
+                completionHandler(plainTmp, item, nil)
+            } catch {
+                completionHandler(nil, nil, lookupError(from: error))
+            }
+        }
+        return progress
+    }
+
+    private static func temporaryFileURL() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
     }
     
     func createItem(basedOn itemTemplate: NSFileProviderItem, fields: NSFileProviderItemFields, contents url: URL?, options: NSFileProviderCreateItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) -> Progress {

--- a/ios/InternxtFileProvider/FileProviderExtension.swift
+++ b/ios/InternxtFileProvider/FileProviderExtension.swift
@@ -9,13 +9,11 @@ import FileProvider
 import InternxtSwiftCore
 
 class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
-    required init(domain: NSFileProviderDomain) {
-        super.init()
-    }
+    private let rootDisplayName: String
 
-    private func currentAuthToken() -> String? {
-        guard let data = SharedAuthKeychain.read(SharedAuthKeychain.photosTokenKey) else { return nil }
-        return String(data: data, encoding: .utf8)
+    required init(domain: NSFileProviderDomain) {
+        self.rootDisplayName = domain.displayName
+        super.init()
     }
 
     func invalidate() {
@@ -23,17 +21,58 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
     }
 
     func item(for identifier: NSFileProviderItemIdentifier, request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, Error?) -> Void) -> Progress {
-        _ = currentAuthToken()
+        if identifier == .rootContainer {
+            let rootItem = FileProviderItem.root(displayName: rootDisplayName)
+            completionHandler(rootItem, nil)
+            return Progress()
+        }
 
-        // TODO: implement the actual lookup using the auth token
+        guard let decoded = FileProviderItemID.decode(identifier) else {
+            completionHandler(nil, NSFileProviderError(.noSuchItem))
+            return Progress()
+        }
 
-        completionHandler(FileProviderItem(identifier: identifier), nil)
-        return Progress()
+        guard let driveAPI = DriveAPIFactory.make() else {
+            completionHandler(nil, NSFileProviderError(.notAuthenticated))
+            return Progress()
+        }
+
+        let progress = Progress(totalUnitCount: 1)
+        Task {
+            do {
+                let item = try await resolveItem(decoded, identifier: identifier, driveAPI: driveAPI)
+                progress.completedUnitCount = 1
+                completionHandler(item, nil)
+            } catch {
+                completionHandler(nil, lookupError(from: error))
+            }
+        }
+        return progress
+    }
+
+    private func resolveItem(
+        _ decoded: (kind: DriveItemKind, uuid: String),
+        identifier: NSFileProviderItemIdentifier,
+        driveAPI: DriveAPI
+    ) async throws -> FileProviderItem {
+        switch decoded.kind {
+        case .folder:
+            let meta = try await driveAPI.getFolderMetaByUuid(uuid: decoded.uuid)
+            return FileProviderItem(folderMeta: meta, identifier: identifier)
+        case .file:
+            let meta = try await driveAPI.getFileMetaByUuid(uuid: decoded.uuid)
+            return FileProviderItem(fileMeta: meta, identifier: identifier)
+        }
+    }
+
+    private func lookupError(from error: Error) -> Error {
+        if let apiError = error as? APIClientError, apiError.statusCode == 401 {
+            return NSFileProviderError(.notAuthenticated)
+        }
+        return error
     }
 
     func fetchContents(for itemIdentifier: NSFileProviderItemIdentifier, version requestedVersion: NSFileProviderItemVersion?, request: NSFileProviderRequest, completionHandler: @escaping (URL?, NSFileProviderItem?, Error?) -> Void) -> Progress {
-        _ = currentAuthToken()
-
         // TODO: implement fetching of the contents for the itemIdentifier at the specified version
 
         completionHandler(nil, nil, NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError, userInfo:[:]))

--- a/ios/InternxtFileProvider/FileProviderExtension.swift
+++ b/ios/InternxtFileProvider/FileProviderExtension.swift
@@ -10,26 +10,32 @@ import InternxtSwiftCore
 
 class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
     required init(domain: NSFileProviderDomain) {
-        // TODO: The containing application must create a domain using `NSFileProviderManager.add(_:, completionHandler:)`. The system will then launch the application extension process, call `FileProviderExtension.init(domain:)` to instantiate the extension for that domain, and call methods on the instance.
         super.init()
     }
-    
+
+    private func currentAuthToken() -> String? {
+        guard let data = SharedAuthKeychain.read(SharedAuthKeychain.photosTokenKey) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
     func invalidate() {
         // TODO: cleanup any resources
     }
-    
+
     func item(for identifier: NSFileProviderItemIdentifier, request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, Error?) -> Void) -> Progress {
-        // resolve the given identifier to a record in the model
-        
-        // TODO: implement the actual lookup
+        _ = currentAuthToken()
+
+        // TODO: implement the actual lookup using the auth token
 
         completionHandler(FileProviderItem(identifier: identifier), nil)
         return Progress()
     }
-    
+
     func fetchContents(for itemIdentifier: NSFileProviderItemIdentifier, version requestedVersion: NSFileProviderItemVersion?, request: NSFileProviderRequest, completionHandler: @escaping (URL?, NSFileProviderItem?, Error?) -> Void) -> Progress {
+        _ = currentAuthToken()
+
         // TODO: implement fetching of the contents for the itemIdentifier at the specified version
-        
+
         completionHandler(nil, nil, NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError, userInfo:[:]))
         return Progress()
     }

--- a/ios/InternxtFileProvider/FileProviderExtension.swift
+++ b/ios/InternxtFileProvider/FileProviderExtension.swift
@@ -12,36 +12,9 @@ import UniformTypeIdentifiers
 class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
     private let rootDisplayName: String
 
-    private enum FriendlyError {
-        static let offlineDescription = "No internet connection"
-        static let offlineReason = "Connect to the internet and try again to upload to Internxt Drive."
-        static let notAuthenticatedDescription = "Sign in required"
-        static let notAuthenticatedReason = "Open the Internxt app and sign in to continue."
-        static let genericDescription = "Couldn’t complete the operation"
-        static let genericReason = "Something went wrong with Internxt Drive. Please try again."
-    }
-
     required init(domain: NSFileProviderDomain) {
         self.rootDisplayName = domain.displayName
         super.init()
-    }
-
-    private static func fileProviderError(_ code: NSFileProviderError.Code, description: String, reason: String? = nil) -> NSError {
-        var userInfo: [String: Any] = [NSLocalizedDescriptionKey: description]
-        userInfo[NSLocalizedFailureReasonErrorKey] = reason ?? description
-        return NSError(domain: NSFileProviderError.errorDomain, code: code.rawValue, userInfo: userInfo)
-    }
-
-    private static var offlineError: NSError {
-        fileProviderError(.serverUnreachable, description: FriendlyError.offlineDescription, reason: FriendlyError.offlineReason)
-    }
-
-    private static var notAuthenticatedError: NSError {
-        fileProviderError(.notAuthenticated, description: FriendlyError.notAuthenticatedDescription, reason: FriendlyError.notAuthenticatedReason)
-    }
-
-    private static var noSuchItemError: NSError {
-        fileProviderError(.noSuchItem, description: FriendlyError.genericDescription, reason: FriendlyError.genericReason)
     }
 
     func invalidate() {
@@ -56,12 +29,12 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         }
 
         guard let decoded = FileProviderItemID.decode(identifier) else {
-            completionHandler(nil, Self.noSuchItemError)
+            completionHandler(nil, NSFileProviderError(.noSuchItem))
             return Progress()
         }
 
         guard let driveAPI = DriveAPIFactory.make() else {
-            completionHandler(nil, Self.notAuthenticatedError)
+            completionHandler(nil, NSFileProviderError(.notAuthenticated))
             return Progress()
         }
 
@@ -111,12 +84,12 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
 
     private func lookupError(from error: Error) -> Error {
         if isUnauthorized(error) {
-            return Self.notAuthenticatedError
+            return NSFileProviderError(.notAuthenticated)
         }
         if isOffline(error) {
-            return Self.offlineError
+            return NSFileProviderError(.serverUnreachable)
         }
-        return Self.noSuchItemError
+        return NSFileProviderError(.noSuchItem)
     }
 
     private func isUnauthorized(_ error: Error) -> Bool {
@@ -156,12 +129,12 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
 
     func fetchContents(for itemIdentifier: NSFileProviderItemIdentifier, version requestedVersion: NSFileProviderItemVersion?, request: NSFileProviderRequest, completionHandler: @escaping (URL?, NSFileProviderItem?, Error?) -> Void) -> Progress {
         guard let decoded = FileProviderItemID.decode(itemIdentifier), decoded.kind == .file else {
-            completionHandler(nil, nil, Self.noSuchItemError)
+            completionHandler(nil, nil, NSFileProviderError(.noSuchItem))
             return Progress()
         }
 
         guard let driveAPI = DriveAPIFactory.make(), let networkFacade = NetworkFacadeFactory.make() else {
-            completionHandler(nil, nil, Self.notAuthenticatedError)
+            completionHandler(nil, nil, NSFileProviderError(.notAuthenticated))
             return Progress()
         }
 
@@ -197,12 +170,12 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
     
     func createItem(basedOn itemTemplate: NSFileProviderItem, fields: NSFileProviderItemFields, contents url: URL?, options: NSFileProviderCreateItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) -> Progress {
         guard let driveAPI = DriveAPIFactory.make(), let networkFacade = NetworkFacadeFactory.make() else {
-            completionHandler(nil, [], false, Self.notAuthenticatedError)
+            completionHandler(nil, [], false, NSFileProviderError(.notAuthenticated))
             return Progress()
         }
 
         guard let parentUuid = FileProviderItemID.folderUuid(for: itemTemplate.parentItemIdentifier) else {
-            completionHandler(nil, [], false, Self.noSuchItemError)
+            completionHandler(nil, [], false, NSFileProviderError(.noSuchItem))
             return Progress()
         }
 
@@ -219,7 +192,7 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         }
 
         guard let contentsURL = url else {
-            completionHandler(nil, [], false, Self.noSuchItemError)
+            completionHandler(nil, [], false, NSFileProviderError(.noSuchItem))
             return Progress()
         }
 
@@ -272,11 +245,11 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
             do {
                 let meta = try await driveAPI.getFolderMetaByUuid(uuid: parentUuid)
                 guard let bucket = try await Self.resolveBucket(parentMeta: meta, driveAPI: driveAPI) else {
-                    completionHandler(nil, [], false, Self.notAuthenticatedError)
+                    completionHandler(nil, [], false, NSFileProviderError(.notAuthenticated))
                     return
                 }
                 guard let input = InputStream(url: contentsURL) else {
-                    completionHandler(nil, [], false, Self.noSuchItemError)
+                    completionHandler(nil, [], false, NSFileProviderError(.noSuchItem))
                     return
                 }
 
@@ -351,12 +324,12 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
     ) -> Progress {
         guard let driveAPI = DriveAPIFactory.make() else {
-            completionHandler(nil, [], false, Self.notAuthenticatedError)
+            completionHandler(nil, [], false, NSFileProviderError(.notAuthenticated))
             return Progress()
         }
 
         guard let decoded = FileProviderItemID.decode(item.itemIdentifier) else {
-            completionHandler(nil, [], false, Self.noSuchItemError)
+            completionHandler(nil, [], false, NSFileProviderError(.noSuchItem))
             return Progress()
         }
 

--- a/ios/InternxtFileProvider/FileProviderExtension.swift
+++ b/ios/InternxtFileProvider/FileProviderExtension.swift
@@ -38,93 +38,18 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
             return Progress()
         }
 
+        let mutationService = FileProviderMutationService(driveAPI: driveAPI)
         let progress = Progress(totalUnitCount: 1)
         Task {
             do {
-                let item = try await resolveItem(decoded, identifier: identifier, driveAPI: driveAPI)
+                let item = try await mutationService.resolveItem(decoded, identifier: identifier)
                 progress.completedUnitCount = 1
                 completionHandler(item, nil)
             } catch {
-                completionHandler(nil, lookupError(from: error))
+                completionHandler(nil, FileProviderErrorMapper.lookupError(from: error))
             }
         }
         return progress
-    }
-
-    private func resolveItem(
-        _ decoded: (kind: DriveItemKind, uuid: String),
-        identifier: NSFileProviderItemIdentifier,
-        driveAPI: DriveAPI
-    ) async throws -> FileProviderItem {
-        switch decoded.kind {
-        case .folder:
-            let meta = try await driveAPI.getFolderMetaByUuid(uuid: decoded.uuid)
-            return FileProviderItem(folderMeta: meta, identifier: identifier)
-        case .file:
-            let meta = try await driveAPI.getFileMetaByUuid(uuid: decoded.uuid)
-            return FileProviderItem(fileMeta: meta, identifier: identifier)
-        }
-    }
-
-    private static let offlineURLErrorCodes: Set<URLError.Code> = [
-        .notConnectedToInternet,
-        .networkConnectionLost,
-        .timedOut,
-        .cannotConnectToHost,
-        .dataNotAllowed,
-        .cannotFindHost
-    ]
-
-    private static let offlineErrorCodes: Set<ErrorCode> = [
-        .networkNoConnection,
-        .networkConnectionLost,
-        .networkTimeout,
-        .networkCannotConnect
-    ]
-
-    private func lookupError(from error: Error) -> Error {
-        if isUnauthorized(error) {
-            return NSFileProviderError(.notAuthenticated)
-        }
-        if isOffline(error) {
-            return NSFileProviderError(.serverUnreachable)
-        }
-        return NSFileProviderError(.noSuchItem)
-    }
-
-    private func isUnauthorized(_ error: Error) -> Bool {
-        if let enriched = error as? EnrichedError {
-            if enriched.code == .apiUnauthorized {
-                return true
-            }
-            if let cause = enriched.cause {
-                return isUnauthorized(cause)
-            }
-            return false
-        }
-        if let apiError = error as? APIClientError {
-            return apiError.statusCode == 401
-        }
-        return false
-    }
-
-    private func isOffline(_ error: Error) -> Bool {
-        if let enriched = error as? EnrichedError {
-            if Self.offlineErrorCodes.contains(enriched.code) {
-                return true
-            }
-            if let cause = enriched.cause {
-                return isOffline(cause)
-            }
-            return false
-        }
-        if let urlError = error as? URLError {
-            return Self.offlineURLErrorCodes.contains(urlError.code)
-        }
-        if let apiError = error as? APIClientError {
-            return apiError.statusCode <= 0
-        }
-        return false
     }
 
     func fetchContents(for itemIdentifier: NSFileProviderItemIdentifier, version requestedVersion: NSFileProviderItemVersion?, request: NSFileProviderRequest, completionHandler: @escaping (URL?, NSFileProviderItem?, Error?) -> Void) -> Progress {
@@ -138,36 +63,22 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
             return Progress()
         }
 
+        let downloadService = FileProviderDownloadService(driveAPI: driveAPI, networkFacade: networkFacade)
         let progress = Progress(totalUnitCount: 100)
         Task {
-            let encryptedTmp = Self.temporaryFileURL()
-            let plainTmp = Self.temporaryFileURL()
-            defer { try? FileManager.default.removeItem(at: encryptedTmp) }
-
             do {
-                let meta = try await driveAPI.getFileMetaByUuid(uuid: decoded.uuid)
-                _ = try await networkFacade.downloadFile(
-                    bucketId: meta.bucket,
-                    fileId: meta.fileId,
-                    encryptedFileDestination: encryptedTmp,
-                    destinationURL: plainTmp,
-                    progressHandler: { fraction in
-                        progress.completedUnitCount = Int64(fraction * 100)
-                    }
-                )
-                let item = FileProviderItem(fileMeta: meta, identifier: itemIdentifier)
-                completionHandler(plainTmp, item, nil)
+                let result = try await downloadService.fetchContents(uuid: decoded.uuid) { fraction in
+                    progress.completedUnitCount = Int64(fraction * 100)
+                }
+                let item = FileProviderItem(fileMeta: result.meta, identifier: itemIdentifier)
+                completionHandler(result.url, item, nil)
             } catch {
-                completionHandler(nil, nil, lookupError(from: error))
+                completionHandler(nil, nil, FileProviderErrorMapper.lookupError(from: error))
             }
         }
         return progress
     }
 
-    private static func temporaryFileURL() -> URL {
-        FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-    }
-    
     func createItem(basedOn itemTemplate: NSFileProviderItem, fields: NSFileProviderItemFields, contents url: URL?, options: NSFileProviderCreateItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) -> Progress {
         guard let driveAPI = DriveAPIFactory.make(), let networkFacade = NetworkFacadeFactory.make() else {
             completionHandler(nil, [], false, NSFileProviderError(.notAuthenticated))
@@ -180,13 +91,14 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         }
 
         let parentIdentifier = itemTemplate.parentItemIdentifier
+        let uploadService = FileProviderUploadService(driveAPI: driveAPI, networkFacade: networkFacade)
 
         if itemTemplate.contentType?.conforms(to: .folder) == true {
             return createFolder(
                 name: itemTemplate.filename,
                 parentUuid: parentUuid,
                 parentIdentifier: parentIdentifier,
-                driveAPI: driveAPI,
+                uploadService: uploadService,
                 completionHandler: completionHandler
             )
         }
@@ -201,8 +113,7 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
             contentsURL: contentsURL,
             parentUuid: parentUuid,
             parentIdentifier: parentIdentifier,
-            driveAPI: driveAPI,
-            networkFacade: networkFacade,
+            uploadService: uploadService,
             completionHandler: completionHandler
         )
     }
@@ -211,18 +122,18 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         name: String,
         parentUuid: String,
         parentIdentifier: NSFileProviderItemIdentifier,
-        driveAPI: DriveAPI,
+        uploadService: FileProviderUploadService,
         completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
     ) -> Progress {
         let progress = Progress(totalUnitCount: 1)
         Task {
             do {
-                let response = try await driveAPI.createFolderNew(parentFolderUuid: parentUuid, folderName: name)
+                let response = try await uploadService.createFolder(name: name, parentUuid: parentUuid)
                 progress.completedUnitCount = 1
                 let item = FileProviderItem(folder: response, parent: parentIdentifier)
                 completionHandler(item, [], false, nil)
             } catch {
-                completionHandler(nil, [], false, lookupError(from: error))
+                completionHandler(nil, [], false, FileProviderErrorMapper.lookupError(from: error))
             }
         }
         return progress
@@ -233,78 +144,41 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         contentsURL: URL,
         parentUuid: String,
         parentIdentifier: NSFileProviderItemIdentifier,
-        driveAPI: DriveAPI,
-        networkFacade: NetworkFacade,
+        uploadService: FileProviderUploadService,
         completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
     ) -> Progress {
         let progress = Progress(totalUnitCount: 100)
         Task {
-            let encryptedTmp = Self.temporaryFileURL()
+            let encryptedTmp = FileProviderDownloadService.temporaryFileURL()
             defer { try? FileManager.default.removeItem(at: encryptedTmp) }
 
             do {
-                let meta = try await driveAPI.getFolderMetaByUuid(uuid: parentUuid)
-                guard let bucket = try await Self.resolveBucket(parentMeta: meta, driveAPI: driveAPI) else {
-                    completionHandler(nil, [], false, NSFileProviderError(.notAuthenticated))
-                    return
-                }
-                guard let input = InputStream(url: contentsURL) else {
-                    completionHandler(nil, [], false, NSFileProviderError(.noSuchItem))
-                    return
-                }
-
-                let fileSize = Self.fileSize(of: contentsURL)
-                let finish = try await networkFacade.uploadFile(
-                    input: input,
+                let result = try await uploadService.uploadFile(
+                    filename: filename,
+                    contentsURL: contentsURL,
+                    parentUuid: parentUuid,
                     encryptedOutput: encryptedTmp,
-                    fileSize: fileSize,
-                    bucketId: bucket,
                     progressHandler: { fraction in
                         progress.completedUnitCount = Int64(fraction * 100)
                     }
                 )
 
-                let (baseName, fileExtension) = Self.splitNameExtension(filename)
-                let created = try await driveAPI.createFileNew(createFile: CreateFileDataNew(
-                    fileId: finish.id,
-                    type: fileExtension,
-                    bucket: bucket,
-                    size: fileSize,
-                    folderId: meta.id,
-                    name: baseName,
-                    plainName: baseName,
-                    folderUuid: parentUuid
-                ))
-
-                let item = FileProviderItem(file: created, parent: parentIdentifier)
-                completionHandler(item, [], false, nil)
+                switch result {
+                case .created(let created):
+                    let item = FileProviderItem(file: created, parent: parentIdentifier)
+                    completionHandler(item, [], false, nil)
+                case .notAuthenticated:
+                    completionHandler(nil, [], false, NSFileProviderError(.notAuthenticated))
+                case .noSuchItem:
+                    completionHandler(nil, [], false, NSFileProviderError(.noSuchItem))
+                }
             } catch {
-                completionHandler(nil, [], false, lookupError(from: error))
+                completionHandler(nil, [], false, FileProviderErrorMapper.lookupError(from: error))
             }
         }
         return progress
     }
 
-    private static func resolveBucket(parentMeta: GetFolderMetaByIdResponse, driveAPI: DriveAPI) async throws -> String? {
-        if let bucket = parentMeta.bucket {
-            return bucket
-        }
-        guard let rootUuid = FileProviderItemID.rootFolderUuid() else {
-            return nil
-        }
-        let rootMeta = try await driveAPI.getFolderMetaByUuid(uuid: rootUuid)
-        return rootMeta.bucket
-    }
-
-    private static func fileSize(of url: URL) -> Int {
-        let values = try? url.resourceValues(forKeys: [.fileSizeKey])
-        return values?.fileSize ?? 0
-    }
-
-    private static func splitNameExtension(_ filename: String) -> (base: String, fileExtension: String?) {
-        FileProviderItem.splitNameExtension(filename, kind: .file)
-    }
-    
     func modifyItem(_ item: NSFileProviderItem, baseVersion version: NSFileProviderItemVersion, changedFields: NSFileProviderItemFields, contents newContents: URL?, options: NSFileProviderModifyItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) -> Progress {
         if changedFields.contains(.contents) || changedFields.contains(.parentItemIdentifier) {
             completionHandler(item, [], false, nil)
@@ -333,43 +207,29 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
             return Progress()
         }
 
+        let mutationService = FileProviderMutationService(driveAPI: driveAPI)
         let newFilename = item.filename
         let progress = Progress(totalUnitCount: 1)
         Task {
             do {
-                try await rename(decoded, to: newFilename, driveAPI: driveAPI)
+                try await mutationService.rename(decoded, to: newFilename)
                 progress.completedUnitCount = 1
                 let renamed = FileProviderItem.renamed(from: item, newFilename: newFilename) ?? item
                 completionHandler(renamed, [], false, nil)
             } catch {
-                completionHandler(nil, [], false, lookupError(from: error))
+                completionHandler(nil, [], false, FileProviderErrorMapper.lookupError(from: error))
             }
         }
         return progress
     }
 
-    private func rename(
-        _ decoded: (kind: DriveItemKind, uuid: String),
-        to newFilename: String,
-        driveAPI: DriveAPI
-    ) async throws {
-        switch decoded.kind {
-        case .folder:
-            _ = try await driveAPI.updateFolderNew(folderUuid: decoded.uuid, folderName: newFilename)
-        case .file:
-            let meta = try await driveAPI.getFileMetaByUuid(uuid: decoded.uuid)
-            let (baseName, _) = Self.splitNameExtension(newFilename)
-            _ = try await driveAPI.updateFileNew(uuid: decoded.uuid, bucketId: meta.bucket, newFilename: baseName)
-        }
-    }
-    
     func deleteItem(identifier: NSFileProviderItemIdentifier, baseVersion version: NSFileProviderItemVersion, options: NSFileProviderDeleteItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (Error?) -> Void) -> Progress {
         // TODO: an item was deleted on disk, process the item's deletion
-        
+
         completionHandler(NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError, userInfo:[:]))
         return Progress()
     }
-    
+
     func enumerator(for containerItemIdentifier: NSFileProviderItemIdentifier, request: NSFileProviderRequest) throws -> NSFileProviderEnumerator {
         return FileProviderEnumerator(enumeratedItemIdentifier: containerItemIdentifier)
     }

--- a/ios/InternxtFileProvider/FileProviderItem.swift
+++ b/ios/InternxtFileProvider/FileProviderItem.swift
@@ -1,0 +1,45 @@
+//
+//  FileProviderItem.swift
+//  InternxtFileProvider
+//
+//  Created by Ramon Candel on 9/4/26.
+//
+
+import FileProvider
+import UniformTypeIdentifiers
+
+class FileProviderItem: NSObject, NSFileProviderItem {
+
+    // TODO: implement an initializer to create an item from your extension's backing model
+    // TODO: implement the accessors to return the values from your extension's backing model
+    
+    private let identifier: NSFileProviderItemIdentifier
+    
+    init(identifier: NSFileProviderItemIdentifier) {
+        self.identifier = identifier
+    }
+    
+    var itemIdentifier: NSFileProviderItemIdentifier {
+        return identifier
+    }
+    
+    var parentItemIdentifier: NSFileProviderItemIdentifier {
+        return .rootContainer
+    }
+    
+    var capabilities: NSFileProviderItemCapabilities {
+        return [.allowsReading, .allowsWriting, .allowsRenaming, .allowsReparenting, .allowsTrashing, .allowsDeleting]
+    }
+    
+    var itemVersion: NSFileProviderItemVersion {
+        NSFileProviderItemVersion(contentVersion: "a content version".data(using: .utf8)!, metadataVersion: "a metadata version".data(using: .utf8)!)
+    }
+    
+    var filename: String {
+        return identifier.rawValue
+    }
+    
+    var contentType: UTType {
+        return identifier == NSFileProviderItemIdentifier.rootContainer ? .folder : .plainText
+    }
+}

--- a/ios/InternxtFileProvider/FileProviderItem.swift
+++ b/ios/InternxtFileProvider/FileProviderItem.swift
@@ -66,6 +66,63 @@ class FileProviderItem: NSObject, NSFileProviderItem {
     )
   }
 
+  convenience init(folder: CreateFolderResponseNew, parent: NSFileProviderItemIdentifier) {
+    self.init(
+      identifier: FileProviderItemID.encode(.folder, uuid: folder.uuid),
+      parent: parent,
+      name: folder.plainName ?? folder.name,
+      kind: .folder,
+      fileExtension: nil,
+      createdAt: folder.createdAt,
+      updatedAt: folder.updatedAt,
+      sizeInBytes: nil
+    )
+  }
+
+  convenience init(file: CreateFileResponseNew, parent: NSFileProviderItemIdentifier) {
+    self.init(
+      identifier: FileProviderItemID.encode(.file, uuid: file.uuid),
+      parent: parent,
+      name: file.plain_name,
+      kind: .file,
+      fileExtension: file.type,
+      createdAt: file.createdAt,
+      updatedAt: file.updatedAt,
+      sizeInBytes: file.size
+    )
+  }
+
+  static func renamed(from item: NSFileProviderItem, newFilename: String) -> FileProviderItem? {
+    guard let decoded = FileProviderItemID.decode(item.itemIdentifier) else { return nil }
+    let (baseName, newExtension) = splitNameExtension(newFilename, kind: decoded.kind)
+    return FileProviderItem(
+      identifier: item.itemIdentifier,
+      parent: item.parentItemIdentifier,
+      name: baseName,
+      kind: decoded.kind,
+      fileExtension: newExtension,
+      createdAt: iso8601String(from: item.creationDate ?? nil),
+      updatedAt: iso8601String(from: item.contentModificationDate ?? nil),
+      sizeInBytes: (item.documentSize ?? nil)?.stringValue
+    )
+  }
+
+  private static func iso8601String(from date: Date?) -> String? {
+    guard let date = date else { return nil }
+    return iso8601Formatter.string(from: date)
+  }
+
+  static func splitNameExtension(_ filename: String, kind: DriveItemKind) -> (base: String, fileExtension: String?) {
+    guard kind == .file else { return (filename, nil) }
+    let url = URL(fileURLWithPath: filename)
+    let fileExtension = url.pathExtension
+    let base = url.deletingPathExtension().lastPathComponent
+    if fileExtension.isEmpty || base.isEmpty {
+      return (filename, nil)
+    }
+    return (base, fileExtension)
+  }
+
   static func root(displayName: String) -> FileProviderItem {
     FileProviderItem(
       identifier: .rootContainer,
@@ -116,9 +173,9 @@ class FileProviderItem: NSObject, NSFileProviderItem {
   var capabilities: NSFileProviderItemCapabilities {
     switch kind {
     case .folder:
-      return [.allowsReading, .allowsContentEnumerating]
+      return [.allowsReading, .allowsContentEnumerating, .allowsAddingSubItems, .allowsRenaming]
     case .file:
-      return [.allowsReading]
+      return [.allowsReading, .allowsRenaming]
     }
   }
 

--- a/ios/InternxtFileProvider/FileProviderItem.swift
+++ b/ios/InternxtFileProvider/FileProviderItem.swift
@@ -173,9 +173,9 @@ class FileProviderItem: NSObject, NSFileProviderItem {
   var capabilities: NSFileProviderItemCapabilities {
     switch kind {
     case .folder:
-      return [.allowsReading, .allowsContentEnumerating, .allowsAddingSubItems, .allowsRenaming]
+      return [.allowsReading, .allowsContentEnumerating, .allowsAddingSubItems, .allowsRenaming, .allowsReparenting, .allowsDeleting]
     case .file:
-      return [.allowsReading, .allowsRenaming]
+      return [.allowsReading, .allowsRenaming, .allowsReparenting, .allowsDeleting]
     }
   }
 

--- a/ios/InternxtFileProvider/FileProviderItem.swift
+++ b/ios/InternxtFileProvider/FileProviderItem.swift
@@ -6,40 +6,188 @@
 //
 
 import FileProvider
+import InternxtSwiftCore
 import UniformTypeIdentifiers
 
 class FileProviderItem: NSObject, NSFileProviderItem {
 
-    // TODO: implement an initializer to create an item from your extension's backing model
-    // TODO: implement the accessors to return the values from your extension's backing model
-    
-    private let identifier: NSFileProviderItemIdentifier
-    
-    init(identifier: NSFileProviderItemIdentifier) {
-        self.identifier = identifier
+  private let identifier: NSFileProviderItemIdentifier
+  private let parent: NSFileProviderItemIdentifier
+  private let name: String
+  private let kind: DriveItemKind
+  private let fileExtension: String?
+  private let updatedAt: String?
+  private let createdAt: String?
+  private let sizeInBytes: String?
+
+  private init(
+    identifier: NSFileProviderItemIdentifier,
+    parent: NSFileProviderItemIdentifier,
+    name: String,
+    kind: DriveItemKind,
+    fileExtension: String?,
+    createdAt: String?,
+    updatedAt: String?,
+    sizeInBytes: String?
+  ) {
+    self.identifier = identifier
+    self.parent = parent
+    self.name = name
+    self.kind = kind
+    self.fileExtension = fileExtension
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
+    self.sizeInBytes = sizeInBytes
+  }
+
+  convenience init(folder: GetFolderFoldersResult, parent: NSFileProviderItemIdentifier) {
+    self.init(
+      identifier: FileProviderItemID.encode(.folder, uuid: folder.uuid ?? ""),
+      parent: parent,
+      name: folder.plainName ?? folder.name,
+      kind: .folder,
+      fileExtension: nil,
+      createdAt: folder.createdAt,
+      updatedAt: folder.updatedAt,
+      sizeInBytes: nil
+    )
+  }
+
+  convenience init(file: GetFolderFilesResultV2, parent: NSFileProviderItemIdentifier) {
+    self.init(
+      identifier: FileProviderItemID.encode(.file, uuid: file.uuid),
+      parent: parent,
+      name: file.plainName ?? file.name ?? file.uuid,
+      kind: .file,
+      fileExtension: file.type,
+      createdAt: file.createdAt,
+      updatedAt: file.updatedAt,
+      sizeInBytes: file.size
+    )
+  }
+
+  static func root(displayName: String) -> FileProviderItem {
+    FileProviderItem(
+      identifier: .rootContainer,
+      parent: .rootContainer,
+      name: displayName,
+      kind: .folder,
+      fileExtension: nil,
+      createdAt: nil,
+      updatedAt: nil,
+      sizeInBytes: nil
+    )
+  }
+
+  convenience init(folderMeta: GetFolderMetaByIdResponse, identifier: NSFileProviderItemIdentifier) {
+    self.init(
+      identifier: identifier,
+      parent: FileProviderItemID.parentIdentifier(folderUuid: folderMeta.parentUuid),
+      name: folderMeta.plainName ?? folderMeta.name ?? identifier.rawValue,
+      kind: .folder,
+      fileExtension: nil,
+      createdAt: folderMeta.createdAt,
+      updatedAt: folderMeta.updatedAt,
+      sizeInBytes: nil
+    )
+  }
+
+  convenience init(fileMeta: GetFileMetaByIdResponse, identifier: NSFileProviderItemIdentifier) {
+    self.init(
+      identifier: identifier,
+      parent: FileProviderItemID.parentIdentifier(folderUuid: fileMeta.folderUuid),
+      name: fileMeta.plainName ?? fileMeta.name,
+      kind: .file,
+      fileExtension: fileMeta.type,
+      createdAt: fileMeta.createdAt,
+      updatedAt: fileMeta.updatedAt,
+      sizeInBytes: fileMeta.size
+    )
+  }
+
+  var itemIdentifier: NSFileProviderItemIdentifier {
+    identifier
+  }
+
+  var parentItemIdentifier: NSFileProviderItemIdentifier {
+    parent
+  }
+
+  var capabilities: NSFileProviderItemCapabilities {
+    switch kind {
+    case .folder:
+      return [.allowsReading, .allowsContentEnumerating]
+    case .file:
+      return [.allowsReading]
     }
-    
-    var itemIdentifier: NSFileProviderItemIdentifier {
-        return identifier
+  }
+
+  var itemVersion: NSFileProviderItemVersion {
+    let version = Data((updatedAt ?? identifier.rawValue).utf8)
+    return NSFileProviderItemVersion(contentVersion: version, metadataVersion: version)
+  }
+
+  var filename: String {
+    guard kind == .file, let fileExtension = fileExtension, !fileExtension.isEmpty else {
+      return name
     }
-    
-    var parentItemIdentifier: NSFileProviderItemIdentifier {
-        return .rootContainer
+    return "\(name).\(fileExtension)"
+  }
+
+  var contentType: UTType {
+    guard kind == .file else { return .folder }
+    if let fileExtension = fileExtension, !fileExtension.isEmpty,
+       let type = UTType(filenameExtension: fileExtension) {
+      return type
     }
-    
-    var capabilities: NSFileProviderItemCapabilities {
-        return [.allowsReading, .allowsWriting, .allowsRenaming, .allowsReparenting, .allowsTrashing, .allowsDeleting]
+    return .data
+  }
+
+  var documentSize: NSNumber? {
+    guard kind == .file, let sizeInBytes = sizeInBytes,
+          let bytes = Int64(sizeInBytes) else {
+      return nil
     }
-    
-    var itemVersion: NSFileProviderItemVersion {
-        NSFileProviderItemVersion(contentVersion: "a content version".data(using: .utf8)!, metadataVersion: "a metadata version".data(using: .utf8)!)
+    return NSNumber(value: bytes)
+  }
+
+  private var isFolder: Bool {
+    kind == .folder
+  }
+
+  var isUploaded: Bool {
+    true
+  }
+
+  var isDownloaded: Bool {
+    isFolder
+  }
+
+  var isMostRecentVersionDownloaded: Bool {
+    isFolder
+  }
+
+  var creationDate: Date? {
+    Self.parseISO8601(createdAt)
+  }
+
+  var contentModificationDate: Date? {
+    Self.parseISO8601(updatedAt)
+  }
+
+  private static let iso8601Formatter: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter
+  }()
+
+  private static func parseISO8601(_ value: String?) -> Date? {
+    guard let value = value, !value.isEmpty else { return nil }
+    if let date = iso8601Formatter.date(from: value) {
+      return date
     }
-    
-    var filename: String {
-        return identifier.rawValue
-    }
-    
-    var contentType: UTType {
-        return identifier == NSFileProviderItemIdentifier.rootContainer ? .folder : .plainText
-    }
+    let fallback = ISO8601DateFormatter()
+    fallback.formatOptions = [.withInternetDateTime]
+    return fallback.date(from: value)
+  }
 }

--- a/ios/InternxtFileProvider/FileProviderItem.swift
+++ b/ios/InternxtFileProvider/FileProviderItem.swift
@@ -168,11 +168,11 @@ class FileProviderItem: NSObject, NSFileProviderItem {
   }
 
   var creationDate: Date? {
-    Self.parseISO8601(createdAt)
+    Self.parseDate(createdAt)
   }
 
   var contentModificationDate: Date? {
-    Self.parseISO8601(updatedAt)
+    Self.parseDate(updatedAt)
   }
 
   private static let iso8601Formatter: ISO8601DateFormatter = {
@@ -181,13 +181,17 @@ class FileProviderItem: NSObject, NSFileProviderItem {
     return formatter
   }()
 
-  private static func parseISO8601(_ value: String?) -> Date? {
+  private static let iso8601FormatterNoFractionalSeconds: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    return formatter
+  }()
+
+  private static func parseDate(_ value: String?) -> Date? {
     guard let value = value, !value.isEmpty else { return nil }
     if let date = iso8601Formatter.date(from: value) {
       return date
     }
-    let fallback = ISO8601DateFormatter()
-    fallback.formatOptions = [.withInternetDateTime]
-    return fallback.date(from: value)
+    return iso8601FormatterNoFractionalSeconds.date(from: value)
   }
 }

--- a/ios/InternxtFileProvider/FileProviderItemIdentifier.swift
+++ b/ios/InternxtFileProvider/FileProviderItemIdentifier.swift
@@ -1,0 +1,49 @@
+import FileProvider
+
+enum DriveItemKind: String {
+  case folder = "f"
+  case file = "d"
+}
+
+enum FileProviderItemID {
+  private static let separator: Character = ":"
+
+  static func encode(_ kind: DriveItemKind, uuid: String) -> NSFileProviderItemIdentifier {
+    NSFileProviderItemIdentifier("\(kind.rawValue)\(separator)\(uuid)")
+  }
+
+  static func decode(_ identifier: NSFileProviderItemIdentifier) -> (kind: DriveItemKind, uuid: String)? {
+    let raw = identifier.rawValue
+    guard let separatorIndex = raw.firstIndex(of: separator) else { return nil }
+    let prefix = String(raw[raw.startIndex..<separatorIndex])
+    let uuid = String(raw[raw.index(after: separatorIndex)...])
+    guard let kind = DriveItemKind(rawValue: prefix), !uuid.isEmpty else { return nil }
+    return (kind, uuid)
+  }
+
+  static func isDriveFolderContainer(_ container: NSFileProviderItemIdentifier) -> Bool {
+    if container == .rootContainer { return true }
+    guard let decoded = decode(container) else { return false }
+    return decoded.kind == .folder
+  }
+
+  static func folderUuid(for container: NSFileProviderItemIdentifier) -> String? {
+    if container == .rootContainer {
+      return rootFolderUuid()
+    }
+    guard let decoded = decode(container), decoded.kind == .folder else { return nil }
+    return decoded.uuid
+  }
+
+  static func rootFolderUuid() -> String? {
+    guard let data = SharedAuthKeychain.read(SharedAuthKeychain.rootFolderIdKey) else { return nil }
+    let uuid = String(decoding: data, as: UTF8.self)
+    return uuid.isEmpty ? nil : uuid
+  }
+
+  static func parentIdentifier(folderUuid: String?) -> NSFileProviderItemIdentifier {
+    guard let folderUuid = folderUuid, !folderUuid.isEmpty else { return .rootContainer }
+    if folderUuid == rootFolderUuid() { return .rootContainer }
+    return encode(.folder, uuid: folderUuid)
+  }
+}

--- a/ios/InternxtFileProvider/FileProviderMutationService.swift
+++ b/ios/InternxtFileProvider/FileProviderMutationService.swift
@@ -10,6 +10,7 @@ import InternxtSwiftCore
 
 struct FileProviderMutationService {
     let driveAPI: DriveAPI
+    var trashAPI: TrashAPI? = nil
 
     func resolveItem(
         _ decoded: (kind: DriveItemKind, uuid: String),
@@ -37,5 +38,34 @@ struct FileProviderMutationService {
             let (baseName, _) = FileProviderItem.splitNameExtension(newFilename, kind: .file)
             _ = try await driveAPI.updateFileNew(uuid: decoded.uuid, bucketId: meta.bucket, newFilename: baseName)
         }
+    }
+
+    func move(
+        _ decoded: (kind: DriveItemKind, uuid: String),
+        toParentUuid destinationFolderUuid: String
+    ) async throws {
+        switch decoded.kind {
+        case .folder:
+            _ = try await driveAPI.moveFolderNew(uuid: decoded.uuid, destinationFolder: destinationFolderUuid)
+        case .file:
+            _ = try await driveAPI.moveFileNew(uuid: decoded.uuid, destinationFolder: destinationFolderUuid)
+        }
+    }
+
+    func trash(_ decoded: (kind: DriveItemKind, uuid: String)) async throws {
+        guard let trashAPI else { throw NSFileProviderError(.notAuthenticated) }
+        let didTrash = try await trashAPI.trashItemsByUuid(itemsToTrash: Self.trashItems(for: decoded))
+        try Self.validateTrashOutcome(didTrash)
+    }
+
+    static func validateTrashOutcome(_ didTrash: Bool) throws {
+        guard didTrash else { throw NSFileProviderError(.serverUnreachable) }
+    }
+
+    static func trashItems(
+        for decoded: (kind: DriveItemKind, uuid: String)
+    ) -> [ItemToTrashV2] {
+        let type: ItemToTrashType = decoded.kind == .folder ? .Folder : .File
+        return [ItemToTrashV2(uuid: decoded.uuid, type: type)]
     }
 }

--- a/ios/InternxtFileProvider/FileProviderMutationService.swift
+++ b/ios/InternxtFileProvider/FileProviderMutationService.swift
@@ -1,0 +1,41 @@
+//
+//  FileProviderMutationService.swift
+//  InternxtFileProvider
+//
+//  Created by Ramon Candel on 9/4/26.
+//
+
+import FileProvider
+import InternxtSwiftCore
+
+struct FileProviderMutationService {
+    let driveAPI: DriveAPI
+
+    func resolveItem(
+        _ decoded: (kind: DriveItemKind, uuid: String),
+        identifier: NSFileProviderItemIdentifier
+    ) async throws -> FileProviderItem {
+        switch decoded.kind {
+        case .folder:
+            let meta = try await driveAPI.getFolderMetaByUuid(uuid: decoded.uuid)
+            return FileProviderItem(folderMeta: meta, identifier: identifier)
+        case .file:
+            let meta = try await driveAPI.getFileMetaByUuid(uuid: decoded.uuid)
+            return FileProviderItem(fileMeta: meta, identifier: identifier)
+        }
+    }
+
+    func rename(
+        _ decoded: (kind: DriveItemKind, uuid: String),
+        to newFilename: String
+    ) async throws {
+        switch decoded.kind {
+        case .folder:
+            _ = try await driveAPI.updateFolderNew(folderUuid: decoded.uuid, folderName: newFilename)
+        case .file:
+            let meta = try await driveAPI.getFileMetaByUuid(uuid: decoded.uuid)
+            let (baseName, _) = FileProviderItem.splitNameExtension(newFilename, kind: .file)
+            _ = try await driveAPI.updateFileNew(uuid: decoded.uuid, bucketId: meta.bucket, newFilename: baseName)
+        }
+    }
+}

--- a/ios/InternxtFileProvider/FileProviderUploadService.swift
+++ b/ios/InternxtFileProvider/FileProviderUploadService.swift
@@ -1,0 +1,86 @@
+//
+//  FileProviderUploadService.swift
+//  InternxtFileProvider
+//
+//  Created by Ramon Candel on 9/4/26.
+//
+
+import FileProvider
+import InternxtSwiftCore
+
+struct FileProviderUploadService {
+    let driveAPI: DriveAPI
+    let networkFacade: NetworkFacade
+
+    func createFolder(
+        name: String,
+        parentUuid: String
+    ) async throws -> CreateFolderResponseNew {
+        try await driveAPI.createFolderNew(parentFolderUuid: parentUuid, folderName: name)
+    }
+
+    func uploadFile(
+        filename: String,
+        contentsURL: URL,
+        parentUuid: String,
+        encryptedOutput: URL,
+        progressHandler: @escaping (Double) -> Void
+    ) async throws -> UploadResult {
+        let meta = try await driveAPI.getFolderMetaByUuid(uuid: parentUuid)
+        guard let bucket = try await resolveBucket(parentMeta: meta) else {
+            return .notAuthenticated
+        }
+        guard let input = InputStream(url: contentsURL) else {
+            return .noSuchItem
+        }
+
+        let fileSize = Self.fileSize(of: contentsURL)
+        let finish = try await networkFacade.uploadFile(
+            input: input,
+            encryptedOutput: encryptedOutput,
+            fileSize: fileSize,
+            bucketId: bucket,
+            progressHandler: progressHandler
+        )
+
+        let (baseName, fileExtension) = Self.splitNameExtension(filename)
+        let created = try await driveAPI.createFileNew(createFile: CreateFileDataNew(
+            fileId: finish.id,
+            type: fileExtension,
+            bucket: bucket,
+            size: fileSize,
+            folderId: meta.id,
+            name: baseName,
+            plainName: baseName,
+            folderUuid: parentUuid
+        ))
+
+        return .created(created)
+    }
+
+    private func resolveBucket(parentMeta: GetFolderMetaByIdResponse) async throws -> String? {
+        if let bucket = parentMeta.bucket {
+            return bucket
+        }
+        guard let rootUuid = FileProviderItemID.rootFolderUuid() else {
+            return nil
+        }
+        let rootMeta = try await driveAPI.getFolderMetaByUuid(uuid: rootUuid)
+        return rootMeta.bucket
+    }
+
+    private static func fileSize(of url: URL) -> Int {
+        let values = try? url.resourceValues(forKeys: [.fileSizeKey])
+        return values?.fileSize ?? 0
+    }
+
+    private static func splitNameExtension(_ filename: String) -> (base: String, fileExtension: String?) {
+        FileProviderItem.splitNameExtension(filename, kind: .file)
+    }
+
+    enum UploadResult {
+        case created(CreateFileResponseNew)
+        case notAuthenticated
+        case noSuchItem
+    }
+}

--- a/ios/InternxtFileProvider/Info.plist
+++ b/ios/InternxtFileProvider/Info.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionFileProviderDocumentGroup</key>
+		<string>group.com.internxt.snacks</string>
+		<key>NSExtensionFileProviderSupportsEnumeration</key>
+		<true/>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.fileprovider-nonui</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).FileProviderExtension</string>
+	</dict>
+	<key>RCTNewArchEnabled</key>
+	<true/>
+</dict>
+</plist>

--- a/ios/InternxtFileProvider/Info.plist
+++ b/ios/InternxtFileProvider/Info.plist
@@ -15,5 +15,7 @@
 	</dict>
 	<key>RCTNewArchEnabled</key>
 	<true/>
+	<key>SharedKeychainGroup</key>
+	<string>$(AppIdentifierPrefix)group.com.internxt.snacks</string>
 </dict>
 </plist>

--- a/ios/InternxtFileProvider/InternxtFileProvider.entitlements
+++ b/ios/InternxtFileProvider/InternxtFileProvider.entitlements
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.com.internxt.snacks</string>
+    </array>
+    <key>keychain-access-groups</key>
+    <array>
+        <string>$(AppIdentifierPrefix)group.com.internxt.snacks</string>
+    </array>
+
+</dict>
+</plist>

--- a/ios/InternxtFileProvider/InternxtFileProvider.plist
+++ b/ios/InternxtFileProvider/InternxtFileProvider.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+   InternxtFileProvider.plist
+   Internxt
+
+   Created by Ramon Candel on 9/4/26.
+   Copyright (c) 2026 ___ORGANIZATIONNAME___. All rights reserved.
+-->
+<plist version="1.0">
+<dict/>
+</plist>

--- a/ios/InternxtFileProvider/NetworkFacadeFactory.swift
+++ b/ios/InternxtFileProvider/NetworkFacadeFactory.swift
@@ -1,0 +1,35 @@
+import Foundation
+import CryptoKit
+import InternxtSwiftCore
+
+enum NetworkFacadeFactory {
+  static func make() -> NetworkFacade? {
+    guard let mnemonic = SharedKeychainCredentials.string(SharedAuthKeychain.mnemonicKey) else {
+      return nil
+    }
+    guard let bridgeBaseUrl = SharedKeychainCredentials.string(SharedAuthKeychain.bridgeBaseUrlKey) else {
+      return nil
+    }
+    guard let bridgeUser = SharedKeychainCredentials.string(SharedAuthKeychain.bridgeUserKey) else {
+      return nil
+    }
+    guard let userId = SharedKeychainCredentials.string(SharedAuthKeychain.userIdKey) else {
+      return nil
+    }
+
+    let bridgePass = deriveBridgePass(userId: userId)
+    let basicAuthToken = Data("\(bridgeUser):\(bridgePass)".utf8).base64EncodedString()
+    let networkAPI = NetworkAPI(
+      baseUrl: bridgeBaseUrl,
+      basicAuthToken: basicAuthToken,
+      clientName: SharedKeychainCredentials.clientName,
+      clientVersion: SharedKeychainCredentials.clientVersion
+    )
+    return NetworkFacade(mnemonic: mnemonic, networkAPI: networkAPI)
+  }
+
+  private static func deriveBridgePass(userId: String) -> String {
+    let digest = SHA256.hash(data: Data(userId.utf8))
+    return digest.map { String(format: "%02x", $0) }.joined()
+  }
+}

--- a/ios/InternxtFileProvider/SharedKeychainCredentials.swift
+++ b/ios/InternxtFileProvider/SharedKeychainCredentials.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum SharedKeychainCredentials {
+  static func string(_ key: String) -> String? {
+    guard let data = SharedAuthKeychain.read(key) else { return nil }
+    let value = String(decoding: data, as: UTF8.self)
+    return value.isEmpty ? nil : value
+  }
+
+  static var clientName: String {
+    bundleString("CFBundleName") ?? "drive-mobile"
+  }
+
+  static var clientVersion: String {
+    bundleString("CFBundleShortVersionString") ?? "0.0.0"
+  }
+
+  private static func bundleString(_ key: String) -> String? {
+    Bundle(for: FileProviderExtension.self).object(forInfoDictionaryKey: key) as? String
+  }
+}

--- a/ios/InternxtFileProvider/SyncAnchorStore.swift
+++ b/ios/InternxtFileProvider/SyncAnchorStore.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+struct SyncAnchorStore {
+  static let appGroupIdentifier = "group.com.internxt.snacks"
+
+  private static let counterFileName = "InternxtFileProviderSyncAnchorCounter"
+  private static let changesFileName = "InternxtFileProviderPendingChanges"
+  private static let snapshotsFileName = "InternxtFileProviderFolderSnapshots"
+  private static let maxEntries = 50
+  private static let maxTrackedFolders = 50
+
+  private let counterURL: URL
+  private let changesURL: URL
+  private let snapshotsURL: URL
+
+  init?(appGroupIdentifier: String = SyncAnchorStore.appGroupIdentifier) {
+    guard let container = FileManager.default.containerURL(
+      forSecurityApplicationGroupIdentifier: appGroupIdentifier
+    ) else { return nil }
+    self.counterURL = container.appendingPathComponent(Self.counterFileName)
+    self.changesURL = container.appendingPathComponent(Self.changesFileName)
+    self.snapshotsURL = container.appendingPathComponent(Self.snapshotsFileName)
+  }
+
+  init(directory: URL) {
+    self.counterURL = directory.appendingPathComponent(Self.counterFileName)
+    self.changesURL = directory.appendingPathComponent(Self.changesFileName)
+    self.snapshotsURL = directory.appendingPathComponent(Self.snapshotsFileName)
+  }
+
+  var currentValue: UInt64 {
+    guard let data = try? Data(contentsOf: counterURL),
+          let value = Self.decode(data) else {
+      return 0
+    }
+    return value
+  }
+
+  var currentData: Data {
+    Self.encode(currentValue)
+  }
+
+  @discardableResult
+  func recordChange(parentUuid: String) -> UInt64 {
+    let next = currentValue &+ 1
+    try? Self.encode(next).write(to: counterURL, options: .atomic)
+
+    var map = readChanges()
+    map[parentUuid] = next
+    writeChanges(boundedChanges(map))
+
+    return next
+  }
+
+  func changedParents(after incoming: UInt64) -> [String] {
+    readChanges()
+      .filter { $0.value > incoming }
+      .sorted { $0.value < $1.value }
+      .map { $0.key }
+  }
+
+  func snapshot(forFolderUuid folderUuid: String) -> [String] {
+    readSnapshots()[folderUuid] ?? []
+  }
+
+  func saveSnapshot(_ identifiers: [String], forFolderUuid folderUuid: String) {
+    var snapshots = readSnapshots()
+    snapshots[folderUuid] = identifiers
+    writeSnapshots(boundedSnapshots(snapshots, keeping: folderUuid))
+  }
+
+  static func encode(_ value: UInt64) -> Data {
+    withUnsafeBytes(of: value.bigEndian) { Data($0) }
+  }
+
+  static func decode(_ data: Data) -> UInt64? {
+    guard data.count == MemoryLayout<UInt64>.size else { return nil }
+    return data.withUnsafeBytes { $0.load(as: UInt64.self).bigEndian }
+  }
+
+  private func readChanges() -> [String: UInt64] {
+    guard let data = try? Data(contentsOf: changesURL),
+          let map = try? JSONDecoder().decode([String: UInt64].self, from: data) else {
+      return [:]
+    }
+    return map
+  }
+
+  private func writeChanges(_ map: [String: UInt64]) {
+    guard let data = try? JSONEncoder().encode(map) else { return }
+    try? data.write(to: changesURL, options: .atomic)
+  }
+
+  private func boundedChanges(_ map: [String: UInt64]) -> [String: UInt64] {
+    guard map.count > Self.maxEntries else { return map }
+    let mostRecent = map.sorted { $0.value > $1.value }.prefix(Self.maxEntries)
+    return Dictionary(uniqueKeysWithValues: mostRecent.map { ($0.key, $0.value) })
+  }
+
+  private func readSnapshots() -> [String: [String]] {
+    guard let data = try? Data(contentsOf: snapshotsURL),
+          let map = try? JSONDecoder().decode([String: [String]].self, from: data) else {
+      return [:]
+    }
+    return map
+  }
+
+  private func writeSnapshots(_ map: [String: [String]]) {
+    guard let data = try? JSONEncoder().encode(map) else { return }
+    try? data.write(to: snapshotsURL, options: .atomic)
+  }
+
+  // Simple eviction: when over the cap, keep the folder just written and an
+  // arbitrary subset of the rest. The snapshot is only an optimization for
+  // detecting removals; a missing snapshot just means "no removals reported",
+  // never incorrect state.
+  private func boundedSnapshots(_ map: [String: [String]], keeping folderUuid: String) -> [String: [String]] {
+    guard map.count > Self.maxTrackedFolders else { return map }
+    var trimmed = map
+    for key in trimmed.keys where key != folderUuid {
+      if trimmed.count <= Self.maxTrackedFolders { break }
+      trimmed.removeValue(forKey: key)
+    }
+    return trimmed
+  }
+}

--- a/ios/InternxtFileProviderTests/FileProviderErrorMapperTests.swift
+++ b/ios/InternxtFileProviderTests/FileProviderErrorMapperTests.swift
@@ -32,27 +32,27 @@ final class FileProviderErrorMapperTests: XCTestCase {
         XCTAssertEqual(mapped.code, expected.rawValue, file: file, line: line)
     }
 
-    func test_whenEnrichedApiUnauthorized_thenNotAuthenticated() {
+    func testWhenEnrichedApiUnauthorizedThenNotAuthenticated() {
         assertCode(enriched(.apiUnauthorized), .notAuthenticated)
     }
 
-    func test_whenApiClientError401_thenNotAuthenticated() {
+    func testWhenApiClientError401ThenNotAuthenticated() {
         assertCode(apiError(statusCode: 401), .notAuthenticated)
     }
 
-    func test_whenEnrichedCauseIsUnauthorized_thenNotAuthenticated() {
+    func testWhenEnrichedCauseIsUnauthorizedThenNotAuthenticated() {
         let nested = enriched(.downloadInfoFailed, cause: apiError(statusCode: 401))
         assertCode(nested, .notAuthenticated)
     }
 
-    func test_whenDeeplyNestedCauseIsUnauthorized_thenNotAuthenticated() {
+    func testWhenDeeplyNestedCauseIsUnauthorizedThenNotAuthenticated() {
         let leaf = enriched(.apiUnauthorized)
         let middle = enriched(.downloadMirrorsFailed, cause: leaf)
         let root = enriched(.downloadFailed, cause: middle)
         assertCode(root, .notAuthenticated)
     }
 
-    func test_whenEnrichedNetworkCodes_thenServerUnreachable() {
+    func testWhenEnrichedNetworkCodesThenServerUnreachable() {
         let offlineCodes: [ErrorCode] = [
             .networkNoConnection,
             .networkConnectionLost,
@@ -64,13 +64,13 @@ final class FileProviderErrorMapperTests: XCTestCase {
         }
     }
 
-    func test_whenApiClientErrorStatusCodeZeroOrNegative_thenServerUnreachable() {
+    func testWhenApiClientErrorStatusCodeZeroOrNegativeThenServerUnreachable() {
         for statusCode in [0, -1, -2] {
             assertCode(apiError(statusCode: statusCode), .serverUnreachable)
         }
     }
 
-    func test_whenURLErrorOfflineCodes_thenServerUnreachable() {
+    func testWhenURLErrorOfflineCodesThenServerUnreachable() {
         let offlineURLCodes: [URLError.Code] = [
             .notConnectedToInternet,
             .networkConnectionLost,
@@ -84,20 +84,20 @@ final class FileProviderErrorMapperTests: XCTestCase {
         }
     }
 
-    func test_whenEnrichedCauseIsOfflineURLError_thenServerUnreachable() {
+    func testWhenEnrichedCauseIsOfflineURLErrorThenServerUnreachable() {
         let nested = enriched(.downloadInfoFailed, cause: URLError(.notConnectedToInternet))
         assertCode(nested, .serverUnreachable)
     }
 
-    func test_whenUnknownEnrichedCodeWithoutCause_thenNoSuchItem() {
+    func testWhenUnknownEnrichedCodeWithoutCauseThenNoSuchItem() {
         assertCode(enriched(.apiNotFound), .noSuchItem)
     }
 
-    func test_whenApiClientErrorNonAuthPositiveStatus_thenNoSuchItem() {
+    func testWhenApiClientErrorNonAuthPositiveStatusThenNoSuchItem() {
         assertCode(apiError(statusCode: 500), .noSuchItem)
     }
 
-    func test_whenUnrelatedError_thenNoSuchItem() {
+    func testWhenUnrelatedErrorThenNoSuchItem() {
         assertCode(URLError(.badURL), .noSuchItem)
     }
 }

--- a/ios/InternxtFileProviderTests/FileProviderErrorMapperTests.swift
+++ b/ios/InternxtFileProviderTests/FileProviderErrorMapperTests.swift
@@ -1,0 +1,103 @@
+//
+//  FileProviderErrorMapperTests.swift
+//  InternxtFileProviderTests
+//
+
+import XCTest
+import FileProvider
+import InternxtSwiftCore
+
+final class FileProviderErrorMapperTests: XCTestCase {
+
+    private func enriched(_ code: ErrorCode, cause: Error? = nil) -> EnrichedError {
+        EnrichedError(code: code, step: .downloadGetInfo, cause: cause)
+    }
+
+    private func apiError(statusCode: Int) -> APIClientError {
+        APIClientError(statusCode: statusCode, message: "test")
+    }
+
+    private func nsError(from error: Error) -> NSError {
+        FileProviderErrorMapper.lookupError(from: error) as NSError
+    }
+
+    private func assertCode(
+        _ error: Error,
+        _ expected: NSFileProviderError.Code,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let mapped = nsError(from: error)
+        XCTAssertEqual(mapped.domain, NSFileProviderErrorDomain, file: file, line: line)
+        XCTAssertEqual(mapped.code, expected.rawValue, file: file, line: line)
+    }
+
+    func test_whenEnrichedApiUnauthorized_thenNotAuthenticated() {
+        assertCode(enriched(.apiUnauthorized), .notAuthenticated)
+    }
+
+    func test_whenApiClientError401_thenNotAuthenticated() {
+        assertCode(apiError(statusCode: 401), .notAuthenticated)
+    }
+
+    func test_whenEnrichedCauseIsUnauthorized_thenNotAuthenticated() {
+        let nested = enriched(.downloadInfoFailed, cause: apiError(statusCode: 401))
+        assertCode(nested, .notAuthenticated)
+    }
+
+    func test_whenDeeplyNestedCauseIsUnauthorized_thenNotAuthenticated() {
+        let leaf = enriched(.apiUnauthorized)
+        let middle = enriched(.downloadMirrorsFailed, cause: leaf)
+        let root = enriched(.downloadFailed, cause: middle)
+        assertCode(root, .notAuthenticated)
+    }
+
+    func test_whenEnrichedNetworkCodes_thenServerUnreachable() {
+        let offlineCodes: [ErrorCode] = [
+            .networkNoConnection,
+            .networkConnectionLost,
+            .networkTimeout,
+            .networkCannotConnect
+        ]
+        for code in offlineCodes {
+            assertCode(enriched(code), .serverUnreachable)
+        }
+    }
+
+    func test_whenApiClientErrorStatusCodeZeroOrNegative_thenServerUnreachable() {
+        for statusCode in [0, -1, -2] {
+            assertCode(apiError(statusCode: statusCode), .serverUnreachable)
+        }
+    }
+
+    func test_whenURLErrorOfflineCodes_thenServerUnreachable() {
+        let offlineURLCodes: [URLError.Code] = [
+            .notConnectedToInternet,
+            .networkConnectionLost,
+            .timedOut,
+            .cannotConnectToHost,
+            .dataNotAllowed,
+            .cannotFindHost
+        ]
+        for code in offlineURLCodes {
+            assertCode(URLError(code), .serverUnreachable)
+        }
+    }
+
+    func test_whenEnrichedCauseIsOfflineURLError_thenServerUnreachable() {
+        let nested = enriched(.downloadInfoFailed, cause: URLError(.notConnectedToInternet))
+        assertCode(nested, .serverUnreachable)
+    }
+
+    func test_whenUnknownEnrichedCodeWithoutCause_thenNoSuchItem() {
+        assertCode(enriched(.apiNotFound), .noSuchItem)
+    }
+
+    func test_whenApiClientErrorNonAuthPositiveStatus_thenNoSuchItem() {
+        assertCode(apiError(statusCode: 500), .noSuchItem)
+    }
+
+    func test_whenUnrelatedError_thenNoSuchItem() {
+        assertCode(URLError(.badURL), .noSuchItem)
+    }
+}

--- a/ios/InternxtFileProviderTests/FileProviderMutationTests.swift
+++ b/ios/InternxtFileProviderTests/FileProviderMutationTests.swift
@@ -1,0 +1,147 @@
+//
+//  FileProviderMutationTests.swift
+//  InternxtFileProviderTests
+//
+
+import XCTest
+import FileProvider
+import InternxtSwiftCore
+
+private final class StubItem: NSObject, NSFileProviderItem {
+    let itemIdentifier: NSFileProviderItemIdentifier
+    let parentItemIdentifier: NSFileProviderItemIdentifier
+    let filename: String
+
+    init(
+        identifier: NSFileProviderItemIdentifier,
+        parent: NSFileProviderItemIdentifier,
+        filename: String
+    ) {
+        self.itemIdentifier = identifier
+        self.parentItemIdentifier = parent
+        self.filename = filename
+    }
+}
+
+final class FileProviderMutationTests: XCTestCase {
+
+    private let fileIdentifier = FileProviderItemID.encode(.file, uuid: "file-uuid")
+    private let folderIdentifier = FileProviderItemID.encode(.folder, uuid: "folder-uuid")
+    private let destinationIdentifier = FileProviderItemID.encode(.folder, uuid: "destination-uuid")
+
+    private func decodedFile() -> (kind: DriveItemKind, uuid: String) {
+        (kind: .file, uuid: "file-uuid")
+    }
+
+    private func decodedFolder() -> (kind: DriveItemKind, uuid: String) {
+        (kind: .folder, uuid: "folder-uuid")
+    }
+
+    private func apiError(statusCode: Int) -> APIClientError {
+        APIClientError(statusCode: statusCode, message: "test")
+    }
+
+    private func mappedCode(from error: Error) -> Int {
+        (FileProviderErrorMapper.lookupError(from: error) as NSError).code
+    }
+
+    func testWhenItemIsFileThenCapabilitiesAllowReparentingAndDeletingButNotTrashing() {
+        let source = StubItem(identifier: fileIdentifier, parent: .rootContainer, filename: "report.pdf")
+
+        let item = FileProviderItem.renamed(from: source, newFilename: "report.pdf")
+
+        let capabilities = item?.capabilities ?? []
+        XCTAssertTrue(capabilities.contains(.allowsReparenting))
+        XCTAssertTrue(capabilities.contains(.allowsDeleting))
+        XCTAssertFalse(capabilities.contains(.allowsTrashing))
+    }
+
+    func testWhenItemIsFolderThenCapabilitiesAllowReparentingAndDeletingButNotTrashing() {
+        let source = StubItem(identifier: folderIdentifier, parent: .rootContainer, filename: "Docs")
+
+        let item = FileProviderItem.renamed(from: source, newFilename: "Docs")
+
+        let capabilities = item?.capabilities ?? []
+        XCTAssertTrue(capabilities.contains(.allowsReparenting))
+        XCTAssertTrue(capabilities.contains(.allowsDeleting))
+        XCTAssertFalse(capabilities.contains(.allowsTrashing))
+    }
+
+    func testWhenRenamingAFileThenItKeepsTheBaseNameWithoutExtension() {
+        let source = StubItem(identifier: fileIdentifier, parent: .rootContainer, filename: "old.pdf")
+
+        let item = FileProviderItem.renamed(from: source, newFilename: "renamed.pdf")
+
+        XCTAssertEqual(item?.filename, "renamed.pdf")
+    }
+
+    func testWhenRenamingAFileThenSplitProducesTheBaseNameOnly() {
+        let split = FileProviderItem.splitNameExtension("renamed.pdf", kind: .file)
+
+        XCTAssertEqual(split.base, "renamed")
+    }
+
+    func testWhenRenamingAFolderThenItUsesTheFullName() {
+        let split = FileProviderItem.splitNameExtension("My Folder", kind: .folder)
+
+        XCTAssertEqual(split.base, "My Folder")
+    }
+
+    func testWhenAMoveSucceedsThenTheReturnedItemKeepsItsIdentifierAndDestinationParent() {
+        let moved = StubItem(identifier: fileIdentifier, parent: destinationIdentifier, filename: "report.pdf")
+
+        let item = FileProviderItem.renamed(from: moved, newFilename: "report.pdf")
+
+        XCTAssertEqual(item?.itemIdentifier, fileIdentifier)
+        XCTAssertEqual(item?.parentItemIdentifier, destinationIdentifier)
+    }
+
+    func testWhenTheDestinationParentIdentifierIsInvalidThenFolderUuidIsNil() {
+        let invalidParent = NSFileProviderItemIdentifier("not-a-valid-id")
+
+        let resolved = FileProviderItemID.folderUuid(for: invalidParent)
+
+        XCTAssertNil(resolved)
+    }
+
+    func testWhenDeletingAFileThenTrashItemsUseTheFileType() {
+        let items = FileProviderMutationService.trashItems(for: decodedFile())
+
+        XCTAssertEqual(items.first?.type, ItemToTrashType.File.rawValue)
+    }
+
+    func testWhenDeletingAFolderThenTrashItemsUseTheFolderType() {
+        let items = FileProviderMutationService.trashItems(for: decodedFolder())
+
+        XCTAssertEqual(items.first?.type, ItemToTrashType.Folder.rawValue)
+    }
+
+    func testWhenDeletingAnItemThenTrashItemCarriesItsUuid() {
+        let items = FileProviderMutationService.trashItems(for: decodedFile())
+
+        XCTAssertEqual(items.first?.uuid, "file-uuid")
+    }
+
+    func testWhenTheMoveApiThrowsA409ConflictThenFilenameCollision() {
+        let code = mappedCode(from: apiError(statusCode: 409))
+
+        XCTAssertEqual(code, NSFileProviderError.Code.filenameCollision.rawValue)
+    }
+
+    func testWhenTheTrashBackendReturnsFalseThenTheOutcomeThrows() {
+        XCTAssertThrowsError(try FileProviderMutationService.validateTrashOutcome(false))
+    }
+
+    func testWhenTheTrashBackendReturnsFalseThenTheErrorMapsToServerUnreachable() {
+        do {
+            try FileProviderMutationService.validateTrashOutcome(false)
+            XCTFail("expected validateTrashOutcome to throw on false")
+        } catch {
+            XCTAssertEqual(mappedCode(from: error), NSFileProviderError.Code.serverUnreachable.rawValue)
+        }
+    }
+
+    func testWhenTheTrashBackendReturnsTrueThenTheOutcomeDoesNotThrow() {
+        XCTAssertNoThrow(try FileProviderMutationService.validateTrashOutcome(true))
+    }
+}

--- a/ios/InternxtFileProviderTests/SyncAnchorStoreTests.swift
+++ b/ios/InternxtFileProviderTests/SyncAnchorStoreTests.swift
@@ -22,7 +22,7 @@ final class SyncAnchorStoreTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_whenChangeRecorded_thenCurrentValueAdvancesByOne() {
+    func testWhenChangeRecordedThenCurrentValueAdvancesByOne() {
         let store = SyncAnchorStore(directory: directory)
         let before = store.currentValue
 
@@ -31,7 +31,7 @@ final class SyncAnchorStoreTests: XCTestCase {
         XCTAssertEqual(store.currentValue, before + 1)
     }
 
-    func test_whenChangeRecorded_thenCurrentDataDiffersFromBefore() {
+    func testWhenChangeRecordedThenCurrentDataDiffersFromBefore() {
         let store = SyncAnchorStore(directory: directory)
         let before = store.currentData
 
@@ -40,7 +40,7 @@ final class SyncAnchorStoreTests: XCTestCase {
         XCTAssertNotEqual(store.currentData, before)
     }
 
-    func test_whenReadFromSeparateInstance_thenSeesPersistedChange() {
+    func testWhenReadFromSeparateInstanceThenSeesPersistedChange() {
         SyncAnchorStore(directory: directory).recordChange(parentUuid: "parent-a")
 
         let reader = SyncAnchorStore(directory: directory)
@@ -48,7 +48,7 @@ final class SyncAnchorStoreTests: XCTestCase {
         XCTAssertEqual(reader.currentValue, 1)
     }
 
-    func test_whenChangeRecorded_thenChangedParentsAfterPreviousAnchorIncludesIt() {
+    func testWhenChangeRecordedThenChangedParentsAfterPreviousAnchorIncludesIt() {
         let store = SyncAnchorStore(directory: directory)
         let before = store.currentValue
 
@@ -57,14 +57,14 @@ final class SyncAnchorStoreTests: XCTestCase {
         XCTAssertEqual(store.changedParents(after: before), ["parent-a"])
     }
 
-    func test_whenAnchorIsAtRecordedValue_thenChangedParentsExcludesIt() {
+    func testWhenAnchorIsAtRecordedValueThenChangedParentsExcludesIt() {
         let store = SyncAnchorStore(directory: directory)
         let recordedAt = store.recordChange(parentUuid: "parent-a")
 
         XCTAssertEqual(store.changedParents(after: recordedAt), [])
     }
 
-    func test_whenMultipleParentsRecorded_thenChangedParentsReturnsOnlyNewerOnesInOrder() {
+    func testWhenMultipleParentsRecordedThenChangedParentsReturnsOnlyNewerOnesInOrder() {
         let store = SyncAnchorStore(directory: directory)
         let afterFirst = store.recordChange(parentUuid: "parent-a")
         store.recordChange(parentUuid: "parent-b")
@@ -73,7 +73,7 @@ final class SyncAnchorStoreTests: XCTestCase {
         XCTAssertEqual(store.changedParents(after: afterFirst), ["parent-b", "parent-c"])
     }
 
-    func test_whenSameParentRecordedTwice_thenItUsesTheLatestAnchorValue() {
+    func testWhenSameParentRecordedTwiceThenItUsesTheLatestAnchorValue() {
         let store = SyncAnchorStore(directory: directory)
         store.recordChange(parentUuid: "parent-a")
         let afterSecond = store.recordChange(parentUuid: "parent-b")
@@ -82,13 +82,13 @@ final class SyncAnchorStoreTests: XCTestCase {
         XCTAssertEqual(store.changedParents(after: afterSecond), ["parent-a"])
     }
 
-    func test_whenNoSnapshotSaved_thenSnapshotIsEmpty() {
+    func testWhenNoSnapshotSavedThenSnapshotIsEmpty() {
         let store = SyncAnchorStore(directory: directory)
 
         XCTAssertEqual(store.snapshot(forFolderUuid: "folder-a"), [])
     }
 
-    func test_whenSnapshotSaved_thenSnapshotRoundTrips() {
+    func testWhenSnapshotSavedThenSnapshotRoundTrips() {
         let store = SyncAnchorStore(directory: directory)
 
         store.saveSnapshot(["d:file-1", "f:folder-1"], forFolderUuid: "folder-a")
@@ -96,7 +96,7 @@ final class SyncAnchorStoreTests: XCTestCase {
         XCTAssertEqual(store.snapshot(forFolderUuid: "folder-a"), ["d:file-1", "f:folder-1"])
     }
 
-    func test_whenSnapshotSavedFromSeparateInstance_thenItIsPersisted() {
+    func testWhenSnapshotSavedFromSeparateInstanceThenItIsPersisted() {
         SyncAnchorStore(directory: directory).saveSnapshot(["d:file-1"], forFolderUuid: "folder-a")
 
         let reader = SyncAnchorStore(directory: directory)
@@ -104,7 +104,7 @@ final class SyncAnchorStoreTests: XCTestCase {
         XCTAssertEqual(reader.snapshot(forFolderUuid: "folder-a"), ["d:file-1"])
     }
 
-    func test_whenSnapshotSavedForDifferentFolders_thenTheyAreIndependent() {
+    func testWhenSnapshotSavedForDifferentFoldersThenTheyAreIndependent() {
         let store = SyncAnchorStore(directory: directory)
 
         store.saveSnapshot(["d:file-1"], forFolderUuid: "folder-a")
@@ -114,7 +114,7 @@ final class SyncAnchorStoreTests: XCTestCase {
         XCTAssertEqual(store.snapshot(forFolderUuid: "folder-b"), ["d:file-2"])
     }
 
-    func test_whenSnapshotSavedAgain_thenItReplacesThePrevious() {
+    func testWhenSnapshotSavedAgainThenItReplacesThePrevious() {
         let store = SyncAnchorStore(directory: directory)
         store.saveSnapshot(["d:file-1", "d:file-2"], forFolderUuid: "folder-a")
 
@@ -123,7 +123,7 @@ final class SyncAnchorStoreTests: XCTestCase {
         XCTAssertEqual(store.snapshot(forFolderUuid: "folder-a"), ["d:file-2"])
     }
 
-    func test_whenEncodingThenDecoding_thenRoundTripIsStable() {
+    func testWhenEncodingThenDecodingThenRoundTripIsStable() {
         let value: UInt64 = 42
 
         let decoded = SyncAnchorStore.decode(SyncAnchorStore.encode(value))
@@ -131,7 +131,7 @@ final class SyncAnchorStoreTests: XCTestCase {
         XCTAssertEqual(decoded, value)
     }
 
-    func test_whenDataLengthIsWrong_thenDecodeReturnsNil() {
+    func testWhenDataLengthIsWrongThenDecodeReturnsNil() {
         let malformed = Data([0x01, 0x02])
 
         let decoded = SyncAnchorStore.decode(malformed)

--- a/ios/InternxtFileProviderTests/SyncAnchorStoreTests.swift
+++ b/ios/InternxtFileProviderTests/SyncAnchorStoreTests.swift
@@ -1,0 +1,141 @@
+//
+//  SyncAnchorStoreTests.swift
+//  InternxtFileProviderTests
+//
+
+import XCTest
+
+final class SyncAnchorStoreTests: XCTestCase {
+
+    private var directory: URL!
+
+    override func setUp() {
+        super.setUp()
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SyncAnchorStoreTests.\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: directory)
+        directory = nil
+        super.tearDown()
+    }
+
+    func test_whenChangeRecorded_thenCurrentValueAdvancesByOne() {
+        let store = SyncAnchorStore(directory: directory)
+        let before = store.currentValue
+
+        store.recordChange(parentUuid: "parent-a")
+
+        XCTAssertEqual(store.currentValue, before + 1)
+    }
+
+    func test_whenChangeRecorded_thenCurrentDataDiffersFromBefore() {
+        let store = SyncAnchorStore(directory: directory)
+        let before = store.currentData
+
+        store.recordChange(parentUuid: "parent-a")
+
+        XCTAssertNotEqual(store.currentData, before)
+    }
+
+    func test_whenReadFromSeparateInstance_thenSeesPersistedChange() {
+        SyncAnchorStore(directory: directory).recordChange(parentUuid: "parent-a")
+
+        let reader = SyncAnchorStore(directory: directory)
+
+        XCTAssertEqual(reader.currentValue, 1)
+    }
+
+    func test_whenChangeRecorded_thenChangedParentsAfterPreviousAnchorIncludesIt() {
+        let store = SyncAnchorStore(directory: directory)
+        let before = store.currentValue
+
+        store.recordChange(parentUuid: "parent-a")
+
+        XCTAssertEqual(store.changedParents(after: before), ["parent-a"])
+    }
+
+    func test_whenAnchorIsAtRecordedValue_thenChangedParentsExcludesIt() {
+        let store = SyncAnchorStore(directory: directory)
+        let recordedAt = store.recordChange(parentUuid: "parent-a")
+
+        XCTAssertEqual(store.changedParents(after: recordedAt), [])
+    }
+
+    func test_whenMultipleParentsRecorded_thenChangedParentsReturnsOnlyNewerOnesInOrder() {
+        let store = SyncAnchorStore(directory: directory)
+        let afterFirst = store.recordChange(parentUuid: "parent-a")
+        store.recordChange(parentUuid: "parent-b")
+        store.recordChange(parentUuid: "parent-c")
+
+        XCTAssertEqual(store.changedParents(after: afterFirst), ["parent-b", "parent-c"])
+    }
+
+    func test_whenSameParentRecordedTwice_thenItUsesTheLatestAnchorValue() {
+        let store = SyncAnchorStore(directory: directory)
+        store.recordChange(parentUuid: "parent-a")
+        let afterSecond = store.recordChange(parentUuid: "parent-b")
+        store.recordChange(parentUuid: "parent-a")
+
+        XCTAssertEqual(store.changedParents(after: afterSecond), ["parent-a"])
+    }
+
+    func test_whenNoSnapshotSaved_thenSnapshotIsEmpty() {
+        let store = SyncAnchorStore(directory: directory)
+
+        XCTAssertEqual(store.snapshot(forFolderUuid: "folder-a"), [])
+    }
+
+    func test_whenSnapshotSaved_thenSnapshotRoundTrips() {
+        let store = SyncAnchorStore(directory: directory)
+
+        store.saveSnapshot(["d:file-1", "f:folder-1"], forFolderUuid: "folder-a")
+
+        XCTAssertEqual(store.snapshot(forFolderUuid: "folder-a"), ["d:file-1", "f:folder-1"])
+    }
+
+    func test_whenSnapshotSavedFromSeparateInstance_thenItIsPersisted() {
+        SyncAnchorStore(directory: directory).saveSnapshot(["d:file-1"], forFolderUuid: "folder-a")
+
+        let reader = SyncAnchorStore(directory: directory)
+
+        XCTAssertEqual(reader.snapshot(forFolderUuid: "folder-a"), ["d:file-1"])
+    }
+
+    func test_whenSnapshotSavedForDifferentFolders_thenTheyAreIndependent() {
+        let store = SyncAnchorStore(directory: directory)
+
+        store.saveSnapshot(["d:file-1"], forFolderUuid: "folder-a")
+        store.saveSnapshot(["d:file-2"], forFolderUuid: "folder-b")
+
+        XCTAssertEqual(store.snapshot(forFolderUuid: "folder-a"), ["d:file-1"])
+        XCTAssertEqual(store.snapshot(forFolderUuid: "folder-b"), ["d:file-2"])
+    }
+
+    func test_whenSnapshotSavedAgain_thenItReplacesThePrevious() {
+        let store = SyncAnchorStore(directory: directory)
+        store.saveSnapshot(["d:file-1", "d:file-2"], forFolderUuid: "folder-a")
+
+        store.saveSnapshot(["d:file-2"], forFolderUuid: "folder-a")
+
+        XCTAssertEqual(store.snapshot(forFolderUuid: "folder-a"), ["d:file-2"])
+    }
+
+    func test_whenEncodingThenDecoding_thenRoundTripIsStable() {
+        let value: UInt64 = 42
+
+        let decoded = SyncAnchorStore.decode(SyncAnchorStore.encode(value))
+
+        XCTAssertEqual(decoded, value)
+    }
+
+    func test_whenDataLengthIsWrong_thenDecodeReturnsNil() {
+        let malformed = Data([0x01, 0x02])
+
+        let decoded = SyncAnchorStore.decode(malformed)
+
+        XCTAssertNil(decoded)
+    }
+}

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -94,6 +94,10 @@ target 'Internxt' do
   end
 end
 
+target 'InternxtFileProvider' do
+  # No use_expo_modules! — InternxtSwiftCore comes via SPM
+end
+
 target 'InternxtShareExtension' do     
   exclude = ["expo-updates", "expo-splash-screen", "expo-dev-client", "react-native-reanimated", "react-native-screens", "react-native-safe-area-context", "react-native-gesture-handler", "react-native-video", "react-native-webview", "react-native-fast-image", "react-native-svg", "@shopify/flash-list", "react-native-pdf", "jail-monkey"]
   use_expo_modules!(exclude: exclude)

--- a/src/components/modals/AddModal/index.tsx
+++ b/src/components/modals/AddModal/index.tsx
@@ -55,7 +55,7 @@ import { isValidFilename } from '../../../helpers';
 import useGetColor from '../../../hooks/useColor';
 import network from '../../../network';
 import analytics, { DriveAnalyticsEvent } from '../../../services/AnalyticsService';
-import { constants } from '../../../services/AppService';
+import appService, { constants } from '../../../services/AppService';
 import { uploadQueueService } from '../../../services/drive/file/uploadQueue.service';
 import {
   createUploadingFiles,
@@ -151,6 +151,17 @@ function AddModal(): JSX.Element {
         Alert.alert('Can not upload files. Grant permissions to upload files');
         throw new Error('Storage permissions not granted');
       }
+    }
+
+    // Android 13+ requires runtime permission for POST_NOTIFICATIONS.
+    // Fire-and-forget: a denial only hides the progress UI, the upload itself still runs.
+    if (appService.isAndroidApiAtLeast(33)) {
+      await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS, {
+        title: 'Notifications Permission',
+        message: 'Internxt needs to show notifications to display upload progress',
+        buttonNegative: strings.buttons.cancel,
+        buttonPositive: strings.buttons.grant,
+      });
     }
 
     const createdFileEntry = await uploadAndCreateFileEntry(

--- a/src/components/modals/AddModal/index.tsx
+++ b/src/components/modals/AddModal/index.tsx
@@ -58,6 +58,7 @@ import analytics, { DriveAnalyticsEvent } from '../../../services/AnalyticsServi
 import appService, { constants } from '../../../services/AppService';
 import { uploadQueueService } from '../../../services/drive/file/uploadQueue.service';
 import {
+  copyFileFromEncodedUri,
   createUploadingFiles,
   handleDuplicateFiles,
   initializeUploads,
@@ -137,7 +138,7 @@ function AddModal(): JSX.Element {
     const fileExtension = fileToUpload.type;
     const destPath = fileSystemService.tmpFilePath(name);
 
-    await fileSystemService.copyFile(fileToUpload.uri, destPath);
+    await copyFileFromEncodedUri(fileToUpload.uri, destPath);
 
     if (fileType === 'document') {
       const granted = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.READ_EXTERNAL_STORAGE, {
@@ -286,7 +287,7 @@ function AddModal(): JSX.Element {
     // If thumbnail generation fails, don't block the upload, we can
     // try thumbnail generation later
     try {
-      const generatedThumbnail = await imageService.generateThumbnail(filePath.replace(/ /g, '%20'), {
+      const generatedThumbnail = await imageService.generateThumbnail(filePath, {
         extension: fileExtension,
         thumbnailFormat: SaveFormat.JPEG,
         // Android needs an extension to generate the thumbnails, otherwise it crashes

--- a/src/components/modals/DriveItemInfoModal/index.tsx
+++ b/src/components/modals/DriveItemInfoModal/index.tsx
@@ -12,6 +12,7 @@ import { logger } from '@internxt-mobile/services/common';
 import { time } from '@internxt-mobile/services/common/time';
 import drive from '@internxt-mobile/services/drive';
 import { driveLocalDB } from '@internxt-mobile/services/drive/database';
+import { notifyParentChanged } from '@internxt-mobile/services/native/InternxtSignalingModule';
 import { Abortable } from '@internxt-mobile/types/index';
 import * as driveUseCases from '@internxt-mobile/useCases/drive';
 import {
@@ -108,6 +109,13 @@ function DriveItemInfoModal(): JSX.Element {
 
       () => handleUndoMoveToTrash(),
     );
+
+    if (success) {
+      const parentFolderUuid = isFolder ? item.parentUuid : item.folderUuid;
+      if (parentFolderUuid) {
+        void notifyParentChanged(parentFolderUuid);
+      }
+    }
 
     if (success && dbItem?.id) {
       await driveLocalDB.deleteItem({ id: dbItem.id });

--- a/src/components/modals/DriveRenameModal/index.tsx
+++ b/src/components/modals/DriveRenameModal/index.tsx
@@ -11,6 +11,7 @@ import strings from '../../../../assets/lang/strings';
 import useGetColor from '../../../hooks/useColor';
 import { logger } from '../../../services/common';
 import errorService from '../../../services/ErrorService';
+import { notifyParentChanged } from '../../../services/native/InternxtSignalingModule';
 import notificationsService from '../../../services/NotificationsService';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import { driveActions } from '../../../store/slices/drive';
@@ -62,6 +63,8 @@ function RenameModal(): JSX.Element {
       } else if (focusedItem.uuid) {
         await drive.file.updateMetaData(focusedItem.uuid, trimmedNewName);
       }
+
+      void notifyParentChanged(driveCtx.focusedFolder.uuid);
 
       notificationsService.show({
         text1: strings.messages.renamedSuccessfully,

--- a/src/services/AppService.ts
+++ b/src/services/AppService.ts
@@ -69,6 +69,10 @@ class AppService {
   public get isIOS() {
     return Platform.OS === 'ios';
   }
+
+  public isAndroidApiAtLeast(api: number): boolean {
+    return this.isAndroid && (Platform.Version as number) >= api;
+  }
 }
 
 const appService = new AppService();

--- a/src/services/common/media/thumbnail.generation.ts
+++ b/src/services/common/media/thumbnail.generation.ts
@@ -4,7 +4,7 @@ import { Platform } from 'react-native';
 import { createThumbnail } from 'react-native-create-thumbnail';
 import PdfThumbnail from 'react-native-pdf-thumbnail';
 
-import { stripFileUri, toFileUri } from '../uri/uriHelpers';
+import { fromFileUri, toFileUri } from '../uri/uriHelpers';
 import {
   IMAGE_THUMBNAIL_EXTENSIONS,
   PDF_THUMBNAIL_QUALITY,
@@ -14,15 +14,6 @@ import {
   VIDEO_THUMBNAIL_EXTENSIONS,
 } from './thumbnail.constants';
 import type { GeneratedThumbnail } from './thumbnail.types';
-
-const fromFileUri = (uri: string): string => {
-  const withoutScheme = uri.replace('file://', '');
-  try {
-    return decodeURIComponent(withoutScheme);
-  } catch {
-    return withoutScheme;
-  }
-};
 
 const statSize = async (path: string): Promise<number> => Number((await RNFS.stat(path)).size);
 

--- a/src/services/common/media/thumbnail.generation.ts
+++ b/src/services/common/media/thumbnail.generation.ts
@@ -15,6 +15,15 @@ import {
 } from './thumbnail.constants';
 import type { GeneratedThumbnail } from './thumbnail.types';
 
+const fromFileUri = (uri: string): string => {
+  const withoutScheme = uri.replace('file://', '');
+  try {
+    return decodeURIComponent(withoutScheme);
+  } catch {
+    return withoutScheme;
+  }
+};
+
 const statSize = async (path: string): Promise<number> => Number((await RNFS.stat(path)).size);
 
 const generateImageThumbnailAndroid = async (sourcePath: string): Promise<GeneratedThumbnail> => {
@@ -24,7 +33,7 @@ const generateImageThumbnailAndroid = async (sourcePath: string): Promise<Genera
   const result = await imageRef.saveAsync({ format: SaveFormat.JPEG, compress: THUMBNAIL_JPEG_COMPRESS });
   imageRef.release();
   imageManipulatorContext.release();
-  const path = stripFileUri(result.uri);
+  const path = fromFileUri(result.uri);
   return { path, width: result.width, height: result.height, size: await statSize(path), type: 'JPEG' };
 };
 
@@ -35,7 +44,7 @@ const generateMediaThumbnail = async (sourcePath: string): Promise<GeneratedThum
     maxWidth: THUMBNAIL_MAX_WIDTH,
     maxHeight: THUMBNAIL_MAX_WIDTH,
   });
-  const path = stripFileUri(result.path);
+  const path = fromFileUri(result.path);
   return { path, width: result.width, height: result.height, size: await statSize(path), type: 'JPEG' };
 };
 
@@ -50,7 +59,7 @@ export const generateVideoThumbnail = (sourcePath: string): Promise<GeneratedThu
 
 export const generatePdfThumbnail = async (sourcePath: string): Promise<GeneratedThumbnail> => {
   const result = await PdfThumbnail.generate(toFileUri(sourcePath), 0, PDF_THUMBNAIL_QUALITY);
-  const path = stripFileUri(result.uri);
+  const path = fromFileUri(result.uri);
   return { path, width: result.width, height: result.height, size: await statSize(path), type: 'JPEG' };
 };
 

--- a/src/services/common/uri/uriHelpers.spec.ts
+++ b/src/services/common/uri/uriHelpers.spec.ts
@@ -1,4 +1,46 @@
-import { decodeUriSafely, fromFileUri } from './uriHelpers';
+import { decodeUriSafely, fromFileUri, toFileUri } from './uriHelpers';
+
+describe('toFileUri', () => {
+  test('when the file name contains a literal percent sign, then it returns a usable uri instead of failing', () => {
+    const pathWithLiteralPercent = '/cache/Nómina 100% final.pdf';
+
+    const result = toFileUri(pathWithLiteralPercent);
+
+    expect(result).toBe('file:///cache/N%C3%B3mina%20100%25%20final.pdf');
+  });
+
+  test('when the path is already percent-encoded, then it returns the same uri without encoding it twice', () => {
+    const encodedPath = '/cache/N%C3%B3mina%2026_04.pdf';
+
+    const result = toFileUri(encodedPath);
+
+    expect(result).toBe('file:///cache/N%C3%B3mina%2026_04.pdf');
+  });
+
+  test('when the path has accents and spaces, then it returns the encoded uri', () => {
+    const pathWithAccents = '/cache/Nómina 26_04.pdf';
+
+    const result = toFileUri(pathWithAccents);
+
+    expect(result).toBe('file:///cache/N%C3%B3mina%2026_04.pdf');
+  });
+
+  test('when the path has no characters to encode, then it returns the path with the scheme', () => {
+    const plainPath = '/cache/plain.pdf';
+
+    const result = toFileUri(plainPath);
+
+    expect(result).toBe('file:///cache/plain.pdf');
+  });
+
+  test('when the path already has the scheme, then it returns it unchanged', () => {
+    const fileUri = 'file:///cache/already.pdf';
+
+    const result = toFileUri(fileUri);
+
+    expect(result).toBe(fileUri);
+  });
+});
 
 describe('fromFileUri', () => {
   test('when the uri is percent-encoded with accents and spaces, then it returns the decoded path without the scheme', () => {

--- a/src/services/common/uri/uriHelpers.spec.ts
+++ b/src/services/common/uri/uriHelpers.spec.ts
@@ -1,0 +1,53 @@
+import { decodeUriSafely, fromFileUri } from './uriHelpers';
+
+describe('fromFileUri', () => {
+  test('when the uri is percent-encoded with accents and spaces, then it returns the decoded path without the scheme', () => {
+    const encodedUri = 'file:///cache/abc/N%C3%B3mina%2026_04.pdf';
+
+    const result = fromFileUri(encodedUri);
+
+    expect(result).toBe('/cache/abc/Nómina 26_04.pdf');
+  });
+
+  test('when the uri has no scheme, then it returns the decoded path unchanged', () => {
+    const plainPath = '/cache/abc/invoice.pdf';
+
+    const result = fromFileUri(plainPath);
+
+    expect(result).toBe(plainPath);
+  });
+
+  test('when the uri has a malformed percent sequence, then it returns the undecoded path without the scheme', () => {
+    const malformedUri = 'file:///cache/100%discount.pdf';
+
+    const result = fromFileUri(malformedUri);
+
+    expect(result).toBe('/cache/100%discount.pdf');
+  });
+
+  test('when the path contains the scheme beyond the start, then only the leading scheme is removed', () => {
+    const nestedUri = 'file:///cache/file:///nested.pdf';
+
+    const result = fromFileUri(nestedUri);
+
+    expect(result).toBe('/cache/file:///nested.pdf');
+  });
+});
+
+describe('decodeUriSafely', () => {
+  test('when the uri is percent-encoded, then it returns the decoded value keeping the scheme', () => {
+    const encodedUri = 'file:///cache/abc/N%C3%B3mina%2026_04.pdf';
+
+    const result = decodeUriSafely(encodedUri);
+
+    expect(result).toBe('file:///cache/abc/Nómina 26_04.pdf');
+  });
+
+  test('when the uri has a malformed percent sequence, then it returns the original value', () => {
+    const malformedUri = 'file:///cache/abc/100%discount.pdf';
+
+    const result = decodeUriSafely(malformedUri);
+
+    expect(result).toBe(malformedUri);
+  });
+});

--- a/src/services/common/uri/uriHelpers.ts
+++ b/src/services/common/uri/uriHelpers.ts
@@ -3,7 +3,7 @@ export const FILE_URI_PREFIX = 'file://';
 export const toFileUri = (path: string): string => {
   if (path.startsWith(FILE_URI_PREFIX)) return path;
   const absolutePath = path.startsWith('/') ? path : `/${path}`;
-  return `${FILE_URI_PREFIX}${encodeURI(decodeURIComponent(absolutePath))}`;
+  return `${FILE_URI_PREFIX}${encodeURI(decodeUriSafely(absolutePath))}`;
 };
 
 export const decodeUriSafely = (uri: string): string => {

--- a/src/services/common/uri/uriHelpers.ts
+++ b/src/services/common/uri/uriHelpers.ts
@@ -6,5 +6,13 @@ export const toFileUri = (path: string): string => {
   return `${FILE_URI_PREFIX}${encodeURI(decodeURIComponent(absolutePath))}`;
 };
 
-export const stripFileUri = (path: string): string =>
-  path.startsWith(FILE_URI_PREFIX) ? decodeURIComponent(path.slice(FILE_URI_PREFIX.length)) : path;
+export const decodeUriSafely = (uri: string): string => {
+  try {
+    return decodeURIComponent(uri);
+  } catch {
+    return uri;
+  }
+};
+
+export const fromFileUri = (uri: string): string =>
+  decodeUriSafely(uri.startsWith(FILE_URI_PREFIX) ? uri.slice(FILE_URI_PREFIX.length) : uri);

--- a/src/services/drive/file/driveFile.service.ts
+++ b/src/services/drive/file/driveFile.service.ts
@@ -16,6 +16,7 @@ import uuid from 'react-native-uuid';
 import { getEnvironmentConfigFromUser } from 'src/lib/network';
 import * as networkDownload from 'src/network/download';
 import network from '../../../network';
+import { notifyParentChanged } from '../../native/InternxtSignalingModule';
 import { uploadService } from '../../common/network/upload/upload.service';
 import { DRIVE_THUMBNAILS_DIRECTORY } from '../constants';
 import { driveFileCache } from './driveFileCache.service';
@@ -107,7 +108,9 @@ class DriveFileService {
     fileUuid: string;
     destinationFolderUuid: string;
   }): Promise<FileMeta> {
-    return this.sdk.storageV2.moveFileByUuid(fileUuid, { destinationFolder: destinationFolderUuid });
+    const moved = await this.sdk.storageV2.moveFileByUuid(fileUuid, { destinationFolder: destinationFolderUuid });
+    void notifyParentChanged(destinationFolderUuid);
+    return moved;
   }
 
   public getSortFunction({

--- a/src/services/drive/file/utils/uploadFileUtils.copyFile.spec.ts
+++ b/src/services/drive/file/utils/uploadFileUtils.copyFile.spec.ts
@@ -1,0 +1,51 @@
+const mockCopyFile = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('@internxt-mobile/services/FileSystemService', () => ({
+  __esModule: true,
+  default: { copyFile: (...args: unknown[]) => mockCopyFile(...args) },
+}));
+
+jest.mock('./checkDuplicatedFiles', () => ({ checkDuplicatedFiles: jest.fn() }));
+jest.mock('./prepareFilesToUpload', () => ({ prepareFilesToUpload: jest.fn() }));
+jest.mock('../../../common/network/upload/upload.service', () => ({
+  uploadService: { createFileEntry: jest.fn(), uploadFile: jest.fn() },
+}));
+jest.mock('../../../native/InternxtSignalingModule', () => ({ notifyParentChanged: jest.fn() }));
+jest.mock('../../../../store/slices/drive', () => ({ driveActions: {} }));
+jest.mock('../../../ErrorService', () => ({ __esModule: true, default: { reportError: jest.fn(), castError: jest.fn() } }));
+jest.mock('../../../AnalyticsService', () => ({ __esModule: true, default: { track: jest.fn() }, DriveAnalyticsEvent: {} }));
+jest.mock('../../../common', () => ({ logger: { error: jest.fn(), info: jest.fn() } }));
+
+import { copyFileFromEncodedUri } from './uploadFileUtils';
+
+const DEST_PATH = 'file:///tmp/internxt/upload-target';
+
+describe('copyFileFromEncodedUri', () => {
+  beforeEach(() => {
+    mockCopyFile.mockClear();
+  });
+
+  test('when the source uri is percent-encoded with accents and spaces, then it copies from the decoded path', async () => {
+    const encodedUri = 'file:///cache/abc/N%C3%B3mina%2026_04.pdf';
+
+    await copyFileFromEncodedUri(encodedUri, DEST_PATH);
+
+    expect(mockCopyFile).toHaveBeenCalledWith('file:///cache/abc/Nómina 26_04.pdf', DEST_PATH);
+  });
+
+  test('when the source uri is a plain ascii path, then it copies it unchanged', async () => {
+    const plainUri = 'file:///cache/abc/invoice.pdf';
+
+    await copyFileFromEncodedUri(plainUri, DEST_PATH);
+
+    expect(mockCopyFile).toHaveBeenCalledWith(plainUri, DEST_PATH);
+  });
+
+  test('when the source uri has a malformed percent sequence, then it falls back to the original path', async () => {
+    const malformedUri = 'file:///cache/abc/100%discount.pdf';
+
+    await copyFileFromEncodedUri(malformedUri, DEST_PATH);
+
+    expect(mockCopyFile).toHaveBeenCalledWith(malformedUri, DEST_PATH);
+  });
+});

--- a/src/services/drive/file/utils/uploadFileUtils.signaling.spec.ts
+++ b/src/services/drive/file/utils/uploadFileUtils.signaling.spec.ts
@@ -65,28 +65,22 @@ describe('uploadSingleFile — picker signaling', () => {
   });
 
   it('when a file upload succeeds, then it signals the destination folder uuid', async () => {
-    // given
     const file = buildUploadingFile({ parentUuid: 'destination-folder-uuid' });
     const uploadFile = jest.fn().mockResolvedValue(undefined);
     const uploadSuccess = jest.fn();
 
-    // when
     await uploadSingleFile(file, dispatch, uploadFile, uploadSuccess);
 
-    // then
     expect(mockNotifyParentChanged).toHaveBeenCalledWith('destination-folder-uuid');
   });
 
   it('when the file upload fails, then it does not signal the file picker', async () => {
-    // given
     const file = buildUploadingFile();
     const uploadFile = jest.fn().mockRejectedValue(new Error('network down'));
     const uploadSuccess = jest.fn();
 
-    // when
     await expect(uploadSingleFile(file, dispatch, uploadFile, uploadSuccess)).rejects.toThrow('network down');
 
-    // then
     expect(mockNotifyParentChanged).not.toHaveBeenCalled();
   });
 });

--- a/src/services/drive/file/utils/uploadFileUtils.signaling.spec.ts
+++ b/src/services/drive/file/utils/uploadFileUtils.signaling.spec.ts
@@ -1,0 +1,92 @@
+import { Action } from 'redux';
+import { Dispatch } from 'react';
+import { UploadingFile } from '../../../../types/drive/operations';
+
+const mockNotifyParentChanged = jest.fn().mockResolvedValue(undefined);
+
+// Sibling modules not exercised by `uploadSingleFile` but pulling in heavy native/network
+// chains at import time — stubbed so the unit under test loads in isolation.
+jest.mock('./checkDuplicatedFiles', () => ({ checkDuplicatedFiles: jest.fn() }));
+jest.mock('./prepareFilesToUpload', () => ({ prepareFilesToUpload: jest.fn() }));
+jest.mock('../../../common/network/upload/upload.service', () => ({
+  uploadService: { createFileEntry: jest.fn(), uploadFile: jest.fn() },
+}));
+
+jest.mock('../../../../store/slices/drive', () => ({
+  driveActions: {
+    uploadFileStart: jest.fn(),
+    uploadFileFailed: jest.fn(),
+    uploadFileFinished: jest.fn(),
+  },
+}));
+
+jest.mock('../../../native/InternxtSignalingModule', () => ({
+  notifyParentChanged: (...args: unknown[]) => mockNotifyParentChanged(...args),
+}));
+
+jest.mock('../../../ErrorService', () => ({
+  __esModule: true,
+  default: { reportError: jest.fn(), castError: (e: Error) => e },
+}));
+
+jest.mock('../../../AnalyticsService', () => ({
+  __esModule: true,
+  default: { track: jest.fn() },
+  DriveAnalyticsEvent: {},
+}));
+
+jest.mock('../../../common', () => ({
+  logger: { error: jest.fn(), info: jest.fn() },
+}));
+
+import { uploadSingleFile } from './uploadFileUtils';
+
+const buildUploadingFile = (overrides: Partial<UploadingFile> = {}): UploadingFile => ({
+  id: 1,
+  uuid: 'file-uuid',
+  uri: 'file:///tmp/file.txt',
+  name: 'file.txt',
+  type: 'txt',
+  parentId: 10,
+  parentUuid: 'destination-folder-uuid',
+  createdAt: '2024-01-01',
+  updatedAt: '2024-01-01',
+  size: 1024,
+  progress: 0,
+  uploaded: false,
+  ...overrides,
+});
+
+describe('uploadSingleFile — picker signaling', () => {
+  const dispatch = jest.fn() as unknown as Dispatch<Action>;
+
+  beforeEach(() => {
+    mockNotifyParentChanged.mockClear();
+  });
+
+  it('when a file upload succeeds, then it signals the destination folder uuid', async () => {
+    // given
+    const file = buildUploadingFile({ parentUuid: 'destination-folder-uuid' });
+    const uploadFile = jest.fn().mockResolvedValue(undefined);
+    const uploadSuccess = jest.fn();
+
+    // when
+    await uploadSingleFile(file, dispatch, uploadFile, uploadSuccess);
+
+    // then
+    expect(mockNotifyParentChanged).toHaveBeenCalledWith('destination-folder-uuid');
+  });
+
+  it('when the file upload fails, then it does not signal the file picker', async () => {
+    // given
+    const file = buildUploadingFile();
+    const uploadFile = jest.fn().mockRejectedValue(new Error('network down'));
+    const uploadSuccess = jest.fn();
+
+    // when
+    await expect(uploadSingleFile(file, dispatch, uploadFile, uploadSuccess)).rejects.toThrow('network down');
+
+    // then
+    expect(mockNotifyParentChanged).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/drive/file/utils/uploadFileUtils.signaling.spec.ts
+++ b/src/services/drive/file/utils/uploadFileUtils.signaling.spec.ts
@@ -64,7 +64,7 @@ describe('uploadSingleFile — picker signaling', () => {
     mockNotifyParentChanged.mockClear();
   });
 
-  it('when a file upload succeeds, then it signals the destination folder uuid', async () => {
+  test('when a file upload succeeds, then it signals the destination folder uuid', async () => {
     const file = buildUploadingFile({ parentUuid: 'destination-folder-uuid' });
     const uploadFile = jest.fn().mockResolvedValue(undefined);
     const uploadSuccess = jest.fn();
@@ -74,7 +74,7 @@ describe('uploadSingleFile — picker signaling', () => {
     expect(mockNotifyParentChanged).toHaveBeenCalledWith('destination-folder-uuid');
   });
 
-  it('when the file upload fails, then it does not signal the file picker', async () => {
+  test('when the file upload fails, then it does not signal the file picker', async () => {
     const file = buildUploadingFile();
     const uploadFile = jest.fn().mockRejectedValue(new Error('network down'));
     const uploadSuccess = jest.fn();

--- a/src/services/drive/file/utils/uploadFileUtils.ts
+++ b/src/services/drive/file/utils/uploadFileUtils.ts
@@ -229,7 +229,7 @@ export async function uploadSingleFile(
       await uploadFile(file, 'document');
     }
     uploadSuccess(file);
-    void notifyParentChanged(file.parentUuid).catch(() => undefined);
+    void notifyParentChanged(file.parentUuid);
   } catch (e) {
     if (e instanceof EmptyFileNotAllowedError) {
       dispatch(uiActions.setShowEmptyFileNotAllowedModal(true));

--- a/src/services/drive/file/utils/uploadFileUtils.ts
+++ b/src/services/drive/file/utils/uploadFileUtils.ts
@@ -8,6 +8,7 @@ import { prepareFilesToUpload } from './prepareFilesToUpload';
 
 import errorService from '../../../ErrorService';
 
+import fileSystemService from '@internxt-mobile/services/FileSystemService';
 import { DriveFileData, EncryptionVersion, FileEntryByUuid } from '@internxt-mobile/types/drive/file';
 import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import { Dispatch } from 'react';
@@ -171,6 +172,18 @@ async function trackUploadError(file: UploadingFile, err: Error) {
  */
 export function isFileEmpty(file: { size: number }): boolean {
   return file.size === 0;
+}
+
+function safeDecodeUri(uri: string): string {
+  try {
+    return decodeURIComponent(uri);
+  } catch {
+    return uri;
+  }
+}
+
+export async function copyFileFromEncodedUri(sourceUri: string, destPath: string): Promise<void> {
+  await fileSystemService.copyFile(safeDecodeUri(sourceUri), destPath);
 }
 
 /**

--- a/src/services/drive/file/utils/uploadFileUtils.ts
+++ b/src/services/drive/file/utils/uploadFileUtils.ts
@@ -19,6 +19,7 @@ import { uiActions } from '../../../../store/slices/ui';
 import analyticsService, { DriveAnalyticsEvent } from '../../../AnalyticsService';
 import { logger } from '../../../common';
 import { uploadService } from '../../../common/network/upload/upload.service';
+import { decodeUriSafely } from '../../../common/uri/uriHelpers';
 import { notifyParentChanged } from '../../../native/InternxtSignalingModule';
 import { EmptyFileNotAllowedError, isEmptyFilePlanError } from './emptyFileErrors';
 import { FileSizeExceededError, isFileSizeExceededError } from './fileSizeErrors';
@@ -174,16 +175,8 @@ export function isFileEmpty(file: { size: number }): boolean {
   return file.size === 0;
 }
 
-function safeDecodeUri(uri: string): string {
-  try {
-    return decodeURIComponent(uri);
-  } catch {
-    return uri;
-  }
-}
-
 export async function copyFileFromEncodedUri(sourceUri: string, destPath: string): Promise<void> {
-  await fileSystemService.copyFile(safeDecodeUri(sourceUri), destPath);
+  await fileSystemService.copyFile(decodeUriSafely(sourceUri), destPath);
 }
 
 /**

--- a/src/services/drive/file/utils/uploadFileUtils.ts
+++ b/src/services/drive/file/utils/uploadFileUtils.ts
@@ -18,6 +18,7 @@ import { uiActions } from '../../../../store/slices/ui';
 import analyticsService, { DriveAnalyticsEvent } from '../../../AnalyticsService';
 import { logger } from '../../../common';
 import { uploadService } from '../../../common/network/upload/upload.service';
+import { notifyParentChanged } from '../../../native/InternxtSignalingModule';
 import { EmptyFileNotAllowedError, isEmptyFilePlanError } from './emptyFileErrors';
 import { FileSizeExceededError, isFileSizeExceededError } from './fileSizeErrors';
 import { BucketNotFoundError } from './upload.errors';
@@ -228,6 +229,7 @@ export async function uploadSingleFile(
       await uploadFile(file, 'document');
     }
     uploadSuccess(file);
+    void notifyParentChanged(file.parentUuid).catch(() => undefined);
   } catch (e) {
     if (e instanceof EmptyFileNotAllowedError) {
       dispatch(uiActions.setShowEmptyFileNotAllowedModal(true));

--- a/src/services/drive/folder/driveFolder.service.signaling.spec.ts
+++ b/src/services/drive/folder/driveFolder.service.signaling.spec.ts
@@ -1,5 +1,6 @@
 const mockNotifyParentChanged = jest.fn().mockResolvedValue(undefined);
 const mockCreateFolderByUuid = jest.fn();
+const mockMoveFolderByUuid = jest.fn();
 
 jest.mock('../../native/InternxtSignalingModule', () => ({
   notifyParentChanged: (...args: unknown[]) => mockNotifyParentChanged(...args),
@@ -10,6 +11,7 @@ jest.mock('@internxt-mobile/services/common', () => ({
     getInstance: () => ({
       storageV2: {
         createFolderByUuid: (...args: unknown[]) => mockCreateFolderByUuid(...args),
+        moveFolderByUuid: (...args: unknown[]) => mockMoveFolderByUuid(...args),
       },
     }),
   },
@@ -23,7 +25,7 @@ describe('driveFolderService.createFolder — picker signaling', () => {
     mockCreateFolderByUuid.mockReset();
   });
 
-  it('when a folder is created, then it signals the parent folder uuid', async () => {
+  test('when a folder is created, then it signals the parent folder uuid', async () => {
     mockCreateFolderByUuid.mockReturnValue([Promise.resolve({ uuid: 'new-folder', name: 'docs' })]);
 
     await driveFolderService.createFolder('parent-folder-uuid', 'docs');
@@ -31,10 +33,25 @@ describe('driveFolderService.createFolder — picker signaling', () => {
     expect(mockNotifyParentChanged).toHaveBeenCalledWith('parent-folder-uuid');
   });
 
-  it('when the SDK returns no result, then it rejects and does not signal', async () => {
+  test('when the SDK returns no result, then it rejects and does not signal', async () => {
     mockCreateFolderByUuid.mockReturnValue(undefined);
 
     await expect(driveFolderService.createFolder('parent-folder-uuid', 'docs')).rejects.toBeDefined();
     expect(mockNotifyParentChanged).not.toHaveBeenCalled();
+  });
+});
+
+describe('driveFolderService.moveFolder — picker signaling', () => {
+  beforeEach(() => {
+    mockNotifyParentChanged.mockClear();
+    mockMoveFolderByUuid.mockReset();
+  });
+
+  test('when a folder is moved, then it signals the destination folder uuid', async () => {
+    mockMoveFolderByUuid.mockResolvedValue({ uuid: 'folder-uuid' });
+
+    await driveFolderService.moveFolder({ folderUuid: 'folder-uuid', destinationFolderUuid: 'destination-uuid' });
+
+    expect(mockNotifyParentChanged).toHaveBeenCalledWith('destination-uuid');
   });
 });

--- a/src/services/drive/folder/driveFolder.service.signaling.spec.ts
+++ b/src/services/drive/folder/driveFolder.service.signaling.spec.ts
@@ -24,21 +24,16 @@ describe('driveFolderService.createFolder — picker signaling', () => {
   });
 
   it('when a folder is created, then it signals the parent folder uuid', async () => {
-    // given
     mockCreateFolderByUuid.mockReturnValue([Promise.resolve({ uuid: 'new-folder', name: 'docs' })]);
 
-    // when
     await driveFolderService.createFolder('parent-folder-uuid', 'docs');
 
-    // then
     expect(mockNotifyParentChanged).toHaveBeenCalledWith('parent-folder-uuid');
   });
 
   it('when the SDK returns no result, then it rejects and does not signal', async () => {
-    // given
     mockCreateFolderByUuid.mockReturnValue(undefined);
 
-    // when / then
     await expect(driveFolderService.createFolder('parent-folder-uuid', 'docs')).rejects.toBeDefined();
     expect(mockNotifyParentChanged).not.toHaveBeenCalled();
   });

--- a/src/services/drive/folder/driveFolder.service.signaling.spec.ts
+++ b/src/services/drive/folder/driveFolder.service.signaling.spec.ts
@@ -1,0 +1,45 @@
+const mockNotifyParentChanged = jest.fn().mockResolvedValue(undefined);
+const mockCreateFolderByUuid = jest.fn();
+
+jest.mock('../../native/InternxtSignalingModule', () => ({
+  notifyParentChanged: (...args: unknown[]) => mockNotifyParentChanged(...args),
+}));
+
+jest.mock('@internxt-mobile/services/common', () => ({
+  SdkManager: {
+    getInstance: () => ({
+      storageV2: {
+        createFolderByUuid: (...args: unknown[]) => mockCreateFolderByUuid(...args),
+      },
+    }),
+  },
+}));
+
+import { driveFolderService } from './driveFolder.service';
+
+describe('driveFolderService.createFolder — picker signaling', () => {
+  beforeEach(() => {
+    mockNotifyParentChanged.mockClear();
+    mockCreateFolderByUuid.mockReset();
+  });
+
+  it('when a folder is created, then it signals the parent folder uuid', async () => {
+    // given
+    mockCreateFolderByUuid.mockReturnValue([Promise.resolve({ uuid: 'new-folder', name: 'docs' })]);
+
+    // when
+    await driveFolderService.createFolder('parent-folder-uuid', 'docs');
+
+    // then
+    expect(mockNotifyParentChanged).toHaveBeenCalledWith('parent-folder-uuid');
+  });
+
+  it('when the SDK returns no result, then it rejects and does not signal', async () => {
+    // given
+    mockCreateFolderByUuid.mockReturnValue(undefined);
+
+    // when / then
+    await expect(driveFolderService.createFolder('parent-folder-uuid', 'docs')).rejects.toBeDefined();
+    expect(mockNotifyParentChanged).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/drive/folder/driveFolder.service.ts
+++ b/src/services/drive/folder/driveFolder.service.ts
@@ -37,7 +37,7 @@ class DriveFolderService {
       throw new Error('Sdk method did not return a valid result');
     }
     const folder = await sdkResult[0];
-    void notifyParentChanged(parentFolderId).catch(() => undefined);
+    void notifyParentChanged(parentFolderId);
     return folder;
   }
 

--- a/src/services/drive/folder/driveFolder.service.ts
+++ b/src/services/drive/folder/driveFolder.service.ts
@@ -52,7 +52,9 @@ class DriveFolderService {
     folderUuid: string;
     destinationFolderUuid: string;
   }) {
-    return this.sdk.storageV2.moveFolderByUuid(folderUuid, { destinationFolder: destinationFolderUuid });
+    const moved = await this.sdk.storageV2.moveFolderByUuid(folderUuid, { destinationFolder: destinationFolderUuid });
+    void notifyParentChanged(destinationFolderUuid);
+    return moved;
   }
 
   public async updateMetaData(folderUuid: string, newName: string): Promise<void> {

--- a/src/services/drive/folder/driveFolder.service.ts
+++ b/src/services/drive/folder/driveFolder.service.ts
@@ -34,7 +34,7 @@ class DriveFolderService {
       plainName: folderName,
     });
     if (!sdkResult) {
-      return Promise.reject('createFolder Sdk method did not return a valid result');
+      throw new Error('Sdk method did not return a valid result');
     }
     const folder = await sdkResult[0];
     void notifyParentChanged(parentFolderId).catch(() => undefined);

--- a/src/services/drive/folder/driveFolder.service.ts
+++ b/src/services/drive/folder/driveFolder.service.ts
@@ -5,6 +5,7 @@ import { FolderAncestor as SdkFolderAncestor } from '@internxt/sdk/dist/drive/st
 import { getHeaders } from '../../../helpers/headers';
 import { ModifiedFolder } from '../../../types/drive/folder';
 import { constants } from '../../AppService';
+import { notifyParentChanged } from '../../native/InternxtSignalingModule';
 
 export type FolderAncestor = SdkFolderAncestor & { parentUuid: string | null };
 
@@ -32,7 +33,12 @@ class DriveFolderService {
       parentFolderUuid: parentFolderId,
       plainName: folderName,
     });
-    return sdkResult ? sdkResult[0] : Promise.reject('createFolder Sdk method did not return a valid result');
+    if (!sdkResult) {
+      return Promise.reject('createFolder Sdk method did not return a valid result');
+    }
+    const folder = await sdkResult[0];
+    void notifyParentChanged(parentFolderId).catch(() => undefined);
+    return folder;
   }
 
   public async checkDuplicatedFolders(parentFolderUuid: string, folderNamesList: string[]) {

--- a/src/services/native/InternxtAuthCredentialsModule.spec.ts
+++ b/src/services/native/InternxtAuthCredentialsModule.spec.ts
@@ -1,0 +1,75 @@
+type Wrapper = typeof import('./InternxtAuthCredentialsModule');
+type Credentials = import('./InternxtAuthCredentialsModule').InternxtAuthCredentials;
+
+const credentials: Credentials = {
+  bearerToken: 'token-abc',
+  userId: 'user-1',
+  bridgeUser: 'bridge@internxt.com',
+  mnemonic: 'pretty cloud secret words',
+  rootFolderUuid: 'root-uuid-123',
+  email: 'user@internxt.com',
+  driveBaseUrl: 'https://drive.example',
+  bridgeBaseUrl: 'https://bridge.example',
+  desktopToken: 'desktop-token',
+};
+
+const loadWrapper = (platformOS: 'android' | 'ios', nativeModule: unknown): Wrapper => {
+  let wrapper!: Wrapper;
+  jest.isolateModules(() => {
+    jest.doMock('react-native', () => ({
+      Platform: { OS: platformOS },
+      NativeModules: nativeModule === undefined ? {} : { InternxtAuthCredentialsModule: nativeModule },
+    }));
+    wrapper = require('./InternxtAuthCredentialsModule');
+  });
+  return wrapper;
+};
+
+const arrangePresentNative = (platformOS: 'android' | 'ios') => {
+  const setCredentials = jest.fn().mockResolvedValue(undefined);
+  const clearCredentials = jest.fn().mockResolvedValue(undefined);
+  const wrapper = loadWrapper(platformOS, { setCredentials, clearCredentials });
+  return { wrapper, setCredentials, clearCredentials };
+};
+
+describe('InternxtAuthCredentialsModule wrapper', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('when on iOS with the module present, then setCredentials delegates with the credentials', async () => {
+    const { wrapper, setCredentials } = arrangePresentNative('ios');
+
+    await wrapper.setCredentials(credentials);
+
+    expect(setCredentials).toHaveBeenCalledWith(credentials);
+  });
+
+  it('when on iOS with the module present, then clearCredentials delegates to the native module', async () => {
+    const { wrapper, clearCredentials } = arrangePresentNative('ios');
+
+    await wrapper.clearCredentials();
+
+    expect(clearCredentials).toHaveBeenCalledTimes(1);
+  });
+
+  it('when on Android with the module present, then setCredentials delegates with the credentials', async () => {
+    const { wrapper, setCredentials } = arrangePresentNative('android');
+
+    await wrapper.setCredentials(credentials);
+
+    expect(setCredentials).toHaveBeenCalledWith(credentials);
+  });
+
+  it('when the native module is absent, then setCredentials resolves without throwing', async () => {
+    const wrapper = loadWrapper('ios', undefined);
+
+    await expect(wrapper.setCredentials(credentials)).resolves.toBeUndefined();
+  });
+
+  it('when the native module is absent, then clearCredentials resolves without throwing', async () => {
+    const wrapper = loadWrapper('ios', undefined);
+
+    await expect(wrapper.clearCredentials()).resolves.toBeUndefined();
+  });
+});

--- a/src/services/native/InternxtAuthCredentialsModule.spec.ts
+++ b/src/services/native/InternxtAuthCredentialsModule.spec.ts
@@ -45,6 +45,14 @@ describe('InternxtAuthCredentialsModule wrapper', () => {
     expect(setCredentials).toHaveBeenCalledWith(credentials);
   });
 
+  it('when on iOS with the module present, then setCredentials forwards driveBaseUrl to the native module', async () => {
+    const { wrapper, setCredentials } = arrangePresentNative('ios');
+
+    await wrapper.setCredentials(credentials);
+
+    expect(setCredentials.mock.calls[0][0]).toMatchObject({ driveBaseUrl: 'https://drive.example' });
+  });
+
   it('when on iOS with the module present, then clearCredentials delegates to the native module', async () => {
     const { wrapper, clearCredentials } = arrangePresentNative('ios');
 

--- a/src/services/native/InternxtAuthCredentialsModule.spec.ts
+++ b/src/services/native/InternxtAuthCredentialsModule.spec.ts
@@ -37,7 +37,7 @@ describe('InternxtAuthCredentialsModule wrapper', () => {
     jest.resetModules();
   });
 
-  it('when on iOS with the module present, then setCredentials delegates with the credentials', async () => {
+  test('when on iOS with the module present, then setCredentials delegates with the credentials', async () => {
     const { wrapper, setCredentials } = arrangePresentNative('ios');
 
     await wrapper.setCredentials(credentials);
@@ -45,7 +45,7 @@ describe('InternxtAuthCredentialsModule wrapper', () => {
     expect(setCredentials).toHaveBeenCalledWith(credentials);
   });
 
-  it('when on iOS with the module present, then setCredentials forwards driveBaseUrl to the native module', async () => {
+  test('when on iOS with the module present, then setCredentials forwards driveBaseUrl to the native module', async () => {
     const { wrapper, setCredentials } = arrangePresentNative('ios');
 
     await wrapper.setCredentials(credentials);
@@ -53,7 +53,15 @@ describe('InternxtAuthCredentialsModule wrapper', () => {
     expect(setCredentials.mock.calls[0][0]).toMatchObject({ driveBaseUrl: 'https://drive.example' });
   });
 
-  it('when on iOS with the module present, then clearCredentials delegates to the native module', async () => {
+  test('when on iOS with the module present, then setCredentials forwards bridgeBaseUrl to the native module', async () => {
+    const { wrapper, setCredentials } = arrangePresentNative('ios');
+
+    await wrapper.setCredentials(credentials);
+
+    expect(setCredentials.mock.calls[0][0]).toMatchObject({ bridgeBaseUrl: 'https://bridge.example' });
+  });
+
+  test('when on iOS with the module present, then clearCredentials delegates to the native module', async () => {
     const { wrapper, clearCredentials } = arrangePresentNative('ios');
 
     await wrapper.clearCredentials();
@@ -61,7 +69,7 @@ describe('InternxtAuthCredentialsModule wrapper', () => {
     expect(clearCredentials).toHaveBeenCalledTimes(1);
   });
 
-  it('when on Android with the module present, then setCredentials delegates with the credentials', async () => {
+  test('when on Android with the module present, then setCredentials delegates with the credentials', async () => {
     const { wrapper, setCredentials } = arrangePresentNative('android');
 
     await wrapper.setCredentials(credentials);
@@ -69,13 +77,13 @@ describe('InternxtAuthCredentialsModule wrapper', () => {
     expect(setCredentials).toHaveBeenCalledWith(credentials);
   });
 
-  it('when the native module is absent, then setCredentials resolves without throwing', async () => {
+  test('when the native module is absent, then setCredentials resolves without throwing', async () => {
     const wrapper = loadWrapper('ios', undefined);
 
     await expect(wrapper.setCredentials(credentials)).resolves.toBeUndefined();
   });
 
-  it('when the native module is absent, then clearCredentials resolves without throwing', async () => {
+  test('when the native module is absent, then clearCredentials resolves without throwing', async () => {
     const wrapper = loadWrapper('ios', undefined);
 
     await expect(wrapper.clearCredentials()).resolves.toBeUndefined();

--- a/src/services/native/InternxtAuthCredentialsModule.ts
+++ b/src/services/native/InternxtAuthCredentialsModule.ts
@@ -19,15 +19,12 @@ interface NativeBridge {
 const bridge: NativeBridge | undefined =
   Platform.OS === 'android' ? NativeModules.InternxtAuthCredentialsModule : undefined;
 
-const InternxtAuthCredentialsModule = {
-  async setCredentials(creds: InternxtAuthCredentials): Promise<void> {
-    if (!bridge) return;
-    await bridge.setCredentials(creds);
-  },
-  async clearCredentials(): Promise<void> {
-    if (!bridge) return;
-    await bridge.clearCredentials();
-  },
-};
+export async function setCredentials(creds: InternxtAuthCredentials): Promise<void> {
+  if (!bridge) return;
+  await bridge.setCredentials(creds);
+}
 
-export default InternxtAuthCredentialsModule;
+export async function clearCredentials(): Promise<void> {
+  if (!bridge) return;
+  await bridge.clearCredentials();
+}

--- a/src/services/native/InternxtAuthCredentialsModule.ts
+++ b/src/services/native/InternxtAuthCredentialsModule.ts
@@ -1,0 +1,33 @@
+import { NativeModules, Platform } from 'react-native';
+
+export interface InternxtAuthCredentials {
+  bearerToken: string;
+  userId: string;
+  bridgeUser: string;
+  rootFolderUuid: string;
+  email?: string | null;
+  driveBaseUrl: string;
+  bridgeBaseUrl: string;
+  desktopToken?: string | null;
+}
+
+interface NativeBridge {
+  setCredentials(creds: InternxtAuthCredentials): Promise<void>;
+  clearCredentials(): Promise<void>;
+}
+
+const bridge: NativeBridge | undefined =
+  Platform.OS === 'android' ? NativeModules.InternxtAuthCredentialsModule : undefined;
+
+const InternxtAuthCredentialsModule = {
+  async setCredentials(creds: InternxtAuthCredentials): Promise<void> {
+    if (!bridge) return;
+    await bridge.setCredentials(creds);
+  },
+  async clearCredentials(): Promise<void> {
+    if (!bridge) return;
+    await bridge.clearCredentials();
+  },
+};
+
+export default InternxtAuthCredentialsModule;

--- a/src/services/native/InternxtAuthCredentialsModule.ts
+++ b/src/services/native/InternxtAuthCredentialsModule.ts
@@ -4,6 +4,7 @@ export interface InternxtAuthCredentials {
   bearerToken: string;
   userId: string;
   bridgeUser: string;
+  mnemonic: string;
   rootFolderUuid: string;
   email?: string | null;
   driveBaseUrl: string;

--- a/src/services/native/InternxtAuthCredentialsModule.ts
+++ b/src/services/native/InternxtAuthCredentialsModule.ts
@@ -18,7 +18,7 @@ interface NativeBridge {
 }
 
 const bridge: NativeBridge | undefined =
-  Platform.OS === 'android' ? NativeModules.InternxtAuthCredentialsModule : undefined;
+  Platform.OS === 'android' || Platform.OS === 'ios' ? NativeModules.InternxtAuthCredentialsModule : undefined;
 
 export async function setCredentials(creds: InternxtAuthCredentials): Promise<void> {
   if (!bridge) return;

--- a/src/services/native/InternxtSignalingModule.spec.ts
+++ b/src/services/native/InternxtSignalingModule.spec.ts
@@ -6,16 +6,10 @@ jest.mock('../common', () => ({
 
 type Wrapper = typeof import('./InternxtSignalingModule');
 
-/**
- * The wrapper resolves the native bridge at module-load time from `Platform.OS` and
- * `NativeModules`, so each scenario loads a fresh copy of the module under a tailored
- * `react-native` mock.
- */
-const loadWrapper = (platformOS: 'android' | 'ios', nativeModule: unknown): { wrapper: Wrapper } => {
+const loadWrapper = (nativeModule: unknown): { wrapper: Wrapper } => {
   let wrapper!: Wrapper;
   jest.isolateModules(() => {
     jest.doMock('react-native', () => ({
-      Platform: { OS: platformOS },
       NativeModules: nativeModule === undefined ? {} : { InternxtSignalingModule: nativeModule },
     }));
     wrapper = require('./InternxtSignalingModule');
@@ -23,13 +17,9 @@ const loadWrapper = (platformOS: 'android' | 'ios', nativeModule: unknown): { wr
   return { wrapper };
 };
 
-/**
- * Builds a native bridge mock and loads the wrapper against it, returning the spy so each
- * test only states the platform and asserts the resulting behaviour.
- */
-const arrangePresentNative = (platformOS: 'android' | 'ios') => {
+const arrangePresentNative = () => {
   const native = jest.fn().mockResolvedValue(undefined);
-  const { wrapper } = loadWrapper(platformOS, { notifyParentChanged: native });
+  const { wrapper } = loadWrapper({ notifyParentChanged: native });
   return { wrapper, native };
 };
 
@@ -39,46 +29,38 @@ describe('InternxtSignalingModule wrapper', () => {
     mockLoggerWarn.mockReset();
   });
 
-  it('when on Android with a valid uuid, then it invokes the native module with that uuid', async () => {
-    const { wrapper, native } = arrangePresentNative('android');
+  test('when the native bridge is present with a valid uuid, then it invokes the native module with that uuid', async () => {
+    const { wrapper, native } = arrangePresentNative();
 
     await wrapper.notifyParentChanged('folder-uuid-123');
 
     expect(native).toHaveBeenCalledWith('folder-uuid-123');
   });
 
-  it('when on iOS, then it resolves without invoking the native module', async () => {
-    const { wrapper, native } = arrangePresentNative('ios');
-
-    await expect(wrapper.notifyParentChanged('folder-uuid-123')).resolves.toBeUndefined();
-
-    expect(native).not.toHaveBeenCalled();
-  });
-
-  it('when the uuid is empty, then it resolves without invoking the native module', async () => {
-    const { wrapper, native } = arrangePresentNative('android');
+  test('when the uuid is empty, then it resolves without invoking the native module', async () => {
+    const { wrapper, native } = arrangePresentNative();
 
     await expect(wrapper.notifyParentChanged('')).resolves.toBeUndefined();
 
     expect(native).not.toHaveBeenCalled();
   });
 
-  it('when the uuid is not a string, then it resolves without invoking the native module', async () => {
-    const { wrapper, native } = arrangePresentNative('android');
+  test('when the uuid is not a string, then it resolves without invoking the native module', async () => {
+    const { wrapper, native } = arrangePresentNative();
 
     await expect(wrapper.notifyParentChanged(undefined as unknown as string)).resolves.toBeUndefined();
 
     expect(native).not.toHaveBeenCalled();
   });
 
-  it('when the native module is absent, then it resolves without throwing', async () => {
-    const { wrapper } = loadWrapper('android', undefined);
+  test('when the native module is absent, then it resolves without throwing', async () => {
+    const { wrapper } = loadWrapper(undefined);
 
     await expect(wrapper.notifyParentChanged('folder-uuid-123')).resolves.toBeUndefined();
   });
 
-  it('when the native module rejects, then it resolves without throwing', async () => {
-    const { wrapper, native } = arrangePresentNative('android');
+  test('when the native module rejects, then it resolves without throwing', async () => {
+    const { wrapper, native } = arrangePresentNative();
     native.mockRejectedValueOnce(new Error('E_INVALID_FOLDER'));
 
     await expect(wrapper.notifyParentChanged('folder-uuid-123')).resolves.toBeUndefined();

--- a/src/services/native/InternxtSignalingModule.spec.ts
+++ b/src/services/native/InternxtSignalingModule.spec.ts
@@ -1,0 +1,82 @@
+type Wrapper = typeof import('./InternxtSignalingModule');
+
+/**
+ * The wrapper resolves the native bridge at module-load time from `Platform.OS` and
+ * `NativeModules`, so each scenario loads a fresh copy of the module under a tailored
+ * `react-native` mock.
+ */
+const loadWrapper = (platformOS: 'android' | 'ios', nativeModule: unknown): { wrapper: Wrapper } => {
+  let wrapper!: Wrapper;
+  jest.isolateModules(() => {
+    jest.doMock('react-native', () => ({
+      Platform: { OS: platformOS },
+      NativeModules: nativeModule === undefined ? {} : { InternxtSignalingModule: nativeModule },
+    }));
+    wrapper = require('./InternxtSignalingModule');
+  });
+  return { wrapper };
+};
+
+describe('InternxtSignalingModule wrapper', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('when on Android with a valid uuid, then it invokes the native module with that uuid', async () => {
+    // given
+    const notifyParentChangedNative = jest.fn().mockResolvedValue(undefined);
+    const { wrapper } = loadWrapper('android', { notifyParentChanged: notifyParentChangedNative });
+
+    // when
+    await wrapper.notifyParentChanged('folder-uuid-123');
+
+    // then
+    expect(notifyParentChangedNative).toHaveBeenCalledWith('folder-uuid-123');
+  });
+
+  it('when on iOS, then it resolves without invoking the native module', async () => {
+    // given
+    const notifyParentChangedNative = jest.fn().mockResolvedValue(undefined);
+    const { wrapper } = loadWrapper('ios', { notifyParentChanged: notifyParentChangedNative });
+
+    // when
+    await expect(wrapper.notifyParentChanged('folder-uuid-123')).resolves.toBeUndefined();
+
+    // then
+    expect(notifyParentChangedNative).not.toHaveBeenCalled();
+  });
+
+  it('when the uuid is empty, then it resolves without invoking the native module', async () => {
+    // given
+    const notifyParentChangedNative = jest.fn().mockResolvedValue(undefined);
+    const { wrapper } = loadWrapper('android', { notifyParentChanged: notifyParentChangedNative });
+
+    // when
+    await expect(wrapper.notifyParentChanged('')).resolves.toBeUndefined();
+
+    // then
+    expect(notifyParentChangedNative).not.toHaveBeenCalled();
+  });
+
+  it('when the uuid is not a string, then it resolves without invoking the native module', async () => {
+    // given
+    const notifyParentChangedNative = jest.fn().mockResolvedValue(undefined);
+    const { wrapper } = loadWrapper('android', { notifyParentChanged: notifyParentChangedNative });
+
+    // when
+    await expect(
+      wrapper.notifyParentChanged(undefined as unknown as string),
+    ).resolves.toBeUndefined();
+
+    // then
+    expect(notifyParentChangedNative).not.toHaveBeenCalled();
+  });
+
+  it('when the native module is absent, then it resolves without throwing', async () => {
+    // given
+    const { wrapper } = loadWrapper('android', undefined);
+
+    // when / then
+    await expect(wrapper.notifyParentChanged('folder-uuid-123')).resolves.toBeUndefined();
+  });
+});

--- a/src/services/native/InternxtSignalingModule.spec.ts
+++ b/src/services/native/InternxtSignalingModule.spec.ts
@@ -23,60 +23,44 @@ describe('InternxtSignalingModule wrapper', () => {
   });
 
   it('when on Android with a valid uuid, then it invokes the native module with that uuid', async () => {
-    // given
     const notifyParentChangedNative = jest.fn().mockResolvedValue(undefined);
     const { wrapper } = loadWrapper('android', { notifyParentChanged: notifyParentChangedNative });
 
-    // when
     await wrapper.notifyParentChanged('folder-uuid-123');
 
-    // then
     expect(notifyParentChangedNative).toHaveBeenCalledWith('folder-uuid-123');
   });
 
   it('when on iOS, then it resolves without invoking the native module', async () => {
-    // given
     const notifyParentChangedNative = jest.fn().mockResolvedValue(undefined);
     const { wrapper } = loadWrapper('ios', { notifyParentChanged: notifyParentChangedNative });
 
-    // when
     await expect(wrapper.notifyParentChanged('folder-uuid-123')).resolves.toBeUndefined();
 
-    // then
     expect(notifyParentChangedNative).not.toHaveBeenCalled();
   });
 
   it('when the uuid is empty, then it resolves without invoking the native module', async () => {
-    // given
     const notifyParentChangedNative = jest.fn().mockResolvedValue(undefined);
     const { wrapper } = loadWrapper('android', { notifyParentChanged: notifyParentChangedNative });
 
-    // when
     await expect(wrapper.notifyParentChanged('')).resolves.toBeUndefined();
 
-    // then
     expect(notifyParentChangedNative).not.toHaveBeenCalled();
   });
 
   it('when the uuid is not a string, then it resolves without invoking the native module', async () => {
-    // given
     const notifyParentChangedNative = jest.fn().mockResolvedValue(undefined);
     const { wrapper } = loadWrapper('android', { notifyParentChanged: notifyParentChangedNative });
 
-    // when
-    await expect(
-      wrapper.notifyParentChanged(undefined as unknown as string),
-    ).resolves.toBeUndefined();
+    await expect(wrapper.notifyParentChanged(undefined as unknown as string)).resolves.toBeUndefined();
 
-    // then
     expect(notifyParentChangedNative).not.toHaveBeenCalled();
   });
 
   it('when the native module is absent, then it resolves without throwing', async () => {
-    // given
     const { wrapper } = loadWrapper('android', undefined);
 
-    // when / then
     await expect(wrapper.notifyParentChanged('folder-uuid-123')).resolves.toBeUndefined();
   });
 });

--- a/src/services/native/InternxtSignalingModule.spec.ts
+++ b/src/services/native/InternxtSignalingModule.spec.ts
@@ -1,3 +1,9 @@
+const mockLoggerWarn = jest.fn();
+
+jest.mock('../common', () => ({
+  logger: { info: jest.fn(), warn: mockLoggerWarn, error: jest.fn() },
+}));
+
 type Wrapper = typeof import('./InternxtSignalingModule');
 
 /**
@@ -30,6 +36,7 @@ const arrangePresentNative = (platformOS: 'android' | 'ios') => {
 describe('InternxtSignalingModule wrapper', () => {
   afterEach(() => {
     jest.resetModules();
+    mockLoggerWarn.mockReset();
   });
 
   it('when on Android with a valid uuid, then it invokes the native module with that uuid', async () => {
@@ -68,5 +75,14 @@ describe('InternxtSignalingModule wrapper', () => {
     const { wrapper } = loadWrapper('android', undefined);
 
     await expect(wrapper.notifyParentChanged('folder-uuid-123')).resolves.toBeUndefined();
+  });
+
+  it('when the native module rejects, then it resolves without throwing', async () => {
+    const { wrapper, native } = arrangePresentNative('android');
+    native.mockRejectedValueOnce(new Error('E_INVALID_FOLDER'));
+
+    await expect(wrapper.notifyParentChanged('folder-uuid-123')).resolves.toBeUndefined();
+
+    expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/native/InternxtSignalingModule.spec.ts
+++ b/src/services/native/InternxtSignalingModule.spec.ts
@@ -17,45 +17,51 @@ const loadWrapper = (platformOS: 'android' | 'ios', nativeModule: unknown): { wr
   return { wrapper };
 };
 
+/**
+ * Builds a native bridge mock and loads the wrapper against it, returning the spy so each
+ * test only states the platform and asserts the resulting behaviour.
+ */
+const arrangePresentNative = (platformOS: 'android' | 'ios') => {
+  const native = jest.fn().mockResolvedValue(undefined);
+  const { wrapper } = loadWrapper(platformOS, { notifyParentChanged: native });
+  return { wrapper, native };
+};
+
 describe('InternxtSignalingModule wrapper', () => {
   afterEach(() => {
     jest.resetModules();
   });
 
   it('when on Android with a valid uuid, then it invokes the native module with that uuid', async () => {
-    const notifyParentChangedNative = jest.fn().mockResolvedValue(undefined);
-    const { wrapper } = loadWrapper('android', { notifyParentChanged: notifyParentChangedNative });
+    const { wrapper, native } = arrangePresentNative('android');
 
     await wrapper.notifyParentChanged('folder-uuid-123');
 
-    expect(notifyParentChangedNative).toHaveBeenCalledWith('folder-uuid-123');
+    expect(native).toHaveBeenCalledWith('folder-uuid-123');
   });
 
   it('when on iOS, then it resolves without invoking the native module', async () => {
-    const notifyParentChangedNative = jest.fn().mockResolvedValue(undefined);
-    const { wrapper } = loadWrapper('ios', { notifyParentChanged: notifyParentChangedNative });
+    const { wrapper, native } = arrangePresentNative('ios');
 
     await expect(wrapper.notifyParentChanged('folder-uuid-123')).resolves.toBeUndefined();
 
-    expect(notifyParentChangedNative).not.toHaveBeenCalled();
+    expect(native).not.toHaveBeenCalled();
   });
 
   it('when the uuid is empty, then it resolves without invoking the native module', async () => {
-    const notifyParentChangedNative = jest.fn().mockResolvedValue(undefined);
-    const { wrapper } = loadWrapper('android', { notifyParentChanged: notifyParentChangedNative });
+    const { wrapper, native } = arrangePresentNative('android');
 
     await expect(wrapper.notifyParentChanged('')).resolves.toBeUndefined();
 
-    expect(notifyParentChangedNative).not.toHaveBeenCalled();
+    expect(native).not.toHaveBeenCalled();
   });
 
   it('when the uuid is not a string, then it resolves without invoking the native module', async () => {
-    const notifyParentChangedNative = jest.fn().mockResolvedValue(undefined);
-    const { wrapper } = loadWrapper('android', { notifyParentChanged: notifyParentChangedNative });
+    const { wrapper, native } = arrangePresentNative('android');
 
     await expect(wrapper.notifyParentChanged(undefined as unknown as string)).resolves.toBeUndefined();
 
-    expect(notifyParentChangedNative).not.toHaveBeenCalled();
+    expect(native).not.toHaveBeenCalled();
   });
 
   it('when the native module is absent, then it resolves without throwing', async () => {

--- a/src/services/native/InternxtSignalingModule.ts
+++ b/src/services/native/InternxtSignalingModule.ts
@@ -1,19 +1,20 @@
-import { NativeModules, Platform } from 'react-native';
+import { NativeModules } from 'react-native';
 import { logger } from '../common';
 
 interface NativeBridge {
   notifyParentChanged(parentFolderUuid: string): Promise<void>;
 }
 
-const bridge: NativeBridge | undefined = Platform.OS === 'android' ? NativeModules.InternxtSignalingModule : undefined;
+const bridge: NativeBridge | undefined = NativeModules.InternxtSignalingModule;
 
 /**
- * Signals the Android file picker (SAF DocumentsProvider) that a folder's children changed
- * after a mutation originated in the React Native app (file upload, folder creation), so it
- * invalidates its cache and re-queries.
+ * Signals the native file browser that a folder's children changed after a mutation originated
+ * in the React Native app (upload, create, move, rename, trash, restore): the Android SAF
+ * DocumentsProvider re-queries the parent; the iOS File Provider re-evaluates the parent against
+ * its child snapshot, so add/rename/move/trash all refresh Files.app live through a single call.
  *
- * Best-effort and cross-platform: no-op on iOS and when the native module is unavailable,
- * never throws to the caller and never invokes the native side with a malformed uuid.
+ * Best-effort and cross-platform: no-op when the native module is unavailable, never throws to
+ * the caller and never invokes the native side with a malformed uuid.
  */
 export async function notifyParentChanged(parentFolderUuid: string): Promise<void> {
   if (!bridge) return;

--- a/src/services/native/InternxtSignalingModule.ts
+++ b/src/services/native/InternxtSignalingModule.ts
@@ -1,11 +1,11 @@
 import { NativeModules, Platform } from 'react-native';
+import { logger } from '../common';
 
 interface NativeBridge {
   notifyParentChanged(parentFolderUuid: string): Promise<void>;
 }
 
-const bridge: NativeBridge | undefined =
-  Platform.OS === 'android' ? NativeModules.InternxtSignalingModule : undefined;
+const bridge: NativeBridge | undefined = Platform.OS === 'android' ? NativeModules.InternxtSignalingModule : undefined;
 
 /**
  * Signals the Android file picker (SAF DocumentsProvider) that a folder's children changed
@@ -18,5 +18,9 @@ const bridge: NativeBridge | undefined =
 export async function notifyParentChanged(parentFolderUuid: string): Promise<void> {
   if (!bridge) return;
   if (typeof parentFolderUuid !== 'string' || parentFolderUuid.length === 0) return;
-  await bridge.notifyParentChanged(parentFolderUuid);
+  try {
+    await bridge.notifyParentChanged(parentFolderUuid);
+  } catch (error) {
+    logger.warn('InternxtSignalingModule.notifyParentChanged failed', error);
+  }
 }

--- a/src/services/native/InternxtSignalingModule.ts
+++ b/src/services/native/InternxtSignalingModule.ts
@@ -1,0 +1,22 @@
+import { NativeModules, Platform } from 'react-native';
+
+interface NativeBridge {
+  notifyParentChanged(parentFolderUuid: string): Promise<void>;
+}
+
+const bridge: NativeBridge | undefined =
+  Platform.OS === 'android' ? NativeModules.InternxtSignalingModule : undefined;
+
+/**
+ * Signals the Android file picker (SAF DocumentsProvider) that a folder's children changed
+ * after a mutation originated in the React Native app (file upload, folder creation), so it
+ * invalidates its cache and re-queries.
+ *
+ * Best-effort and cross-platform: no-op on iOS and when the native module is unavailable,
+ * never throws to the caller and never invokes the native side with a malformed uuid.
+ */
+export async function notifyParentChanged(parentFolderUuid: string): Promise<void> {
+  if (!bridge) return;
+  if (typeof parentFolderUuid !== 'string' || parentFolderUuid.length === 0) return;
+  await bridge.notifyParentChanged(parentFolderUuid);
+}

--- a/src/store/slices/auth/auth.syncNativeCredentials.spec.ts
+++ b/src/store/slices/auth/auth.syncNativeCredentials.spec.ts
@@ -1,0 +1,109 @@
+jest.mock('../../../services/native/InternxtAuthCredentialsModule', () => ({
+  setCredentials: jest.fn().mockResolvedValue(undefined),
+  clearCredentials: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@internxt-mobile/services/common', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+  imageService: {},
+  PROFILE_PICTURE_CACHE_KEY: 'profile-picture',
+  SdkManager: { init: jest.fn(), setApiSecurity: jest.fn(), getInstance: jest.fn() },
+}));
+
+jest.mock('../drive', () => ({ driveActions: { resetState: jest.fn(() => ({ type: 'drive/resetState' })) } }));
+jest.mock('../ui', () => ({ uiActions: { resetState: jest.fn(() => ({ type: 'ui/resetState' })) } }));
+
+jest.mock('@internxt-mobile/services/drive', () => ({
+  __esModule: true,
+  default: { clear: jest.fn().mockResolvedValue(undefined) },
+}));
+
+jest.mock('src/services/ErrorService', () => ({ __esModule: true, default: { reportError: jest.fn() } }));
+
+jest.mock('../../../services/AppService', () => {
+  const appConstants = {
+    DRIVE_NEW_API_URL: 'https://drive',
+    BRIDGE_URL: 'https://bridge',
+    CLOUDFLARE_TOKEN: 'cf',
+    CRYPTO_SECRET: 'crypto-secret',
+    CRYPTO_SECRET2: 'crypto-secret-2',
+  };
+  return { __esModule: true, default: { constants: appConstants }, constants: appConstants };
+});
+
+jest.mock('../../../services/AsyncStorageService', () => ({
+  __esModule: true,
+  default: {
+    saveItem: jest.fn().mockResolvedValue(undefined),
+    getItem: jest.fn().mockResolvedValue('current-photos-token'),
+    deleteItem: jest.fn().mockResolvedValue(undefined),
+    clearStorage: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock('../../../services/AuthService', () => ({
+  __esModule: true,
+  default: {
+    emitLoginEvent: jest.fn(),
+    emitLogoutEvent: jest.fn(),
+    signout: jest.fn().mockResolvedValue(undefined),
+    refreshAuthToken: jest.fn(),
+    getAuthCredentials: jest.fn(),
+  },
+}));
+
+jest.mock('../../../services/NotificationsService', () => ({ __esModule: true, default: {} }));
+jest.mock('../../../services/UserService', () => ({ __esModule: true, default: {} }));
+
+import authService from '../../../services/AuthService';
+import { clearCredentials, setCredentials } from '../../../services/native/InternxtAuthCredentialsModule';
+import { refreshTokensThunk, signInThunk, signOutThunk } from './index';
+
+const setCredentialsMock = setCredentials as jest.Mock;
+const clearCredentialsMock = clearCredentials as jest.Mock;
+const refreshAuthTokenMock = authService.refreshAuthToken as jest.Mock;
+const getAuthCredentialsMock = authService.getAuthCredentials as jest.Mock;
+
+const user = {
+  userId: 'user-1',
+  bridgeUser: 'bridge@internxt.com',
+  mnemonic: 'pretty cloud secret words',
+  rootFolderUuid: 'root-uuid-123',
+  email: 'user@internxt.com',
+} as never;
+
+type DispatchableThunk = (dispatch: jest.Mock, getState: jest.Mock, extra: undefined) => Promise<unknown>;
+
+const runThunk = (action: unknown) =>
+  (action as DispatchableThunk)(jest.fn(), jest.fn(), undefined);
+
+describe('auth thunks native credentials handoff', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('when the login completes, then the wrapper receives the new token', async () => {
+    await runThunk(signInThunk({ user, token: 'access-token', newToken: 'login-new-token' }));
+
+    expect(setCredentialsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ bearerToken: 'login-new-token', rootFolderUuid: 'root-uuid-123' }),
+    );
+  });
+
+  it('when the token is refreshed in the foreground, then the wrapper receives the refreshed token', async () => {
+    refreshAuthTokenMock.mockResolvedValue({ token: 'access-2', newToken: 'refreshed-new-token' });
+    getAuthCredentialsMock.mockResolvedValue({
+      credentials: { accessToken: 'access-2', photosToken: 'refreshed-new-token', user },
+    });
+
+    await runThunk(refreshTokensThunk());
+
+    expect(setCredentialsMock).toHaveBeenCalledWith(expect.objectContaining({ bearerToken: 'refreshed-new-token' }));
+  });
+
+  it('when the logout completes, then clearCredentials is invoked', async () => {
+    await runThunk(signOutThunk({ reason: 'manual' }));
+
+    expect(clearCredentialsMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/store/slices/auth/index.ts
+++ b/src/store/slices/auth/index.ts
@@ -11,7 +11,7 @@ import strings from '../../../../assets/lang/strings';
 import appService from '../../../services/AppService';
 import asyncStorageService from '../../../services/AsyncStorageService';
 import authService from '../../../services/AuthService';
-import InternxtAuthCredentialsModule from '../../../services/native/InternxtAuthCredentialsModule';
+import { clearCredentials, setCredentials } from '../../../services/native/InternxtAuthCredentialsModule';
 import notificationsService from '../../../services/NotificationsService';
 import { default as userService } from '../../../services/UserService';
 import { AsyncStorageKey, NotificationType } from '../../../types';
@@ -37,7 +37,7 @@ const initialState: AuthState = {
 
 async function syncNativeCredentials(token: string, user: UserSettings): Promise<void> {
   try {
-    await InternxtAuthCredentialsModule.setCredentials({
+    await setCredentials({
       bearerToken: token,
       userId: user.userId,
       bridgeUser: user.bridgeUser,
@@ -228,7 +228,7 @@ export const signOutThunk = createAsyncThunk<
   const reason = payload.reason;
   authService.signout(reason).catch(errorService.reportError);
   drive.clear().catch(errorService.reportError);
-  InternxtAuthCredentialsModule.clearCredentials().catch(errorService.reportError);
+  clearCredentials().catch(errorService.reportError);
   dispatch(uiActions.resetState());
   dispatch(authActions.resetState());
   dispatch(driveActions.resetState());

--- a/src/store/slices/auth/index.ts
+++ b/src/store/slices/auth/index.ts
@@ -8,8 +8,10 @@ import { UserSettings } from '@internxt/sdk/dist/shared/types/userSettings';
 import errorService from 'src/services/ErrorService';
 import { RootState } from '../..';
 import strings from '../../../../assets/lang/strings';
+import appService from '../../../services/AppService';
 import asyncStorageService from '../../../services/AsyncStorageService';
 import authService from '../../../services/AuthService';
+import InternxtAuthCredentialsModule from '../../../services/native/InternxtAuthCredentialsModule';
 import notificationsService from '../../../services/NotificationsService';
 import { default as userService } from '../../../services/UserService';
 import { AsyncStorageKey, NotificationType } from '../../../types';
@@ -32,6 +34,22 @@ const initialState: AuthState = {
   securityDetails: undefined,
   sessionPassword: undefined,
 };
+
+async function syncNativeCredentials(token: string, user: UserSettings): Promise<void> {
+  try {
+    await InternxtAuthCredentialsModule.setCredentials({
+      bearerToken: token,
+      userId: user.userId,
+      bridgeUser: user.bridgeUser,
+      rootFolderUuid: user.rootFolderUuid || user.rootFolderId,
+      email: user.email,
+      driveBaseUrl: appService.constants.DRIVE_NEW_API_URL,
+      bridgeBaseUrl: appService.constants.BRIDGE_URL,
+    });
+  } catch (err) {
+    errorService.reportError(err);
+  }
+}
 
 export const initializeThunk = createAsyncThunk<void, void, { state: RootState }>(
   'auth/initialize',
@@ -116,6 +134,9 @@ export const signInThunk = createAsyncThunk<
   await asyncStorageService.saveItem(AsyncStorageKey.User, JSON.stringify(userToSave));
   // Reset this, in case we logged out during the pull process
   await asyncStorageService.deleteItem(AsyncStorageKey.LastPhotoPulledDate);
+
+  await syncNativeCredentials(payload.token, userToSave);
+
   dispatch(
     authActions.setSignInData({
       token: payload.token,
@@ -154,6 +175,8 @@ export const refreshTokensThunk = createAsyncThunk<void, void, { state: RootStat
 
       // Get the current credentials
       const { credentials } = await authService.getAuthCredentials();
+
+      await syncNativeCredentials(refreshed.token, credentials.user);
 
       // Pass the new tokens to the SdkManager
       SdkManager.init({
@@ -205,6 +228,7 @@ export const signOutThunk = createAsyncThunk<
   const reason = payload.reason;
   authService.signout(reason).catch(errorService.reportError);
   drive.clear().catch(errorService.reportError);
+  InternxtAuthCredentialsModule.clearCredentials().catch(errorService.reportError);
   dispatch(uiActions.resetState());
   dispatch(authActions.resetState());
   dispatch(driveActions.resetState());

--- a/src/store/slices/auth/index.ts
+++ b/src/store/slices/auth/index.ts
@@ -51,6 +51,7 @@ async function syncNativeCredentials(token: string, user: UserSettings): Promise
       bearerToken: token,
       userId: user.userId,
       bridgeUser: user.bridgeUser,
+      mnemonic: user.mnemonic,
       rootFolderUuid: user.rootFolderUuid,
       email: user.email,
       driveBaseUrl: appService.constants.DRIVE_NEW_API_URL,

--- a/src/store/slices/auth/index.ts
+++ b/src/store/slices/auth/index.ts
@@ -147,7 +147,7 @@ export const signInThunk = createAsyncThunk<
   // Reset this, in case we logged out during the pull process
   await asyncStorageService.deleteItem(AsyncStorageKey.LastPhotoPulledDate);
 
-  await syncNativeCredentials(payload.token, userToSave);
+  await syncNativeCredentials(payload.newToken, userToSave);
 
   dispatch(
     authActions.setSignInData({
@@ -188,7 +188,7 @@ export const refreshTokensThunk = createAsyncThunk<void, void, { state: RootStat
       // Get the current credentials
       const { credentials } = await authService.getAuthCredentials();
 
-      await syncNativeCredentials(refreshed.token, credentials.user);
+      await syncNativeCredentials(refreshed.newToken, credentials.user);
 
       // Pass the new tokens to the SdkManager
       SdkManager.init({

--- a/src/store/slices/auth/index.ts
+++ b/src/store/slices/auth/index.ts
@@ -35,16 +35,27 @@ const initialState: AuthState = {
   sessionPassword: undefined,
 };
 
+async function ensureRootFolderUuid(user: UserSettings): Promise<UserSettings> {
+  if (user.rootFolderUuid || !user.root_folder_id) return user;
+  const meta = await SdkManager.getInstance().storageV2.getFolderMetaById(user.root_folder_id);
+  return { ...user, rootFolderUuid: meta.uuid };
+}
+
 async function syncNativeCredentials(token: string, user: UserSettings): Promise<void> {
+  if (!user.rootFolderUuid) {
+    errorService.reportError(new Error('syncNativeCredentials: missing rootFolderUuid'));
+    return;
+  }
   try {
     await setCredentials({
       bearerToken: token,
       userId: user.userId,
       bridgeUser: user.bridgeUser,
-      rootFolderUuid: user.rootFolderUuid || user.rootFolderId,
+      rootFolderUuid: user.rootFolderUuid,
       email: user.email,
       driveBaseUrl: appService.constants.DRIVE_NEW_API_URL,
       bridgeBaseUrl: appService.constants.BRIDGE_URL,
+      desktopToken: appService.constants.CLOUDFLARE_TOKEN,
     });
   } catch (err) {
     errorService.reportError(err);
@@ -117,7 +128,6 @@ export const signInThunk = createAsyncThunk<
   { user: UserSettings; token: string; newToken: string },
   { state: RootState }
 >('auth/signIn', async (payload, { dispatch }) => {
-  const userToSave = payload.user;
   SdkManager.init({
     token: payload.token,
     newToken: payload.newToken,
@@ -128,6 +138,8 @@ export const signInThunk = createAsyncThunk<
     token: payload.token,
     newToken: payload.newToken,
   });
+
+  const userToSave = await ensureRootFolderUuid(payload.user);
 
   await asyncStorageService.saveItem(AsyncStorageKey.Token, payload.token);
   await asyncStorageService.saveItem(AsyncStorageKey.PhotosToken, payload.newToken); // Photos access token

--- a/src/store/slices/auth/index.ts
+++ b/src/store/slices/auth/index.ts
@@ -240,7 +240,7 @@ export const signOutThunk = createAsyncThunk<
   const reason = payload.reason;
   authService.signout(reason).catch(errorService.reportError);
   drive.clear().catch(errorService.reportError);
-  clearCredentials().catch(errorService.reportError);
+  await clearCredentials().catch(errorService.reportError);
   dispatch(uiActions.resetState());
   dispatch(authActions.resetState());
   dispatch(driveActions.resetState());

--- a/src/store/slices/drive/index.ts
+++ b/src/store/slices/drive/index.ts
@@ -7,6 +7,7 @@ import { items } from '@internxt/lib';
 import { checkIsFolder, isValidFilename, mapRecentFile } from 'src/helpers';
 import authService from 'src/services/AuthService';
 import errorService from 'src/services/ErrorService';
+import { notifyParentChanged } from 'src/services/native/InternxtSignalingModule';
 import { ErrorCodes } from 'src/types/errors';
 import { RootState } from '../..';
 import strings from '../../../../assets/lang/strings';
@@ -368,6 +369,8 @@ const moveItemThunk = createAsyncThunk<void, MoveItemThunkPayload, { state: Root
           destinationFolderUuid: destinationUuid,
         });
       }
+
+      void notifyParentChanged(origin.parentUuid);
 
       optimisticCallbacks?.onOptimisticUpdate();
 


### PR DESCRIPTION
Uploads of files whose names contain spaces or non-ASCII characters failed with ENOENT because percent-encoded cache URIs were passed unmodified to RNFS.copyFile and to the native thumbnail generator. Decode the source URI before copy (copyFileFromEncodedUri) and the native-returned thumbnail URI (fromFileUri); drop the stale manual %20 encoding. Device-verified on Android.