### PR TITLE
[PB-6592] bugfix/Fix Photos timeline scroll position when open Photos

### DIFF
--- a/src/screens/PhotosScreen/components/PhotosTimeline.tsx
+++ b/src/screens/PhotosScreen/components/PhotosTimeline.tsx
@@ -1,4 +1,4 @@
-import { FlashList, ListRenderItem } from '@shopify/flash-list';
+import { FlashList, FlashListRef, ListRenderItem } from '@shopify/flash-list';
 import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { Animated, Platform, StyleSheet, View } from 'react-native';
 import { GestureDetector } from 'react-native-gesture-handler';
@@ -12,6 +12,7 @@ import PhotosEmptyState from './PhotosEmptyState';
 
 export interface PhotosTimelineHandle {
   scrollToAssetId: (id: string) => void;
+  scrollToTop: () => void;
 }
 
 export type TimelineDateGroup = { group: PhotoDateGroup; syncStatus: GroupSyncStatus };
@@ -90,7 +91,7 @@ const PhotosTimeline = forwardRef<PhotosTimelineHandle, PhotosTimelineProps>(
 
     const [topGroupId, setTopGroupId] = useState<string | undefined>(() => boundaries[0]?.id);
 
-    const flashListRef = useRef<any>(null);
+    const flashListRef = useRef<FlashListRef<TimelinePhotoItem>>(null);
     const boundariesRef = useRef<GroupBoundary[]>(boundaries);
     boundariesRef.current = boundaries;
 
@@ -141,6 +142,9 @@ const PhotosTimeline = forwardRef<PhotosTimelineHandle, PhotosTimelineProps>(
             return;
           }
           flashListRef.current?.scrollToIndex({ index, animated: false, viewPosition: 0.3 });
+        },
+        scrollToTop: () => {
+          flashListRef.current?.scrollToOffset({ offset: 0, animated: false });
         },
       }),
       [idToIndex],
@@ -206,6 +210,7 @@ const PhotosTimeline = forwardRef<PhotosTimelineHandle, PhotosTimelineProps>(
             onScroll={onScroll}
             scrollEventThrottle={16}
             progressViewOffset={HEADER_HEIGHT}
+            maintainVisibleContentPosition={{ disabled: true }}
           />
 
           {!isEmpty && currentBoundary && (

--- a/src/screens/PhotosScreen/hooks/useCloudAssets.spec.ts
+++ b/src/screens/PhotosScreen/hooks/useCloudAssets.spec.ts
@@ -154,6 +154,40 @@ describe('useCloudAssets', () => {
     expect(mockPhotosLocalDB.getAllCloudAssets).toHaveBeenCalledWith(undefined);
   });
 
+  test('when the device filter id changes, then the previous filter cloud items are cleared before the new query resolves', async () => {
+    mockPhotosLocalDB.getAllCloudAssets
+      .mockResolvedValueOnce([
+        {
+          remoteFileId: 'device-1-photo',
+          deviceId: 'device-1',
+          createdAt: 1000,
+          fileName: 'photo.jpg',
+          fileSize: null,
+          fileId: null,
+          thumbnailPath: null,
+          thumbnailBucketId: null,
+          thumbnailBucketFile: null,
+          thumbnailType: null,
+          discoveredAt: 1000,
+        },
+      ])
+      .mockImplementationOnce(() => new Promise(() => undefined)); // never resolves for device-2
+
+    const { result, rerender } = renderHook(({ deviceFilterId }) => useCloudAssets(deviceFilterId), {
+      initialProps: { deviceFilterId: 'device-1' },
+    });
+
+    await act(flushAsync);
+    expect(result.current.cloudItems.map((item) => item.id)).toEqual(['device-1-photo']);
+
+    await act(async () => {
+      rerender({ deviceFilterId: 'device-2' });
+      await flushAsync();
+    });
+
+    expect(result.current.cloudItems).toEqual([]);
+  });
+
   test('when synced remote ids overlap with cloud assets, then duplicates are excluded', async () => {
     mockPhotosLocalDB.getAllCloudAssets.mockResolvedValueOnce([
       {

--- a/src/screens/PhotosScreen/hooks/useCloudAssets.ts
+++ b/src/screens/PhotosScreen/hooks/useCloudAssets.ts
@@ -29,6 +29,7 @@ export const useCloudAssets = (deviceFilterId?: string | null): CloudAssetsResul
   }, [deviceFilterId]);
 
   useEffect(() => {
+    setCloudItems([]);
     reloadCloudFromDB();
   }, [reloadCloudFromDB]);
 

--- a/src/screens/PhotosScreen/hooks/useLocalAssets.spec.ts
+++ b/src/screens/PhotosScreen/hooks/useLocalAssets.spec.ts
@@ -69,12 +69,15 @@ describe('useLocalAssets', () => {
 
     const { result } = renderHook(() => useLocalAssets());
 
+    expect(result.current.hasLoadedLocalAssetsOnce).toBe(false);
+
     await act(async () => {
       await Promise.resolve();
     });
 
     expect(result.current.assets).toEqual(assets);
     expect(result.current.isLoading).toBe(false);
+    expect(result.current.hasLoadedLocalAssetsOnce).toBe(true);
   });
 
   test('when loadNextPage is called and there is a next page, then the new assets are appended', async () => {

--- a/src/screens/PhotosScreen/hooks/useLocalAssets.ts
+++ b/src/screens/PhotosScreen/hooks/useLocalAssets.ts
@@ -14,6 +14,7 @@ const MEDIA_TYPES = [MediaLibrary.MediaType.photo, MediaLibrary.MediaType.video]
 export interface LocalAssetsResult {
   assets: MediaLibrary.Asset[];
   isLoading: boolean;
+  hasLoadedLocalAssetsOnce: boolean;
   syncedIds: Set<string>;
   cloudDeletedIds: Set<string>;
   uploadingIdSet: Set<string>;
@@ -27,6 +28,7 @@ export interface LocalAssetsResult {
 export const useLocalAssets = (): LocalAssetsResult => {
   const [assets, setAssets] = useState<MediaLibrary.Asset[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [hasLoadedLocalAssetsOnce, setHasLoadedLocalAssetsOnce] = useState(false);
   const [syncedIds, setSyncedIds] = useState<Set<string>>(new Set());
   // TODO: Reserved for show a distinct icon for cloud-deleted vs never-backed assets. Remove if finally will be the same.
   const [cloudDeletedIds, setCloudDeletedIds] = useState<Set<string>>(new Set());
@@ -229,6 +231,7 @@ export const useLocalAssets = (): LocalAssetsResult => {
   useEffect(() => {
     if (!isPhotosEnabled) {
       setIsLoading(false);
+      setHasLoadedLocalAssetsOnce(true);
       return;
     }
     const loadFirstPage = async () => {
@@ -243,6 +246,7 @@ export const useLocalAssets = (): LocalAssetsResult => {
         }
       } finally {
         setIsLoading(false);
+        setHasLoadedLocalAssetsOnce(true);
       }
     };
     loadFirstPage();
@@ -296,6 +300,7 @@ export const useLocalAssets = (): LocalAssetsResult => {
   return {
     assets,
     isLoading,
+    hasLoadedLocalAssetsOnce,
     syncedIds,
     cloudDeletedIds,
     uploadingIdSet,

--- a/src/screens/PhotosScreen/hooks/usePhotosTimeline.spec.ts
+++ b/src/screens/PhotosScreen/hooks/usePhotosTimeline.spec.ts
@@ -64,6 +64,7 @@ beforeEach(() => {
   mockUseLocalAssets.mockReturnValue({
     assets: [localAsset],
     isLoading: false,
+    hasLoadedLocalAssetsOnce: true,
     syncedIds: new Set(),
     uploadingIdSet: new Set(),
     burstRepresentativeIdSet: new Set(),
@@ -99,5 +100,44 @@ describe('usePhotosTimeline', () => {
     const allIds = result.current.timelineDateGroups.flatMap((entry) => entry.group.photos.map((photo) => photo.id));
     expect(allIds).toEqual(['cloud-1']);
     expect(allIds).not.toContain('local-1');
+  });
+
+  test('when local assets have not finished their first load yet, then cloud items are withheld to avoid a reorder-after-mount scroll jump', () => {
+    mockUseLocalAssets.mockReturnValue({
+      assets: [],
+      isLoading: true,
+      hasLoadedLocalAssetsOnce: false,
+      syncedIds: new Set(),
+      uploadingIdSet: new Set(),
+      burstRepresentativeIdSet: new Set(),
+      incompleteUploadBurstIdSet: new Set(),
+      localDeletionDetectedCount: 0,
+      loadNextPage: jest.fn(),
+      reload: jest.fn(),
+    });
+
+    const { result } = renderHook(() => usePhotosTimeline(null));
+
+    expect(result.current.timelineDateGroups).toEqual([]);
+  });
+
+  test('when local assets have not finished loading but the filter targets another device, then that device cloud items still show', () => {
+    mockUseLocalAssets.mockReturnValue({
+      assets: [],
+      isLoading: true,
+      hasLoadedLocalAssetsOnce: false,
+      syncedIds: new Set(),
+      uploadingIdSet: new Set(),
+      burstRepresentativeIdSet: new Set(),
+      incompleteUploadBurstIdSet: new Set(),
+      localDeletionDetectedCount: 0,
+      loadNextPage: jest.fn(),
+      reload: jest.fn(),
+    });
+
+    const { result } = renderHook(() => usePhotosTimeline('other-device'));
+
+    const allIds = result.current.timelineDateGroups.flatMap((entry) => entry.group.photos.map((photo) => photo.id));
+    expect(allIds).toEqual(['cloud-1']);
   });
 });

--- a/src/screens/PhotosScreen/hooks/usePhotosTimeline.ts
+++ b/src/screens/PhotosScreen/hooks/usePhotosTimeline.ts
@@ -17,6 +17,7 @@ export const usePhotosTimeline = (deviceFilterId?: string | null): PhotosTimelin
   const {
     assets,
     isLoading,
+    hasLoadedLocalAssetsOnce,
     syncedIds,
     uploadingIdSet,
     burstRepresentativeIdSet,
@@ -27,7 +28,7 @@ export const usePhotosTimeline = (deviceFilterId?: string | null): PhotosTimelin
   } = useLocalAssets();
   const { cloudItems, reloadCloud } = useCloudAssets(deviceFilterId);
   const currentDeviceId = useAppSelector((state) => state.photos.deviceId);
-  const showLocal = deviceFilterId == null || deviceFilterId === currentDeviceId;
+  const showLocalAssets = deviceFilterId == null || deviceFilterId === currentDeviceId;
 
   // When local assets are deleted, their asset_sync entries are removed so the cloud
   // copies become visible as cloud-only. Reload the cloud view to reflect that.
@@ -48,13 +49,17 @@ export const usePhotosTimeline = (deviceFilterId?: string | null): PhotosTimelin
 
   const localGroups = useMemo(
     () =>
-      showLocal
+      showLocalAssets
         ? groupAssetsByDate(assets, syncedIds, uploadingIdSet, burstRepresentativeIdSet, incompleteBurstIdSet)
         : [],
-    [showLocal, assets, syncedIds, uploadingIdSet, burstRepresentativeIdSet, incompleteBurstIdSet],
+    [showLocalAssets, assets, syncedIds, uploadingIdSet, burstRepresentativeIdSet, incompleteBurstIdSet],
   );
 
-  const mergedGroups = useMemo(() => mergeCloudIntoGroups(localGroups, cloudItems), [localGroups, cloudItems]);
+  const readyToMergeCloud = !showLocalAssets || hasLoadedLocalAssetsOnce;
+  const mergedGroups = useMemo(
+    () => mergeCloudIntoGroups(localGroups, readyToMergeCloud ? cloudItems : []),
+    [localGroups, cloudItems, readyToMergeCloud],
+  );
 
   const timelineDateGroups = useMemo(() => {
     const sessionRemaining = Math.max(0, sessionTotalAssets - sessionUploadedAssets);

--- a/src/screens/PhotosScreen/index.tsx
+++ b/src/screens/PhotosScreen/index.tsx
@@ -55,6 +55,7 @@ const PhotosScreen = (): JSX.Element => {
 
   const timelineRef = useRef<PhotosTimelineHandle>(null);
   const lastViewedIdRef = useRef<string | null>(null);
+  const isFirstDeviceFilterRenderRef = useRef(true);
 
   const allItems = useMemo<TimelinePhotoItem[]>(
     () => timelineDateGroups.flatMap((dateGroup) => dateGroup.group.photos),
@@ -159,6 +160,14 @@ const PhotosScreen = (): JSX.Element => {
       setRefreshing(false);
     }
   }, [dispatch, reloadLocal]);
+
+  useEffect(() => {
+    if (isFirstDeviceFilterRenderRef.current) {
+      isFirstDeviceFilterRenderRef.current = false;
+      return;
+    }
+    timelineRef.current?.scrollToTop();
+  }, [deviceFilterId]);
 
   useEffect(() => {
     dispatch(uiActions.setIsTabBarHidden(selection.isSelectMode));


### PR DESCRIPTION
Whenn opening Photos (cold start, or after switching the device filter) landed the timeline mid-way on an old date instead of showing the most recent photos at the top.

  **Root cause:** `@shopify/flash-list` v2 ships `maintainVisibleContentPosition` enabled by default, which anchors scroll to whatever is already on screen. Since our timeline is always sorted newest-first, whenever local/cloud data resolved asynchronously and reordered the top of the list, that anchoring kept the user pinned to old content instead of showing the new top.

  **Main fixes:**

  - **`PhotosTimeline.tsx`**: disable `maintainVisibleContentPosition` on the `FlashList`, and add `scrollToTop` to the imperative handle.
  - **`index.tsx`**: force `scrollToTop()` whenever the device filter changes.
  - **`useCloudAssets.ts`**: clear the previous filter's `cloudItems` before firing the new query, so switching devices doesn't briefly show the old device's photos.
  - **`useLocalAssets.ts` / `usePhotosTimeline.ts`**:  new `hasLoadedLocalAssetsOnce` flag that withholds cloud items until local assets have loaded once, avoiding a flash of stale cloud-only content on the first cold-start render.
