### PR TITLE
[BR-2114]: iOS generation + add list-view thumbnails

### DIFF
--- a/src/components/drive/lists/items/DriveGridModeItem/DriveGridModeItem.tsx
+++ b/src/components/drive/lists/items/DriveGridModeItem/DriveGridModeItem.tsx
@@ -1,18 +1,15 @@
 import { time } from '@internxt-mobile/services/common/time';
 import strings from '../../../../../../assets/lang/strings';
-import { driveFileService } from '@internxt-mobile/services/drive/file';
+import { useDownloadedThumbnail } from '@internxt-mobile/hooks/drive';
 import { items } from '@internxt/lib';
 import { ArrowCircleUpIcon, XCircleIcon } from 'phosphor-react-native';
 import prettysize from 'prettysize';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { TouchableHighlight, TouchableOpacity, View } from 'react-native';
 import FastImage from 'react-native-fast-image';
 import { useTailwind } from 'tailwind-rn';
 import { FolderIcon, getFileTypeIcon } from '../../../../../helpers';
 import useGetColor from '../../../../../hooks/useColor';
-import { logger } from '../../../../../services/common';
-import { useAppSelector } from '../../../../../store/hooks';
-import { DownloadedThumbnail } from '../../../../../types/drive/file';
 import { DriveItemStatus } from '../../../../../types/drive/item';
 import { DriveItemProps } from '../../../../../types/drive/ui';
 import AppText from '../../../../AppText';
@@ -20,8 +17,7 @@ import AppText from '../../../../AppText';
 function DriveGridModeItemComp(props: DriveItemProps): JSX.Element {
   const tailwind = useTailwind();
   const getColor = useGetColor();
-  const user = useAppSelector((state) => state.auth.user);
-  const [downloadedThumbnail, setDownloadedThumbnail] = useState<DownloadedThumbnail | null>(null);
+  const downloadedThumbnail = useDownloadedThumbnail(props.data);
   const [maxThumbnailWidth, setMaxThumbnailWidth] = useState<number | null>(null);
   const thumbnailSize = downloadedThumbnail || null;
   const IconFile = getFileTypeIcon(props.data.type || '');
@@ -45,26 +41,6 @@ function DriveGridModeItemComp(props: DriveItemProps): JSX.Element {
 
     return thumbnailHeight > maxThumbnailHeight ? maxThumbnailHeight : thumbnailHeight;
   };
-
-  useEffect(() => {
-    let isMounted = true;
-
-    if (props.data.thumbnails?.length && !downloadedThumbnail && user) {
-      driveFileService
-        // TODO: NEED TO UPDATE SDK TYPES
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        .getThumbnail(props.data.thumbnails[0], user)
-        .then((thumbnail) => {
-          if (isMounted) setDownloadedThumbnail(thumbnail);
-        })
-        .catch(logger.error);
-    }
-
-    return () => {
-      isMounted = false;
-    };
-  }, [props.data.thumbnails, user]);
 
   const renderThumbnail = (thumbnail: { width: number; height: number; uri: string }) => {
     const height = getThumbnailHeight();

--- a/src/components/drive/lists/items/DriveListModeItem/DriveListModeItem.spec.tsx
+++ b/src/components/drive/lists/items/DriveListModeItem/DriveListModeItem.spec.tsx
@@ -1,0 +1,67 @@
+import { render } from '@testing-library/react-native';
+import { useDownloadedThumbnail } from '@internxt-mobile/hooks/drive';
+import { DownloadedThumbnail } from '@internxt-mobile/types/drive/file';
+import { DriveItemData } from '@internxt-mobile/types/drive/item';
+import { DriveItemStatus } from '../../../../../types/drive/item';
+import { DriveItemProps, DriveListType, DriveListViewMode } from '../../../../../types/drive/ui';
+import { DriveListModeItem } from './DriveListModeItem';
+
+jest.mock('@internxt-mobile/hooks/drive', () => ({
+  useDownloadedThumbnail: jest.fn(),
+}));
+
+jest.mock('@internxt/lib', () => ({
+  items: {
+    getItemDisplayName: ({ name, type }: { name: string; type?: string }) => (type ? `${name}.${type}` : name),
+  },
+}));
+
+jest.mock('tailwind-rn', () => ({
+  useTailwind: () => () => ({}),
+}));
+
+jest.mock('../../../../../hooks/useColor', () => () => () => '#000000');
+
+jest.mock('react-native-fast-image', () => 'FastImage');
+
+jest.mock('../../../../../helpers', () => {
+  const { Text: MockText } = jest.requireActual('react-native');
+  return {
+    FolderIcon: () => <MockText testID="drive-list-item-folder-icon" />,
+    getFileTypeIcon: () => () => <MockText testID="drive-list-item-generic-icon" />,
+  };
+});
+
+const useDownloadedThumbnailMock = useDownloadedThumbnail as jest.Mock;
+const thumbnail: DownloadedThumbnail = { width: 40, height: 40, uri: 'file:///thumb.png' };
+
+const arrange = (): DriveItemProps => ({
+  type: DriveListType.Drive,
+  viewMode: DriveListViewMode.List,
+  status: DriveItemStatus.Idle,
+  data: { name: 'photo', type: 'png', isFolder: false } as DriveItemData,
+});
+
+describe('DriveListModeItem', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('when the item has a downloaded thumbnail, then the row renders the thumbnail instead of the generic icon', () => {
+    useDownloadedThumbnailMock.mockReturnValue(thumbnail);
+
+    const { queryByTestId } = render(<DriveListModeItem {...arrange()} />);
+
+    expect(queryByTestId('drive-list-item-thumbnail')).not.toBeNull();
+    expect(queryByTestId('drive-list-item-generic-icon')).toBeNull();
+  });
+
+  test('when the item has no downloaded thumbnail, then the row renders the generic icon', () => {
+    useDownloadedThumbnailMock.mockReturnValue(null);
+
+    const { queryByTestId } = render(<DriveListModeItem {...arrange()} />);
+
+    expect(queryByTestId('drive-list-item-generic-icon')).not.toBeNull();
+    expect(queryByTestId('drive-list-item-thumbnail')).toBeNull();
+  });
+});

--- a/src/components/drive/lists/items/DriveListModeItem/DriveListModeItem.tsx
+++ b/src/components/drive/lists/items/DriveListModeItem/DriveListModeItem.tsx
@@ -9,7 +9,9 @@ import ProgressBar from '../../../../AppProgressBar';
 import AppText from '../../../../AppText';
 
 import { time } from '@internxt-mobile/services/common/time';
+import { useDownloadedThumbnail } from '@internxt-mobile/hooks/drive';
 import { DriveListType } from '@internxt-mobile/types/drive/ui';
+import FastImage from 'react-native-fast-image';
 import { useTailwind } from 'tailwind-rn';
 import useGetColor from '../../../../../hooks/useColor';
 import { DriveItemStatus } from '../../../../../types/drive/item';
@@ -18,6 +20,7 @@ import { DriveItemProps } from '../../../../../types/drive/ui';
 export function DriveListModeItem(props: DriveItemProps): JSX.Element {
   const tailwind = useTailwind();
   const getColor = useGetColor();
+  const downloadedThumbnail = useDownloadedThumbnail(props.data);
 
   const iconSize = 40;
   const IconFile = getFileTypeIcon(props.data.type || '');
@@ -125,6 +128,13 @@ export function DriveListModeItem(props: DriveItemProps): JSX.Element {
           <View style={[tailwind('mb-1 mr-4 items-center justify-center'), isUploading && tailwind('opacity-40')]}>
             {isFolder ? (
               <FolderIcon width={iconSize} height={iconSize} />
+            ) : downloadedThumbnail ? (
+              <FastImage
+                testID="drive-list-item-thumbnail"
+                source={{ uri: downloadedThumbnail.uri }}
+                style={{ width: iconSize, height: iconSize, borderRadius: 6 }}
+                resizeMode="cover"
+              />
             ) : (
               <IconFile width={iconSize} height={iconSize} />
             )}

--- a/src/components/drive/lists/items/DriveListModeItem/DriveListModeItem.tsx
+++ b/src/components/drive/lists/items/DriveListModeItem/DriveListModeItem.tsx
@@ -115,6 +115,24 @@ export function DriveListModeItem(props: DriveItemProps): JSX.Element {
     );
   };
 
+  const isThumbnailVisible = Boolean(downloadedThumbnail);
+
+  let leadingVisual: JSX.Element;
+  if (isFolder) {
+    leadingVisual = <FolderIcon width={iconSize} height={iconSize} />;
+  } else if (isThumbnailVisible) {
+    leadingVisual = (
+      <FastImage
+        testID="drive-list-item-thumbnail"
+        source={{ uri: downloadedThumbnail?.uri }}
+        style={{ width: iconSize, height: iconSize, borderRadius: 6 }}
+        resizeMode="cover"
+      />
+    );
+  } else {
+    leadingVisual = <IconFile width={iconSize} height={iconSize} />;
+  }
+
   return (
     <TouchableHighlight
       disabled={!isFolderUploading && (isUploading || isDownloading)}
@@ -126,18 +144,7 @@ export function DriveListModeItem(props: DriveItemProps): JSX.Element {
       <View style={[tailwind('flex-row pl-5'), { backgroundColor: getColor('bg-surface') }]}>
         <View style={[tailwind('flex-row flex-1 py-3')]}>
           <View style={[tailwind('mb-1 mr-4 items-center justify-center'), isUploading && tailwind('opacity-40')]}>
-            {isFolder ? (
-              <FolderIcon width={iconSize} height={iconSize} />
-            ) : downloadedThumbnail ? (
-              <FastImage
-                testID="drive-list-item-thumbnail"
-                source={{ uri: downloadedThumbnail.uri }}
-                style={{ width: iconSize, height: iconSize, borderRadius: 6 }}
-                resizeMode="cover"
-              />
-            ) : (
-              <IconFile width={iconSize} height={iconSize} />
-            )}
+            {leadingVisual}
             {props.type === DriveListType.Shared && (
               <View
                 style={[

--- a/src/hooks/drive/index.ts
+++ b/src/hooks/drive/index.ts
@@ -1,1 +1,2 @@
 export * from './useDrive';
+export * from './useDownloadedThumbnail';

--- a/src/hooks/drive/useDownloadedThumbnail.spec.ts
+++ b/src/hooks/drive/useDownloadedThumbnail.spec.ts
@@ -1,0 +1,95 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { driveFileService } from '@internxt-mobile/services/drive/file';
+import { logger } from '@internxt-mobile/services/common';
+import { DownloadedThumbnail } from '@internxt-mobile/types/drive/file';
+import { DriveItemData } from '@internxt-mobile/types/drive/item';
+import { useAppSelector } from '../../store/hooks';
+import { useDownloadedThumbnail } from './useDownloadedThumbnail';
+
+jest.mock('@internxt-mobile/services/drive/file', () => ({
+  driveFileService: {
+    getThumbnail: jest.fn(),
+  },
+}));
+
+jest.mock('@internxt-mobile/services/common', () => ({
+  logger: {
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('../../store/hooks', () => ({
+  useAppSelector: jest.fn(),
+}));
+
+const getThumbnailMock = driveFileService.getThumbnail as jest.Mock;
+const useAppSelectorMock = useAppSelector as jest.Mock;
+
+const authenticatedUser = { uuid: 'user-uuid' };
+const thumbnailEntry = { bucketFile: 'bucket-file' };
+const thumbnail: DownloadedThumbnail = { width: 100, height: 80, uri: 'file:///thumb.png' };
+
+const arrange = (data: Partial<Pick<DriveItemData, 'isFolder' | 'thumbnails'>>, user: unknown = authenticatedUser) => {
+  useAppSelectorMock.mockReturnValue(user);
+
+  return {
+    isFolder: false,
+    thumbnails: [thumbnailEntry],
+    ...data,
+  } as Pick<DriveItemData, 'isFolder' | 'thumbnails'>;
+};
+
+describe('useDownloadedThumbnail', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getThumbnailMock.mockResolvedValue(thumbnail);
+  });
+
+  test('when the item has thumbnails and there is a user, then it downloads and returns the thumbnail', async () => {
+    const data = arrange({});
+
+    const { result } = renderHook(() => useDownloadedThumbnail(data));
+
+    await waitFor(() => expect(result.current).toEqual(thumbnail));
+    expect(getThumbnailMock).toHaveBeenCalledTimes(1);
+    expect(getThumbnailMock).toHaveBeenCalledWith(thumbnailEntry, authenticatedUser);
+  });
+
+  test('when the item has no thumbnails, then it does not download and returns null', async () => {
+    const data = arrange({ thumbnails: [] });
+
+    const { result } = renderHook(() => useDownloadedThumbnail(data));
+
+    await waitFor(() => expect(getThumbnailMock).not.toHaveBeenCalled());
+    expect(result.current).toBeNull();
+  });
+
+  test('when the item is a folder, then it does not download and returns null', async () => {
+    const data = arrange({ isFolder: true });
+
+    const { result } = renderHook(() => useDownloadedThumbnail(data));
+
+    await waitFor(() => expect(getThumbnailMock).not.toHaveBeenCalled());
+    expect(result.current).toBeNull();
+  });
+
+  test('when the thumbnail download fails, then it logs the error and returns null without throwing', async () => {
+    const downloadError = new Error('download failed');
+    getThumbnailMock.mockRejectedValue(downloadError);
+    const data = arrange({});
+
+    const { result } = renderHook(() => useDownloadedThumbnail(data));
+
+    await waitFor(() => expect(logger.error).toHaveBeenCalledWith(downloadError));
+    expect(result.current).toBeNull();
+  });
+
+  test('when there is no authenticated user, then it does not download and returns null', async () => {
+    const data = arrange({}, null);
+
+    const { result } = renderHook(() => useDownloadedThumbnail(data));
+
+    await waitFor(() => expect(getThumbnailMock).not.toHaveBeenCalled());
+    expect(result.current).toBeNull();
+  });
+});

--- a/src/hooks/drive/useDownloadedThumbnail.ts
+++ b/src/hooks/drive/useDownloadedThumbnail.ts
@@ -1,0 +1,35 @@
+import { logger } from '@internxt-mobile/services/common';
+import { driveFileService } from '@internxt-mobile/services/drive/file';
+import { DownloadedThumbnail } from '@internxt-mobile/types/drive/file';
+import { DriveItemData } from '@internxt-mobile/types/drive/item';
+import { useEffect, useState } from 'react';
+import { useAppSelector } from '../../store/hooks';
+
+export const useDownloadedThumbnail = (
+  data: Pick<DriveItemData, 'isFolder' | 'thumbnails'>,
+): DownloadedThumbnail | null => {
+  const user = useAppSelector((state) => state.auth.user);
+  const [downloadedThumbnail, setDownloadedThumbnail] = useState<DownloadedThumbnail | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    if (!data.isFolder && data.thumbnails?.length && !downloadedThumbnail && user) {
+      driveFileService
+        // TODO: NEED TO UPDATE SDK TYPES
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        .getThumbnail(data.thumbnails[0], user)
+        .then((thumbnail) => {
+          if (isMounted) setDownloadedThumbnail(thumbnail);
+        })
+        .catch(logger.error);
+    }
+
+    return () => {
+      isMounted = false;
+    };
+  }, [data.thumbnails, user]);
+
+  return downloadedThumbnail;
+};

--- a/src/services/common/media/thumbnail.generation.ts
+++ b/src/services/common/media/thumbnail.generation.ts
@@ -24,15 +24,6 @@ const fromFileUri = (uri: string): string => {
   }
 };
 
-const fromFileUri = (uri: string): string => {
-  const withoutScheme = uri.replace('file://', '');
-  try {
-    return decodeURIComponent(withoutScheme);
-  } catch {
-    return withoutScheme;
-  }
-};
-
 const statSize = async (path: string): Promise<number> => Number((await RNFS.stat(path)).size);
 
 const generateImageThumbnailAndroid = async (sourcePath: string): Promise<GeneratedThumbnail> => {

--- a/src/services/common/media/thumbnail.generation.ts
+++ b/src/services/common/media/thumbnail.generation.ts
@@ -24,6 +24,15 @@ const fromFileUri = (uri: string): string => {
   }
 };
 
+const fromFileUri = (uri: string): string => {
+  const withoutScheme = uri.replace('file://', '');
+  try {
+    return decodeURIComponent(withoutScheme);
+  } catch {
+    return withoutScheme;
+  }
+};
+
 const statSize = async (path: string): Promise<number> => Number((await RNFS.stat(path)).size);
 
 const generateImageThumbnailAndroid = async (sourcePath: string): Promise<GeneratedThumbnail> => {


### PR DESCRIPTION
- **fix(ios):** `toFileUri` now emits absolute `file:///…` URIs. A relative path
  became `file://var/…` (parsed as host), so iOS thumbnail generation failed with
  `CreateThumbnail Code=1` and uploads showed no preview.
- **feat:** image thumbnails now render in Drive **list view** (previously grid
  only), via a shared `useDownloadedThumbnail` hook used by both grid and list.
  Falls back to the type icon for non-images/folders/download errors.