### PR TITLE
[_] bugfix/Photos upload cycle fixes

### DIFF
--- a/src/screens/PhotosScreen/components/PhotosTimeline.tsx
+++ b/src/screens/PhotosScreen/components/PhotosTimeline.tsx
@@ -1,5 +1,5 @@
 import { FlashList, FlashListRef, ListRenderItem } from '@shopify/flash-list';
-import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { Animated, Platform, StyleSheet, View } from 'react-native';
 import { GestureDetector } from 'react-native-gesture-handler';
 import { useTailwind } from 'tailwind-rn';
@@ -110,7 +110,7 @@ const PhotosTimeline = forwardRef<PhotosTimelineHandle, PhotosTimelineProps>(
       extrapolate: 'clamp',
     });
 
-    const { gesture, onContainerLayout, onScroll } = useDragSelectGesture({
+    const { gesture, onContainerLayout, onScroll, scrollOffsetRef } = useDragSelectGesture({
       isSelectMode: !!isSelectMode,
       photos,
       scrollY,
@@ -180,6 +180,18 @@ const PhotosTimeline = forwardRef<PhotosTimelineHandle, PhotosTimelineProps>(
     );
 
     const isIosRefreshing = Platform.OS === 'ios' && !!refreshing;
+
+    const wasIosRefreshingRef = useRef(isIosRefreshing);
+    useEffect(() => {
+      if (wasIosRefreshingRef.current && !isIosRefreshing) {
+        flashListRef.current?.scrollToOffset({
+          offset: scrollOffsetRef.current,
+          animated: false,
+        });
+      }
+      wasIosRefreshingRef.current = isIosRefreshing;
+    }, [isIosRefreshing]);
+
     const isEmpty = !isLoading && assetsGroupsByDate.length === 0;
     const currentBoundary = boundaries.find((b) => b.id === topGroupId) ?? boundaries[0];
     const overlaySyncStatus: GroupSyncStatus = isSelectMode

--- a/src/screens/PhotosScreen/components/PhotosTimeline.tsx
+++ b/src/screens/PhotosScreen/components/PhotosTimeline.tsx
@@ -179,6 +179,7 @@ const PhotosTimeline = forwardRef<PhotosTimelineHandle, PhotosTimelineProps>(
       [isSelectMode, selectedIds, onPhotoPress, onPhotoLongPress, tailwind],
     );
 
+    const isIosRefreshing = Platform.OS === 'ios' && !!refreshing;
     const isEmpty = !isLoading && assetsGroupsByDate.length === 0;
     const currentBoundary = boundaries.find((b) => b.id === topGroupId) ?? boundaries[0];
     const overlaySyncStatus: GroupSyncStatus = isSelectMode
@@ -198,7 +199,9 @@ const PhotosTimeline = forwardRef<PhotosTimelineHandle, PhotosTimelineProps>(
             ListHeaderComponent={ListHeaderComponent}
             ListEmptyComponent={isEmpty ? <PhotosEmptyState /> : undefined}
             contentContainerStyle={
-              isEmpty ? { paddingBottom: 80, flexGrow: 1 } : { paddingTop: HEADER_HEIGHT, paddingBottom: 80 }
+              isEmpty
+                ? { paddingBottom: 80, flexGrow: 1 }
+                : { paddingTop: isIosRefreshing ? 0 : HEADER_HEIGHT, paddingBottom: 80 }
             }
             showsVerticalScrollIndicator={false}
             onEndReached={onEndReached}
@@ -209,7 +212,7 @@ const PhotosTimeline = forwardRef<PhotosTimelineHandle, PhotosTimelineProps>(
             viewabilityConfig={{ itemVisiblePercentThreshold: 10 }}
             onScroll={onScroll}
             scrollEventThrottle={16}
-            progressViewOffset={HEADER_HEIGHT}
+            progressViewOffset={Platform.OS === 'android' ? HEADER_HEIGHT : 0}
             maintainVisibleContentPosition={{ disabled: true }}
           />
 
@@ -217,7 +220,7 @@ const PhotosTimeline = forwardRef<PhotosTimelineHandle, PhotosTimelineProps>(
             <>
               <Animated.View
                 pointerEvents="none"
-                style={[styles.headerOverlay, { opacity: Platform.OS === 'ios' && refreshing ? 0 : solidOpacity }]}
+                style={[styles.headerOverlay, { opacity: isIosRefreshing ? 0 : solidOpacity }]}
               >
                 <PhotosGroupHeader label={currentBoundary.label} syncStatus={overlaySyncStatus} isSticky={false} />
               </Animated.View>

--- a/src/screens/PhotosScreen/hooks/useDragSelectGesture.ts
+++ b/src/screens/PhotosScreen/hooks/useDragSelectGesture.ts
@@ -198,5 +198,5 @@ export const useDragSelectGesture = ({
     scrollYAnimHandler(e);
   }).current;
 
-  return { gesture: panGesture, onContainerLayout, onScroll };
+  return { gesture: panGesture, onContainerLayout, onScroll, scrollOffsetRef: scrollYOffsetRef };
 };

--- a/src/services/photos/PhotoUploadQueue.spec.ts
+++ b/src/services/photos/PhotoUploadQueue.spec.ts
@@ -168,6 +168,31 @@ describe('PhotoUploadQueue.abortAll', () => {
     expect(mockUpload).toHaveBeenCalledTimes(1);
   });
 
+  test('when abort is requested after a cycle begins but before the queue starts, then no jobs are uploaded', async () => {
+    const onAssetStart = jest.fn();
+    PhotoUploadQueue.beginCycle();
+    PhotoUploadQueue.abortAll();
+
+    await PhotoUploadQueue.start([{ asset: makeAsset('a1') }], DEVICE_ID, PHOTOS_BUCKET, { onAssetStart });
+
+    expect(onAssetStart).not.toHaveBeenCalled();
+    expect(mockUpload).not.toHaveBeenCalled();
+  });
+
+  test('when a cycle ends, then a later abort request does not affect the next run', async () => {
+    mockUpload.mockResolvedValue('remote-id');
+    PhotoUploadQueue.beginCycle();
+    PhotoUploadQueue.endCycle();
+    PhotoUploadQueue.abortAll();
+
+    const onAssetDone = jest.fn();
+    const asset = makeAsset('a1');
+    await PhotoUploadQueue.start([{ asset }], DEVICE_ID, PHOTOS_BUCKET, { onAssetDone });
+
+    expect(mockUpload).toHaveBeenCalledTimes(1);
+    expect(onAssetDone).toHaveBeenCalledWith('a1', expect.any(String), asset.modificationTime);
+  });
+
   test('when start is called again after abort, then a fresh abort signal is created for each run', async () => {
     const asset = makeAsset('a1');
     mockUpload.mockResolvedValue('remote-id');

--- a/src/services/photos/PhotoUploadQueue.ts
+++ b/src/services/photos/PhotoUploadQueue.ts
@@ -21,13 +21,22 @@ let currentController: AbortController | null = null;
 
 // TODO: MAKE IT CLASS
 export const PhotoUploadQueue = {
+  beginCycle(): AbortSignal {
+    currentController = new AbortController();
+    return currentController.signal;
+  },
+
+  endCycle(): void {
+    currentController = null;
+  },
+
   async start(
     jobs: AssetUploadJob[],
     deviceId: string,
     photosBucket: string,
     callbacks: UploadQueueCallbacks,
   ): Promise<void> {
-    currentController = new AbortController();
+    currentController = currentController ?? new AbortController();
     const { signal } = currentController;
 
     try {

--- a/src/store/slices/photos/index.spec.ts
+++ b/src/store/slices/photos/index.spec.ts
@@ -8,6 +8,7 @@ import { photoCloudBrowser } from 'src/services/photos/PhotoCloudBrowser';
 import { PhotoDeduplicator } from 'src/services/photos/PhotoDeduplicator';
 import { PhotoDeviceManager } from 'src/services/photos/PhotoDeviceId';
 import { PhotoUploadQueue } from 'src/services/photos/PhotoUploadQueue';
+import { retryIncompleteBursts } from 'src/services/photos/burst/BurstUploadHandler';
 import { photosLocalDB } from 'src/services/photos/database/photosLocalDB';
 import { AppDispatch } from 'src/store';
 import { storageSelectors } from 'src/store/slices/storage';
@@ -68,7 +69,16 @@ jest.mock('src/services/photos/PhotoAssetScanner', () => ({
 }));
 
 jest.mock('src/services/photos/PhotoUploadQueue', () => ({
-  PhotoUploadQueue: { start: jest.fn().mockResolvedValue(undefined), abortAll: jest.fn() },
+  PhotoUploadQueue: {
+    start: jest.fn().mockResolvedValue(undefined),
+    abortAll: jest.fn(),
+    beginCycle: jest.fn(),
+    endCycle: jest.fn(),
+  },
+}));
+
+jest.mock('src/services/photos/burst/BurstUploadHandler', () => ({
+  retryIncompleteBursts: jest.fn().mockResolvedValue(0),
 }));
 
 jest.mock('src/services/photos/PhotoDeduplicator', () => ({
@@ -120,10 +130,17 @@ const mockScanner = PhotoAssetScanner as jest.Mocked<typeof PhotoAssetScanner>;
 const mockDeduplicator = PhotoDeduplicator as jest.Mocked<typeof PhotoDeduplicator>;
 const mockPhotosLocalDB = photosLocalDB as jest.Mocked<typeof photosLocalDB>;
 const mockUploadQueue = PhotoUploadQueue as jest.Mocked<typeof PhotoUploadQueue>;
+const mockRetryIncompleteBursts = retryIncompleteBursts as jest.Mock;
 
 const makeStore = () => {
   const store = configureStore({ reducer: { photos: photosReducer } });
   return { ...store, dispatch: store.dispatch as AppDispatch };
+};
+
+const flushAsyncWork = async () => {
+  for (let i = 0; i < 5; i++) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
 };
 
 const getPersistedState = (): PhotosState => {
@@ -134,8 +151,19 @@ const getPersistedState = (): PhotosState => {
 };
 
 describe('photos slice', () => {
+  let uploadCycleController: AbortController | null = null;
+
   beforeEach(() => {
     jest.resetAllMocks();
+    uploadCycleController = null;
+    mockUploadQueue.beginCycle.mockImplementation(() => {
+      uploadCycleController = new AbortController();
+      return uploadCycleController.signal;
+    });
+    mockUploadQueue.abortAll.mockImplementation(() => uploadCycleController?.abort());
+    mockUploadQueue.endCycle.mockImplementation(() => {
+      uploadCycleController = null;
+    });
     // Re-set default implementations after reset clears them
     mockAsyncStorage.saveItem.mockResolvedValue(undefined);
     mockAsyncStorage.getItem.mockResolvedValue(null);
@@ -147,6 +175,7 @@ describe('photos slice', () => {
     mockScanner.scanAll.mockResolvedValue([]);
     mockScanner.getAssetsByIds.mockResolvedValue([]);
     mockUploadQueue.start.mockResolvedValue(undefined);
+    mockRetryIncompleteBursts.mockResolvedValue(0);
     mockDeduplicator.getAssetsToSync.mockResolvedValue({ newAssets: [], editedAssets: [] });
     mockPhotosLocalDB.init.mockResolvedValue(undefined);
     mockPhotosLocalDB.getPendingAssets.mockResolvedValue([]);
@@ -1094,6 +1123,213 @@ describe('photos slice', () => {
 
       expect(store.getState().photos.syncStatus).toBe('paused-no-connection');
       expect(mockUploadQueue.abortAll).toHaveBeenCalled();
+    });
+
+    test('when the backup is paused during the burst retry pass, then the cycle signal is aborted and the status ends as paused', async () => {
+      mockPhotosLocalDB.getPendingAssets.mockResolvedValue([{ assetId: 'a1', status: 'pending' }] as never);
+      const store = makeStore();
+      store.dispatch(
+        photosSlice.actions.setState({
+          enabled: true,
+          permissionStatus: 'granted',
+          deviceId: 'device-1',
+          photosBucket: 'photos-bucket-1',
+          networkCondition: 'wifi-and-data',
+        }),
+      );
+      let burstPassSignal: AbortSignal | undefined;
+      mockRetryIncompleteBursts.mockImplementationOnce(async ({ signal }: { signal?: AbortSignal }) => {
+        burstPassSignal = signal;
+        await store.dispatch(pauseBackupThunk());
+        return 0;
+      });
+
+      await store.dispatch(runUploadThunk());
+
+      expect(burstPassSignal?.aborted).toBe(true);
+      expect(store.getState().photos.syncStatus).toBe('paused');
+    });
+
+    test('when the connection is lost during the burst retry pass, then the cycle signal is aborted and the no connection state is kept', async () => {
+      let networkListener: ((state: NetworkState) => void) | null = null;
+      (networkMonitorService.subscribe as jest.Mock).mockImplementationOnce((listener) => {
+        networkListener = listener;
+        return jest.fn();
+      });
+      mockPhotosLocalDB.getPendingAssets.mockResolvedValue([{ assetId: 'a1', status: 'pending' }] as never);
+      let burstPassSignal: AbortSignal | undefined;
+      mockRetryIncompleteBursts.mockImplementationOnce(async ({ signal }: { signal?: AbortSignal }) => {
+        burstPassSignal = signal;
+        networkListener?.({ type: NetworkStateType.NONE, isConnected: false, isInternetReachable: false });
+        return 0;
+      });
+
+      const store = makeStore();
+      store.dispatch(
+        photosSlice.actions.setState({
+          enabled: true,
+          permissionStatus: 'granted',
+          deviceId: 'device-1',
+          photosBucket: 'photos-bucket-1',
+          networkCondition: 'wifi-and-data',
+        }),
+      );
+
+      await store.dispatch(runUploadThunk());
+
+      expect(burstPassSignal?.aborted).toBe(true);
+      expect(store.getState().photos.syncStatus).toBe('paused-no-connection');
+    });
+
+    test('when the backup is paused just before the queue would start, then the cycle signal is aborted and the status ends as paused', async () => {
+      mockPhotosLocalDB.getPendingAssets.mockResolvedValue([{ assetId: 'a1', status: 'pending' }] as never);
+      const store = makeStore();
+      store.dispatch(
+        photosSlice.actions.setState({
+          enabled: true,
+          permissionStatus: 'granted',
+          deviceId: 'device-1',
+          photosBucket: 'photos-bucket-1',
+          networkCondition: 'wifi-and-data',
+        }),
+      );
+      mockScanner.getAssetsByIds.mockImplementationOnce(async () => {
+        await store.dispatch(pauseBackupThunk());
+        return [];
+      });
+
+      await store.dispatch(runUploadThunk());
+
+      const cycleSignal = mockUploadQueue.beginCycle.mock.results[0].value as AbortSignal;
+      expect(cycleSignal.aborted).toBe(true);
+      expect(store.getState().photos.syncStatus).toBe('paused');
+    });
+
+    test('when only permanently failing bursts remain after a cycle with no progress, then the backup cycle is not restarted', async () => {
+      mockPhotosLocalDB.getIncompleteBurstAssets.mockResolvedValue([{ assetId: 'b1' }] as never);
+      const store = makeStore();
+      store.dispatch(
+        photosSlice.actions.setState({
+          enabled: true,
+          permissionStatus: 'granted',
+          deviceId: 'device-1',
+          photosBucket: 'photos-bucket-1',
+          networkCondition: 'wifi-and-data',
+        }),
+      );
+
+      await store.dispatch(runUploadThunk());
+      await flushAsyncWork();
+
+      expect(store.getState().photos.syncStatus).toBe('synced');
+      expect(mockPhotoDeviceManager.ensureDeviceFolder).not.toHaveBeenCalled();
+    });
+
+    test('when work remains after a cycle that made progress, then the backup cycle is restarted', async () => {
+      mockPhotosLocalDB.getPendingAssets.mockResolvedValue([{ assetId: 'a1', status: 'pending' }] as never);
+      mockScanner.getAssetsByIds.mockResolvedValue([{ id: 'a1', modificationTime: 1 }] as never);
+      mockUploadQueue.start.mockImplementationOnce(async (jobs, deviceId, bucket, callbacks) => {
+        await callbacks.onAssetDone?.('a1', { photoUuid: 'u1' } as never, 1);
+      });
+      const store = makeStore();
+      store.dispatch(
+        photosSlice.actions.setState({
+          enabled: true,
+          permissionStatus: 'granted',
+          deviceId: 'device-1',
+          photosBucket: 'photos-bucket-1',
+          networkCondition: 'wifi-and-data',
+        }),
+      );
+
+      await store.dispatch(runUploadThunk());
+      await flushAsyncWork();
+
+      expect(mockPhotoDeviceManager.ensureDeviceFolder).toHaveBeenCalled();
+    });
+
+    test('when an upload cycle is already running, then a second upload request is ignored', async () => {
+      mockPhotosLocalDB.getPendingAssets.mockResolvedValue([{ assetId: 'a1', status: 'pending' }] as never);
+      const store = makeStore();
+      store.dispatch(
+        photosSlice.actions.setState({
+          enabled: true,
+          permissionStatus: 'granted',
+          deviceId: 'device-1',
+          photosBucket: 'photos-bucket-1',
+          networkCondition: 'wifi-and-data',
+        }),
+      );
+      mockUploadQueue.start.mockImplementationOnce(async () => {
+        await store.dispatch(runUploadThunk({ bypassEnabled: true }));
+      });
+
+      await store.dispatch(runUploadThunk());
+
+      expect(mockUploadQueue.beginCycle).toHaveBeenCalledTimes(1);
+    });
+
+    test('when the connection comes back while the backup is waiting for network, then the backup cycle resumes automatically', async () => {
+      const store = makeStore();
+      await store.dispatch(hydratePhotosStateThunk());
+      store.dispatch(
+        photosSlice.actions.setState({
+          enabled: true,
+          permissionStatus: 'granted',
+          deviceId: 'device-1',
+          photosBucket: 'photos-bucket-1',
+          networkCondition: 'wifi-only',
+          syncStatus: 'paused-no-wifi',
+        }),
+      );
+      const [recoveryListener] = (networkMonitorService.subscribe as jest.Mock).mock.calls[0] as [
+        (state: NetworkState) => void,
+      ];
+
+      recoveryListener({ type: NetworkStateType.WIFI, isConnected: true, isInternetReachable: true });
+      await flushAsyncWork();
+
+      expect(mockPhotoDeviceManager.ensureDeviceFolder).toHaveBeenCalled();
+    });
+
+    test('when the network comes back but the user paused the backup manually, then the backup does not resume', async () => {
+      const store = makeStore();
+      await store.dispatch(hydratePhotosStateThunk());
+      store.dispatch(
+        photosSlice.actions.setState({
+          enabled: true,
+          permissionStatus: 'granted',
+          deviceId: 'device-1',
+          photosBucket: 'photos-bucket-1',
+          networkCondition: 'wifi-only',
+          syncStatus: 'paused-no-wifi',
+          isPaused: true,
+        }),
+      );
+      const [recoveryListener] = (networkMonitorService.subscribe as jest.Mock).mock.calls[0] as [
+        (state: NetworkState) => void,
+      ];
+
+      recoveryListener({ type: NetworkStateType.WIFI, isConnected: true, isInternetReachable: true });
+      await flushAsyncWork();
+
+      expect(mockPhotoDeviceManager.ensureDeviceFolder).not.toHaveBeenCalled();
+    });
+
+    test('when only incomplete bursts remain, then a normal backup cycle retries them', async () => {
+      mockPhotosLocalDB.getIncompleteBurstAssets.mockResolvedValue([{ assetId: 'b1' }] as never);
+      const store = makeStore();
+      store.dispatch(
+        photosSlice.actions.setState({
+          enabled: true,
+          permissionStatus: 'granted',
+        }),
+      );
+
+      await store.dispatch(runBackupCycleThunk());
+      await flushAsyncWork();
+
+      expect(mockRetryIncompleteBursts).toHaveBeenCalled();
     });
   });
 

--- a/src/store/slices/photos/index.ts
+++ b/src/store/slices/photos/index.ts
@@ -22,7 +22,7 @@ import { AsyncStorageKey } from 'src/types';
 import { logger } from '../../../services/common';
 import { RootState } from '../../index';
 import { hasPhotosFeatureAccess } from './selectors';
-import { runUploadThunk } from './thunks/upload';
+import { evaluateNetworkPause, runUploadThunk } from './thunks/upload';
 export { runUploadThunk };
 
 export type PhotoNetworkCondition = 'wifi-only' | 'wifi-and-data';
@@ -110,9 +110,24 @@ const persistPhotosSettings = async (state: PhotosState): Promise<void> => {
   );
 };
 
+let unsubscribeNetworkRecovery: (() => void) | null = null;
+
 export const hydratePhotosStateThunk = createAsyncThunk<void, void, { state: RootState }>(
   'photos/setState',
-  async (_, { dispatch }) => {
+  async (_, { dispatch, getState }) => {
+    unsubscribeNetworkRecovery?.();
+    unsubscribeNetworkRecovery = networkMonitorService.subscribe((networkState) => {
+      const { enabled, isPaused, syncStatus, networkCondition } = getState().photos;
+      const isWaitingForNetwork = syncStatus === 'paused-no-wifi' || syncStatus === 'paused-no-connection';
+      if (!enabled || isPaused || !isWaitingForNetwork) {
+        return;
+      }
+      if (evaluateNetworkPause(networkState, networkCondition) === null) {
+        logger.info('[Photos] Network recovered — resuming backup cycle');
+        dispatch(runBackupCycleThunk());
+      }
+    });
+
     await photosLocalDB.init();
     const persistedState = await asyncStorageService.getItem(AsyncStorageKey.PhotosSettings);
 
@@ -392,7 +407,8 @@ export const runBackupCycleThunk = createAsyncThunk<void, void, { state: RootSta
       return;
     }
 
-    if (pendingBackupAssets > 0) {
+    const incompleteBursts = Platform.OS === 'ios' ? await photosLocalDB.getIncompleteBurstAssets() : [];
+    if (pendingBackupAssets > 0 || incompleteBursts.length > 0) {
       await dispatch(runUploadThunk());
     }
   },

--- a/src/store/slices/photos/thunks/upload.ts
+++ b/src/store/slices/photos/thunks/upload.ts
@@ -21,7 +21,10 @@ type NetworkPauseStatus = 'paused-no-connection' | 'paused-no-wifi' | null;
 const PROGRESS_STEP = 0.02;
 const REPRESENTATIVE_ASSET_COUNT = 1;
 
-const evaluateNetworkPause = (state: NetworkState, networkCondition: PhotoNetworkCondition): NetworkPauseStatus => {
+export const evaluateNetworkPause = (
+  state: NetworkState,
+  networkCondition: PhotoNetworkCondition,
+): NetworkPauseStatus => {
   const hasConnection = state.isConnected !== false && state.type !== NetworkStateType.NONE;
   if (!hasConnection) {
     return 'paused-no-connection';
@@ -93,6 +96,8 @@ const hasRemainingAssets = async (isIOS: boolean): Promise<boolean> => {
   return remainingPending.length > 0 || remainingBursts.length > 0;
 };
 
+let isUploadCycleRunning = false;
+
 export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean } | void, { state: RootState }>(
   'photos/runUpload',
   async (args, { getState, dispatch }) => {
@@ -107,12 +112,13 @@ export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean }
     ) {
       return;
     }
-    const initialNetworkState = await networkMonitorService.getNetworkStateAsync();
-    const pauseStatus = evaluateNetworkPause(initialNetworkState, networkCondition);
-    if (pauseStatus) {
-      dispatch(photosSlice.actions.setSyncStatus(pauseStatus));
+    if (isUploadCycleRunning) {
+      logger.info('[Upload] Skipped — an upload cycle is already running');
       return;
     }
+    isUploadCycleRunning = true;
+
+    const uploadCycleAbortSignal = PhotoUploadQueue.beginCycle();
     const unsubscribeNetworkMonitor = networkMonitorService.subscribe((state) => {
       const pauseStatusSub = evaluateNetworkPause(state, networkCondition);
       if (pauseStatusSub) {
@@ -122,6 +128,12 @@ export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean }
     });
 
     try {
+      const initialNetworkState = await networkMonitorService.getNetworkStateAsync();
+      const pauseStatus = evaluateNetworkPause(initialNetworkState, networkCondition);
+      if (pauseStatus) {
+        dispatch(photosSlice.actions.setSyncStatus(pauseStatus));
+        return;
+      }
       const isIOS = Platform.OS === 'ios';
       const availableStorage = storageSelectors.availableStorage(getState());
       if (availableStorage <= 0) {
@@ -187,6 +199,7 @@ export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean }
         const completedBursts = await retryIncompleteBursts({
           deviceId,
           photosBucket,
+          signal: uploadCycleAbortSignal,
           uploadMember: uploadSingleFile,
           onBurstEvent: applyBurstEvent,
         });
@@ -247,6 +260,7 @@ export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean }
         isPaused: finalIsPaused,
         disabledReason: finalDisabledReason,
         syncStatus: finalSyncStatus,
+        sessionUploadedAssets: finalSessionUploadedAssets,
       } = getState().photos;
 
       if (finalSyncStatus === 'paused-no-wifi' || finalSyncStatus === 'paused-no-connection') {
@@ -256,12 +270,15 @@ export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean }
       dispatch(photosSlice.actions.clearUploadProgress());
       dispatch(photosSlice.actions.setAssetUploadErroredCount(await photosLocalDB.getAssetUploadErroredCount()));
 
-      if (!finalIsPaused && finalDisabledReason === null && (await hasRemainingAssets(isIOS))) {
+      const hasUploadSomeAssets = finalSessionUploadedAssets > 0;
+      if (!finalIsPaused && finalDisabledReason === null && hasUploadSomeAssets && (await hasRemainingAssets(isIOS))) {
         logger.info('[Upload] Work remains after this cycle — restarting');
         dispatch(runBackupCycleThunk());
       }
     } finally {
+      isUploadCycleRunning = false;
       unsubscribeNetworkMonitor();
+      PhotoUploadQueue.endCycle();
     }
   },
 );


### PR DESCRIPTION
  Fixes the QA-reported iOS bug where pausing the backup showed "Paused" but the item count kept changing, and
  hardens the upload cycle against races found while reviewing all its paths.

  **Root cause:** the abort controller was created inside `PhotoUploadQueue.start()`, so pausing during the burst
  retry pass (which runs before the queue and can take minutes) aborted nothing, the whole queue then uploaded
  while paused.

  - **PhotoUploadQueue.ts*: cycle-level abort controller: `beginCycle()`/`endCycle()` let the upload thunk own the signal for the whole cycle; `start()` reuses it and keeps a fallback for standalone use
  - **thunks/upload.ts**: the cycle signal is created before the first await and shared with the burst retry pass, so a pause (manual or from the network listener) at any point stops all uploads; adds a reentrancy guard (the thunk has four entry points with check-then-act gaps that could double-upload the same assets) and only restarts the cycle when it made progress, so a permanently failing burst can no longer restart it forever
  - **photos/index.ts** — global network subscription registered on hydrate that auto-resumes the backup cycle when connectivity recovers while in `paused-no-wifi`/`paused-no-connection` (unless manually paused); `runBackupCycleThunk` now also checks incomplete bursts, matching `forceRefreshThunk`
  - **PhotosTimeline.tsx** — fix the iOS pull-to-refresh spinner offset so it doesn't overlap the header