### PR TITLE
[PB-6593] Bugfix/Display cloud assets in correct order

### DIFF
--- a/src/screens/PhotosScreen/hooks/usePhotoDevices.spec.ts
+++ b/src/screens/PhotosScreen/hooks/usePhotoDevices.spec.ts
@@ -134,6 +134,46 @@ describe('usePhotoDevices', () => {
     expect(result.current.devices).toEqual([]);
   });
 
+  describe('when a plainName carries a trailing unique id', () => {
+    test('when the plainName is "model (uniqueId)", then only the model is shown', async () => {
+      mockPhotosDeviceService.listDevices.mockResolvedValueOnce([
+        {
+          uuid: 'd1',
+          plainName: 'iPhone 16 Pro (05B85ECD-97E7-426F-AB2A-3F040D683939)',
+          bucket: 'b1',
+          status: 'EXISTS',
+        },
+      ]);
+
+      const { result } = renderHook(() => usePhotoDevices());
+      await act(flushAsync);
+
+      expect(result.current.devices).toEqual([{ uuid: 'd1', name: 'iPhone 16 Pro' }]);
+    });
+
+    test('when the plainName has no trailing parentheses, then it is shown as-is', async () => {
+      mockPhotosDeviceService.listDevices.mockResolvedValueOnce([
+        { uuid: 'd1', plainName: 'legacy-android-id', bucket: 'b1', status: 'EXISTS' },
+      ]);
+
+      const { result } = renderHook(() => usePhotoDevices());
+      await act(flushAsync);
+
+      expect(result.current.devices).toEqual([{ uuid: 'd1', name: 'legacy-android-id' }]);
+    });
+
+    test('when the model name itself contains parentheses in the middle, then only the trailing group is stripped', async () => {
+      mockPhotosDeviceService.listDevices.mockResolvedValueOnce([
+        { uuid: 'd1', plainName: 'Galaxy (2024) (test-android-id)', bucket: 'b1', status: 'EXISTS' },
+      ]);
+
+      const { result } = renderHook(() => usePhotoDevices());
+      await act(flushAsync);
+
+      expect(result.current.devices).toEqual([{ uuid: 'd1', name: 'Galaxy (2024)' }]);
+    });
+  });
+
   test('when the dropdown menu is reopened after devices change on the backend, then reload replaces the list', async () => {
     mockPhotosDeviceService.listDevices.mockResolvedValueOnce([
       { uuid: 'd1', plainName: 'iPhone', bucket: 'b1', status: 'EXISTS' },

--- a/src/screens/PhotosScreen/hooks/usePhotoDevices.ts
+++ b/src/screens/PhotosScreen/hooks/usePhotoDevices.ts
@@ -20,7 +20,8 @@ export interface PhotoDevicesResult {
 const sortAlphabetically = (devices: PhotoDeviceOption[]): PhotoDeviceOption[] =>
   [...devices].sort((a, b) => a.name.localeCompare(b.name));
 
-const stripUniqueIdSuffix = (plainName: string): string => plainName.replace(/\s*\([^)]*\)\s*$/, '');
+const UNIQUE_ID_SUFFIX_PATTERN = / \([^()]*\)$/;
+const stripUniqueIdSuffix = (plainName: string): string => plainName.replace(UNIQUE_ID_SUFFIX_PATTERN, '');
 
 /**
  * Lists the devices registered for Photos backup.

--- a/src/screens/PhotosScreen/hooks/usePhotoDevices.ts
+++ b/src/screens/PhotosScreen/hooks/usePhotoDevices.ts
@@ -20,6 +20,8 @@ export interface PhotoDevicesResult {
 const sortAlphabetically = (devices: PhotoDeviceOption[]): PhotoDeviceOption[] =>
   [...devices].sort((a, b) => a.name.localeCompare(b.name));
 
+const stripUniqueIdSuffix = (plainName: string): string => plainName.replace(/\s*\([^)]*\)\s*$/, '');
+
 /**
  * Lists the devices registered for Photos backup.
  */
@@ -35,7 +37,7 @@ export const usePhotoDevices = (): PhotoDevicesResult => {
       const options = sortAlphabetically(
         allDevices
           .filter((device) => device.status === 'EXISTS')
-          .map((device) => ({ uuid: device.uuid, name: device.plainName })),
+          .map((device) => ({ uuid: device.uuid, name: stripUniqueIdSuffix(device.plainName) })),
       );
       setDevices(options);
       await asyncStorageService.saveItem(AsyncStorageKey.PhotosDevicesCache, JSON.stringify(options));

--- a/src/services/photos/PhotoDeviceId.spec.ts
+++ b/src/services/photos/PhotoDeviceId.spec.ts
@@ -7,6 +7,7 @@ import { photosDeviceService } from './photosDeviceService';
 
 jest.mock('expo-application', () => ({
   getAndroidId: jest.fn(() => 'test-android-id'),
+  getIosIdForVendorAsync: jest.fn(() => Promise.resolve('test-idfv')),
 }));
 
 jest.mock('react-native-uuid', () => ({
@@ -74,23 +75,23 @@ describe('PhotoDeviceManager.ensureDeviceFolder', () => {
     test('when the stored folder has been deleted on the backend, then a new one is created by device key', async () => {
       mockGetItem.mockResolvedValue('folder-uuid-old');
       mockGetDevice.mockResolvedValue({ ...makeDevice('test-android-id'), uuid: 'folder-uuid-old', status: 'DELETED' });
-      mockCreateDevice.mockResolvedValue(makeDevice('test-android-id'));
+      mockCreateDevice.mockResolvedValue(makeDevice('Internxt iPhone (test-android-id)'));
 
       const result = await PhotoDeviceManager.ensureDeviceFolder();
 
       expect(result.deviceId).toBe('folder-uuid-123');
-      expect(mockCreateDevice).toHaveBeenCalledWith('test-android-id');
+      expect(mockCreateDevice).toHaveBeenCalledWith('Internxt iPhone (test-android-id)');
       expect(mockSetItem).toHaveBeenCalledWith(expect.any(String), 'folder-uuid-123');
     });
 
     test('when the stored folder is not found on the backend, then a new one is created by device key', async () => {
       mockGetItem.mockResolvedValue('folder-uuid-gone');
       mockGetDevice.mockResolvedValue(null);
-      mockCreateDevice.mockResolvedValue(makeDevice('test-android-id'));
+      mockCreateDevice.mockResolvedValue(makeDevice('Internxt iPhone (test-android-id)'));
 
       await PhotoDeviceManager.ensureDeviceFolder();
 
-      expect(mockCreateDevice).toHaveBeenCalledWith('test-android-id');
+      expect(mockCreateDevice).toHaveBeenCalledWith('Internxt iPhone (test-android-id)');
     });
   });
 
@@ -100,36 +101,54 @@ describe('PhotoDeviceManager.ensureDeviceFolder', () => {
       mockGetItem.mockResolvedValue(null);
     });
 
-    test('when no folder exists yet, then a new device folder is created using the android hardware id', async () => {
-      mockCreateDevice.mockResolvedValue(makeDevice('test-android-id'));
+    test('when no folder exists yet, then a new device folder is created using the device name and the android hardware id', async () => {
+      mockCreateDevice.mockResolvedValue(makeDevice('Internxt iPhone (test-android-id)'));
 
       const result = await PhotoDeviceManager.ensureDeviceFolder();
 
-      expect(result).toEqual({ deviceId: 'folder-uuid-123', plainName: 'test-android-id', bucket: 'photos-bucket' });
-      expect(mockCreateDevice).toHaveBeenCalledWith('test-android-id');
+      expect(result).toEqual({
+        deviceId: 'folder-uuid-123',
+        plainName: 'Internxt iPhone (test-android-id)',
+        bucket: 'photos-bucket',
+      });
+      expect(mockCreateDevice).toHaveBeenCalledWith('Internxt iPhone (test-android-id)');
       expect(mockSetItem).toHaveBeenCalledWith(expect.any(String), 'folder-uuid-123');
     });
 
     test('when creation returns 409, then the existing folder matching the android hardware id is adopted', async () => {
-      mockCreateDevice.mockRejectedValue(new PhotoDeviceNameConflictError('test-android-id'));
-      mockListDevices.mockResolvedValue([makeDevice('test-android-id')]);
+      mockCreateDevice.mockRejectedValue(new PhotoDeviceNameConflictError('Internxt iPhone (test-android-id)'));
+      mockListDevices.mockResolvedValue([makeDevice('Internxt iPhone (test-android-id)')]);
 
       const result = await PhotoDeviceManager.ensureDeviceFolder();
 
-      expect(result).toEqual({ deviceId: 'folder-uuid-123', plainName: 'test-android-id', bucket: 'photos-bucket' });
+      expect(result).toEqual({
+        deviceId: 'folder-uuid-123',
+        plainName: 'Internxt iPhone (test-android-id)',
+        bucket: 'photos-bucket',
+      });
+      expect(mockSetItem).toHaveBeenCalledWith(expect.any(String), 'folder-uuid-123');
+    });
+
+    test('when creation returns 409 and the remote device name has a different model but contains the same hardware id, then it is adopted anyway', async () => {
+      mockCreateDevice.mockRejectedValue(new PhotoDeviceNameConflictError('Internxt iPhone (test-android-id)'));
+      mockListDevices.mockResolvedValue([makeDevice('Old Model Name (test-android-id)')]);
+
+      const result = await PhotoDeviceManager.ensureDeviceFolder();
+
+      expect(result.plainName).toBe('Old Model Name (test-android-id)');
       expect(mockSetItem).toHaveBeenCalledWith(expect.any(String), 'folder-uuid-123');
     });
 
     test('when creation returns 409 but no folder matches the android hardware id, then the error is rethrown', async () => {
-      mockCreateDevice.mockRejectedValue(new PhotoDeviceNameConflictError('test-android-id'));
-      mockListDevices.mockResolvedValue([makeDevice('other-device-id')]);
+      mockCreateDevice.mockRejectedValue(new PhotoDeviceNameConflictError('Internxt iPhone (test-android-id)'));
+      mockListDevices.mockResolvedValue([makeDevice('Internxt iPhone (other-device-id)')]);
 
       await expect(PhotoDeviceManager.ensureDeviceFolder()).rejects.toThrow(PhotoDeviceNameConflictError);
     });
 
     test('when creation returns 409 and the matching folder is deleted, then the error is rethrown', async () => {
-      mockCreateDevice.mockRejectedValue(new PhotoDeviceNameConflictError('test-android-id'));
-      mockListDevices.mockResolvedValue([{ ...makeDevice('test-android-id'), status: 'DELETED' }]);
+      mockCreateDevice.mockRejectedValue(new PhotoDeviceNameConflictError('Internxt iPhone (test-android-id)'));
+      mockListDevices.mockResolvedValue([{ ...makeDevice('Internxt iPhone (test-android-id)'), status: 'DELETED' }]);
 
       await expect(PhotoDeviceManager.ensureDeviceFolder()).rejects.toThrow(PhotoDeviceNameConflictError);
     });
@@ -141,18 +160,18 @@ describe('PhotoDeviceManager.ensureDeviceFolder', () => {
       mockGetItem.mockResolvedValue(null);
     });
 
-    test('when no folder exists yet, then a new device folder is created using the device name', async () => {
-      mockCreateDevice.mockResolvedValue(makeDevice('Internxt iPhone'));
+    test('when no folder exists yet, then a new device folder is created using the model name and the identifierForVendor', async () => {
+      mockCreateDevice.mockResolvedValue(makeDevice('iPhone 15 (test-idfv)'));
 
       const result = await PhotoDeviceManager.ensureDeviceFolder();
 
       expect(result.deviceId).toBe('folder-uuid-123');
-      expect(mockCreateDevice).toHaveBeenCalledWith('Internxt iPhone');
+      expect(mockCreateDevice).toHaveBeenCalledWith('iPhone 15 (test-idfv)');
     });
 
-    test('when creation returns 409, then the existing folder matching the device name is adopted', async () => {
-      mockCreateDevice.mockRejectedValue(new PhotoDeviceNameConflictError('Internxt iPhone'));
-      mockListDevices.mockResolvedValue([makeDevice('Internxt iPhone')]);
+    test('when creation returns 409, then the existing folder matching the identifierForVendor is adopted', async () => {
+      mockCreateDevice.mockRejectedValue(new PhotoDeviceNameConflictError('iPhone 15 (test-idfv)'));
+      mockListDevices.mockResolvedValue([makeDevice('iPhone 15 (test-idfv)')]);
 
       const result = await PhotoDeviceManager.ensureDeviceFolder();
 
@@ -170,11 +189,11 @@ describe('PhotoDeviceManager.ensureDeviceFolder', () => {
     });
 
     test('when no device key is stored either, then a uuid is generated, persisted and used as device key', async () => {
-      mockCreateDevice.mockResolvedValue(makeDevice('generated-uuid-fallback'));
+      mockCreateDevice.mockResolvedValue(makeDevice('Internxt iPhone (generated-uuid-fallback)'));
 
       await PhotoDeviceManager.ensureDeviceFolder();
 
-      expect(mockCreateDevice).toHaveBeenCalledWith('generated-uuid-fallback');
+      expect(mockCreateDevice).toHaveBeenCalledWith('Internxt iPhone (generated-uuid-fallback)');
       expect(mockSetItem).toHaveBeenCalledWith('photos-device-key', 'generated-uuid-fallback');
     });
 
@@ -182,11 +201,11 @@ describe('PhotoDeviceManager.ensureDeviceFolder', () => {
       mockGetItem
         .mockResolvedValueOnce(null) // PhotosDeviceId
         .mockResolvedValueOnce('previously-generated-key'); // PhotosDeviceKey
-      mockCreateDevice.mockResolvedValue(makeDevice('previously-generated-key'));
+      mockCreateDevice.mockResolvedValue(makeDevice('Internxt iPhone (previously-generated-key)'));
 
       await PhotoDeviceManager.ensureDeviceFolder();
 
-      expect(mockCreateDevice).toHaveBeenCalledWith('previously-generated-key');
+      expect(mockCreateDevice).toHaveBeenCalledWith('Internxt iPhone (previously-generated-key)');
       expect(mockSetItem).not.toHaveBeenCalledWith('photos-device-key', expect.anything());
     });
   });

--- a/src/services/photos/PhotoDeviceId.ts
+++ b/src/services/photos/PhotoDeviceId.ts
@@ -29,23 +29,35 @@ const getOrGenerateFallbackKey = async (): Promise<string> => {
 };
 
 /**
- * Returns a stable, opaque key used as the backend device name.
- * - Android: androidId (survives reinstalls, unique per device + signing key)
- * - iOS: human-readable device name (Keychain survives reinstalls, name is stable)
- * - Fallback: UUID generated once and persisted in SecureStorage (collision-proof)
+ * Returns a stable, opaque per-device identifier.
+ * - Android: androidId
+ * - iOS: identifierForVendor
+ * - Fallback: UUID generated once and persisted in SecureStorage
  */
-const getDeviceKey = async (): Promise<string> => {
+const getDeviceUniqueId = async (): Promise<string> => {
   if (Platform.OS === 'android') {
     const androidId = Application.getAndroidId?.();
-    if (androidId) return androidId;
+    if (androidId) {
+      return androidId;
+    }
   } else {
-    const name = Device.deviceName ?? Device.modelName;
-    if (name) return name;
+    const idfv = await Application.getIosIdForVendorAsync();
+    if (idfv) {
+      return idfv;
+    }
   }
   return getOrGenerateFallbackKey();
 };
 
-const persist = (uuid: string): Promise<void> => secureStorageService.setItem(AsyncStorageKey.PhotosDeviceId, uuid);
+const getDisplayName = (): string | null =>
+  Platform.OS === 'android' ? (Device.deviceName ?? Device.modelName) : Device.modelName;
+
+const buildDeviceKey = (uniqueId: string): string => {
+  const displayName = getDisplayName();
+  return displayName ? `${displayName} (${uniqueId})` : uniqueId;
+};
+
+const storeDevice = (uuid: string): Promise<void> => secureStorageService.setItem(AsyncStorageKey.PhotosDeviceId, uuid);
 
 const parseDeviceInfo = (device: PhotoDevice): PhotoDeviceInfo => ({
   deviceId: device.uuid,
@@ -87,10 +99,11 @@ class PhotoDeviceManagerService {
       logger.warn(TAG, `Stored uuid=${storedUuid} not found or DELETED — recreating by key`);
     }
 
-    const deviceKey = await getDeviceKey();
+    const uniqueId = await getDeviceUniqueId();
+    const deviceKey = buildDeviceKey(uniqueId);
     try {
       const createdDevice = await photosDeviceService.createDevice(deviceKey);
-      await persist(createdDevice.uuid);
+      await storeDevice(createdDevice.uuid);
       logger.info(
         TAG,
         `Created device folder uuid=${createdDevice.uuid} key="${createdDevice.plainName}" bucket=${createdDevice.bucket}`,
@@ -98,11 +111,11 @@ class PhotoDeviceManagerService {
       return parseDeviceInfo(createdDevice);
     } catch (err) {
       if (err instanceof PhotoDeviceNameConflictError) {
-        logger.info(TAG, `Device key "${deviceKey}" already exists (409) — adopting by key`);
+        logger.info(TAG, `Device key "${deviceKey}" already exists (409) — adopting by uniqueId`);
         const devices = await photosDeviceService.listDevices();
-        const device = devices.find((device) => device.plainName === deviceKey && device.status === 'EXISTS');
+        const device = devices.find((device) => device.plainName.includes(uniqueId) && device.status === 'EXISTS');
         if (device) {
-          await persist(device.uuid);
+          await storeDevice(device.uuid);
           logger.info(TAG, `Adopted device folder uuid=${device.uuid} bucket=${device.bucket}`);
           return parseDeviceInfo(device);
         }

--- a/src/services/photos/database/photosLocalDB.spec.ts
+++ b/src/services/photos/database/photosLocalDB.spec.ts
@@ -685,6 +685,17 @@ describe('photosLocalDB cloud asset methods', () => {
     expect(params).toEqual(['device-1']);
   });
 
+  test('when cloud assets are fetched with or without a device filter, then they are ordered by real capture time with a deterministic tiebreaker', async () => {
+    mockSqlite.getAllAsync.mockResolvedValue([]);
+
+    await photosLocalDB.getAllCloudAssets();
+    await photosLocalDB.getAllCloudAssets('device-1');
+
+    for (const [, stmt] of mockSqlite.getAllAsync.mock.calls) {
+      expect(stmt).toContain('ORDER BY COALESCE(creation_time_api, created_at) DESC, remote_file_id ASC');
+    }
+  });
+
   test('when a cloud thumbnail path is set, then the path and remote file id are passed to the database', async () => {
     await photosLocalDB.setCloudThumbnailPath('remote-1', '/path/to/thumb.jpg');
 

--- a/src/services/photos/database/tables/cloud_asset.ts
+++ b/src/services/photos/database/tables/cloud_asset.ts
@@ -81,13 +81,13 @@ const statements = {
     FROM ${TABLE_NAME}
     WHERE (live_photo_role IS NULL OR live_photo_role != 'paired_video')
       AND (burst_role IS NULL OR burst_role != 'member')
-    ORDER BY created_at DESC;
+    ORDER BY COALESCE(creation_time_api, created_at) DESC, remote_file_id ASC;
   `,
 
   getAllIncludingPaired: `
     SELECT ${COLUMNS}
     FROM ${TABLE_NAME}
-    ORDER BY created_at DESC;
+    ORDER BY COALESCE(creation_time_api, created_at) DESC, remote_file_id ASC;
   `,
 
   getByRange: `
@@ -96,7 +96,7 @@ const statements = {
     WHERE (created_at >= ? AND created_at <= ?)
       AND (live_photo_role IS NULL OR live_photo_role != 'paired_video')
       AND (burst_role IS NULL OR burst_role != 'member')
-    ORDER BY created_at DESC;
+    ORDER BY COALESCE(creation_time_api, created_at) DESC, remote_file_id ASC;
   `,
 
   getAllByDevice: `
@@ -105,7 +105,7 @@ const statements = {
     WHERE device_id = ?
       AND (live_photo_role IS NULL OR live_photo_role != 'paired_video')
       AND (burst_role IS NULL OR burst_role != 'member')
-    ORDER BY created_at DESC;
+    ORDER BY COALESCE(creation_time_api, created_at) DESC, remote_file_id ASC;
   `,
 
   getByRangeAndDevice: `
@@ -115,7 +115,7 @@ const statements = {
       AND device_id = ?
       AND (live_photo_role IS NULL OR live_photo_role != 'paired_video')
       AND (burst_role IS NULL OR burst_role != 'member')
-    ORDER BY created_at DESC;
+    ORDER BY COALESCE(creation_time_api, created_at) DESC, remote_file_id ASC;
   `,
 
   getBurstMembers: `


### PR DESCRIPTION
- Fix cloud asset order to order also by hour and not only by day (added id in case of date tie)
- Added device model in order to display friendly names in device filter 