### PR TITLE
[PB-6378] feature/Delete cloud copy of Photos assets

### DIFF
--- a/assets/lang/strings.ts
+++ b/assets/lang/strings.ts
@@ -225,6 +225,8 @@ const translations = {
         photoPreview: {
           back: 'Back',
           waitingToUpload: 'Waiting to upload',
+          deletedFromCloud: 'Deleted from the cloud',
+          backup: 'Backup',
           uploading: 'Uploading',
           burstBadge: 'Burst',
           burstIncomplete: 'Burst not fully backed up. Grant full Photos access to back up all burst photos.',
@@ -1229,6 +1231,8 @@ const translations = {
         photoPreview: {
           back: 'Volver',
           waitingToUpload: 'Pendiente de subir',
+          deletedFromCloud: 'Eliminado de la nube',
+          backup: 'Copia de seguridad',
           uploading: 'Subiendo',
           burstBadge: 'Ráfaga',
           burstIncomplete:

--- a/src/screens/PhotoPreviewScreen/components/PreviewCarousel.tsx
+++ b/src/screens/PhotoPreviewScreen/components/PreviewCarousel.tsx
@@ -1,15 +1,18 @@
 import { LinearGradient } from 'expo-linear-gradient';
-import { DotsThreeOutlineIcon, ExportIcon, TrashIcon } from 'phosphor-react-native';
+import { CloudArrowUpIcon, DotsThreeOutlineIcon, ExportIcon, TrashIcon } from 'phosphor-react-native';
 import { memo, useCallback, useEffect, useRef } from 'react';
 import { FlatList, Image, ListRenderItem, TouchableOpacity, View, useWindowDimensions } from 'react-native';
 import Animated, { Easing, useAnimatedStyle, withTiming } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTailwind } from 'tailwind-rn';
+import strings from '../../../../assets/lang/strings';
 import AppText from '../../../components/AppText';
 import useGetColor from '../../../hooks/useColor';
 import { logger } from '../../../services/common';
 import { useCloudThumbnail } from '../../PhotosScreen/hooks/useCloudThumbnail';
 import { TimelinePhotoItem } from '../../PhotosScreen/types';
+
+const photoPreviewStrings = strings.screens.photos.photoPreview;
 
 const THUMB_W_INACTIVE = 17;
 const THUMB_W_ACTIVE = 26;
@@ -117,7 +120,9 @@ interface PreviewCarouselProps {
   onExport: () => void;
   onMore: () => void;
   onDelete: () => void;
+  onBackup: () => void;
   isSynced: boolean;
+  isCloudDeleted: boolean;
 }
 
 export const PreviewCarousel = ({
@@ -131,7 +136,9 @@ export const PreviewCarousel = ({
   onExport,
   onMore,
   onDelete,
+  onBackup,
   isSynced,
+  isCloudDeleted,
 }: PreviewCarouselProps): JSX.Element => {
   const tailwind = useTailwind();
   const insets = useSafeAreaInsets();
@@ -267,20 +274,34 @@ export const PreviewCarousel = ({
         </View>
 
         <View style={[tailwind('flex-row'), { paddingBottom: insets.bottom + 8 }]}>
-          <ActionButton
-            icon={<ExportIcon size={26} color="white" />}
-            label="Export"
-            onPress={onExport}
-            disabled={!isSynced}
-          />
-          {/* <ActionButton icon={<StarIcon size={26} color="white" />} label="Favorite" onPress={() => undefined} /> */}
-          <ActionButton icon={<DotsThreeOutlineIcon size={26} color="white" />} label="More" onPress={onMore} />
-          <ActionButton
-            icon={<TrashIcon size={26} color="white" />}
-            label="Delete"
-            onPress={onDelete}
-            disabled={!isSynced}
-          />
+          {isCloudDeleted ? (
+            <View style={tailwind('flex-1 items-center')}>
+              <View style={{ width: 80 }}>
+                <ActionButton
+                  icon={<CloudArrowUpIcon size={26} color="white" />}
+                  label={photoPreviewStrings.backup}
+                  onPress={onBackup}
+                />
+              </View>
+            </View>
+          ) : (
+            <>
+              <ActionButton
+                icon={<ExportIcon size={26} color="white" />}
+                label="Export"
+                onPress={onExport}
+                disabled={!isSynced}
+              />
+              {/* <ActionButton icon={<StarIcon size={26} color="white" />} label="Favorite" onPress={() => undefined} /> */}
+              <ActionButton icon={<DotsThreeOutlineIcon size={26} color="white" />} label="More" onPress={onMore} />
+              <ActionButton
+                icon={<TrashIcon size={26} color="white" />}
+                label="Delete"
+                onPress={onDelete}
+                disabled={!isSynced}
+              />
+            </>
+          )}
         </View>
       </LinearGradient>
     </Animated.View>

--- a/src/screens/PhotoPreviewScreen/components/PreviewHeader.tsx
+++ b/src/screens/PhotoPreviewScreen/components/PreviewHeader.tsx
@@ -1,5 +1,5 @@
 import { LinearGradient } from 'expo-linear-gradient';
-import { ArrowUpIcon, CloudSlashIcon, DotsThreeVerticalIcon, XIcon } from 'phosphor-react-native';
+import { ArrowUpIcon, CloudSlashIcon, CloudXIcon, DotsThreeVerticalIcon, XIcon } from 'phosphor-react-native';
 import { useEffect } from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import Animated, {
@@ -70,6 +70,7 @@ const AnimatedArrowUp = ({ size, color }: { size: number; color: string }): JSX.
 };
 interface TimelineInfoProps {
   isWaitingToUpload: boolean;
+  isCloudDeleted: boolean;
   isUploading: boolean;
   isBurst: boolean;
   burstLiveProgress: { uploaded: number; total: number } | null;
@@ -80,6 +81,7 @@ interface TimelineInfoProps {
 
 const TimelineInfo = ({
   isWaitingToUpload,
+  isCloudDeleted,
   isUploading,
   isBurst,
   burstLiveProgress,
@@ -92,7 +94,7 @@ const TimelineInfo = ({
   const uploadLabel = getUploadingLabel(isBurst, burstLiveProgress);
   const backedBurstLabel = getBackedBurstLabel(isBurst, isUploading, burstTotal);
 
-  const showUploadRow = isWaitingToUpload || isUploading;
+  const showUploadRow = isWaitingToUpload || isCloudDeleted || isUploading;
   if (!showUploadRow && !backedBurstLabel && (!timestamp || !hasTimeAccuracy)) {
     return null;
   }
@@ -104,6 +106,12 @@ const TimelineInfo = ({
         <AppText style={tailwind('text-sm text-white')}>{formatHeaderTime(timestamp)}</AppText>
       )}
       {showSeparator && <AppText style={tailwind('text-sm text-white')}>·</AppText>}
+      {isCloudDeleted && (
+        <View style={[tailwind('flex-row items-center'), { gap: 4 }]}>
+          <CloudXIcon size={16} color="white" />
+          <AppText style={tailwind('text-sm text-white')}>{photoPreviewStrings.deletedFromCloud}</AppText>
+        </View>
+      )}
       {isWaitingToUpload && (
         <View style={[tailwind('flex-row items-center'), { gap: 4 }]}>
           <CloudSlashIcon size={16} color="white" />
@@ -136,6 +144,7 @@ export const PreviewHeader = ({ visible, item, onClose, onMore }: PreviewHeaderP
 
   const {
     isWaitingToUpload,
+    isCloudDeleted,
     isUploading,
     progress: uploadProgress,
     isBurst,
@@ -177,6 +186,7 @@ export const PreviewHeader = ({ visible, item, onClose, onMore }: PreviewHeaderP
               </AppText>
               <TimelineInfo
                 isWaitingToUpload={isWaitingToUpload}
+                isCloudDeleted={isCloudDeleted}
                 isUploading={isUploading}
                 isBurst={isBurst}
                 burstLiveProgress={burstLiveProgress}

--- a/src/screens/PhotoPreviewScreen/hooks/useLiveBackupStatus.ts
+++ b/src/screens/PhotoPreviewScreen/hooks/useLiveBackupStatus.ts
@@ -10,6 +10,7 @@ export interface BurstLiveProgress {
 
 export interface LiveBackupStatus {
   isWaitingToUpload: boolean;
+  isCloudDeleted: boolean;
   isUploading: boolean;
   progress: number;
   isBurst: boolean;
@@ -50,6 +51,7 @@ export const useLiveBackupStatus = (item: TimelinePhotoItem | undefined): LiveBa
 
   const snapshotState = item?.type === 'local' ? item.backupState : undefined;
   const isWaitingToUpload = snapshotState === 'not-backed' && !isInUploadQueue && !completedDuringSession;
+  const isCloudDeleted = snapshotState === 'cloud-deleted' && !isInUploadQueue && !completedDuringSession;
 
   useEffect(() => {
     if (!isBurst || !assetId || isInUploadQueue) {
@@ -75,6 +77,7 @@ export const useLiveBackupStatus = (item: TimelinePhotoItem | undefined): LiveBa
   return {
     isUploading: isInUploadQueue,
     isWaitingToUpload,
+    isCloudDeleted,
     progress: isInUploadQueue ? progress : 0,
     isBurst,
     burstLiveProgress: isInUploadQueue ? burstLiveProgress : null,

--- a/src/screens/PhotoPreviewScreen/index.tsx
+++ b/src/screens/PhotoPreviewScreen/index.tsx
@@ -12,7 +12,7 @@ import { RootStackScreenProps } from 'src/types/navigation';
 import { useTailwind } from 'tailwind-rn';
 import MoreActionsBottomSheet from '../PhotosScreen/components/MoreActionsBottomSheet';
 import { usePhotoActionHandlers } from '../PhotosScreen/hooks/usePhotoActionHandlers';
-import { isItemBacked } from '../PhotosScreen/utils/photoUtils';
+import { isItemBacked, isItemCloudDeleted } from '../PhotosScreen/utils/photoUtils';
 import { BurstIncompleteBanner } from './components/BurstIncompleteBanner';
 import { MetadataPanel } from './components/MetadataPanel';
 import { PreviewCarousel } from './components/PreviewCarousel';
@@ -146,6 +146,7 @@ export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
 
   const showCarousel = isUiVisible && !zoomActive && !hasVideoStarted;
   const isSynced = currentItem ? isItemBacked(currentItem) : false;
+  const isCloudDeleted = currentItem ? isItemCloudDeleted(currentItem) : false;
   const isBurstIncomplete = currentItem?.type === 'local' && currentItem?.isBurstUploadIncomplete === true;
 
   return (
@@ -184,7 +185,9 @@ export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
               onExport={handleExport}
               onMore={() => setIsMoreActionsOpen(true)}
               onDelete={handleDeletePress}
+              onBackup={handleRestore}
               isSynced={isSynced}
+              isCloudDeleted={isCloudDeleted}
             />
           )}
           <BurstIncompleteBanner visible={isUiVisible && isBurstIncomplete} />

--- a/src/screens/PhotosScreen/components/PhotoItem.tsx
+++ b/src/screens/PhotosScreen/components/PhotoItem.tsx
@@ -1,6 +1,14 @@
 import strings from 'assets/lang/strings';
 import { LinearGradient } from 'expo-linear-gradient';
-import { ArrowUpIcon, CheckIcon, CloudSlashIcon, ImageIcon, PlayIcon, WarningIcon } from 'phosphor-react-native';
+import {
+  ArrowUpIcon,
+  CheckIcon,
+  CloudSlashIcon,
+  CloudXIcon,
+  ImageIcon,
+  PlayIcon,
+  WarningIcon,
+} from 'phosphor-react-native';
 import { memo, useCallback, useEffect, useRef } from 'react';
 import { Animated, Easing, Image, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { Circle } from 'react-native-progress';
@@ -172,13 +180,21 @@ const LocalPhotoCell = memo(
     }
 
     const containerStyle = [styles.container, { backgroundColor: getColor('bg-gray-1') }];
+    const isCloudDeleted = item.backupState === 'cloud-deleted';
 
     return (
       <TouchableOpacity activeOpacity={0.85} style={containerStyle} onPress={handlePress} onLongPress={handleLongPress}>
         {/* key forces Image to remount on cell recycle, preventing the previous photo from flashing */}
-        <Image key={item.id} source={{ uri: item.uri }} style={StyleSheet.absoluteFillObject} resizeMode="cover" />
+        <Image
+          key={item.id}
+          source={{ uri: item.uri }}
+          style={[StyleSheet.absoluteFillObject, isCloudDeleted && styles.dimmed]}
+          resizeMode="cover"
+        />
 
-        {(item.backupState === 'not-backed' || item.backupState === 'uploading') && (
+        {(item.backupState === 'not-backed' ||
+          item.backupState === 'uploading' ||
+          item.backupState === 'cloud-deleted') && (
           <View style={[tailwind('absolute justify-center items-center'), { bottom: 8, left: 8 }]} pointerEvents="none">
             <LinearGradient
               colors={['transparent', 'rgba(0,0,0,0.08)', 'rgba(0,0,0,0.32)', 'rgba(0,0,0,0.6)']}
@@ -187,10 +203,12 @@ const LocalPhotoCell = memo(
               end={{ x: 0, y: 1 }}
               style={styles.badgeShadow}
             />
-            {item.backupState === 'not-backed' ? (
-              <CloudSlashIcon size={18} color={getColor('text-white')} weight="light" />
-            ) : (
+            {item.backupState === 'uploading' ? (
               <UploadProgressRing assetId={item.id} color={getColor('text-white')} />
+            ) : item.backupState === 'cloud-deleted' ? (
+              <CloudXIcon size={18} color={getColor('text-white')} weight="light" />
+            ) : (
+              <CloudSlashIcon size={18} color={getColor('text-white')} weight="light" />
             )}
           </View>
         )}
@@ -264,6 +282,9 @@ const styles = StyleSheet.create({
     aspectRatio: 1,
     borderRadius: 2,
     overflow: 'hidden',
+  },
+  dimmed: {
+    opacity: 0.5,
   },
   badgeShadow: {
     position: 'absolute',

--- a/src/screens/PhotosScreen/hooks/useLocalAssets.spec.ts
+++ b/src/screens/PhotosScreen/hooks/useLocalAssets.spec.ts
@@ -483,6 +483,22 @@ describe('useLocalAssets', () => {
     expect(result.current.syncedIds.has('a1')).toBe(false);
   });
 
+  test('when an asset was deleted in-app, then it appears in cloudDeletedIds and not in syncedIds', async () => {
+    mockMediaLibrary.getAssetsAsync.mockResolvedValueOnce(makePage([makeAsset('a1')]));
+    mockPhotosLocalDB.getSyncedEntries.mockResolvedValue(
+      new Map([['a1', { modificationTime: null, status: 'deleted' as const }]]),
+    );
+
+    const { result } = renderHook(() => useLocalAssets());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.cloudDeletedIds.has('a1')).toBe(true);
+    expect(result.current.syncedIds.has('a1')).toBe(false);
+  });
+
   test('when an asset failed to upload, then it does not appear in syncedIds or cloudDeletedIds', async () => {
     mockMediaLibrary.getAssetsAsync.mockResolvedValueOnce(makePage([makeAsset('a1')]));
     mockPhotosLocalDB.getSyncedEntries.mockResolvedValue(

--- a/src/screens/PhotosScreen/hooks/useLocalAssets.ts
+++ b/src/screens/PhotosScreen/hooks/useLocalAssets.ts
@@ -31,7 +31,6 @@ export const useLocalAssets = (): LocalAssetsResult => {
   const [isLoading, setIsLoading] = useState(true);
   const [hasLoadedLocalAssetsOnce, setHasLoadedLocalAssetsOnce] = useState(false);
   const [syncedIds, setSyncedIds] = useState<Set<string>>(new Set());
-  // TODO: Reserved for show a distinct icon for cloud-deleted vs never-backed assets. Remove if finally will be the same.
   const [cloudDeletedIds, setCloudDeletedIds] = useState<Set<string>>(new Set());
   const [localDeletionDetectedCount, setLocalDeletionDetectedCount] = useState(0);
   const [burstRepresentativeIdSet, setBurstRepresentativeIdSet] = useState<Set<string>>(new Set());
@@ -112,7 +111,7 @@ export const useLocalAssets = (): LocalAssetsResult => {
     const synced = new Set<string>();
     const cloudDeleted = new Set<string>();
     for (const [id, info] of entries) {
-      if (info.status === 'cloud_deleted') {
+      if (info.status === 'cloud_deleted' || info.status === 'deleted') {
         cloudDeleted.add(id);
       } else if (info.status === 'synced') {
         synced.add(id);

--- a/src/screens/PhotosScreen/hooks/usePhotoSelection.spec.ts
+++ b/src/screens/PhotosScreen/hooks/usePhotoSelection.spec.ts
@@ -1,12 +1,12 @@
 import { act, renderHook } from '@testing-library/react-native';
-import { TimelinePhotoItem } from '../types';
+import { PhotoBackupState, TimelinePhotoItem } from '../types';
 import { usePhotoSelection } from './usePhotoSelection';
 
-const makeLocalItem = (id: string): TimelinePhotoItem => ({
+const makeLocalItem = (id: string, backupState: PhotoBackupState = 'backed'): TimelinePhotoItem => ({
   id,
   type: 'local',
   createdAt: 0,
-  backupState: 'backed',
+  backupState,
   mediaType: 'photo',
 });
 
@@ -97,5 +97,29 @@ describe('usePhotoSelection', () => {
 
     expect(result.current.selectedItems).toHaveLength(1);
     expect(result.current.selectedItems[0].id).toBe('c');
+  });
+
+  test('when a drag-select starts on a cloud-deleted photo, then the anchor is rejected and nothing is selected', () => {
+    const items = [makeLocalItem('a', 'cloud-deleted'), makeLocalItem('b')];
+    const { result } = renderHook(() => usePhotoSelection(items));
+
+    act(() => result.current.enterSelectMode());
+    act(() => result.current.beginDragSelect(0));
+    act(() => result.current.updateDragSelect(1));
+
+    expect(result.current.selectedIds.size).toBe(0);
+  });
+
+  test('when a drag-select range includes a cloud-deleted photo, then that photo is skipped while others are selected', () => {
+    const items = [makeLocalItem('a'), makeLocalItem('b', 'cloud-deleted'), makeLocalItem('c')];
+    const { result } = renderHook(() => usePhotoSelection(items));
+
+    act(() => result.current.enterSelectMode());
+    act(() => result.current.beginDragSelect(0));
+    act(() => result.current.updateDragSelect(2));
+
+    expect(result.current.selectedIds.has('a')).toBe(true);
+    expect(result.current.selectedIds.has('b')).toBe(false);
+    expect(result.current.selectedIds.has('c')).toBe(true);
   });
 });

--- a/src/screens/PhotosScreen/hooks/usePhotoSelection.ts
+++ b/src/screens/PhotosScreen/hooks/usePhotoSelection.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { TimelinePhotoItem } from '../types';
+import { isItemSelectable } from '../utils/photoUtils';
 
 export interface PhotoSelection {
   isSelectMode: boolean;
@@ -49,7 +50,7 @@ export const usePhotoSelection = (allItems: TimelinePhotoItem[]): PhotoSelection
   const beginDragSelect = useCallback(
     (index: number) => {
       const anchorItem = allItems[index];
-      if (!anchorItem) {
+      if (!anchorItem || !isItemSelectable(anchorItem)) {
         return;
       }
       dragAnchorIndexRef.current = index;
@@ -73,7 +74,7 @@ export const usePhotoSelection = (allItems: TimelinePhotoItem[]): PhotoSelection
         const updatedSelection = new Set(selectionSnapshot);
         for (let i = rangeStart; i <= rangeEnd; i++) {
           const item = allItems[i];
-          if (!item) {
+          if (!item || !isItemSelectable(item)) {
             continue;
           }
           if (shouldSelect) {

--- a/src/screens/PhotosScreen/hooks/usePhotosTimeline.ts
+++ b/src/screens/PhotosScreen/hooks/usePhotosTimeline.ts
@@ -19,6 +19,7 @@ export const usePhotosTimeline = (deviceFilterId?: string | null): PhotosTimelin
     isLoading,
     hasLoadedLocalAssetsOnce,
     syncedIds,
+    cloudDeletedIds,
     uploadingIdSet,
     burstRepresentativeIdSet,
     incompleteUploadBurstIdSet: incompleteBurstIdSet,
@@ -50,9 +51,24 @@ export const usePhotosTimeline = (deviceFilterId?: string | null): PhotosTimelin
   const localGroups = useMemo(
     () =>
       showLocalAssets
-        ? groupAssetsByDate(assets, syncedIds, uploadingIdSet, burstRepresentativeIdSet, incompleteBurstIdSet)
+        ? groupAssetsByDate(
+            assets,
+            syncedIds,
+            uploadingIdSet,
+            burstRepresentativeIdSet,
+            incompleteBurstIdSet,
+            cloudDeletedIds,
+          )
         : [],
-    [showLocalAssets, assets, syncedIds, uploadingIdSet, burstRepresentativeIdSet, incompleteBurstIdSet],
+    [
+      showLocalAssets,
+      assets,
+      syncedIds,
+      uploadingIdSet,
+      burstRepresentativeIdSet,
+      incompleteBurstIdSet,
+      cloudDeletedIds,
+    ],
   );
 
   const readyToMergeCloud = !showLocalAssets || hasLoadedLocalAssetsOnce;

--- a/src/screens/PhotosScreen/index.tsx
+++ b/src/screens/PhotosScreen/index.tsx
@@ -35,6 +35,7 @@ import { usePhotoSelection } from './hooks/usePhotoSelection';
 import { usePhotosTimeline } from './hooks/usePhotosTimeline';
 import useSelectMorePhotos from './hooks/useSelectMorePhotos';
 import { PhotosAccessState, TimelinePhotoItem } from './types';
+import { isItemSelectable } from './utils/photoUtils';
 
 const PhotosScreen = (): JSX.Element => {
   const tailwind = useTailwind();
@@ -76,6 +77,10 @@ const PhotosScreen = (): JSX.Element => {
   const handlePhotoPress = useCallback(
     (id: string) => {
       if (selection.isSelectMode) {
+        const item = allItems.find((candidate) => candidate.id === id);
+        if (item && !isItemSelectable(item)) {
+          return;
+        }
         selection.toggleSelect(id);
         return;
       }
@@ -92,10 +97,14 @@ const PhotosScreen = (): JSX.Element => {
   const handlePhotoLongPress = useCallback(
     (id: string) => {
       if (!selection.isSelectMode) {
+        const item = allItems.find((candidate) => candidate.id === id);
+        if (item && !isItemSelectable(item)) {
+          return;
+        }
         selection.enterSelectMode(id);
       }
     },
-    [selection],
+    [selection, allItems],
   );
 
   const accessState = useMemo<PhotosAccessState>(() => {

--- a/src/screens/PhotosScreen/types.ts
+++ b/src/screens/PhotosScreen/types.ts
@@ -1,4 +1,4 @@
-export type PhotoBackupState = 'loading' | 'backed' | 'not-backed' | 'uploading';
+export type PhotoBackupState = 'loading' | 'backed' | 'not-backed' | 'uploading' | 'cloud-deleted';
 export type PhotoMediaType = 'photo' | 'video';
 
 export interface PhotoItem {

--- a/src/screens/PhotosScreen/utils/photoTimelineGroups.spec.ts
+++ b/src/screens/PhotosScreen/utils/photoTimelineGroups.spec.ts
@@ -137,6 +137,38 @@ describe('local asset to photo item conversion', () => {
     expect(item.mediaType).toBe('video');
     expect(item.duration).toBe('2:05');
   });
+
+  test('when the asset is in the cloud-deleted set, then its backup state is cloud-deleted', () => {
+    const asset = makeAsset({ id: 'asset-1' });
+    const item = assetToPhotoItem(asset, new Set(), new Set(), undefined, undefined, new Set(['asset-1']));
+    expect(item.backupState).toBe('cloud-deleted');
+  });
+
+  test('when the asset is both synced and cloud-deleted, then synced takes priority', () => {
+    const asset = makeAsset({ id: 'asset-1' });
+    const item = assetToPhotoItem(
+      asset,
+      new Set(['asset-1']),
+      new Set(),
+      undefined,
+      undefined,
+      new Set(['asset-1']),
+    );
+    expect(item.backupState).toBe('backed');
+  });
+
+  test('when the asset is both uploading and cloud-deleted, then uploading takes priority', () => {
+    const asset = makeAsset({ id: 'asset-1' });
+    const item = assetToPhotoItem(
+      asset,
+      new Set(),
+      new Set(['asset-1']),
+      undefined,
+      undefined,
+      new Set(['asset-1']),
+    );
+    expect(item.backupState).toBe('uploading');
+  });
 });
 
 describe('grouping assets by date', () => {
@@ -168,6 +200,13 @@ describe('grouping assets by date', () => {
     const groups = groupAssetsByDate([asset], new Set(['a1']), new Set());
     const photo = groups[0].photos[0] as import('../types').PhotoItem;
     expect(photo.backupState).toBe('backed');
+  });
+
+  test('when an asset is cloud-deleted, then the corresponding photo item has a cloud-deleted state', () => {
+    const asset = makeAsset({ id: 'a1' });
+    const groups = groupAssetsByDate([asset], new Set(), new Set(), undefined, undefined, new Set(['a1']));
+    const photo = groups[0].photos[0] as import('../types').PhotoItem;
+    expect(photo.backupState).toBe('cloud-deleted');
   });
 });
 

--- a/src/screens/PhotosScreen/utils/photoTimelineGroups.spec.ts
+++ b/src/screens/PhotosScreen/utils/photoTimelineGroups.spec.ts
@@ -198,14 +198,14 @@ describe('grouping assets by date', () => {
   test('when an asset is synced, then the corresponding photo item has a backed state', () => {
     const asset = makeAsset({ id: 'a1' });
     const groups = groupAssetsByDate([asset], new Set(['a1']), new Set());
-    const photo = groups[0].photos[0] as import('../types').PhotoItem;
+    const photo = groups[0].photos[0] as PhotoItem;
     expect(photo.backupState).toBe('backed');
   });
 
   test('when an asset is cloud-deleted, then the corresponding photo item has a cloud-deleted state', () => {
     const asset = makeAsset({ id: 'a1' });
     const groups = groupAssetsByDate([asset], new Set(), new Set(), undefined, undefined, new Set(['a1']));
-    const photo = groups[0].photos[0] as import('../types').PhotoItem;
+    const photo = groups[0].photos[0] as PhotoItem;
     expect(photo.backupState).toBe('cloud-deleted');
   });
 });

--- a/src/screens/PhotosScreen/utils/photoTimelineGroups.ts
+++ b/src/screens/PhotosScreen/utils/photoTimelineGroups.ts
@@ -35,12 +35,15 @@ export const assetToPhotoItem = (
   uploadingIdSet: Set<string>,
   burstRepresentativeIdSet?: Set<string>,
   incompleteBurstIdSet?: Set<string>,
+  cloudDeletedIds?: Set<string>,
 ): PhotoItem => {
   let backupState: PhotoBackupState;
   if (uploadingIdSet.has(asset.id)) {
     backupState = 'uploading';
   } else if (syncedIds.has(asset.id)) {
     backupState = 'backed';
+  } else if (cloudDeletedIds?.has(asset.id)) {
+    backupState = 'cloud-deleted';
   } else {
     backupState = 'not-backed';
   }
@@ -66,6 +69,7 @@ export const groupAssetsByDate = (
   uploadingIdSet: Set<string>,
   burstRepresentativeIdSet?: Set<string>,
   incompleteBurstIdSet?: Set<string>,
+  cloudDeletedIds?: Set<string>,
 ): PhotoDateGroup[] => {
   const now = new Date();
   const groupMap = new Map<string, { label: string; photos: PhotoItem[] }>();
@@ -80,7 +84,14 @@ export const groupAssetsByDate = (
       groupMap.set(groupKey, group);
     }
     group.photos.push(
-      assetToPhotoItem(asset, syncedIds, uploadingIdSet, burstRepresentativeIdSet, incompleteBurstIdSet),
+      assetToPhotoItem(
+        asset,
+        syncedIds,
+        uploadingIdSet,
+        burstRepresentativeIdSet,
+        incompleteBurstIdSet,
+        cloudDeletedIds,
+      ),
     );
   }
 

--- a/src/screens/PhotosScreen/utils/photoUtils.spec.ts
+++ b/src/screens/PhotosScreen/utils/photoUtils.spec.ts
@@ -1,0 +1,82 @@
+import { CloudPhotoItem, PhotoItem } from '../types';
+import { isItemBacked, isItemCloudDeleted, isItemSelectable, isLocalItemNotBacked } from './photoUtils';
+
+const makeLocalItem = (overrides: Partial<PhotoItem> = {}): PhotoItem => ({
+  id: 'asset-1',
+  type: 'local',
+  uri: 'file:///photo.jpg',
+  createdAt: Date.now(),
+  backupState: 'not-backed',
+  mediaType: 'photo',
+  ...overrides,
+});
+
+const makeCloudItem = (overrides: Partial<CloudPhotoItem> = {}): CloudPhotoItem => ({
+  id: 'remote-1',
+  type: 'cloud-only',
+  mediaType: 'photo',
+  thumbnailPath: null,
+  thumbnailBucketId: null,
+  thumbnailBucketFile: null,
+  thumbnailType: null,
+  deviceId: 'device-1',
+  createdAt: Date.now(),
+  fileName: 'photo.jpg',
+  ...overrides,
+});
+
+describe('isItemCloudDeleted', () => {
+  test('when a local item has cloud-deleted backup state, then it is cloud-deleted', () => {
+    expect(isItemCloudDeleted(makeLocalItem({ backupState: 'cloud-deleted' }))).toBe(true);
+  });
+
+  test('when a local item has not-backed backup state, then it is not cloud-deleted', () => {
+    expect(isItemCloudDeleted(makeLocalItem({ backupState: 'not-backed' }))).toBe(false);
+  });
+
+  test('when the item is cloud-only, then it is not cloud-deleted', () => {
+    expect(isItemCloudDeleted(makeCloudItem())).toBe(false);
+  });
+});
+
+describe('isItemSelectable', () => {
+  test('when an item is cloud-deleted, then it is not selectable', () => {
+    expect(isItemSelectable(makeLocalItem({ backupState: 'cloud-deleted' }))).toBe(false);
+  });
+
+  test('when a local item is not-backed, then it is selectable', () => {
+    expect(isItemSelectable(makeLocalItem({ backupState: 'not-backed' }))).toBe(true);
+  });
+
+  test('when a local item is backed, then it is selectable', () => {
+    expect(isItemSelectable(makeLocalItem({ backupState: 'backed' }))).toBe(true);
+  });
+
+  test('when the item is cloud-only, then it is selectable', () => {
+    expect(isItemSelectable(makeCloudItem())).toBe(true);
+  });
+});
+
+describe('isItemBacked', () => {
+  test('when the item is cloud-only, then it is backed', () => {
+    expect(isItemBacked(makeCloudItem())).toBe(true);
+  });
+
+  test('when a local item has backed state, then it is backed', () => {
+    expect(isItemBacked(makeLocalItem({ backupState: 'backed' }))).toBe(true);
+  });
+
+  test('when a local item is cloud-deleted, then it is not backed', () => {
+    expect(isItemBacked(makeLocalItem({ backupState: 'cloud-deleted' }))).toBe(false);
+  });
+});
+
+describe('isLocalItemNotBacked', () => {
+  test('when a local item is not-backed, then it is true', () => {
+    expect(isLocalItemNotBacked(makeLocalItem({ backupState: 'not-backed' }))).toBe(true);
+  });
+
+  test('when a local item is cloud-deleted, then it is false', () => {
+    expect(isLocalItemNotBacked(makeLocalItem({ backupState: 'cloud-deleted' }))).toBe(false);
+  });
+});

--- a/src/screens/PhotosScreen/utils/photoUtils.ts
+++ b/src/screens/PhotosScreen/utils/photoUtils.ts
@@ -7,6 +7,11 @@ export const isItemBacked = (item: TimelinePhotoItem): boolean =>
 export const isLocalItemNotBacked = (item: TimelinePhotoItem): boolean =>
   item.type === 'local' && item.backupState === 'not-backed';
 
+export const isItemCloudDeleted = (item: TimelinePhotoItem): boolean =>
+  item.type === 'local' && item.backupState === 'cloud-deleted';
+
+export const isItemSelectable = (item: TimelinePhotoItem): boolean => !isItemCloudDeleted(item);
+
 const isVideo = (item: TimelinePhotoItem): boolean => item.mediaType === 'video';
 
 export const getSavedNotificationMessage = (item: TimelinePhotoItem): string =>

--- a/src/services/photos/PhotoDeduplicator.spec.ts
+++ b/src/services/photos/PhotoDeduplicator.spec.ts
@@ -2,7 +2,7 @@ import { PhotoDeduplicator } from './PhotoDeduplicator';
 import { photosLocalDB } from './database/photosLocalDB';
 
 jest.mock('./database/photosLocalDB', () => ({
-  photosLocalDB: { getSyncedEntries: jest.fn(), getDeletedAssetIds: jest.fn() },
+  photosLocalDB: { getSyncedEntries: jest.fn() },
 }));
 
 const mockDB = photosLocalDB as jest.Mocked<typeof photosLocalDB>;
@@ -12,7 +12,6 @@ const makeAsset = (id: string, modificationTime = 1000) => ({ id, modificationTi
 describe('PhotoDeduplicator', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockDB.getDeletedAssetIds.mockResolvedValue(new Set());
   });
 
   test('when no photos have been synced before, then all photos are queued as new', async () => {
@@ -92,25 +91,25 @@ describe('PhotoDeduplicator', () => {
     expect(editedAssets).toHaveLength(0);
   });
 
-  test('when a photo was explicitly deleted from cloud, then it is excluded from new assets', async () => {
-    mockDB.getSyncedEntries.mockResolvedValueOnce(new Map());
-    mockDB.getDeletedAssetIds.mockResolvedValueOnce(new Set(['a']));
-
-    const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([makeAsset('a'), makeAsset('b')]);
-
-    expect(newAssets.map((asset) => asset.id)).toEqual(['b']);
-    expect(editedAssets).toHaveLength(0);
-  });
-
-  test('when a previously synced photo was explicitly deleted from cloud, then it is excluded from edited assets', async () => {
+  test('when a photo was deleted in-app and not edited on device, then it is not re-queued', async () => {
     mockDB.getSyncedEntries.mockResolvedValueOnce(
-      new Map([['a', { modificationTime: 500, status: 'synced' as const }]]),
+      new Map([['a', { modificationTime: 1000, status: 'deleted' as const }]]),
     );
-    mockDB.getDeletedAssetIds.mockResolvedValueOnce(new Set(['a']));
 
     const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([makeAsset('a', 1000)]);
 
     expect(newAssets).toHaveLength(0);
+    expect(editedAssets).toHaveLength(0);
+  });
+
+  test('when a photo was deleted in-app and was later edited on device, then it is treated as a new upload', async () => {
+    mockDB.getSyncedEntries.mockResolvedValueOnce(
+      new Map([['a', { modificationTime: 500, status: 'deleted' as const }]]),
+    );
+
+    const { newAssets, editedAssets } = await PhotoDeduplicator.getAssetsToSync([makeAsset('a', 1000)]);
+
+    expect(newAssets.map((asset) => asset.id)).toEqual(['a']);
     expect(editedAssets).toHaveLength(0);
   });
 

--- a/src/services/photos/PhotoDeduplicator.ts
+++ b/src/services/photos/PhotoDeduplicator.ts
@@ -20,23 +20,16 @@ export const PhotoDeduplicator = {
       return { newAssets: [], editedAssets: [] };
     }
 
-    const [syncedEntries, deletedIds] = await Promise.all([
-      photosLocalDB.getSyncedEntries(assets.map((asset) => asset.id)),
-      photosLocalDB.getDeletedAssetIds(),
-    ]);
+    const syncedEntries = await photosLocalDB.getSyncedEntries(assets.map((asset) => asset.id));
 
     const newAssets: MediaLibrary.Asset[] = [];
     const editedAssets: MediaLibrary.Asset[] = [];
 
     for (const asset of assets) {
-      const skipBecauseDeleted = deletedIds.has(asset.id);
-      if (skipBecauseDeleted) {
-        continue;
-      }
       const syncedInfo = syncedEntries.get(asset.id);
       if (!syncedInfo) {
         newAssets.push(asset);
-      } else if (syncedInfo.status === 'cloud_deleted') {
+      } else if (syncedInfo.status === 'cloud_deleted' || syncedInfo.status === 'deleted') {
         if (hasBeenEdited(asset, syncedInfo.modificationTime)) {
           newAssets.push(asset);
         }

--- a/src/services/photos/database/photosLocalDB.spec.ts
+++ b/src/services/photos/database/photosLocalDB.spec.ts
@@ -139,13 +139,13 @@ describe('photosLocalDB', () => {
     expect(stmt).toContain('status != \'synced\'');
   });
 
-  test('when looking up synced photos, then synced, cloud_deleted and error statuses are queried', async () => {
+  test('when looking up synced photos, then synced, cloud_deleted, deleted and error statuses are queried', async () => {
     mockSqlite.getAllAsync.mockResolvedValueOnce([]);
 
     await photosLocalDB.getSyncedEntries(['asset-1']);
 
     const [, stmt] = mockSqlite.getAllAsync.mock.calls[0];
-    expect(stmt).toContain('status IN (\'synced\', \'cloud_deleted\', \'error\')');
+    expect(stmt).toContain('status IN (\'synced\', \'cloud_deleted\', \'deleted\', \'error\')');
   });
 
   test('when looking up 300 photos at once, then a single database query is made with all ids', async () => {

--- a/src/services/photos/database/photosLocalDB.ts
+++ b/src/services/photos/database/photosLocalDB.ts
@@ -123,7 +123,7 @@ interface AssetSyncRow {
 
 export interface SyncedAssetInfo {
   modificationTime: number | null;
-  status: 'synced' | 'cloud_deleted' | 'error';
+  status: 'synced' | 'cloud_deleted' | 'deleted' | 'error';
 }
 
 export interface IncompleteBurstAsset {
@@ -306,7 +306,7 @@ class PhotosLocalDB {
         return sqliteService.getAllAsync<{
           asset_id: string;
           modification_time: number | null;
-          status: 'synced' | 'cloud_deleted' | 'error';
+          status: 'synced' | 'cloud_deleted' | 'deleted' | 'error';
         }>(DB_NAME, assetSyncTable.statements.getSyncedInList(placeholders), chunk);
       }),
     );
@@ -411,14 +411,6 @@ class PhotosLocalDB {
 
   async markAssetDeleted(assetId: string): Promise<void> {
     await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.markDeleted, [assetId]);
-  }
-
-  async getDeletedAssetIds(): Promise<Set<string>> {
-    const rows = await sqliteService.getAllAsync<{ asset_id: string }>(
-      DB_NAME,
-      assetSyncTable.statements.getDeletedIds,
-    );
-    return new Set(rows.map((row) => row.asset_id));
   }
 
   async deleteAssetSync(assetId: string): Promise<void> {

--- a/src/services/photos/database/tables/asset_sync.ts
+++ b/src/services/photos/database/tables/asset_sync.ts
@@ -134,7 +134,7 @@ const statements = {
     FROM ${TABLE_NAME} WHERE asset_id = ?;
   `,
   getSyncedInList: (placeholders: string) =>
-    `SELECT asset_id, modification_time, status FROM ${TABLE_NAME} WHERE asset_id IN (${placeholders}) AND status IN ('synced', 'cloud_deleted', 'error');`,
+    `SELECT asset_id, modification_time, status FROM ${TABLE_NAME} WHERE asset_id IN (${placeholders}) AND status IN ('synced', 'cloud_deleted', 'deleted', 'error');`,
   getSyncedRemoteIdsByCreationMonth: `
     SELECT remote_file_id FROM ${TABLE_NAME}
     WHERE status = 'synced'
@@ -165,7 +165,6 @@ const statements = {
       status     = 'deleted',
       deleted_at = (unixepoch() * 1000);
   `,
-  getDeletedIds: `SELECT asset_id FROM ${TABLE_NAME} WHERE status = 'deleted';`,
   markCloudDeleted: `UPDATE ${TABLE_NAME} SET status = 'cloud_deleted' WHERE remote_file_id = ?;`,
   resetSyncedToPending: `
     UPDATE ${TABLE_NAME} SET


### PR DESCRIPTION
Show a distinct icon and disabled state for cloud-deleted assets in the Photos timeline and preview screen

  ## Summary

  - **`PhotoItem.tsx`**: cloud-deleted local assets now render dimmed with a `CloudXIcon` badge instead of reusing the "not backed" `CloudSlashIcon`
  - **`PreviewCarousel.tsx`**: preview action bar swaps Export/More/Delete for a single "Backup" action when the current item is cloud-deleted
  - **`PreviewHeader.tsx`**: adds a "Deleted from the cloud" label with `CloudXIcon` in the timeline info row for cloud-deleted items
  - **`useLiveBackupStatus.ts`**: derives `isCloudDeleted` from `snapshotState`, excluding items currently queued or just completed in-session
  - **`usePhotoSelection.ts` / `PhotosScreen/index.tsx`**: cloud-deleted assets are excluded from tap-select, drag-select and range-select
  - **`photoTimelineGroups.ts` / `useLocalAssets.ts`**: threads `cloudDeletedIds` through timeline grouping and DB status `'deleted'` is now treated the same as `'cloud_deleted'`
  - **`PhotoDeduplicator.ts` / `photosLocalDB.ts` / `asset_sync.ts`**: removes the now-unused separate `getDeletedAssetIds` query/statement, folding `'deleted'` into the existing `'cloud_deleted'` handling path