### PR TITLE
[_] feature/Upload manually asset action

### DIFF
--- a/assets/lang/strings.ts
+++ b/assets/lang/strings.ts
@@ -206,7 +206,7 @@ const translations = {
         enableSheet: {
           title: 'All your photos,\none gallery',
           featurePrivacy: 'Keep your memories safe and private, only you can access them.',
-          featureDevices: 'Access from all your devices, even from the browser with Photos Web.',
+          featureDevices: 'Access from all your devices',
           featureBackup: 'Backup all your photos in case you lose your device.',
           allowButton: 'Back up my gallery',
           deniedHintPrefix: 'On the following screen, change Photos access from ',
@@ -1212,7 +1212,7 @@ const translations = {
         enableSheet: {
           title: 'Todas tus fotos,\nuna galería',
           featurePrivacy: 'Mantén tus recuerdos seguros y privados, solo tú puedes acceder a ellos.',
-          featureDevices: 'Accede desde todos tus dispositivos, incluso desde el navegador con Photos Web.',
+          featureDevices: 'Accede desde todos tus dispositivos.',
           featureBackup: 'Haz backup de todas tus fotos por si pierdes tu dispositivo.',
           allowButton: 'Guardar mi galería',
           deniedHintPrefix: 'En la siguiente pantalla, cambia el acceso a Fotos de ',

--- a/src/screens/PhotoPreviewScreen/hooks/useLiveBackupStatus.spec.ts
+++ b/src/screens/PhotoPreviewScreen/hooks/useLiveBackupStatus.spec.ts
@@ -117,6 +117,20 @@ describe('useLiveBackupStatus', () => {
     expect(result.current.progress).toBe(0);
   });
 
+  test('when the asset is cloud-deleted and completed during this session, then cloud-deleted is no longer reported', () => {
+    photosState.sessionCompletedAssetIds = ['a1'];
+
+    const { result } = renderHook(() => useLiveBackupStatus(makeLocalItem('a1', 'cloud-deleted')));
+
+    expect(result.current.isCloudDeleted).toBe(false);
+  });
+
+  test('when the asset is cloud-deleted and was not completed during this session, then cloud-deleted is reported', () => {
+    const { result } = renderHook(() => useLiveBackupStatus(makeLocalItem('a1', 'cloud-deleted')));
+
+    expect(result.current.isCloudDeleted).toBe(true);
+  });
+
   test('when the snapshot says uploading but the queue no longer contains the asset, then it is shown as backed', () => {
     const { result } = renderHook(() => useLiveBackupStatus(makeLocalItem('a1', 'uploading')));
 
@@ -148,7 +162,14 @@ describe('useLiveBackupStatus', () => {
     photosState.uploadProgressById = { b1: 0.6 };
     photosState.burstUploadProgressById = { b1: { uploaded: 3, total: 5 } };
 
-    const item: PhotoItem = { id: 'b1', type: 'local', createdAt: 1000, backupState: 'not-backed', mediaType: 'photo', isBurst: true };
+    const item: PhotoItem = {
+      id: 'b1',
+      type: 'local',
+      createdAt: 1000,
+      backupState: 'not-backed',
+      mediaType: 'photo',
+      isBurst: true,
+    };
     const { result } = renderHook(() => useLiveBackupStatus(item));
 
     expect(result.current.isBurst).toBe(true);
@@ -160,7 +181,14 @@ describe('useLiveBackupStatus', () => {
   test('when a burst is backed, then the member count from the database is reported as total', async () => {
     mockGetStatus.mockResolvedValue({ burstMemberCount: 4 });
 
-    const item: PhotoItem = { id: 'b2', type: 'local', createdAt: 1000, backupState: 'backed', mediaType: 'photo', isBurst: true };
+    const item: PhotoItem = {
+      id: 'b2',
+      type: 'local',
+      createdAt: 1000,
+      backupState: 'backed',
+      mediaType: 'photo',
+      isBurst: true,
+    };
     const { result } = renderHook(() => useLiveBackupStatus(item));
 
     await waitFor(() => expect(result.current.burstTotal).toBe(5)); // 4 members + 1 representative

--- a/src/screens/PhotoPreviewScreen/hooks/useLiveBackupStatus.ts
+++ b/src/screens/PhotoPreviewScreen/hooks/useLiveBackupStatus.ts
@@ -42,6 +42,7 @@ export const useLiveBackupStatus = (item: TimelinePhotoItem | undefined): LiveBa
     assetId ? state.photos.uploadingAssetIds.includes(assetId) : false,
   );
   const progress = useAppSelector((state) => (assetId ? (state.photos.uploadProgressById[assetId] ?? 0) : 0));
+
   const completedDuringSession = useAppSelector((state) =>
     assetId ? state.photos.sessionCompletedAssetIds.includes(assetId) : false,
   );

--- a/src/screens/PhotoPreviewScreen/hooks/usePreviewItems.spec.ts
+++ b/src/screens/PhotoPreviewScreen/hooks/usePreviewItems.spec.ts
@@ -1,0 +1,57 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { PhotoItem } from '../../PhotosScreen/types';
+import { usePreviewItems } from './usePreviewItems';
+
+const makeItem = (id: string, backupState: PhotoItem['backupState']): PhotoItem => ({
+  id,
+  type: 'local',
+  createdAt: 0,
+  backupState,
+  mediaType: 'photo',
+});
+
+describe('usePreviewItems', () => {
+  test('when the hook mounts, then the initial index points to the item matching initialId', () => {
+    const items = [makeItem('a', 'backed'), makeItem('b', 'backed'), makeItem('c', 'backed')];
+
+    const { result } = renderHook(() => usePreviewItems('b', items));
+
+    expect(result.current.currentIndex).toBe(1);
+  });
+
+  test('when markAssetBackedUp is called, then the matching item is reported as backed', () => {
+    const items = [makeItem('a', 'cloud-deleted')];
+    const { result } = renderHook(() => usePreviewItems('a', items));
+
+    act(() => result.current.markAssetBackedUp('a'));
+
+    expect((result.current.items[0] as PhotoItem).backupState).toBe('backed');
+  });
+
+  test('when an asset is marked backed up and the current index moves to another item and back, then it is still reported as backed', () => {
+    const items = [makeItem('a', 'cloud-deleted'), makeItem('b', 'backed')];
+    const { result } = renderHook(() => usePreviewItems('a', items));
+
+    act(() => result.current.markAssetBackedUp('a'));
+    act(() => result.current.setCurrentIndex(1));
+    act(() => result.current.setCurrentIndex(0));
+
+    expect((result.current.items[0] as PhotoItem).backupState).toBe('backed');
+  });
+
+  test('when one item is marked backed up, then other items are left unchanged', () => {
+    const items = [makeItem('a', 'cloud-deleted'), makeItem('b', 'not-backed')];
+    const { result } = renderHook(() => usePreviewItems('a', items));
+
+    act(() => result.current.markAssetBackedUp('a'));
+
+    expect((result.current.items[1] as PhotoItem).backupState).toBe('not-backed');
+  });
+
+  test('when no asset has been marked backed up, then items are returned as-is', () => {
+    const items = [makeItem('a', 'cloud-deleted')];
+    const { result } = renderHook(() => usePreviewItems('a', items));
+
+    expect(result.current.items).toEqual(items);
+  });
+});

--- a/src/screens/PhotoPreviewScreen/hooks/usePreviewItems.ts
+++ b/src/screens/PhotoPreviewScreen/hooks/usePreviewItems.ts
@@ -1,10 +1,11 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { TimelinePhotoItem } from '../../PhotosScreen/types';
 
 export interface UsePreviewItemsResult {
   items: TimelinePhotoItem[];
   currentIndex: number;
   setCurrentIndex: (index: number) => void;
+  markAssetBackedUp: (id: string) => void;
 }
 
 export const usePreviewItems = (initialId: string, items: TimelinePhotoItem[]): UsePreviewItemsResult => {
@@ -17,5 +18,21 @@ export const usePreviewItems = (initialId: string, items: TimelinePhotoItem[]): 
     [initialId, items],
   );
   const [currentIndex, setCurrentIndex] = useState(initialIndex);
-  return { items, currentIndex, setCurrentIndex };
+  const [backedUpIds, setBackedUpIds] = useState<Set<string>>(new Set());
+
+  const overriddenItems = useMemo(
+    () =>
+      backedUpIds.size === 0
+        ? items
+        : items.map((item) =>
+            item.type === 'local' && backedUpIds.has(item.id) ? { ...item, backupState: 'backed' as const } : item,
+          ),
+    [items, backedUpIds],
+  );
+
+  const markAssetBackedUp = useCallback((id: string) => {
+    setBackedUpIds((prev) => new Set(prev).add(id));
+  }, []);
+
+  return { items: overriddenItems, currentIndex, setCurrentIndex, markAssetBackedUp };
 };

--- a/src/screens/PhotoPreviewScreen/index.tsx
+++ b/src/screens/PhotoPreviewScreen/index.tsx
@@ -6,28 +6,26 @@ import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, { runOnJS, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { ConfirmModal } from 'src/components/modals/ConfirmModal/ConfirmModal';
 import { logger } from 'src/services/common';
-import { useAppDispatch } from 'src/store/hooks';
-import { runUploadThunk } from 'src/store/slices/photos';
 import { RootStackScreenProps } from 'src/types/navigation';
 import { useTailwind } from 'tailwind-rn';
 import MoreActionsBottomSheet from '../PhotosScreen/components/MoreActionsBottomSheet';
 import { usePhotoActionHandlers } from '../PhotosScreen/hooks/usePhotoActionHandlers';
-import { isItemBacked, isItemCloudDeleted } from '../PhotosScreen/utils/photoUtils';
+import { TimelinePhotoItem } from '../PhotosScreen/types';
 import { BurstIncompleteBanner } from './components/BurstIncompleteBanner';
 import { MetadataPanel } from './components/MetadataPanel';
 import { PreviewCarousel } from './components/PreviewCarousel';
 import { PreviewHeader } from './components/PreviewHeader';
 import { PreviewPager } from './components/PreviewPager';
+import { useLiveBackupStatus } from './hooks/useLiveBackupStatus';
 import { usePreviewItems } from './hooks/usePreviewItems';
 
 type Props = RootStackScreenProps<'PhotoPreview'>;
 
 export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
   const { initialId, items: routeItems, onItemChanged, onCurrentItemChange } = route.params;
-  const { items, currentIndex, setCurrentIndex } = usePreviewItems(initialId, routeItems);
+  const { items, currentIndex, setCurrentIndex, markAssetBackedUp } = usePreviewItems(initialId, routeItems);
   const tailwind = useTailwind();
   const navigation = useNavigation();
-  const dispatch = useAppDispatch();
 
   const [isUiVisible, setIsUiVisible] = useState(true);
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
@@ -132,9 +130,15 @@ export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
       await onItemChanged?.();
       navigation.goBack();
     }, [onItemChanged, navigation]),
-    onAfterRestore: useCallback(async () => {
-      await dispatch(runUploadThunk({ bypassEnabled: true })).unwrap();
-    }, [dispatch]),
+    onAfterRestore: useCallback(
+      async (restoredItems: TimelinePhotoItem[]) => {
+        for (const restoredItem of restoredItems) {
+          markAssetBackedUp(restoredItem.id);
+        }
+        await onItemChanged?.();
+      },
+      [onItemChanged, markAssetBackedUp],
+    ),
   });
 
   const handleDeletePress = useCallback(() => setIsDeleteConfirmOpen(true), []);
@@ -145,8 +149,8 @@ export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
   }, [handleTrashConfirm]);
 
   const showCarousel = isUiVisible && !zoomActive && !hasVideoStarted;
-  const isSynced = currentItem ? isItemBacked(currentItem) : false;
-  const isCloudDeleted = currentItem ? isItemCloudDeleted(currentItem) : false;
+  const { isWaitingToUpload, isCloudDeleted, isUploading } = useLiveBackupStatus(currentItem);
+  const isSynced = !isWaitingToUpload && !isCloudDeleted && !isUploading;
   const isBurstIncomplete = currentItem?.type === 'local' && currentItem?.isBurstUploadIncomplete === true;
 
   return (

--- a/src/screens/PhotosScreen/hooks/usePhotoActionHandlers.spec.ts
+++ b/src/screens/PhotosScreen/hooks/usePhotoActionHandlers.spec.ts
@@ -3,6 +3,8 @@ import { Linking } from 'react-native';
 import { notifications } from 'src/services/NotificationsService';
 import { SavePermissionDeniedError } from 'src/services/photos/errors';
 import { photoActionsService } from 'src/services/photos/PhotoActionsService';
+import { useAppDispatch } from 'src/store/hooks';
+import { uploadAssetsManuallyThunk } from 'src/store/slices/photos';
 import { CloudPhotoItem, PhotoItem } from '../types';
 import { usePhotoActionHandlers } from './usePhotoActionHandlers';
 
@@ -12,7 +14,6 @@ jest.mock('src/services/photos/PhotoActionsService', () => ({
     saveToDevice: jest.fn(),
     copyToClipboard: jest.fn(),
     trash: jest.fn(),
-    restoreToCloud: jest.fn(),
   },
 }));
 
@@ -24,8 +25,17 @@ jest.mock('src/services/common', () => ({
   logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn() },
 }));
 
+jest.mock('src/store/hooks', () => ({
+  useAppDispatch: jest.fn(),
+}));
+
+jest.mock('src/store/slices/photos', () => ({
+  uploadAssetsManuallyThunk: jest.fn(),
+}));
+
 const mockService = photoActionsService as jest.Mocked<typeof photoActionsService>;
 const mockNotifications = notifications as jest.Mocked<typeof notifications>;
+const mockUseAppDispatch = useAppDispatch as jest.Mock;
 
 const makeLocalBacked = (id = 'asset-1'): PhotoItem => ({
   id,
@@ -49,13 +59,22 @@ const makeCloudOnly = (id = 'remote-1'): CloudPhotoItem => ({
   deviceId: 'device-1',
 });
 
+let mockDispatch: jest.Mock;
+let mockUnwrap: jest.Mock;
+
 beforeEach(() => {
   jest.clearAllMocks();
   mockService.exportItems.mockResolvedValue(undefined);
   mockService.saveToDevice.mockResolvedValue(undefined);
   mockService.copyToClipboard.mockResolvedValue(undefined);
   mockService.trash.mockResolvedValue(undefined);
-  mockService.restoreToCloud.mockResolvedValue(undefined);
+  mockUnwrap = jest.fn().mockResolvedValue(undefined);
+  mockDispatch = jest.fn().mockReturnValue({ unwrap: mockUnwrap });
+  mockUseAppDispatch.mockReturnValue(mockDispatch);
+  (uploadAssetsManuallyThunk as unknown as jest.Mock).mockImplementation((arg) => ({
+    type: 'photos/uploadAssetsNow',
+    arg,
+  }));
 });
 
 describe('handleExport', () => {
@@ -227,17 +246,43 @@ describe('handleTrashConfirm', () => {
 });
 
 describe('handleRestore', () => {
-  test('when restore succeeds, then onAfterRestore is called', async () => {
+  test('when restore succeeds, then uploadAssetsManuallyThunk is dispatched with the local item ids and onAfterRestore is called with the items', async () => {
+    const items = [makeLocalBacked('a'), makeLocalBacked('b')];
     const onAfterRestore = jest.fn().mockResolvedValue(undefined);
-    const { result } = renderHook(() => usePhotoActionHandlers({ items: [makeLocalBacked()], onAfterRestore }));
+    const { result } = renderHook(() => usePhotoActionHandlers({ items, onAfterRestore }));
 
     await act(() => result.current.handleRestore());
 
-    expect(onAfterRestore).toHaveBeenCalledTimes(1);
+    expect(uploadAssetsManuallyThunk).toHaveBeenCalledWith(
+      expect.objectContaining({ assetIds: ['a', 'b'], signal: expect.any(AbortSignal) }),
+    );
+    expect(onAfterRestore).toHaveBeenCalledWith(items);
   });
 
-  test('when restore throws, then the restore-error toast is shown and onAfterRestore is not called', async () => {
-    mockService.restoreToCloud.mockRejectedValueOnce(new Error('network error'));
+  test('when the screen unmounts while a restore upload is in flight, then the signal passed to the upload thunk is not aborted', async () => {
+    const { result, unmount } = renderHook(() => usePhotoActionHandlers({ items: [makeLocalBacked()] }));
+
+    const restorePromise = act(() => result.current.handleRestore());
+    unmount();
+    await restorePromise;
+
+    const dispatchedArg = (uploadAssetsManuallyThunk as unknown as jest.Mock).mock.calls[0][0] as { signal: AbortSignal };
+    expect(dispatchedArg.signal.aborted).toBe(false);
+  });
+
+  test('when there are no local items, then uploadAssetsManuallyThunk is not dispatched but onAfterRestore still runs', async () => {
+    const items = [makeCloudOnly()];
+    const onAfterRestore = jest.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => usePhotoActionHandlers({ items, onAfterRestore }));
+
+    await act(() => result.current.handleRestore());
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(onAfterRestore).toHaveBeenCalledWith(items);
+  });
+
+  test('when the upload thunk rejects, then the restore-error toast is shown and onAfterRestore is not called', async () => {
+    mockUnwrap.mockRejectedValueOnce(new Error('network error'));
     const onAfterRestore = jest.fn();
     const { result } = renderHook(() => usePhotoActionHandlers({ items: [makeLocalBacked()], onAfterRestore }));
 

--- a/src/screens/PhotosScreen/hooks/usePhotoActionHandlers.ts
+++ b/src/screens/PhotosScreen/hooks/usePhotoActionHandlers.ts
@@ -5,6 +5,8 @@ import { logger } from 'src/services/common';
 import { notifications } from 'src/services/NotificationsService';
 import { SavePermissionDeniedError } from 'src/services/photos/errors';
 import { photoActionsService } from 'src/services/photos/PhotoActionsService';
+import { useAppDispatch } from 'src/store/hooks';
+import { uploadAssetsManuallyThunk } from 'src/store/slices/photos';
 import { NotificationType } from 'src/types';
 import { TimelinePhotoItem } from '../types';
 import { getSavedNotificationMessage, getTrashNotificationMessage } from '../utils/photoUtils';
@@ -15,7 +17,7 @@ interface UsePhotoActionHandlersOpts {
   onActionEnd?: () => void;
   onAfterSave?: () => void | Promise<void>;
   onAfterTrash?: () => void | Promise<void>;
-  onAfterRestore?: () => void | Promise<void>;
+  onAfterRestore?: (items: TimelinePhotoItem[]) => void | Promise<void>;
 }
 
 export interface UsePhotoActionHandlersReturn {
@@ -34,6 +36,7 @@ export const usePhotoActionHandlers = ({
   onAfterTrash,
   onAfterRestore,
 }: UsePhotoActionHandlersOpts): UsePhotoActionHandlersReturn => {
+  const dispatch = useAppDispatch();
   const abortRef = useRef<AbortController | null>(null);
 
   useEffect(
@@ -130,17 +133,21 @@ export const usePhotoActionHandlers = ({
   }, [startAction, onActionEnd, items, onAfterTrash]);
 
   const handleRestore = useCallback(async () => {
-    const { signal } = startAction(strings.screens.photos.selection.actionProgress.uploadingToCloud);
+    startAction(strings.screens.photos.selection.actionProgress.uploadingToCloud);
     try {
-      await photoActionsService.restoreToCloud(items, signal);
-      await onAfterRestore?.();
+      const assetIds = items.filter((item) => item.type === 'local').map((item) => item.id);
+      if (assetIds.length > 0) {
+        const uploadSignal = new AbortController().signal;
+        await dispatch(uploadAssetsManuallyThunk({ assetIds, signal: uploadSignal })).unwrap();
+      }
+      await onAfterRestore?.(items);
     } catch (error) {
       logger.error(`[usePhotoActionHandlers] Restore error: ${error}`);
       notifications.error(strings.screens.photos.notifications.restoreError);
     } finally {
       onActionEnd?.();
     }
-  }, [startAction, onActionEnd, items, onAfterRestore]);
+  }, [startAction, onActionEnd, items, onAfterRestore, dispatch]);
 
   return { handleExport, handleSave, handleCopy, handleTrashConfirm, handleRestore };
 };

--- a/src/screens/PhotosScreen/hooks/usePhotoActions.spec.ts
+++ b/src/screens/PhotosScreen/hooks/usePhotoActions.spec.ts
@@ -2,7 +2,7 @@ import { act, renderHook } from '@testing-library/react-native';
 import { notifications } from 'src/services/NotificationsService';
 import { photoActionsService } from 'src/services/photos/PhotoActionsService';
 import { useAppDispatch } from 'src/store/hooks';
-import { runBackupCycleThunk, runUploadThunk } from 'src/store/slices/photos';
+import { runBackupCycleThunk, uploadAssetsManuallyThunk } from 'src/store/slices/photos';
 import { PhotoItem } from '../types';
 import { usePhotoActions } from './usePhotoActions';
 import { PhotoSelection } from './usePhotoSelection';
@@ -13,7 +13,6 @@ jest.mock('src/services/photos/PhotoActionsService', () => ({
     saveToDevice: jest.fn(),
     copyToClipboard: jest.fn(),
     trash: jest.fn(),
-    restoreToCloud: jest.fn(),
   },
 }));
 
@@ -30,7 +29,7 @@ jest.mock('src/store/hooks', () => ({
 }));
 
 jest.mock('src/store/slices/photos', () => ({
-  runUploadThunk: jest.fn(),
+  uploadAssetsManuallyThunk: jest.fn(),
   runBackupCycleThunk: jest.fn(),
 }));
 
@@ -87,11 +86,13 @@ beforeEach(() => {
   mockService.saveToDevice.mockResolvedValue(undefined);
   mockService.copyToClipboard.mockResolvedValue(undefined);
   mockService.trash.mockResolvedValue(undefined);
-  mockService.restoreToCloud.mockResolvedValue(undefined);
   mockUnwrap = jest.fn().mockResolvedValue(undefined);
   mockDispatch = jest.fn().mockReturnValue({ unwrap: mockUnwrap });
   mockUseAppDispatch.mockReturnValue(mockDispatch);
-  (runUploadThunk as unknown as jest.Mock).mockReturnValue({ type: 'photos/runUploadThunk' });
+  (uploadAssetsManuallyThunk as unknown as jest.Mock).mockImplementation((arg) => ({
+    type: 'photos/uploadAssetsNow',
+    arg,
+  }));
   (runBackupCycleThunk as unknown as jest.Mock).mockReturnValue({ type: 'photos/runBackupCycle' });
 });
 
@@ -213,27 +214,17 @@ describe('handleTrashConfirm', () => {
 });
 
 describe('handleRestore', () => {
-  test('when restore succeeds, then dispatch is called with runUploadThunk and reloads run', async () => {
+  test('when restore succeeds, then dispatch is called with uploadAssetsManuallyThunk and reloads run', async () => {
     const opts = makeOpts();
     const { result } = renderHook(() => usePhotoActions(makeSelection(), opts));
 
     await act(() => result.current.handleRestore());
 
-    expect(mockDispatch).toHaveBeenCalledWith(runUploadThunk({ bypassEnabled: true }));
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ arg: expect.objectContaining({ assetIds: ['asset-1'] }) }),
+    );
     expect(opts.reloadLocal).toHaveBeenCalledTimes(1);
     expect(opts.reloadCloud).toHaveBeenCalledTimes(1);
-  });
-
-  test('when restore throws, then dispatch and reloads are not called', async () => {
-    mockService.restoreToCloud.mockRejectedValueOnce(new Error('network error'));
-    const opts = makeOpts();
-    const { result } = renderHook(() => usePhotoActions(makeSelection(), opts));
-
-    await act(() => result.current.handleRestore());
-
-    expect(mockDispatch).not.toHaveBeenCalled();
-    expect(opts.reloadLocal).not.toHaveBeenCalled();
-    expect(opts.reloadCloud).not.toHaveBeenCalled();
   });
 
   test('when dispatch unwrap rejects, then reloads are not called and the restore-error toast is shown', async () => {

--- a/src/screens/PhotosScreen/hooks/usePhotoActions.ts
+++ b/src/screens/PhotosScreen/hooks/usePhotoActions.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 import { useAppDispatch } from 'src/store/hooks';
-import { runBackupCycleThunk, runUploadThunk } from 'src/store/slices/photos';
+import { runBackupCycleThunk } from 'src/store/slices/photos';
 import { usePhotoActionHandlers } from './usePhotoActionHandlers';
 import { PhotoSelection } from './usePhotoSelection';
 
@@ -57,10 +57,9 @@ export const usePhotoActions = (
       await reloadCloud();
     }, [reloadLocal, reloadCloud]),
     onAfterRestore: useCallback(async () => {
-      await dispatch(runUploadThunk({ bypassEnabled: true })).unwrap();
       await reloadLocal();
       await reloadCloud();
-    }, [dispatch, reloadLocal, reloadCloud]),
+    }, [reloadLocal, reloadCloud]),
   });
 
   const handleDelete = useCallback(() => {

--- a/src/services/photos/PhotoActionsService.spec.ts
+++ b/src/services/photos/PhotoActionsService.spec.ts
@@ -42,7 +42,6 @@ jest.mock('./database/photosLocalDB', () => ({
     getStatus: jest.fn(),
     deleteCloudAsset: jest.fn(),
     markAssetDeleted: jest.fn(),
-    markPending: jest.fn(),
   },
 }));
 
@@ -101,7 +100,6 @@ beforeEach(() => {
   mockDB.getStatus.mockResolvedValue(null);
   mockDB.deleteCloudAsset.mockResolvedValue(undefined);
   mockDB.markAssetDeleted.mockResolvedValue(undefined);
-  mockDB.markPending.mockResolvedValue(undefined);
   mockMoveToTrash.mockResolvedValue(undefined);
 });
 
@@ -271,34 +269,5 @@ describe('trash', () => {
     await photoActionsService.trash([makeCloudOnly()], controller.signal);
 
     expect(mockMoveToTrash).not.toHaveBeenCalled();
-  });
-});
-
-describe('restoreToCloud', () => {
-  test('when a local item is restored, then it is marked pending', async () => {
-    const item = makeLocalNotBacked('local-1');
-
-    await photoActionsService.restoreToCloud([item], makeSignal());
-
-    expect(mockDB.markPending).toHaveBeenCalledWith('local-1');
-  });
-
-  test('when a cloud-only item is in the list, then it is ignored', async () => {
-    const cloud = makeCloudOnly('remote-1');
-    const local = makeLocalNotBacked('local-1');
-
-    await photoActionsService.restoreToCloud([cloud, local], makeSignal());
-
-    expect(mockDB.markPending).toHaveBeenCalledTimes(1);
-    expect(mockDB.markPending).toHaveBeenCalledWith('local-1');
-  });
-
-  test('when the signal is aborted before processing starts, then nothing is marked pending', async () => {
-    const controller = new AbortController();
-    controller.abort();
-
-    await photoActionsService.restoreToCloud([makeLocalNotBacked()], controller.signal);
-
-    expect(mockDB.markPending).not.toHaveBeenCalled();
   });
 });

--- a/src/services/photos/PhotoActionsService.ts
+++ b/src/services/photos/PhotoActionsService.ts
@@ -174,18 +174,6 @@ class PhotoActionsService {
     }
   }
 
-  async restoreToCloud(items: TimelinePhotoItem[], signal: AbortSignal): Promise<void> {
-    for (const item of items) {
-      if (signal.aborted) {
-        return;
-      }
-      if (item.type !== 'local') {
-        continue;
-      }
-      await photosLocalDB.markPending(item.id);
-    }
-  }
-
   async trash(items: TimelinePhotoItem[], signal: AbortSignal): Promise<void> {
     const { trashPayload, cleanupItems } = await this.classifyItems(items, signal);
 

--- a/src/services/photos/PhotoUploadQueue.spec.ts
+++ b/src/services/photos/PhotoUploadQueue.spec.ts
@@ -132,6 +132,52 @@ describe('PhotoUploadQueue.start', () => {
   });
 });
 
+describe('PhotoUploadQueue.start with an external signal', () => {
+  test('when an external signal is provided, then it is used instead of the shared cycle controller', async () => {
+    const asset = makeAsset('a1');
+    mockUpload.mockResolvedValue('remote-id');
+    const controller = new AbortController();
+
+    await PhotoUploadQueue.start([{ asset }], DEVICE_ID, PHOTOS_BUCKET, {}, controller.signal);
+
+    expect(mockUpload).toHaveBeenCalledWith(
+      asset,
+      DEVICE_ID,
+      PHOTOS_BUCKET,
+      expect.objectContaining({ signal: controller.signal }),
+    );
+  });
+
+  test('when an external signal is already aborted, then no job is uploaded', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const onAssetStart = jest.fn();
+
+    await PhotoUploadQueue.start([{ asset: makeAsset('a1') }], DEVICE_ID, PHOTOS_BUCKET, { onAssetStart }, controller.signal);
+
+    expect(onAssetStart).not.toHaveBeenCalled();
+    expect(mockUpload).not.toHaveBeenCalled();
+  });
+
+  test('when a run uses an external signal, then abortAll on the shared cycle controller does not cancel it', async () => {
+    const asset = makeAsset('a1');
+    const controller = new AbortController();
+    mockUpload.mockImplementationOnce(async () => {
+      PhotoUploadQueue.beginCycle();
+      PhotoUploadQueue.abortAll();
+      return 'remote-id';
+    });
+
+    const onAssetDone = jest.fn();
+    await PhotoUploadQueue.start([{ asset }], DEVICE_ID, PHOTOS_BUCKET, { onAssetDone }, controller.signal);
+
+    expect(controller.signal.aborted).toBe(false);
+    expect(onAssetDone).toHaveBeenCalledWith('a1', 'remote-id', asset.modificationTime);
+
+    PhotoUploadQueue.endCycle();
+  });
+});
+
 describe('PhotoUploadQueue.abortAll', () => {
   test('when the upload service rejects with an abort error, then onAssetError receives the original abort error and not a wrapped error', async () => {
     const asset = makeAsset('a1');

--- a/src/services/photos/PhotoUploadQueue.ts
+++ b/src/services/photos/PhotoUploadQueue.ts
@@ -35,43 +35,58 @@ export const PhotoUploadQueue = {
     deviceId: string,
     photosBucket: string,
     callbacks: UploadQueueCallbacks,
+    externalAbortSignal?: AbortSignal,
   ): Promise<void> {
+    if (externalAbortSignal) {
+      return PhotoUploadQueue.runJobs(jobs, deviceId, photosBucket, callbacks, externalAbortSignal);
+    }
+
     currentController = currentController ?? new AbortController();
     const { signal } = currentController;
 
     try {
-      const limit = pLimit(UPLOAD_CONCURRENCY);
-
-      await Promise.all(
-        jobs.map((job) =>
-          limit(async () => {
-            if (signal.aborted) {
-              return;
-            }
-            const { asset, existingRemoteFileId } = job;
-            callbacks.onAssetStart?.(asset.id);
-
-            try {
-              const uploadOptions = {
-                onProgress: (ratio: number) => callbacks.onAssetProgress?.(asset.id, ratio),
-                signal,
-                onEvent: (event: PhotoUploadEvent) => callbacks.onAssetEvent?.(asset.id, event),
-              };
-              const photoUploadResult = existingRemoteFileId
-                ? await PhotoUploadService.replace(asset, existingRemoteFileId, deviceId, photosBucket, uploadOptions)
-                : await PhotoUploadService.upload(asset, deviceId, photosBucket, uploadOptions);
-              await callbacks.onAssetDone?.(asset.id, photoUploadResult, asset.modificationTime);
-            } catch (uploadError) {
-              await callbacks.onAssetError?.(asset.id, uploadError as Error);
-            }
-          }),
-        ),
-      );
+      await PhotoUploadQueue.runJobs(jobs, deviceId, photosBucket, callbacks, signal);
     } finally {
       if (currentController?.signal === signal) {
         currentController = null;
       }
     }
+  },
+
+  async runJobs(
+    jobs: AssetUploadJob[],
+    deviceId: string,
+    photosBucket: string,
+    callbacks: UploadQueueCallbacks,
+    signal: AbortSignal,
+  ): Promise<void> {
+    const limit = pLimit(UPLOAD_CONCURRENCY);
+
+    await Promise.all(
+      jobs.map((job) =>
+        limit(async () => {
+          if (signal.aborted) {
+            return;
+          }
+          const { asset, existingRemoteFileId } = job;
+          callbacks.onAssetStart?.(asset.id);
+
+          try {
+            const uploadOptions = {
+              onProgress: (ratio: number) => callbacks.onAssetProgress?.(asset.id, ratio),
+              signal,
+              onEvent: (event: PhotoUploadEvent) => callbacks.onAssetEvent?.(asset.id, event),
+            };
+            const photoUploadResult = existingRemoteFileId
+              ? await PhotoUploadService.replace(asset, existingRemoteFileId, deviceId, photosBucket, uploadOptions)
+              : await PhotoUploadService.upload(asset, deviceId, photosBucket, uploadOptions);
+            await callbacks.onAssetDone?.(asset.id, photoUploadResult, asset.modificationTime);
+          } catch (uploadError) {
+            await callbacks.onAssetError?.(asset.id, uploadError as Error);
+          }
+        }),
+      ),
+    );
   },
 
   abortAll(): void {

--- a/src/store/slices/photos/index.spec.ts
+++ b/src/store/slices/photos/index.spec.ts
@@ -28,6 +28,7 @@ import photosReducer, {
   runFullCloudHistorySyncThunk,
   runUploadThunk,
   setNetworkConditionThunk,
+  uploadAssetsManuallyThunk,
 } from './index';
 import { hasPhotosFeatureAccess } from './selectors';
 
@@ -1469,6 +1470,129 @@ describe('photos slice', () => {
       await store.dispatch(runUploadThunk());
 
       expect(store.getState().photos.sessionCompletedAssetIds).toEqual([]);
+    });
+  });
+
+  describe('uploadAssetsManuallyThunk', () => {
+    const makeSignal = () => new AbortController().signal;
+
+    const makeReadyStore = () => {
+      const store = makeStore();
+      store.dispatch(
+        photosSlice.actions.setState({
+          enabled: true,
+          permissionStatus: 'granted',
+          deviceId: 'device-1',
+          photosBucket: 'photos-bucket-1',
+        }),
+      );
+      return store;
+    };
+
+    test('when the upload succeeds, then the asset is marked synced and removed from the uploading set', async () => {
+      mockScanner.getAssetsByIds.mockResolvedValueOnce([{ id: 'a1' }] as never);
+      mockUploadQueue.start.mockImplementationOnce(async (_jobs, _deviceId, _photosBucket, callbacks) => {
+        callbacks.onAssetStart?.('a1');
+        await callbacks.onAssetDone?.('a1', { photoUuid: 'remote-1' }, 12345);
+      });
+      const store = makeReadyStore();
+
+      await store.dispatch(uploadAssetsManuallyThunk({ assetIds: ['a1'], signal: makeSignal() })).unwrap();
+
+      expect(mockPhotosLocalDB.markSynced).toHaveBeenCalledWith('a1', 'remote-1', 12345);
+      expect(store.getState().photos.uploadingAssetIds).toEqual([]);
+      expect(mockPhotosLocalDB.markPending).not.toHaveBeenCalled();
+    });
+
+    test('when the upload succeeds, then the asset is not added to sessionCompletedAssetIds', async () => {
+      mockScanner.getAssetsByIds.mockResolvedValueOnce([{ id: 'a1' }] as never);
+      mockUploadQueue.start.mockImplementationOnce(async (_jobs, _deviceId, _photosBucket, callbacks) => {
+        await callbacks.onAssetDone?.('a1', { photoUuid: 'remote-1' }, 12345);
+      });
+      const store = makeReadyStore();
+
+      await store.dispatch(uploadAssetsManuallyThunk({ assetIds: ['a1'], signal: makeSignal() })).unwrap();
+
+      expect(store.getState().photos.sessionCompletedAssetIds).toEqual([]);
+    });
+
+    test('when the upload fails, then the asset is marked errored and the thunk rejects', async () => {
+      mockScanner.getAssetsByIds.mockResolvedValueOnce([{ id: 'a1' }] as never);
+      const uploadError = Object.assign(new Error('network error'), { name: 'Error' });
+      mockUploadQueue.start.mockImplementationOnce(async (_jobs, _deviceId, _photosBucket, callbacks) => {
+        await callbacks.onAssetError?.('a1', uploadError);
+      });
+      const store = makeReadyStore();
+
+      await expect(
+        store.dispatch(uploadAssetsManuallyThunk({ assetIds: ['a1'], signal: makeSignal() })).unwrap(),
+      ).rejects.toMatchObject({ message: 'network error' });
+
+      expect(mockPhotosLocalDB.markError).toHaveBeenCalledWith('a1', 'network error');
+    });
+
+    test('when wifi-only is enabled and the device is on cellular, then the upload is blocked and the queue never starts', async () => {
+      (networkMonitorService.getNetworkStateAsync as jest.Mock).mockResolvedValueOnce({
+        type: NetworkStateType.CELLULAR,
+        isConnected: true,
+        isInternetReachable: true,
+      } as NetworkState);
+      const store = makeReadyStore();
+      store.dispatch(photosSlice.actions.setNetworkCondition('wifi-only'));
+
+      await expect(
+        store.dispatch(uploadAssetsManuallyThunk({ assetIds: ['a1'], signal: makeSignal() })).unwrap(),
+      ).rejects.toBeTruthy();
+
+      expect(mockUploadQueue.start).not.toHaveBeenCalled();
+    });
+
+    test('when available storage is exhausted, then the upload is blocked and backup is paused for quota', async () => {
+      mockStorageSelectors.availableStorage.mockReturnValueOnce(0);
+      const store = makeReadyStore();
+
+      await expect(
+        store.dispatch(uploadAssetsManuallyThunk({ assetIds: ['a1'], signal: makeSignal() })).unwrap(),
+      ).rejects.toBeTruthy();
+
+      expect(mockUploadQueue.start).not.toHaveBeenCalled();
+      expect(store.getState().photos.disabledReason).toBe('quota-exceeded');
+    });
+
+    test('when backup is disabled, then the manual upload still runs', async () => {
+      mockScanner.getAssetsByIds.mockResolvedValueOnce([{ id: 'a1' }] as never);
+      mockUploadQueue.start.mockImplementationOnce(async (_jobs, _deviceId, _photosBucket, callbacks) => {
+        await callbacks.onAssetDone?.('a1', { photoUuid: 'remote-1' }, Date.now());
+      });
+      const store = makeReadyStore();
+      store.dispatch(photosSlice.actions.setEnabled(false));
+
+      await store.dispatch(uploadAssetsManuallyThunk({ assetIds: ['a1'], signal: makeSignal() })).unwrap();
+
+      expect(mockUploadQueue.start).toHaveBeenCalled();
+    });
+
+    test('when the signal is already aborted, then nothing is uploaded', async () => {
+      const controller = new AbortController();
+      controller.abort();
+      const store = makeReadyStore();
+
+      await store.dispatch(uploadAssetsManuallyThunk({ assetIds: ['a1'], signal: controller.signal })).unwrap();
+
+      expect(mockUploadQueue.start).not.toHaveBeenCalled();
+    });
+
+    test('when the asset upload is aborted mid-flight, then it is not marked as errored and the thunk does not reject', async () => {
+      mockScanner.getAssetsByIds.mockResolvedValueOnce([{ id: 'a1' }] as never);
+      const abortError = new AbortError();
+      mockUploadQueue.start.mockImplementationOnce(async (_jobs, _deviceId, _photosBucket, callbacks) => {
+        await callbacks.onAssetError?.('a1', abortError);
+      });
+      const store = makeReadyStore();
+
+      await store.dispatch(uploadAssetsManuallyThunk({ assetIds: ['a1'], signal: makeSignal() })).unwrap();
+
+      expect(mockPhotosLocalDB.markError).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/store/slices/photos/index.ts
+++ b/src/store/slices/photos/index.ts
@@ -22,8 +22,8 @@ import { AsyncStorageKey } from 'src/types';
 import { logger } from '../../../services/common';
 import { RootState } from '../../index';
 import { hasPhotosFeatureAccess } from './selectors';
-import { evaluateNetworkPause, runUploadThunk } from './thunks/upload';
-export { runUploadThunk };
+import { evaluateNetworkPause, runUploadThunk, uploadAssetsManuallyThunk } from './thunks/upload';
+export { runUploadThunk, uploadAssetsManuallyThunk };
 
 export type PhotoNetworkCondition = 'wifi-only' | 'wifi-and-data';
 export type PhotoSyncStatus =

--- a/src/store/slices/photos/index.ts
+++ b/src/store/slices/photos/index.ts
@@ -22,8 +22,9 @@ import { AsyncStorageKey } from 'src/types';
 import { logger } from '../../../services/common';
 import { RootState } from '../../index';
 import { hasPhotosFeatureAccess } from './selectors';
-import { evaluateNetworkPause, runUploadThunk, uploadAssetsManuallyThunk } from './thunks/upload';
-export { runUploadThunk, uploadAssetsManuallyThunk };
+import { evaluateNetworkPause, runUploadThunk } from './thunks/upload';
+export { runUploadThunk };
+export { uploadAssetsManuallyThunk } from './thunks/upload';
 
 export type PhotoNetworkCondition = 'wifi-only' | 'wifi-and-data';
 export type PhotoSyncStatus =

--- a/src/store/slices/photos/thunks/upload.ts
+++ b/src/store/slices/photos/thunks/upload.ts
@@ -1,8 +1,8 @@
-import { createAsyncThunk } from '@reduxjs/toolkit';
+import { AnyAction, createAsyncThunk, ThunkDispatch } from '@reduxjs/toolkit';
 import * as MediaLibrary from 'expo-media-library';
 import { Platform } from 'react-native';
 import { AbortError } from 'src/network/errors';
-import { NetworkState, NetworkStateType, networkMonitorService } from 'src/services/NetworkMonitorService';
+import { networkMonitorService, NetworkState, NetworkStateType } from 'src/services/NetworkMonitorService';
 import { HTTP_QUOTA_EXCEEDED } from 'src/services/common/httpStatusCodes';
 import { PhotoAssetScanner } from 'src/services/photos/PhotoAssetScanner';
 import { AssetUploadJob, PhotoUploadQueue } from 'src/services/photos/PhotoUploadQueue';
@@ -54,7 +54,7 @@ const buildUploadJobs = (
     return [{ asset }];
   });
 
-const completeSyncForAsset = async (
+export const completeSyncForAsset = async (
   assetId: string,
   result: PhotoUploadResult,
   modificationTime: number,
@@ -94,6 +94,54 @@ const hasRemainingAssets = async (isIOS: boolean): Promise<boolean> => {
   const remainingPending = await photosLocalDB.getPendingAssets();
   const remainingBursts = isIOS ? await photosLocalDB.getIncompleteBurstAssets() : [];
   return remainingPending.length > 0 || remainingBursts.length > 0;
+};
+
+const isQuotaExceededError = (error: Error): boolean => (error as { status?: number })?.status === HTTP_QUOTA_EXCEEDED;
+
+const isAbortSignalError = (error: Error): boolean => error.name === AbortError.errorName;
+
+type UploadThunkDispatch = ThunkDispatch<RootState, unknown, AnyAction>;
+
+const finishAssetUpload = async (
+  dispatch: UploadThunkDispatch,
+  assetId: string,
+  result: PhotoUploadResult,
+  modificationTime: number,
+): Promise<void> => {
+  await completeSyncForAsset(assetId, result, modificationTime);
+  dispatch(photosSlice.actions.removeUploadingAssetId(assetId));
+  dispatch(photosSlice.actions.incrementTotalAssetsUploaded());
+};
+
+const finishAssetUploadInCycle = async (
+  dispatch: UploadThunkDispatch,
+  assetId: string,
+  result: PhotoUploadResult,
+  modificationTime: number,
+): Promise<void> => {
+  await finishAssetUpload(dispatch, assetId, result, modificationTime);
+  dispatch(photosSlice.actions.markAssetUploadCompleted(assetId));
+};
+
+type AssetErrorOutcome = 'quota' | 'aborted' | 'failed';
+
+const handleAssetUploadError = async (
+  dispatch: UploadThunkDispatch,
+  assetId: string,
+  error: Error,
+): Promise<AssetErrorOutcome> => {
+  dispatch(photosSlice.actions.removeUploadingAssetId(assetId));
+  if (isQuotaExceededError(error)) {
+    dispatch(photosSlice.actions.pauseForQuotaExceeded());
+    return 'quota';
+  }
+  if (isAbortSignalError(error)) {
+    logger.info(`[Upload] Asset ${assetId} aborted (pause or wifi loss)`);
+    return 'aborted';
+  }
+  logger.error(`[Upload] Asset ${assetId} failed: ${error?.message ?? String(error)}`);
+  await photosLocalDB.markError(assetId, error.message);
+  return 'failed';
 };
 
 let isUploadCycleRunning = false;
@@ -228,31 +276,16 @@ export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean }
         },
         onAssetDone: async (assetId, result, modificationTime) => {
           lastDispatchedUploadProgressStep.delete(assetId);
-          await completeSyncForAsset(assetId, result, modificationTime);
-          dispatch(photosSlice.actions.markAssetUploadCompleted(assetId));
-          dispatch(photosSlice.actions.removeUploadingAssetId(assetId));
-          dispatch(photosSlice.actions.incrementTotalAssetsUploaded());
+          await finishAssetUploadInCycle(dispatch, assetId, result, modificationTime);
           dispatch(photosSlice.actions.incrementSessionUploadedAssets());
         },
         onAssetEvent: applyBurstEvent,
         onAssetError: async (assetId, error) => {
           lastDispatchedUploadProgressStep.delete(assetId);
-          const isQuotaError = (error as { status?: number })?.status === HTTP_QUOTA_EXCEEDED;
-          if (isQuotaError) {
-            dispatch(photosSlice.actions.pauseForQuotaExceeded());
-            dispatch(photosSlice.actions.removeUploadingAssetId(assetId));
+          const errorOutcome = await handleAssetUploadError(dispatch, assetId, error);
+          if (errorOutcome === 'quota') {
             PhotoUploadQueue.abortAll();
-            return;
           }
-
-          if (error.name === AbortError.errorName) {
-            logger.info(`[Upload] Asset ${assetId} aborted (pause or wifi loss)`);
-            dispatch(photosSlice.actions.removeUploadingAssetId(assetId));
-            return;
-          }
-          logger.error(`[Upload] Asset ${assetId} failed: ${error?.message ?? String(error)}`);
-          await photosLocalDB.markError(assetId, error.message);
-          dispatch(photosSlice.actions.removeUploadingAssetId(assetId));
         },
       });
 
@@ -282,3 +315,76 @@ export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean }
     }
   },
 );
+
+/**
+ * Uploads the given assets for the manual "Backup" action, independent of the automatic backup
+ * cycle: not gated by `enabled`/`isPaused`/`isUploadCycleRunning`, never marks the asset
+ * `pending`, and skips session bookkeeping — so it can't be swallowed by a running cycle or
+ * silently resume an entire backlog when backup is off. Not retried automatically if interrupted.
+ */
+export const uploadAssetsManuallyThunk = createAsyncThunk<
+  void,
+  { assetIds: string[]; signal: AbortSignal },
+  { state: RootState }
+>('photos/uploadAssetsNow', async ({ assetIds, signal }, { getState, dispatch }) => {
+  if (assetIds.length === 0 || signal.aborted) {
+    return;
+  }
+
+  const { permissionStatus, deviceId, photosBucket, networkCondition } = getState().photos;
+  if (!isPermissionActive(permissionStatus) || !deviceId || !photosBucket) {
+    throw new Error('[Upload] uploadAssetsNow — missing device/bucket/permission prerequisites');
+  }
+
+  const networkState = await networkMonitorService.getNetworkStateAsync();
+  const pauseStatus = evaluateNetworkPause(networkState, networkCondition);
+  if (pauseStatus) {
+    throw new Error(`[Upload] uploadAssetsNow — blocked by network condition: ${pauseStatus}`);
+  }
+
+  const availableStorage = storageSelectors.availableStorage(getState());
+  if (availableStorage <= 0) {
+    dispatch(photosSlice.actions.pauseForQuotaExceeded());
+    throw new Error('[Upload] uploadAssetsNow — storage quota exceeded');
+  }
+
+  const resolvedAssets = await PhotoAssetScanner.getAssetsByIds(assetIds);
+  const assetById = new Map(resolvedAssets.map((a) => [a.id, a]));
+  const jobs: AssetUploadJob[] = assetIds.flatMap((id) => {
+    const asset = assetById.get(id);
+    return asset ? [{ asset }] : [];
+  });
+  if (jobs.length === 0) {
+    return;
+  }
+
+  let uploadError: Error | null = null;
+
+  await PhotoUploadQueue.start(
+    jobs,
+    deviceId,
+    photosBucket,
+    {
+      onAssetStart: (assetId) => {
+        dispatch(photosSlice.actions.addUploadingAssetId(assetId));
+      },
+      onAssetProgress: (assetId, ratio) => {
+        dispatch(photosSlice.actions.setAssetUploadProgress({ assetId, progress: ratio }));
+      },
+      onAssetDone: async (assetId, result, modificationTime) => {
+        await finishAssetUpload(dispatch, assetId, result, modificationTime);
+      },
+      onAssetError: async (assetId, error) => {
+        const errorOutcome = await handleAssetUploadError(dispatch, assetId, error);
+        if (errorOutcome !== 'aborted') {
+          uploadError ??= error;
+        }
+      },
+    },
+    signal,
+  );
+
+  if (uploadError) {
+    throw uploadError;
+  }
+});


### PR DESCRIPTION
Upload the asset immediately when the "Backup" button is pressed, instead of queueing it into the automatic backup cycle

  ## Summary

  - **`thunks/upload.ts`**: added `uploadAssetsManuallyThunk` independent of `runUploadThunk`
  - **`PhotoUploadQueue.ts`**: added to `start()` an optional `externalSignal` param so a manual upload uses its own `AbortController`, decoupled from the automatic cycle's in order to paused/aborted cycle can no longer cancel a manual upload in progress
  - **`PhotoActionsService.ts`**: removed `restoreToCloud`, superseded by `uploadAssetsManuallyThunk`, it no longer did anything useful.
  - **`usePhotoActionHandlers.ts`**: `handleRestore` dispatches `uploadAssetsManuallyThunk` with its own throwaway signal, not the shared action abort ref, so closing the preview during upload doesn't cancel it.
  - **`usePreviewItems.ts`**: new `markAssetBackedUp`. The preview receives its items as a frozen snapshot that never re-syncs with Redux or DB while open, so this locally flags a uploaded item as backed to reflect state we already know, without waiting for the user to leave and re-open the preview.
  - **`PhotoPreviewScreen/index.tsx`**: `isCloudDeleted`/`isSynced` now derived from `useLiveBackupStatus` instead of the frozen snapshot.
  - **`useLiveBackupStatus.ts`**, **`usePhotoActions.ts`**: minor adjustments to keep automatic backup cycle completion tracking untouched by the manual path.