### PR TITLE
[PB-6591] feature/Photos database backup

### DIFF
--- a/assets/lang/strings.ts
+++ b/assets/lang/strings.ts
@@ -856,6 +856,7 @@ const translations = {
 
       SignOutModal: {
         title: 'Log out from this account?',
+        signingOut: 'Saving your latest Photos data…',
       },
       ConfirmMoveItemModal: {
         title: 'Move {0} item(s) from',
@@ -1864,6 +1865,7 @@ const translations = {
 
       SignOutModal: {
         title: '¿Salir de esta cuenta?',
+        signingOut: 'Guardando tus últimos datos de Photos…',
       },
       ConfirmMoveItemModal: {
         title: 'Mover {0} item(s) desde',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -249,7 +249,13 @@ function AppContent(): JSX.Element {
                     onClose={onChangeProfilePictureModalClosed}
                   />
                   <LanguageModal isOpen={isLanguageModalOpen} onClose={onLanguageModalClosed} />
-                  <SignOutModal onSignedOut={() => navigationRef.reset({ index: 0, routes: [{ name: 'SignIn' }] })} />
+                  <SignOutModal
+                    onSignedOut={() => {
+                      if (navigationRef.isReady()) {
+                        navigationRef.reset({ index: 0, routes: [{ name: 'SignIn' }] });
+                      }
+                    }}
+                  />
                 </Portal.Host>
               </DriveContextProvider>
             ) : (

--- a/src/components/modals/SignOutModal/index.tsx
+++ b/src/components/modals/SignOutModal/index.tsx
@@ -46,7 +46,6 @@ function SignOutModal({ onSignedOut }: SignOutModalProps): JSX.Element {
 
   return (
     <CenterModal
-      // signOutThunk resets isSignOutModalOpen early — the local flag keeps the loader open until done.
       isOpen={isSignOutModalOpen || isSigningOut}
       onClosed={onClosed}
       backdropPressToClose={false}
@@ -54,7 +53,6 @@ function SignOutModal({ onSignedOut }: SignOutModalProps): JSX.Element {
     >
       {isSigningOut ? (
         <View style={tailwind('w-full px-6 py-8 items-center')}>
-          {/* LoadingSpinner sizes itself via flex-1 and collapses without a fixed-height container */}
           <View style={{ width: 48, height: 48 }}>
             <LoadingSpinner size={40} />
           </View>

--- a/src/components/modals/SignOutModal/index.tsx
+++ b/src/components/modals/SignOutModal/index.tsx
@@ -1,3 +1,4 @@
+import { useRef, useState } from 'react';
 import { View } from 'react-native';
 
 import { useTailwind } from 'tailwind-rn';
@@ -7,6 +8,7 @@ import { authSelectors, authThunks } from '../../../store/slices/auth';
 import { uiActions } from '../../../store/slices/ui';
 import AppButton from '../../AppButton';
 import AppText from '../../AppText';
+import LoadingSpinner from '../../LoadingSpinner';
 import UserProfilePicture from '../../UserProfilePicture';
 import CenterModal from '../CenterModal';
 
@@ -20,48 +22,76 @@ function SignOutModal({ onSignedOut }: SignOutModalProps): JSX.Element {
   const userFullName = useAppSelector(authSelectors.userFullName);
   const user = useAppSelector((state) => state.auth.user);
   const { isSignOutModalOpen } = useAppSelector((state) => state.ui);
+  const [isSigningOut, setIsSigningOut] = useState(false);
+  const isSigningOutRef = useRef(false);
+
   const onClosed = () => {
     dispatch(uiActions.setIsSignOutModalOpen(false));
   };
   const onCancelButtonPressed = () => {
     onClosed();
   };
-  const onSignOutButtonPressed = () => {
-    dispatch(authThunks.signOutThunk({ reason: 'manual' }));
+  const onSignOutButtonPressed = async () => {
+    if (isSigningOutRef.current) {
+      return;
+    }
+    isSigningOutRef.current = true;
+    setIsSigningOut(true);
+    await dispatch(authThunks.signOutThunk({ reason: 'manual' }));
+    isSigningOutRef.current = false;
+    setIsSigningOut(false);
     onSignedOut();
     onClosed();
   };
 
   return (
-    <CenterModal isOpen={isSignOutModalOpen} onClosed={onClosed} backdropPressToClose={false}>
-      <View style={tailwind('w-full px-3 pt-7 pb-3')}>
-        <AppText style={tailwind('mx-4 text-center text-xl')} numberOfLines={1} semibold>
-          {strings.modals.SignOutModal.title}
-        </AppText>
-
-        <View style={tailwind('items-center my-6')}>
-          <UserProfilePicture uri={user?.avatar} size={80} />
-          <AppText style={tailwind('text-lg text-gray-80 mt-2')} medium>
-            {userFullName}
+    <CenterModal
+      // signOutThunk resets isSignOutModalOpen early — the local flag keeps the loader open until done.
+      isOpen={isSignOutModalOpen || isSigningOut}
+      onClosed={onClosed}
+      backdropPressToClose={false}
+      backButtonClose={!isSigningOut}
+    >
+      {isSigningOut ? (
+        <View style={tailwind('w-full px-6 py-8 items-center')}>
+          {/* LoadingSpinner sizes itself via flex-1 and collapses without a fixed-height container */}
+          <View style={{ width: 48, height: 48 }}>
+            <LoadingSpinner size={40} />
+          </View>
+          <AppText style={tailwind('text-gray-80 text-center text-base mt-5')} medium>
+            {strings.modals.SignOutModal.signingOut}
           </AppText>
-          <AppText style={tailwind('text-gray-40')}>{user?.email}</AppText>
         </View>
+      ) : (
+        <View style={tailwind('w-full px-3 pt-7 pb-3')}>
+          <AppText style={tailwind('mx-4 text-center text-xl')} numberOfLines={1} semibold>
+            {strings.modals.SignOutModal.title}
+          </AppText>
 
-        <View style={tailwind('flex-row')}>
-          <AppButton
-            style={tailwind('flex-1 mr-2')}
-            title={strings.buttons.cancel}
-            type="cancel"
-            onPress={onCancelButtonPressed}
-          />
-          <AppButton
-            style={tailwind('flex-1')}
-            title={strings.buttons.signOut}
-            type="delete"
-            onPress={onSignOutButtonPressed}
-          />
+          <View style={tailwind('items-center my-6')}>
+            <UserProfilePicture uri={user?.avatar} size={80} />
+            <AppText style={tailwind('text-lg text-gray-80 mt-2')} medium>
+              {userFullName}
+            </AppText>
+            <AppText style={tailwind('text-gray-40')}>{user?.email}</AppText>
+          </View>
+
+          <View style={tailwind('flex-row')}>
+            <AppButton
+              style={tailwind('flex-1 mr-2')}
+              title={strings.buttons.cancel}
+              type="cancel"
+              onPress={onCancelButtonPressed}
+            />
+            <AppButton
+              style={tailwind('flex-1')}
+              title={strings.buttons.signOut}
+              type="delete"
+              onPress={onSignOutButtonPressed}
+            />
+          </View>
         </View>
-      </View>
+      )}
     </CenterModal>
   );
 }

--- a/src/services/photos/PhotoBackupFolders.ts
+++ b/src/services/photos/PhotoBackupFolders.ts
@@ -1,10 +1,21 @@
 import { logger } from 'src/services/common';
 import { createFolderWithMerge } from 'src/services/drive/folder/folderOrchestration.service';
 
+const SYNC_MANIFEST_FOLDER_NAME = '.sync';
+
 class PhotoBackupFolderService {
   private readonly yearFolderUuid = new Map<string, string>();
   private readonly monthFolderUuid = new Map<string, string>();
   private readonly dayFolderUuid = new Map<string, string>();
+  private readonly syncFolderUuid = new Map<string, string>();
+
+  /**
+   * Returns the uuid of the `.sync` folder under the given device folder, creating it if needed.
+   * The device manifest is stored inside it.
+   */
+  async getOrCreateSyncFolder(deviceFolderUuid: string): Promise<string> {
+    return this.getOrCreateFolder(this.syncFolderUuid, deviceFolderUuid, deviceFolderUuid, SYNC_MANIFEST_FOLDER_NAME);
+  }
 
   /**
    * Returns the uuid of the day folder under the given device folder, creating
@@ -20,7 +31,9 @@ class PhotoBackupFolderService {
 
     const dayKey = `${deviceFolderUuid}/${year}/${month}/${day}`;
     const localDayFolderUuid = this.dayFolderUuid.get(dayKey);
-    if (localDayFolderUuid) return localDayFolderUuid;
+    if (localDayFolderUuid) {
+      return localDayFolderUuid;
+    }
 
     const yearUuid = await this.getOrCreateYearFolder(deviceFolderUuid, year);
     const monthUuid = await this.getOrCreateMonthFolder(deviceFolderUuid, year, month, yearUuid);
@@ -35,6 +48,7 @@ class PhotoBackupFolderService {
     this.yearFolderUuid.clear();
     this.monthFolderUuid.clear();
     this.dayFolderUuid.clear();
+    this.syncFolderUuid.clear();
   }
 
   private async getOrCreateFolder(
@@ -44,7 +58,9 @@ class PhotoBackupFolderService {
     name: string,
   ): Promise<string> {
     const cached = cache.get(key);
-    if (cached) return cached;
+    if (cached) {
+      return cached;
+    }
     const uuid = await createFolderWithMerge(parentUuid, name);
     cache.set(key, uuid);
     return uuid;

--- a/src/services/photos/PhotoSyncManifestService.spec.ts
+++ b/src/services/photos/PhotoSyncManifestService.spec.ts
@@ -1,0 +1,310 @@
+import * as RNFS from '@dr.pogodin/react-native-fs';
+import { uploadFile } from 'src/network/upload';
+import asyncStorageService from 'src/services/AsyncStorageService';
+import { uploadService } from 'src/services/common/network/upload/upload.service';
+import { driveFolderService } from 'src/services/drive/folder/driveFolder.service';
+import fileSystemService from 'src/services/FileSystemService';
+import { photosLocalDB } from './database/photosLocalDB';
+import { PhotoAssetScanner } from './PhotoAssetScanner';
+import { photoBackupFolders } from './PhotoBackupFolders';
+import { photoSyncManifestService } from './PhotoSyncManifestService';
+
+jest.mock('@dr.pogodin/react-native-fs', () => ({
+  writeFile: jest.fn(),
+  readFile: jest.fn(),
+}));
+
+jest.mock('src/network/upload', () => ({
+  uploadFile: jest.fn(),
+}));
+
+jest.mock('src/services/AsyncStorageService', () => ({
+  __esModule: true,
+  default: { getUser: jest.fn() },
+}));
+
+jest.mock('src/lib/network', () => ({
+  getEnvironmentConfigFromUser: jest.fn().mockReturnValue({
+    encryptionKey: 'mnemonic',
+    bridgeUser: 'bridge-user',
+    bridgePass: 'bridge-pass',
+  }),
+}));
+
+jest.mock('src/services/AppService', () => ({
+  constants: { BRIDGE_URL: 'https://bridge.example.com' },
+}));
+
+jest.mock('src/services/common/network/upload/upload.service', () => ({
+  uploadService: {
+    checkFileExistence: jest.fn(),
+    createFileEntry: jest.fn(),
+    replaceFileEntry: jest.fn(),
+  },
+}));
+
+jest.mock('src/services/drive/file/driveFile.service', () => ({
+  driveFileService: { downloadFile: jest.fn() },
+}));
+
+jest.mock('src/services/drive/folder/driveFolder.service', () => ({
+  driveFolderService: { getFolderContentByUuid: jest.fn() },
+}));
+
+jest.mock('src/services/FileSystemService', () => ({
+  __esModule: true,
+  default: {
+    getCacheDir: jest.fn().mockReturnValue('/cache'),
+    stat: jest.fn(),
+    unlinkIfExists: jest.fn(),
+  },
+}));
+
+jest.mock('./database/photosLocalDB', () => ({
+  photosLocalDB: {
+    getManifestEntries: jest.fn(),
+    restoreEntries: jest.fn(),
+  },
+}));
+
+jest.mock('./PhotoAssetScanner', () => ({
+  PhotoAssetScanner: { getAssetsByIds: jest.fn() },
+}));
+
+jest.mock('./PhotoBackupFolders', () => ({
+  photoBackupFolders: { getOrCreateSyncFolder: jest.fn() },
+}));
+
+const mockWriteFile = RNFS.writeFile as jest.Mock;
+const mockReadFile = RNFS.readFile as jest.Mock;
+const mockUploadFile = uploadFile as jest.Mock;
+const mockGetUser = asyncStorageService.getUser as jest.Mock;
+const mockCheckFileExistence = uploadService.checkFileExistence as jest.Mock;
+const mockCreateFileEntry = uploadService.createFileEntry as jest.Mock;
+const mockReplaceFileEntry = uploadService.replaceFileEntry as jest.Mock;
+const mockGetFolderContentByUuid = driveFolderService.getFolderContentByUuid as jest.Mock;
+const mockStat = fileSystemService.stat as jest.Mock;
+const mockGetOrCreateSyncFolder = photoBackupFolders.getOrCreateSyncFolder as jest.Mock;
+const mockGetManifestEntries = photosLocalDB.getManifestEntries as jest.Mock;
+const mockRestoreEntries = photosLocalDB.restoreEntries as jest.Mock;
+const mockGetAssetsByIds = PhotoAssetScanner.getAssetsByIds as jest.Mock;
+
+const DEVICE_ID = 'device-123';
+const PHOTOS_BUCKET = 'photos-bucket';
+const SYNC_FOLDER_UUID = 'sync-folder-uuid';
+const SYNCED_ENTRIES = [{ assetId: 'asset-1', status: 'synced' }];
+
+describe('photo sync manifest service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetUser.mockResolvedValue({});
+    mockGetOrCreateSyncFolder.mockResolvedValue(SYNC_FOLDER_UUID);
+    mockStat.mockResolvedValue({ size: 1234 });
+    mockUploadFile.mockResolvedValue('bridge-file-id');
+  });
+
+  describe('uploadManifest', () => {
+    test('when the manifest does not exist yet in Drive, then a new file entry is created', async () => {
+      mockGetManifestEntries.mockResolvedValue(SYNCED_ENTRIES);
+      mockCheckFileExistence.mockResolvedValue({ existentFiles: [] });
+
+      await photoSyncManifestService.uploadManifest(DEVICE_ID, PHOTOS_BUCKET);
+
+      expect(mockCreateFileEntry).toHaveBeenCalledWith(
+        expect.objectContaining({
+          plainName: 'manifest',
+          type: 'json',
+          folderUuid: SYNC_FOLDER_UUID,
+          bucket: PHOTOS_BUCKET,
+        }),
+      );
+      expect(mockReplaceFileEntry).not.toHaveBeenCalled();
+    });
+
+    test('when a manifest already exists in Drive, then it is replaced instead of duplicated', async () => {
+      mockGetManifestEntries.mockResolvedValue(SYNCED_ENTRIES);
+      mockCheckFileExistence.mockResolvedValue({ existentFiles: [{ uuid: 'existing-manifest-uuid' }] });
+
+      await photoSyncManifestService.uploadManifest(DEVICE_ID, PHOTOS_BUCKET);
+
+      expect(mockReplaceFileEntry).toHaveBeenCalledWith('existing-manifest-uuid', {
+        fileId: 'bridge-file-id',
+        size: 1234,
+      });
+      expect(mockCreateFileEntry).not.toHaveBeenCalled();
+    });
+
+    test('when synced assets exist, then the uploaded manifest content includes them and the temp file is cleaned up', async () => {
+      mockGetManifestEntries.mockResolvedValue([{ assetId: 'asset-1', status: 'synced' }]);
+      mockCheckFileExistence.mockResolvedValue({ existentFiles: [] });
+
+      await photoSyncManifestService.uploadManifest(DEVICE_ID, PHOTOS_BUCKET);
+
+      const [, content] = mockWriteFile.mock.calls[0];
+      const manifest = JSON.parse(content);
+      expect(manifest.deviceId).toBe(DEVICE_ID);
+      expect(manifest.entries).toEqual([{ assetId: 'asset-1', status: 'synced' }]);
+      expect(fileSystemService.unlinkIfExists).toHaveBeenCalled();
+    });
+
+    test('when uploading the manifest fails, then the error is swallowed and never thrown', async () => {
+      mockGetManifestEntries.mockRejectedValue(new Error('DB error'));
+
+      await expect(photoSyncManifestService.uploadManifest(DEVICE_ID, PHOTOS_BUCKET)).resolves.toBeUndefined();
+    });
+
+    test('when there are no synced assets to export, then no manifest is uploaded', async () => {
+      mockGetManifestEntries.mockResolvedValue([]);
+
+      await photoSyncManifestService.uploadManifest(DEVICE_ID, PHOTOS_BUCKET);
+
+      expect(mockUploadFile).not.toHaveBeenCalled();
+      expect(mockCreateFileEntry).not.toHaveBeenCalled();
+      expect(mockReplaceFileEntry).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('maybeUploadManifest', () => {
+    let currentTime = 1_700_000_000_000;
+    let nowSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+      currentTime = 1_700_000_000_000;
+      nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => currentTime);
+      mockGetManifestEntries.mockResolvedValue(SYNCED_ENTRIES);
+      mockCheckFileExistence.mockResolvedValue({ existentFiles: [] });
+
+      await photoSyncManifestService.uploadManifest(DEVICE_ID, PHOTOS_BUCKET);
+      jest.clearAllMocks();
+      mockGetManifestEntries.mockResolvedValue(SYNCED_ENTRIES);
+      mockCheckFileExistence.mockResolvedValue({ existentFiles: [] });
+    });
+
+    afterEach(() => {
+      nowSpy.mockRestore();
+    });
+
+    test('when fewer assets than the checkpoint threshold have synced and the TTL has not elapsed, then no checkpoint upload happens', async () => {
+      for (let i = 0; i < 99; i++) {
+        await photoSyncManifestService.maybeUploadManifest(DEVICE_ID, PHOTOS_BUCKET);
+      }
+
+      expect(mockCreateFileEntry).not.toHaveBeenCalled();
+      expect(mockReplaceFileEntry).not.toHaveBeenCalled();
+    });
+
+    test('when the checkpoint asset threshold is reached, then the manifest is uploaded', async () => {
+      for (let i = 0; i < 100; i++) {
+        await photoSyncManifestService.maybeUploadManifest(DEVICE_ID, PHOTOS_BUCKET);
+      }
+
+      expect(mockCreateFileEntry).toHaveBeenCalledTimes(1);
+    });
+
+    test('when the checkpoint TTL has elapsed, then the manifest is uploaded even with a single asset synced', async () => {
+      currentTime += 5 * 60 * 1000 + 1;
+
+      await photoSyncManifestService.maybeUploadManifest(DEVICE_ID, PHOTOS_BUCKET);
+
+      expect(mockCreateFileEntry).toHaveBeenCalledTimes(1);
+    });
+
+    test('when a checkpoint just fired, then the very next asset synced does not trigger another one', async () => {
+      for (let i = 0; i < 100; i++) {
+        await photoSyncManifestService.maybeUploadManifest(DEVICE_ID, PHOTOS_BUCKET);
+      }
+      expect(mockCreateFileEntry).toHaveBeenCalledTimes(1);
+
+      await photoSyncManifestService.maybeUploadManifest(DEVICE_ID, PHOTOS_BUCKET);
+
+      expect(mockCreateFileEntry).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('restoreManifest', () => {
+    test('when no manifest file exists in the sync folder, then restore is a no-op', async () => {
+      mockGetFolderContentByUuid.mockResolvedValue({ files: [] });
+
+      const result = await photoSyncManifestService.restoreManifest(DEVICE_ID);
+
+      expect(result).toBeNull();
+      expect(mockRestoreEntries).not.toHaveBeenCalled();
+    });
+
+    test('when the manifest belongs to a different device, then it is discarded', async () => {
+      mockGetFolderContentByUuid.mockResolvedValue({
+        files: [{ plainName: 'manifest', type: 'json', fileId: 'file-1', bucket: PHOTOS_BUCKET, size: 10 }],
+      });
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({ schemaVersion: 1, deviceId: 'other-device', entries: [{ assetId: 'asset-1' }] }),
+      );
+
+      const result = await photoSyncManifestService.restoreManifest(DEVICE_ID);
+
+      expect(result).toBeNull();
+      expect(mockRestoreEntries).not.toHaveBeenCalled();
+    });
+
+    test('when the manifest was written with a different schema version, then it is discarded', async () => {
+      mockGetFolderContentByUuid.mockResolvedValue({
+        files: [{ plainName: 'manifest', type: 'json', fileId: 'file-1', bucket: PHOTOS_BUCKET, size: 10 }],
+      });
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({ schemaVersion: 2, deviceId: DEVICE_ID, entries: [{ assetId: 'asset-1' }] }),
+      );
+
+      const result = await photoSyncManifestService.restoreManifest(DEVICE_ID);
+
+      expect(result).toBeNull();
+      expect(mockRestoreEntries).not.toHaveBeenCalled();
+    });
+
+    test('when a manifest entry no longer exists in the local gallery, then it is not restored', async () => {
+      mockGetFolderContentByUuid.mockResolvedValue({
+        files: [{ plainName: 'manifest', type: 'json', fileId: 'file-1', bucket: PHOTOS_BUCKET, size: 10 }],
+      });
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({
+          schemaVersion: 1,
+          deviceId: DEVICE_ID,
+          entries: [
+            { assetId: 'asset-still-here', status: 'synced' },
+            { assetId: 'asset-deleted-from-device', status: 'synced' },
+          ],
+        }),
+      );
+      mockGetAssetsByIds.mockResolvedValue([{ id: 'asset-still-here' }]);
+
+      const result = await photoSyncManifestService.restoreManifest(DEVICE_ID);
+
+      expect(result).toEqual({ restoredCount: 1 });
+      expect(mockRestoreEntries).toHaveBeenCalledWith([{ assetId: 'asset-still-here', status: 'synced' }]);
+    });
+
+    test('when restoring the manifest fails, then the error is swallowed and null is returned', async () => {
+      mockGetFolderContentByUuid.mockRejectedValue(new Error('network error'));
+
+      const result = await photoSyncManifestService.restoreManifest(DEVICE_ID);
+
+      expect(result).toBeNull();
+    });
+
+    test('when restoreManifest is called twice concurrently, then the second call reuses the first call result instead of running again', async () => {
+      let resolveFolderContent!: (value: { files: unknown[] }) => void;
+      mockGetFolderContentByUuid.mockReturnValue(
+        new Promise((resolve) => {
+          resolveFolderContent = resolve;
+        }),
+      );
+
+      const firstCall = photoSyncManifestService.restoreManifest(DEVICE_ID);
+      const secondCall = photoSyncManifestService.restoreManifest(DEVICE_ID);
+      resolveFolderContent({ files: [] });
+      const [firstResult, secondResult] = await Promise.all([firstCall, secondCall]);
+
+      expect(mockGetFolderContentByUuid).toHaveBeenCalledTimes(1);
+      expect(firstResult).toBeNull();
+      expect(secondResult).toBeNull();
+    });
+  });
+});

--- a/src/services/photos/PhotoSyncManifestService.ts
+++ b/src/services/photos/PhotoSyncManifestService.ts
@@ -1,0 +1,240 @@
+import * as RNFS from '@dr.pogodin/react-native-fs';
+import { EncryptionVersion } from '@internxt/sdk/dist/drive/storage/types';
+import { getEnvironmentConfigFromUser } from 'src/lib/network';
+import { uploadFile } from 'src/network/upload';
+import { constants } from 'src/services/AppService';
+import asyncStorageService from 'src/services/AsyncStorageService';
+import { logger } from 'src/services/common';
+import { HTTP_CONFLICT } from 'src/services/common/httpStatusCodes';
+import { uploadService } from 'src/services/common/network/upload/upload.service';
+import { driveFileService } from 'src/services/drive/file/driveFile.service';
+import { driveFolderService } from 'src/services/drive/folder/driveFolder.service';
+import fileSystemService from 'src/services/FileSystemService';
+import { ManifestAssetEntry, photosLocalDB } from './database/photosLocalDB';
+import { PhotoAssetScanner } from './PhotoAssetScanner';
+import { photoBackupFolders } from './PhotoBackupFolders';
+
+const TAG = '[PhotoSyncManifestService]';
+const MANIFEST_SCHEMA_VERSION = 1;
+const MANIFEST_PLAIN_NAME = 'manifest';
+const MANIFEST_TYPE = 'json';
+
+const MANIFEST_CHECKPOINT_TTL_MS = 5 * 60 * 1000;
+const MANIFEST_CHECKPOINT_ASSET_THRESHOLD = 100;
+
+interface PhotoSyncManifest {
+  schemaVersion: number;
+  deviceId: string;
+  generatedAt: number;
+  entries: ManifestAssetEntry[];
+}
+
+class PhotoSyncManifestService {
+  private lastManifestUploadAt = Date.now();
+  private assetsSyncedSinceLastManifestUpload = 0;
+
+  private inFlightRestore: Promise<{ restoredCount: number } | null> | null = null;
+
+  /**
+   * Exports the `synced`/`cloud_deleted` asset_sync rows to a JSON manifest and uploads it to
+   * `.sync/manifest.json` under the device folder, replacing any previous version.
+   * Best-effort: errors are logged and swallowed, never thrown.
+   */
+  async uploadManifest(deviceId: string, photosBucket: string): Promise<void> {
+    let tempPath: string | undefined;
+    try {
+      logger.info(TAG, `Uploading manifest for device=${deviceId}...`);
+      const entries = await photosLocalDB.getManifestEntries();
+      if (entries.length === 0) {
+        logger.info(TAG, 'No synced entries to export — skipping manifest upload');
+        return;
+      }
+
+      const manifest: PhotoSyncManifest = {
+        schemaVersion: MANIFEST_SCHEMA_VERSION,
+        deviceId,
+        generatedAt: Date.now(),
+        entries,
+      };
+
+      tempPath = this.manifestTempPath(`upload-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+      await RNFS.writeFile(tempPath, JSON.stringify(manifest), 'utf8');
+      const fileStat = await fileSystemService.stat(tempPath);
+
+      const [syncFolderUuid, user] = await Promise.all([
+        photoBackupFolders.getOrCreateSyncFolder(deviceId),
+        asyncStorageService.getUser(),
+      ]);
+      const { encryptionKey, bridgeUser, bridgePass } = getEnvironmentConfigFromUser(user);
+
+      const fileId = await uploadFile(
+        tempPath,
+        photosBucket,
+        encryptionKey,
+        constants.BRIDGE_URL,
+        { user: bridgeUser, pass: bridgePass },
+        {},
+      );
+
+      await this.replaceOrCreateManifestEntry({ syncFolderUuid, photosBucket, fileId, size: fileStat.size });
+      this.resetCheckpointWindow();
+
+      logger.info(TAG, `Manifest uploaded — ${entries.length} entries`);
+    } catch (error) {
+      logger.error(TAG, `Failed to upload manifest: ${error}`);
+    } finally {
+      if (tempPath) {
+        await fileSystemService.unlinkIfExists(tempPath);
+      }
+    }
+  }
+
+  /**
+   * Counts one synced asset and uploads the manifest once a checkpoint threshold is reached
+   * (time elapsed or assets synced). Call after each asset finishes uploading during a cycle.
+   * Safe to call concurrently: at most one upload fires per checkpoint window.
+   */
+  async maybeUploadManifest(deviceId: string, photosBucket: string): Promise<void> {
+    this.assetsSyncedSinceLastManifestUpload += 1;
+    const dueByTime = Date.now() - this.lastManifestUploadAt >= MANIFEST_CHECKPOINT_TTL_MS;
+    const dueByCount = this.assetsSyncedSinceLastManifestUpload >= MANIFEST_CHECKPOINT_ASSET_THRESHOLD;
+    if (!dueByTime && !dueByCount) {
+      return;
+    }
+
+    logger.info(TAG, `Checkpoint triggered (${dueByTime ? 'TTL elapsed' : 'asset threshold reached'})`);
+    this.resetCheckpointWindow();
+    await this.uploadManifest(deviceId, photosBucket);
+  }
+
+  /**
+   * Downloads device's manifest from Drive and restores into `asset_sync` the
+   * entries whose asset still exists in the local gallery. Concurrent calls share the same
+   * in-flight restore. Returns the restored count, or null if nothing was restored or it failed.
+   */
+  async restoreManifest(deviceId: string): Promise<{ restoredCount: number } | null> {
+    if (this.inFlightRestore) {
+      return this.inFlightRestore;
+    }
+    this.inFlightRestore = this.restoreManifestFromDrive(deviceId).finally(() => {
+      this.inFlightRestore = null;
+    });
+
+    return this.inFlightRestore;
+  }
+
+  private resetCheckpointWindow(): void {
+    this.lastManifestUploadAt = Date.now();
+    this.assetsSyncedSinceLastManifestUpload = 0;
+  }
+
+  private manifestTempPath(suffix: string): string {
+    return `${fileSystemService.getCacheDir()}/photo_sync_manifest_${suffix}.json`;
+  }
+
+  private async replaceOrCreateManifestEntry(params: {
+    syncFolderUuid: string;
+    photosBucket: string;
+    fileId: string;
+    size: number;
+  }): Promise<void> {
+    const { syncFolderUuid, photosBucket, fileId, size } = params;
+    const { existentFiles } = await uploadService.checkFileExistence(syncFolderUuid, [
+      { plainName: MANIFEST_PLAIN_NAME, type: MANIFEST_TYPE },
+    ]);
+
+    if (existentFiles[0]?.uuid) {
+      await uploadService.replaceFileEntry(existentFiles[0].uuid, { fileId, size });
+      return;
+    }
+
+    try {
+      await uploadService.createFileEntry({
+        fileId,
+        type: MANIFEST_TYPE,
+        size,
+        plainName: MANIFEST_PLAIN_NAME,
+        bucket: photosBucket,
+        folderUuid: syncFolderUuid,
+        encryptVersion: EncryptionVersion.Aes03,
+        modificationTime: new Date().toISOString(),
+        creationTime: new Date().toISOString(),
+      });
+    } catch (err) {
+      if ((err as { status?: number })?.status !== HTTP_CONFLICT) throw err;
+      const { existentFiles: retryFiles } = await uploadService.checkFileExistence(syncFolderUuid, [
+        { plainName: MANIFEST_PLAIN_NAME, type: MANIFEST_TYPE },
+      ]);
+      if (!retryFiles[0]?.uuid) {
+        throw err;
+      }
+      await uploadService.replaceFileEntry(retryFiles[0].uuid, { fileId, size });
+    }
+  }
+
+  private async restoreManifestFromDrive(deviceId: string): Promise<{ restoredCount: number } | null> {
+    let tempPath: string | undefined;
+    try {
+      const syncFolderUuid = await photoBackupFolders.getOrCreateSyncFolder(deviceId);
+      const folderContent = await driveFolderService.getFolderContentByUuid(syncFolderUuid);
+      const manifestFile = folderContent.files.find(
+        (file) => (file.plainName ?? file.name) === MANIFEST_PLAIN_NAME && file.type === MANIFEST_TYPE,
+      );
+      if (!manifestFile?.fileId || !manifestFile.bucket) {
+        logger.info(TAG, 'No manifest found for this device — skipping restore');
+        return null;
+      }
+
+      const user = await asyncStorageService.getUser();
+      tempPath = this.manifestTempPath('restore');
+
+      await driveFileService.downloadFile(
+        user,
+        manifestFile.bucket,
+        manifestFile.fileId,
+        { downloadPath: tempPath },
+        manifestFile.size ? Number(manifestFile.size) : 0,
+      );
+
+      const raw = await RNFS.readFile(tempPath, 'utf8');
+      const manifest = JSON.parse(raw) as PhotoSyncManifest;
+
+      if (manifest.schemaVersion !== MANIFEST_SCHEMA_VERSION) {
+        logger.warn(
+          TAG,
+          `Manifest schema version mismatch (manifest=${manifest.schemaVersion}, supported=${MANIFEST_SCHEMA_VERSION}) — discarding`,
+        );
+        return null;
+      }
+      if (manifest.deviceId !== deviceId) {
+        logger.warn(
+          TAG,
+          `Manifest deviceId mismatch (manifest=${manifest.deviceId}, current=${deviceId}) — discarding`,
+        );
+        return null;
+      }
+      if (!Array.isArray(manifest.entries) || manifest.entries.length === 0) {
+        return null;
+      }
+
+      const localAssets = await PhotoAssetScanner.getAssetsByIds(manifest.entries.map((entry) => entry.assetId));
+      const localAssetIds = new Set(localAssets.map((asset) => asset.id));
+      const restorableEntries = manifest.entries.filter((entry) => localAssetIds.has(entry.assetId));
+
+      await photosLocalDB.restoreEntries(restorableEntries);
+
+      logger.info(
+        TAG,
+        `Manifest restored — ${restorableEntries.length}/${manifest.entries.length} entries matched local assets`,
+      );
+      return { restoredCount: restorableEntries.length };
+    } catch (error) {
+      logger.error(TAG, `Failed to restore manifest: ${error}`);
+      return null;
+    } finally {
+      if (tempPath) await fileSystemService.unlinkIfExists(tempPath);
+    }
+  }
+}
+
+export const photoSyncManifestService = new PhotoSyncManifestService();

--- a/src/services/photos/PhotoUploadQueue.spec.ts
+++ b/src/services/photos/PhotoUploadQueue.spec.ts
@@ -153,7 +153,13 @@ describe('PhotoUploadQueue.start with an external signal', () => {
     controller.abort();
     const onAssetStart = jest.fn();
 
-    await PhotoUploadQueue.start([{ asset: makeAsset('a1') }], DEVICE_ID, PHOTOS_BUCKET, { onAssetStart }, controller.signal);
+    await PhotoUploadQueue.start(
+      [{ asset: makeAsset('a1') }],
+      DEVICE_ID,
+      PHOTOS_BUCKET,
+      { onAssetStart },
+      controller.signal,
+    );
 
     expect(onAssetStart).not.toHaveBeenCalled();
     expect(mockUpload).not.toHaveBeenCalled();
@@ -258,5 +264,46 @@ describe('PhotoUploadQueue.abortAll', () => {
     expect(secondSignal.aborted).toBe(false);
     // The second run must receive a different signal instance from the first
     expect(secondSignal).not.toBe(firstSignal);
+  });
+});
+
+describe('PhotoUploadQueue cycle lifecycle', () => {
+  afterEach(() => {
+    PhotoUploadQueue.endCycle();
+  });
+
+  test('when no cycle has begun, then nothing is reported as running and waiting resolves immediately', async () => {
+    expect(PhotoUploadQueue.isCycleRunning()).toBe(false);
+    await expect(PhotoUploadQueue.waitForCycleEnd()).resolves.toBeUndefined();
+  });
+
+  test('when a cycle has begun, then it is reported as running until it ends', () => {
+    PhotoUploadQueue.beginCycle();
+    expect(PhotoUploadQueue.isCycleRunning()).toBe(true);
+
+    PhotoUploadQueue.endCycle();
+    expect(PhotoUploadQueue.isCycleRunning()).toBe(false);
+  });
+
+  test('when a cycle is running, then waiting for it only resolves after the cycle ends', async () => {
+    PhotoUploadQueue.beginCycle();
+    let hasCycleEnded = false;
+    const cycleEndWait = PhotoUploadQueue.waitForCycleEnd().then(() => {
+      hasCycleEnded = true;
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(hasCycleEnded).toBe(false);
+
+    PhotoUploadQueue.endCycle();
+    await cycleEndWait;
+    expect(hasCycleEnded).toBe(true);
+  });
+
+  test('when a cycle is stuck and never ends, then waiting with a timeout gives up instead of hanging forever', async () => {
+    PhotoUploadQueue.beginCycle();
+
+    await expect(PhotoUploadQueue.waitForCycleEnd(50)).resolves.toBeUndefined();
+    expect(PhotoUploadQueue.isCycleRunning()).toBe(true);
   });
 });

--- a/src/services/photos/PhotoUploadQueue.ts
+++ b/src/services/photos/PhotoUploadQueue.ts
@@ -19,15 +19,57 @@ interface UploadQueueCallbacks {
 
 let currentController: AbortController | null = null;
 
+interface PromiseWithResolvers<T> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+}
+
+// Local stand-in for ES2024 Promise.withResolvers(), which Hermes doesn't support yet.
+const promiseWithResolvers = <T = void>(): PromiseWithResolvers<T> => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
+let currentCycleEnd: PromiseWithResolvers<void> | null = null;
+
 // TODO: MAKE IT CLASS
 export const PhotoUploadQueue = {
   beginCycle(): AbortSignal {
     currentController = new AbortController();
+    currentCycleEnd = promiseWithResolvers();
     return currentController.signal;
   },
 
   endCycle(): void {
     currentController = null;
+    currentCycleEnd?.resolve();
+    currentCycleEnd = null;
+  },
+
+  isCycleRunning(): boolean {
+    return currentCycleEnd !== null;
+  },
+
+  /**
+   * Resolves once the current cycle ends, or immediately if none is running.
+   * With `timeoutMs`, resolves after that long even if the cycle has not ended.
+   */
+  waitForCycleEnd(timeoutMs?: number): Promise<void> {
+    if (!currentCycleEnd) {
+      return Promise.resolve();
+    }
+    const cycleEndPromise = currentCycleEnd.promise;
+    if (timeoutMs === undefined) {
+      return cycleEndPromise;
+    }
+    let timeoutHandle: ReturnType<typeof setTimeout>;
+    const timedOut = new Promise<void>((res) => {
+      timeoutHandle = setTimeout(res, timeoutMs);
+    });
+    return Promise.race([cycleEndPromise.finally(() => clearTimeout(timeoutHandle)), timedOut]);
   },
 
   async start(

--- a/src/services/photos/database/photosLocalDB.spec.ts
+++ b/src/services/photos/database/photosLocalDB.spec.ts
@@ -8,6 +8,7 @@ jest.mock('../../SqliteService', () => ({
     executeSql: jest.fn().mockResolvedValue(undefined),
     getAllAsync: jest.fn().mockResolvedValue([]),
     getFirstAsync: jest.fn().mockResolvedValue(null),
+    transaction: jest.fn(),
   },
 }));
 
@@ -875,6 +876,143 @@ describe('photosLocalDB cloud asset methods', () => {
       const result = await photosLocalDB.getAssetUploadErroredCount();
 
       expect(result).toBe(0);
+    });
+  });
+
+  describe('when checking whether the local asset_sync table has any state', () => {
+    test('when the table has at least one row, then it returns true', async () => {
+      mockSqlite.getFirstAsync.mockResolvedValueOnce({ result: 1 });
+
+      const result = await photosLocalDB.hasAnyAssetSyncEntry();
+
+      expect(result).toBe(true);
+    });
+
+    test('when the table is empty, then it returns false', async () => {
+      mockSqlite.getFirstAsync.mockResolvedValueOnce({ result: 0 });
+
+      const result = await photosLocalDB.hasAnyAssetSyncEntry();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('when exporting entries for the sync manifest', () => {
+    test('when there are synced and cloud_deleted assets, then only those statuses are queried', async () => {
+      mockSqlite.getAllAsync.mockResolvedValueOnce([]);
+
+      await photosLocalDB.getManifestEntries();
+
+      const [, sql] = mockSqlite.getAllAsync.mock.calls[0];
+      expect(sql).toContain('status IN (\'synced\', \'cloud_deleted\')');
+    });
+
+    test('when a burst entry is exported, then its member remote file ids are parsed from JSON', async () => {
+      mockSqlite.getAllAsync.mockResolvedValueOnce([
+        {
+          asset_id: 'asset-1',
+          status: 'synced',
+          remote_file_id: 'remote-1',
+          modification_time: 111,
+          file_name: 'IMG_1.jpg',
+          creation_time: 222,
+          width: 100,
+          height: 200,
+          duration: 0,
+          media_type: 'photo',
+          is_live_photo: 0,
+          paired_video_remote_file_id: null,
+          paired_video_status: null,
+          is_burst: 1,
+          burst_id: 'burst-1',
+          burst_member_remote_file_ids: '["remote-2","remote-3"]',
+          burst_member_count: 2,
+        },
+      ]);
+
+      const result = await photosLocalDB.getManifestEntries();
+
+      expect(result[0].burstMemberRemoteFileIds).toEqual(['remote-2', 'remote-3']);
+      expect(result[0].isBurst).toBe(true);
+    });
+  });
+
+  describe('when restoring entries from a sync manifest', () => {
+    test('when there are no entries to restore, then no transaction is started', async () => {
+      await photosLocalDB.restoreEntries([]);
+
+      expect(mockSqlite.transaction).not.toHaveBeenCalled();
+    });
+
+    test('when restoring entries, then each one is inserted inside a single transaction', async () => {
+      const executeSql = jest.fn();
+      mockSqlite.transaction.mockImplementation(async (_name, scope) => {
+        await scope({ executeSql });
+      });
+
+      await photosLocalDB.restoreEntries([
+        {
+          assetId: 'asset-1',
+          status: 'synced',
+          remoteFileId: 'remote-1',
+          modificationTime: 111,
+          fileName: 'IMG_1.jpg',
+          creationTime: 222,
+          width: 100,
+          height: 200,
+          duration: 0,
+          mediaType: 'photo',
+          isLivePhoto: false,
+          pairedVideoRemoteFileId: null,
+          pairedVideoStatus: null,
+          isBurst: false,
+          burstId: null,
+          burstMemberRemoteFileIds: null,
+          burstMemberCount: null,
+        },
+        {
+          assetId: 'asset-2',
+          status: 'cloud_deleted',
+          remoteFileId: 'remote-2',
+          modificationTime: 333,
+          fileName: 'IMG_2.jpg',
+          creationTime: 444,
+          width: 50,
+          height: 60,
+          duration: 0,
+          mediaType: 'photo',
+          isLivePhoto: false,
+          pairedVideoRemoteFileId: null,
+          pairedVideoStatus: null,
+          isBurst: false,
+          burstId: null,
+          burstMemberRemoteFileIds: null,
+          burstMemberCount: null,
+        },
+      ]);
+
+      expect(mockSqlite.transaction).toHaveBeenCalledTimes(1);
+      expect(executeSql).toHaveBeenCalledTimes(2);
+      const [, firstParams] = executeSql.mock.calls[0];
+      expect(firstParams).toEqual([
+        'asset-1',
+        'synced',
+        'remote-1',
+        111,
+        'IMG_1.jpg',
+        222,
+        100,
+        200,
+        0,
+        'photo',
+        0,
+        null,
+        null,
+        0,
+        null,
+        null,
+        null,
+      ]);
     });
   });
 });

--- a/src/services/photos/database/photosLocalDB.ts
+++ b/src/services/photos/database/photosLocalDB.ts
@@ -134,6 +134,66 @@ export interface IncompleteBurstAsset {
   modificationTime: number | null;
 }
 
+export interface ManifestAssetEntry {
+  assetId: string;
+  status: 'synced' | 'cloud_deleted';
+  remoteFileId: string | null;
+  modificationTime: number | null;
+  fileName: string | null;
+  creationTime: number | null;
+  width: number | null;
+  height: number | null;
+  duration: number | null;
+  mediaType: string | null;
+  isLivePhoto: boolean;
+  pairedVideoRemoteFileId: string | null;
+  pairedVideoStatus: PairedVideoStatus | null;
+  isBurst: boolean;
+  burstId: string | null;
+  burstMemberRemoteFileIds: string[] | null;
+  burstMemberCount: number | null;
+}
+
+interface ManifestAssetRow {
+  asset_id: string;
+  status: 'synced' | 'cloud_deleted';
+  remote_file_id: string | null;
+  modification_time: number | null;
+  file_name: string | null;
+  creation_time: number | null;
+  width: number | null;
+  height: number | null;
+  duration: number | null;
+  media_type: string | null;
+  is_live_photo: number;
+  paired_video_remote_file_id: string | null;
+  paired_video_status: PairedVideoStatus | null;
+  is_burst: number;
+  burst_id: string | null;
+  burst_member_remote_file_ids: string | null;
+  burst_member_count: number | null;
+}
+
+const rowToManifestEntry = (row: ManifestAssetRow): ManifestAssetEntry => ({
+  assetId: row.asset_id,
+  status: row.status,
+  remoteFileId: row.remote_file_id,
+  modificationTime: row.modification_time,
+  fileName: row.file_name,
+  creationTime: row.creation_time,
+  width: row.width,
+  height: row.height,
+  duration: row.duration,
+  mediaType: row.media_type,
+  isLivePhoto: row.is_live_photo === 1,
+  pairedVideoRemoteFileId: row.paired_video_remote_file_id,
+  pairedVideoStatus: row.paired_video_status,
+  isBurst: row.is_burst === 1,
+  burstId: row.burst_id,
+  burstMemberRemoteFileIds: row.burst_member_remote_file_ids ? JSON.parse(row.burst_member_remote_file_ids) : null,
+  burstMemberCount: row.burst_member_count,
+});
+
 export interface AssetMediaInfo {
   fileName: string;
   creationTime: number;
@@ -284,7 +344,10 @@ class PhotosLocalDB {
   }
 
   async getAssetUploadErroredCount(): Promise<number> {
-    const rows = await sqliteService.getAllAsync<{ count: number }>(DB_NAME, assetSyncTable.statements.getAssetUploadErroredCount);
+    const rows = await sqliteService.getAllAsync<{ count: number }>(
+      DB_NAME,
+      assetSyncTable.statements.getAssetUploadErroredCount,
+    );
     return rows[0]?.count ?? 0;
   }
 
@@ -489,9 +552,7 @@ class PhotosLocalDB {
 
   async getAllCloudAssets(deviceId?: string): Promise<CloudAssetEntry[]> {
     const rows = deviceId
-      ? await sqliteService.getAllAsync<CloudAssetRow>(DB_NAME, cloudAssetTable.statements.getAllByDevice, [
-          deviceId,
-        ])
+      ? await sqliteService.getAllAsync<CloudAssetRow>(DB_NAME, cloudAssetTable.statements.getAllByDevice, [deviceId])
       : await sqliteService.getAllAsync<CloudAssetRow>(DB_NAME, cloudAssetTable.statements.getAll);
     return rows.map(rowToCloudAssetEntry);
   }
@@ -582,6 +643,48 @@ class PhotosLocalDB {
       creationTime: r.creation_time,
       modificationTime: r.modification_time,
     }));
+  }
+
+  async hasAnyAssetSyncEntry(): Promise<boolean> {
+    const row = await sqliteService.getFirstAsync<{ result: number }>(DB_NAME, assetSyncTable.statements.hasAnyEntry);
+    return row?.result === 1;
+  }
+
+  async getManifestEntries(): Promise<ManifestAssetEntry[]> {
+    const rows = await sqliteService.getAllAsync<ManifestAssetRow>(
+      DB_NAME,
+      assetSyncTable.statements.getManifestEntries,
+    );
+    return rows.map(rowToManifestEntry);
+  }
+
+  async restoreEntries(entries: ManifestAssetEntry[]): Promise<void> {
+    if (entries.length === 0) {
+      return;
+    }
+    await sqliteService.transaction(DB_NAME, async (tx) => {
+      for (const entry of entries) {
+        await tx.executeSql(assetSyncTable.statements.restoreEntry, [
+          entry.assetId,
+          entry.status,
+          entry.remoteFileId,
+          entry.modificationTime,
+          entry.fileName,
+          entry.creationTime,
+          entry.width,
+          entry.height,
+          entry.duration,
+          entry.mediaType,
+          entry.isLivePhoto ? 1 : 0,
+          entry.pairedVideoRemoteFileId,
+          entry.pairedVideoStatus,
+          entry.isBurst ? 1 : 0,
+          entry.burstId,
+          entry.burstMemberRemoteFileIds ? JSON.stringify(entry.burstMemberRemoteFileIds) : null,
+          entry.burstMemberCount,
+        ]);
+      }
+    });
   }
 
   async getCloudFetchCacheAge(deviceId: string, year: number, month: number): Promise<number | null> {

--- a/src/services/photos/database/tables/asset_sync.ts
+++ b/src/services/photos/database/tables/asset_sync.ts
@@ -205,6 +205,28 @@ const statements = {
       AND is_burst = 1
       AND burst_member_count IS NULL;
   `,
+
+  hasAnyEntry: `SELECT EXISTS(SELECT 1 FROM ${TABLE_NAME}) AS result;`,
+
+  getManifestEntries: `
+    SELECT asset_id, status, remote_file_id, modification_time, file_name, creation_time,
+           width, height, duration, media_type,
+           is_live_photo, paired_video_remote_file_id, paired_video_status,
+           is_burst, burst_id, burst_member_remote_file_ids, burst_member_count
+    FROM ${TABLE_NAME}
+    WHERE status IN ('synced', 'cloud_deleted');
+  `,
+
+  restoreEntry: `
+    INSERT OR IGNORE INTO ${TABLE_NAME} (
+      asset_id, status, remote_file_id, modification_time, file_name, creation_time,
+      width, height, duration, media_type,
+      is_live_photo, paired_video_remote_file_id, paired_video_status,
+      is_burst, burst_id, burst_member_remote_file_ids, burst_member_count,
+      synced_at, last_attempt_at
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, (unixepoch() * 1000), (unixepoch() * 1000));
+  `,
 };
 
 export default { TABLE_NAME, statements };

--- a/src/store/slices/auth/index.ts
+++ b/src/store/slices/auth/index.ts
@@ -198,20 +198,30 @@ export const checkAndRefreshTokenThunk = createAsyncThunk<void, void, { state: R
   },
 );
 
+let isSignOutInFlight = false;
+
 export const signOutThunk = createAsyncThunk<
   void,
   { reason: 'manual' | 'unauthorized' | 'token_expired' },
   { state: RootState }
 >('auth/signOut', async (payload, { dispatch }) => {
-  const reason = payload.reason;
-  authService.signout(reason).catch(errorService.reportError);
-  drive.clear().catch(errorService.reportError);
-  dispatch(uiActions.resetState());
-  dispatch(authActions.resetState());
-  dispatch(driveActions.resetState());
-  dispatch(photosSignOutThunk());
-  dispatch(authActions.setLoggedIn(false));
-  authService.emitLogoutEvent();
+  if (isSignOutInFlight) {
+    return;
+  }
+  isSignOutInFlight = true;
+  try {
+    // The Photos snapshot needs credentials, so it runs before the wipes below.
+    await dispatch(photosSignOutThunk());
+    authService.signout(payload.reason).catch(errorService.reportError);
+    drive.clear().catch(errorService.reportError);
+    dispatch(uiActions.resetState());
+    dispatch(authActions.resetState());
+    dispatch(driveActions.resetState());
+    dispatch(authActions.setLoggedIn(false));
+    authService.emitLogoutEvent();
+  } finally {
+    isSignOutInFlight = false;
+  }
 });
 
 export const refreshUserThunk = createAsyncThunk<void, void, { state: RootState }>(

--- a/src/store/slices/auth/index.ts
+++ b/src/store/slices/auth/index.ts
@@ -210,7 +210,6 @@ export const signOutThunk = createAsyncThunk<
   }
   isSignOutInFlight = true;
   try {
-    // The Photos snapshot needs credentials, so it runs before the wipes below.
     await dispatch(photosSignOutThunk());
     authService.signout(payload.reason).catch(errorService.reportError);
     drive.clear().catch(errorService.reportError);

--- a/src/store/slices/photos/index.spec.ts
+++ b/src/store/slices/photos/index.spec.ts
@@ -3,13 +3,14 @@ import { configureStore } from '@reduxjs/toolkit';
 import { AbortError } from 'src/network/errors';
 import asyncStorageService from 'src/services/AsyncStorageService';
 import { networkMonitorService, NetworkState, NetworkStateType } from 'src/services/NetworkMonitorService';
+import { retryIncompleteBursts } from 'src/services/photos/burst/BurstUploadHandler';
+import { photosLocalDB } from 'src/services/photos/database/photosLocalDB';
 import { PhotoAssetScanner } from 'src/services/photos/PhotoAssetScanner';
 import { photoCloudBrowser } from 'src/services/photos/PhotoCloudBrowser';
 import { PhotoDeduplicator } from 'src/services/photos/PhotoDeduplicator';
 import { PhotoDeviceManager } from 'src/services/photos/PhotoDeviceId';
+import { photoSyncManifestService } from 'src/services/photos/PhotoSyncManifestService';
 import { PhotoUploadQueue } from 'src/services/photos/PhotoUploadQueue';
-import { retryIncompleteBursts } from 'src/services/photos/burst/BurstUploadHandler';
-import { photosLocalDB } from 'src/services/photos/database/photosLocalDB';
 import { AppDispatch } from 'src/store';
 import { storageSelectors } from 'src/store/slices/storage';
 import photosReducer, {
@@ -22,12 +23,14 @@ import photosReducer, {
   pauseBackupThunk,
   photosSlice,
   PhotosState,
+  restoreLocalDbFromManifestThunk,
   resumeBackupThunk,
   runBackupCycleThunk,
   runDiscoveryThunk,
   runFullCloudHistorySyncThunk,
   runUploadThunk,
   setNetworkConditionThunk,
+  signOutThunk,
   uploadAssetsManuallyThunk,
 } from './index';
 import { hasPhotosFeatureAccess } from './selectors';
@@ -75,6 +78,8 @@ jest.mock('src/services/photos/PhotoUploadQueue', () => ({
     abortAll: jest.fn(),
     beginCycle: jest.fn(),
     endCycle: jest.fn(),
+    isCycleRunning: jest.fn(),
+    waitForCycleEnd: jest.fn(),
   },
 }));
 
@@ -118,8 +123,24 @@ jest.mock('src/services/photos/database/photosLocalDB', () => ({
     cleanupOrphanedAssetSync: jest.fn().mockResolvedValue(0),
     resetErrorsToPending: jest.fn().mockResolvedValue(undefined),
     getAssetUploadErroredCount: jest.fn().mockResolvedValue(0),
+    hasAnyAssetSyncEntry: jest.fn().mockResolvedValue(true),
+    reset: jest.fn().mockResolvedValue(undefined),
+    resetCloudAssets: jest.fn().mockResolvedValue(undefined),
   },
 }));
+
+jest.mock('src/services/photos/PhotoSyncManifestService', () => ({
+  photoSyncManifestService: {
+    uploadManifest: jest.fn().mockResolvedValue(undefined),
+    maybeUploadManifest: jest.fn().mockResolvedValue(undefined),
+    restoreManifest: jest.fn().mockResolvedValue(null),
+  },
+}));
+
+// The cycle lifecycle (begin/end/isCycleRunning/waitForCycleEnd) is pure in-memory state, so the
+// mocks delegate to the real implementation — drain and reentrancy tests exercise real logic.
+const actualUploadQueue = jest.requireActual('src/services/photos/PhotoUploadQueue')
+  .PhotoUploadQueue as typeof PhotoUploadQueue;
 
 const mockStorageSelectors = storageSelectors as jest.Mocked<typeof storageSelectors>;
 const mockHasPhotosFeatureAccess = hasPhotosFeatureAccess as jest.MockedFunction<typeof hasPhotosFeatureAccess>;
@@ -130,6 +151,7 @@ const mockPhotoDeviceManager = PhotoDeviceManager as jest.Mocked<typeof PhotoDev
 const mockScanner = PhotoAssetScanner as jest.Mocked<typeof PhotoAssetScanner>;
 const mockDeduplicator = PhotoDeduplicator as jest.Mocked<typeof PhotoDeduplicator>;
 const mockPhotosLocalDB = photosLocalDB as jest.Mocked<typeof photosLocalDB>;
+const mockPhotoSyncManifestService = photoSyncManifestService as jest.Mocked<typeof photoSyncManifestService>;
 const mockUploadQueue = PhotoUploadQueue as jest.Mocked<typeof PhotoUploadQueue>;
 const mockRetryIncompleteBursts = retryIncompleteBursts as jest.Mock;
 
@@ -152,19 +174,14 @@ const getPersistedState = (): PhotosState => {
 };
 
 describe('photos slice', () => {
-  let uploadCycleController: AbortController | null = null;
-
   beforeEach(() => {
     jest.resetAllMocks();
-    uploadCycleController = null;
-    mockUploadQueue.beginCycle.mockImplementation(() => {
-      uploadCycleController = new AbortController();
-      return uploadCycleController.signal;
-    });
-    mockUploadQueue.abortAll.mockImplementation(() => uploadCycleController?.abort());
-    mockUploadQueue.endCycle.mockImplementation(() => {
-      uploadCycleController = null;
-    });
+    actualUploadQueue.endCycle(); // clear any cycle left over from a previous test
+    mockUploadQueue.beginCycle.mockImplementation(actualUploadQueue.beginCycle);
+    mockUploadQueue.endCycle.mockImplementation(actualUploadQueue.endCycle);
+    mockUploadQueue.abortAll.mockImplementation(actualUploadQueue.abortAll);
+    mockUploadQueue.isCycleRunning.mockImplementation(actualUploadQueue.isCycleRunning);
+    mockUploadQueue.waitForCycleEnd.mockImplementation(actualUploadQueue.waitForCycleEnd);
     // Re-set default implementations after reset clears them
     mockAsyncStorage.saveItem.mockResolvedValue(undefined);
     mockAsyncStorage.getItem.mockResolvedValue(null);
@@ -186,6 +203,12 @@ describe('photos slice', () => {
     mockPhotosLocalDB.markSyncedBurst.mockResolvedValue(undefined);
     mockPhotosLocalDB.markError.mockResolvedValue(undefined);
     mockPhotosLocalDB.getIncompleteBurstAssets.mockResolvedValue([]);
+    mockPhotosLocalDB.hasAnyAssetSyncEntry.mockResolvedValue(true);
+    mockPhotosLocalDB.reset.mockResolvedValue(undefined);
+    mockPhotosLocalDB.resetCloudAssets.mockResolvedValue(undefined);
+    mockPhotoSyncManifestService.uploadManifest.mockResolvedValue(undefined);
+    mockPhotoSyncManifestService.maybeUploadManifest.mockResolvedValue(undefined);
+    mockPhotoSyncManifestService.restoreManifest.mockResolvedValue(null);
     mockCloudBrowser.listDeviceFolders.mockResolvedValue([]);
     mockCloudBrowser.syncAllHistory.mockResolvedValue(undefined);
     // Prevent checkPermissionRevocationThunk from overwriting permissionStatus with undefined
@@ -827,6 +850,166 @@ describe('photos slice', () => {
     });
   });
 
+  describe('restoring the local database from the sync manifest', () => {
+    test('when the local database already has state, then no manifest restore is attempted', async () => {
+      mockPhotosLocalDB.hasAnyAssetSyncEntry.mockResolvedValue(true);
+      const store = makeStore();
+      store.dispatch(photosSlice.actions.setState({ deviceId: 'device-1', photosBucket: 'bucket-1' }));
+
+      await store.dispatch(restoreLocalDbFromManifestThunk());
+
+      expect(mockPhotoSyncManifestService.restoreManifest).not.toHaveBeenCalled();
+    });
+
+    test('when the local database is empty and a device is registered, then the manifest is checked for a restore', async () => {
+      mockPhotosLocalDB.hasAnyAssetSyncEntry.mockResolvedValue(false);
+      const store = makeStore();
+      store.dispatch(photosSlice.actions.setState({ deviceId: 'device-1', photosBucket: 'bucket-1' }));
+
+      await store.dispatch(restoreLocalDbFromManifestThunk());
+
+      expect(mockPhotoSyncManifestService.restoreManifest).toHaveBeenCalledWith('device-1');
+    });
+
+    test('when there is no device registered yet, then no manifest restore is attempted', async () => {
+      mockPhotosLocalDB.hasAnyAssetSyncEntry.mockResolvedValue(false);
+      const store = makeStore();
+
+      await store.dispatch(restoreLocalDbFromManifestThunk());
+
+      expect(mockPhotoSyncManifestService.restoreManifest).not.toHaveBeenCalled();
+    });
+
+    test('when a backup cycle runs on a freshly emptied database, then the manifest restore is attempted before discovery starts', async () => {
+      mockPhotosLocalDB.hasAnyAssetSyncEntry.mockResolvedValue(false);
+      const callOrder: string[] = [];
+      mockPhotoSyncManifestService.restoreManifest.mockImplementation(async () => {
+        callOrder.push('restoreManifest');
+        return null;
+      });
+      mockScanner.scanAll.mockImplementation(async () => {
+        callOrder.push('scanAll');
+        return [];
+      });
+
+      const store = makeStore();
+      store.dispatch(photosSlice.actions.setState({ enabled: true, permissionStatus: 'granted' }));
+      mockPermissionService.getStatus.mockResolvedValue('granted');
+
+      await store.dispatch(runBackupCycleThunk());
+
+      expect(callOrder).toEqual(['restoreManifest', 'scanAll']);
+    });
+  });
+
+  describe('signing out', () => {
+    test('when the user signs out with a device already registered, then the manifest is uploaded before local state is wiped', async () => {
+      const store = makeStore();
+      store.dispatch(photosSlice.actions.setState({ deviceId: 'device-1', photosBucket: 'bucket-1' }));
+
+      await store.dispatch(signOutThunk());
+
+      expect(mockPhotoSyncManifestService.uploadManifest).toHaveBeenCalledWith('device-1', 'bucket-1');
+      expect(mockPhotosLocalDB.reset).toHaveBeenCalled();
+      expect(mockPhotosLocalDB.resetCloudAssets).toHaveBeenCalled();
+    });
+
+    test('when sign out starts, then enabled is flipped to false right away so a still-running cloud history sync cancels itself instead of running to completion', async () => {
+      const store = makeStore();
+      store.dispatch(photosSlice.actions.setState({ deviceId: 'device-1', photosBucket: 'bucket-1', enabled: true }));
+
+      await store.dispatch(signOutThunk());
+
+      expect(store.getState().photos.enabled).toBe(false);
+    });
+
+    test('when the user signs out without a device registered yet, then no manifest upload is attempted', async () => {
+      const store = makeStore();
+
+      await store.dispatch(signOutThunk());
+
+      expect(mockPhotoSyncManifestService.uploadManifest).not.toHaveBeenCalled();
+      expect(mockPhotosLocalDB.reset).toHaveBeenCalled();
+    });
+
+    test('when uploading the manifest fails during sign out, then local state is still wiped', async () => {
+      mockPhotoSyncManifestService.uploadManifest.mockRejectedValue(new Error('network error'));
+      const store = makeStore();
+      store.dispatch(photosSlice.actions.setState({ deviceId: 'device-1', photosBucket: 'bucket-1' }));
+
+      await store.dispatch(signOutThunk());
+
+      expect(mockPhotosLocalDB.reset).toHaveBeenCalled();
+      expect(mockPhotosLocalDB.resetCloudAssets).toHaveBeenCalled();
+    });
+
+    test('when an upload cycle is still finishing when sign out starts, then local state is not wiped until the cycle drains', async () => {
+      const store = makeStore();
+      store.dispatch(
+        photosSlice.actions.setState({
+          enabled: true,
+          permissionStatus: 'granted',
+          deviceId: 'device-1',
+          photosBucket: 'bucket-1',
+        }),
+      );
+      mockPhotosLocalDB.getPendingAssets.mockResolvedValueOnce([{ assetId: 'a1', status: 'pending' }] as never);
+
+      let releaseUploadCycle!: () => void;
+      mockUploadQueue.start.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseUploadCycle = resolve;
+          }),
+      );
+
+      const uploadCyclePromise = store.dispatch(runUploadThunk());
+      await flushAsyncWork();
+
+      const signOutPromise = store.dispatch(signOutThunk());
+      await flushAsyncWork();
+
+      expect(mockPhotosLocalDB.reset).not.toHaveBeenCalled();
+
+      releaseUploadCycle();
+      await uploadCyclePromise;
+      await signOutPromise;
+
+      expect(mockPhotosLocalDB.reset).toHaveBeenCalled();
+    });
+
+    test('when a backup cycle is dispatched while sign out is in progress, then it returns immediately without touching device or restore state', async () => {
+      const store = makeStore();
+      store.dispatch(
+        photosSlice.actions.setState({
+          enabled: true,
+          permissionStatus: 'granted',
+          deviceId: 'device-1',
+          photosBucket: 'bucket-1',
+        }),
+      );
+
+      let releaseManifestUpload!: () => void;
+      mockPhotoSyncManifestService.uploadManifest.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseManifestUpload = resolve;
+          }),
+      );
+
+      const signOutPromise = store.dispatch(signOutThunk());
+      await flushAsyncWork();
+
+      await store.dispatch(runBackupCycleThunk());
+
+      expect(mockPhotoDeviceManager.ensureDeviceFolder).not.toHaveBeenCalled();
+      expect(mockPhotoSyncManifestService.restoreManifest).not.toHaveBeenCalled();
+
+      releaseManifestUpload();
+      await signOutPromise;
+    });
+  });
+
   describe('pausing backup', () => {
     test('when the user pauses the backup, then is paused flag persists and sync status becomes pausing', async () => {
       const store = makeStore();
@@ -1247,6 +1430,48 @@ describe('photos slice', () => {
       await flushAsyncWork();
 
       expect(mockPhotoDeviceManager.ensureDeviceFolder).toHaveBeenCalled();
+    });
+
+    test('when an upload cycle finishes assets, then the sync manifest is uploaded for that device', async () => {
+      mockPhotosLocalDB.getPendingAssets.mockResolvedValue([{ assetId: 'a1', status: 'pending' }] as never);
+      mockScanner.getAssetsByIds.mockResolvedValue([{ id: 'a1', modificationTime: 1 }] as never);
+      mockUploadQueue.start.mockImplementationOnce(async (jobs, deviceId, bucket, callbacks) => {
+        await callbacks.onAssetDone?.('a1', { photoUuid: 'u1' } as never, 1);
+      });
+      const store = makeStore();
+      store.dispatch(
+        photosSlice.actions.setState({
+          enabled: true,
+          permissionStatus: 'granted',
+          deviceId: 'device-1',
+          photosBucket: 'photos-bucket-1',
+          networkCondition: 'wifi-and-data',
+        }),
+      );
+
+      await store.dispatch(runUploadThunk());
+      await flushAsyncWork();
+
+      expect(mockPhotoSyncManifestService.uploadManifest).toHaveBeenCalledWith('device-1', 'photos-bucket-1');
+    });
+
+    test('when an upload cycle finishes with nothing uploaded, then the sync manifest is not touched', async () => {
+      mockPhotosLocalDB.getPendingAssets.mockResolvedValue([]);
+      const store = makeStore();
+      store.dispatch(
+        photosSlice.actions.setState({
+          enabled: true,
+          permissionStatus: 'granted',
+          deviceId: 'device-1',
+          photosBucket: 'photos-bucket-1',
+          networkCondition: 'wifi-and-data',
+        }),
+      );
+
+      await store.dispatch(runUploadThunk());
+      await flushAsyncWork();
+
+      expect(mockPhotoSyncManifestService.uploadManifest).not.toHaveBeenCalled();
     });
 
     test('when an upload cycle is already running, then a second upload request is ignored', async () => {

--- a/src/store/slices/photos/index.ts
+++ b/src/store/slices/photos/index.ts
@@ -9,6 +9,7 @@ import { PhotoAssetScanner } from 'src/services/photos/PhotoAssetScanner';
 import { photoCloudBrowser } from 'src/services/photos/PhotoCloudBrowser';
 import { PhotoDeduplicator } from 'src/services/photos/PhotoDeduplicator';
 import { PhotoDeviceManager } from 'src/services/photos/PhotoDeviceId';
+import { photoSyncManifestService } from 'src/services/photos/PhotoSyncManifestService';
 import { PhotoUploadQueue } from 'src/services/photos/PhotoUploadQueue';
 import { BurstNativeModule } from 'src/services/photos/burst/BurstNativeModule';
 import { photosLocalDB } from 'src/services/photos/database/photosLocalDB';
@@ -23,8 +24,8 @@ import { logger } from '../../../services/common';
 import { RootState } from '../../index';
 import { hasPhotosFeatureAccess } from './selectors';
 import { evaluateNetworkPause, runUploadThunk } from './thunks/upload';
-export { runUploadThunk };
 export { uploadAssetsManuallyThunk } from './thunks/upload';
+export { runUploadThunk };
 
 export type PhotoNetworkCondition = 'wifi-only' | 'wifi-and-data';
 export type PhotoSyncStatus =
@@ -240,6 +241,24 @@ export const initDeviceIdThunk = createAsyncThunk<string, void, { state: RootSta
   },
 );
 
+export const restoreLocalDbFromManifestThunk = createAsyncThunk<void, void, { state: RootState }>(
+  'photos/restoreLocalDbFromManifest',
+  async (_, { getState }) => {
+    const { deviceId, photosBucket } = getState().photos;
+    if (!deviceId || !photosBucket) {
+      return;
+    }
+
+    const hasLocalState = await photosLocalDB.hasAnyAssetSyncEntry();
+    if (hasLocalState) {
+      return;
+    }
+
+    logger.info('[Manifest] asset_sync is empty — checking for a same-device manifest to restore');
+    await photoSyncManifestService.restoreManifest(deviceId);
+  },
+);
+
 export const runDiscoveryThunk = createAsyncThunk<void, void, { state: RootState }>(
   'photos/runDiscovery',
   async (_, { getState, dispatch }) => {
@@ -392,6 +411,7 @@ export const runBackupCycleThunk = createAsyncThunk<void, void, { state: RootSta
       return;
     }
     await dispatch(initDeviceIdThunk());
+    await dispatch(restoreLocalDbFromManifestThunk());
 
     dispatch(runFullCloudHistorySyncThunk());
 
@@ -551,10 +571,22 @@ export const photosSlice = createSlice({
 
 export const photosActions = photosSlice.actions;
 
+const SIGN_OUT_DRAIN_TIMEOUT_MS = 2 * 60 * 1000;
+
 export const signOutThunk = createAsyncThunk<void, void, { state: RootState }>(
   'photos/signOut',
-  async (_, { dispatch }) => {
+  async (_, { getState, dispatch }) => {
     PhotoUploadQueue.abortAll();
+    // Cancellation signal for the fire-and-forget cloud history sync — it checks !enabled between months.
+    dispatch(photosSlice.actions.setEnabled(false));
+    logger.info('[Manifest] signOutThunk — draining any in-flight upload cycle before wiping local state');
+    await PhotoUploadQueue.waitForCycleEnd(SIGN_OUT_DRAIN_TIMEOUT_MS);
+
+    const { deviceId, photosBucket } = getState().photos;
+    if (deviceId && photosBucket) {
+      await photoSyncManifestService.uploadManifest(deviceId, photosBucket).catch(errorService.reportError);
+    }
+
     await Promise.all([photosLocalDB.reset(), photosLocalDB.resetCloudAssets()]).catch(errorService.reportError);
     dispatch(photosActions.resetState());
   },

--- a/src/store/slices/photos/index.ts
+++ b/src/store/slices/photos/index.ts
@@ -577,7 +577,6 @@ export const signOutThunk = createAsyncThunk<void, void, { state: RootState }>(
   'photos/signOut',
   async (_, { getState, dispatch }) => {
     PhotoUploadQueue.abortAll();
-    // Cancellation signal for the fire-and-forget cloud history sync — it checks !enabled between months.
     dispatch(photosSlice.actions.setEnabled(false));
     logger.info('[Manifest] signOutThunk — draining any in-flight upload cycle before wiping local state');
     await PhotoUploadQueue.waitForCycleEnd(SIGN_OUT_DRAIN_TIMEOUT_MS);

--- a/src/store/slices/photos/thunks/upload.ts
+++ b/src/store/slices/photos/thunks/upload.ts
@@ -5,6 +5,7 @@ import { AbortError } from 'src/network/errors';
 import { networkMonitorService, NetworkState, NetworkStateType } from 'src/services/NetworkMonitorService';
 import { HTTP_QUOTA_EXCEEDED } from 'src/services/common/httpStatusCodes';
 import { PhotoAssetScanner } from 'src/services/photos/PhotoAssetScanner';
+import { photoSyncManifestService } from 'src/services/photos/PhotoSyncManifestService';
 import { AssetUploadJob, PhotoUploadQueue } from 'src/services/photos/PhotoUploadQueue';
 import { PhotoUploadEvent, PhotoUploadResult, uploadSingleFile } from 'src/services/photos/PhotoUploadService';
 import { retryIncompleteBursts } from 'src/services/photos/burst/BurstUploadHandler';
@@ -144,8 +145,6 @@ const handleAssetUploadError = async (
   return 'failed';
 };
 
-let isUploadCycleRunning = false;
-
 export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean } | void, { state: RootState }>(
   'photos/runUpload',
   async (args, { getState, dispatch }) => {
@@ -160,11 +159,10 @@ export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean }
     ) {
       return;
     }
-    if (isUploadCycleRunning) {
+    if (PhotoUploadQueue.isCycleRunning()) {
       logger.info('[Upload] Skipped — an upload cycle is already running');
       return;
     }
-    isUploadCycleRunning = true;
 
     const uploadCycleAbortSignal = PhotoUploadQueue.beginCycle();
     const unsubscribeNetworkMonitor = networkMonitorService.subscribe((state) => {
@@ -278,6 +276,9 @@ export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean }
           lastDispatchedUploadProgressStep.delete(assetId);
           await finishAssetUploadInCycle(dispatch, assetId, result, modificationTime);
           dispatch(photosSlice.actions.incrementSessionUploadedAssets());
+          photoSyncManifestService
+            .maybeUploadManifest(deviceId, photosBucket)
+            .catch((err) => logger.error('[Upload] Failed to checkpoint sync manifest', err));
         },
         onAssetEvent: applyBurstEvent,
         onAssetError: async (assetId, error) => {
@@ -304,12 +305,16 @@ export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean }
       dispatch(photosSlice.actions.setAssetUploadErroredCount(await photosLocalDB.getAssetUploadErroredCount()));
 
       const hasUploadSomeAssets = finalSessionUploadedAssets > 0;
+      if (hasUploadSomeAssets) {
+        photoSyncManifestService
+          .uploadManifest(deviceId, photosBucket)
+          .catch((err) => logger.error('[Upload] Failed to upload sync manifest', err));
+      }
       if (!finalIsPaused && finalDisabledReason === null && hasUploadSomeAssets && (await hasRemainingAssets(isIOS))) {
         logger.info('[Upload] Work remains after this cycle — restarting');
         dispatch(runBackupCycleThunk());
       }
     } finally {
-      isUploadCycleRunning = false;
       unsubscribeNetworkMonitor();
       PhotoUploadQueue.endCycle();
     }
@@ -318,7 +323,7 @@ export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean }
 
 /**
  * Uploads the given assets for the manual "Backup" action, independent of the automatic backup
- * cycle: not gated by `enabled`/`isPaused`/`isUploadCycleRunning`, never marks the asset
+ * cycle: not gated by `enabled`/`isPaused`/a running cycle, never marks the asset
  * `pending`, and skips session bookkeeping — so it can't be swallowed by a running cycle or
  * silently resume an entire backlog when backup is off. Not retried automatically if interrupted.
  */


### PR DESCRIPTION
Add a device sync manifest so a reinstall or re-login restores Photos backup state without re-checking every asset against the backend.

## Summary

  - **`PhotoSyncManifestService`**: exports `asset_sync` to an encrypted `manifest.json` under {deviceFolder}/.sync/`. Restore validates schema version and device id, keeps only entries whose asset still exists in the local gallery, and inserts them back in a transaction.
  - **`thunks/upload.ts`**: manifest checkpoint during the cycle plus a final upload at the end of any cycle that uploaded something.
  - **`store/slices/photos`**: `restoreLocalDbFromManifestThunk` runs at the start of each backup cycle.
  - **`PhotoUploadQueue`**: added `isCycleRunning()` and `waitForCycleEnd(timeoutMs)`, backed by a deferred resolved in `endCycle()`.
  - **Sign-out flow** (`auth` + `photos` slices): Photos drains any in-flight upload cycle, uploads a last-chance manifest snapshot and wipes its local DB before credentials are cleared.
  - **`SignOutModal`**: shows a spinner and a "Saving your latest Photos data…" message while sign-out runs.
