### PR TITLE
[BR-2094]: surface out-of-storage upload failures instead of a generic error

### DIFF
--- a/src/services/FileSystemService.spec.ts
+++ b/src/services/FileSystemService.spec.ts
@@ -1,0 +1,37 @@
+import * as RNFS from '@dr.pogodin/react-native-fs';
+import fileSystemService from './FileSystemService';
+
+jest.mock('@dr.pogodin/react-native-fs', () => ({ getFSInfo: jest.fn() }));
+
+const mockedGetFSInfo = RNFS.getFSInfo as jest.Mock;
+
+const arrangeFreeSpace = (freeSpace: number) => {
+  mockedGetFSInfo.mockResolvedValue({ freeSpace, totalSpace: freeSpace });
+};
+
+describe('FileSystemService.checkAvailableStorage', () => {
+  beforeEach(() => {
+    mockedGetFSInfo.mockReset();
+  });
+
+  test('when the free space is below size * multiplier, then checkAvailableStorage is false', async () => {
+    arrangeFreeSpace(150);
+
+    await expect(fileSystemService.checkAvailableStorage(100, 2)).resolves.toBe(false);
+  });
+
+  test('when the free space is greater than or equal to size * multiplier, then checkAvailableStorage is true', async () => {
+    arrangeFreeSpace(250);
+
+    await expect(fileSystemService.checkAvailableStorage(100, 2)).resolves.toBe(true);
+  });
+
+  test('when no multiplier is passed, then it keeps the 1.3 buffer for downloads/folder callers', async () => {
+    arrangeFreeSpace(120);
+
+    await expect(fileSystemService.checkAvailableStorage(100)).resolves.toBe(false);
+
+    arrangeFreeSpace(130);
+    await expect(fileSystemService.checkAvailableStorage(100)).resolves.toBe(true);
+  });
+});

--- a/src/services/FileSystemService.ts
+++ b/src/services/FileSystemService.ts
@@ -344,12 +344,12 @@ class FileSystemService {
     await this.clearTempDir();
   }
 
-  public async checkAvailableStorage(requiredSpace: number): Promise<boolean> {
+  public async checkAvailableStorage(requiredSpace: number, bufferMultiplier = 1.3): Promise<boolean> {
     try {
       const fsInfo = await RNFS.getFSInfo();
       const freeSpace = fsInfo.freeSpace;
 
-      const spaceWithBuffer = requiredSpace * 1.3;
+      const spaceWithBuffer = requiredSpace * bufferMultiplier;
 
       return freeSpace >= spaceWithBuffer;
     } catch (error) {

--- a/src/services/drive/file/utils/deviceStorageErrors.spec.ts
+++ b/src/services/drive/file/utils/deviceStorageErrors.spec.ts
@@ -1,0 +1,34 @@
+import { UPLOAD_FREE_SPACE_MULTIPLIER, isNativeIOError } from './deviceStorageErrors';
+
+describe('isNativeIOError', () => {
+  const nativeIOSignatures = [
+    'Cannot convert argument of type class java.io.IOException',
+    'java.io.IOException: write failed',
+    'ENOSPC: no space left on device',
+    'No space left on device',
+  ];
+
+  test.each(nativeIOSignatures)(
+    'when the error is a native IOException/ENOSPC (%s), then isNativeIOError recognizes it',
+    (signature) => {
+      expect(isNativeIOError(new Error(signature))).toBe(true);
+      expect(isNativeIOError(signature)).toBe(true);
+    },
+  );
+
+  test('when the signature casing differs, then isNativeIOError still recognizes it', () => {
+    expect(isNativeIOError(new Error('WRITE FAILED: JAVA.IO.IOEXCEPTION'))).toBe(true);
+  });
+
+  test('when the error is a normal network error, then isNativeIOError is false', () => {
+    expect(isNativeIOError(new Error('Network request failed'))).toBe(false);
+    expect(isNativeIOError({ status: 500, message: 'Internal Server Error' })).toBe(false);
+    expect(isNativeIOError(null)).toBe(false);
+  });
+});
+
+describe('UPLOAD_FREE_SPACE_MULTIPLIER', () => {
+  test('when reserving space for an upload, then it requires ~2.2x the file size', () => {
+    expect(UPLOAD_FREE_SPACE_MULTIPLIER).toBe(2.2);
+  });
+});

--- a/src/services/drive/file/utils/deviceStorageErrors.ts
+++ b/src/services/drive/file/utils/deviceStorageErrors.ts
@@ -1,0 +1,19 @@
+// Upload transiently needs ~2x the file size in free space: the pipeline copies
+// the file to cache AND writes an encrypted copy. We use 2.2x rather than 2x
+// because RNFS.getFSInfo().freeSpace reads slightly higher than actually-usable
+// space (reserved blocks), so 2x let a borderline upload slip through on-device.
+// Repro: a 493MB file failed at ~965MB free (~1.96x) and succeeded above ~1.1GB
+// (~2.23x), so 2.2x sits at the safe edge.
+export const UPLOAD_FREE_SPACE_MULTIPLIER = 2.2;
+
+const NATIVE_IO_ERROR_SIGNATURES = [
+  'cannot convert argument of type class java.io.ioexception',
+  'java.io.ioexception',
+  'enospc',
+  'no space left',
+];
+
+export const isNativeIOError = (error: unknown): boolean => {
+  const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
+  return NATIVE_IO_ERROR_SIGNATURES.some((signature) => message.includes(signature));
+};

--- a/src/services/drive/file/utils/uploadFileUtils.spec.ts
+++ b/src/services/drive/file/utils/uploadFileUtils.spec.ts
@@ -1,0 +1,144 @@
+import { Dispatch } from 'react';
+import { Action } from 'redux';
+import { UploadingFile } from '../../../../types/drive/operations';
+
+const mockCheckAvailableStorage = jest.fn();
+const mockReportError = jest.fn();
+const mockCastError = jest.fn((error: Error) => error);
+
+jest.mock('@internxt-mobile/services/FileSystemService', () => ({
+  __esModule: true,
+  default: { checkAvailableStorage: (...args: unknown[]) => mockCheckAvailableStorage(...args) },
+}));
+
+jest.mock('./checkDuplicatedFiles', () => ({ checkDuplicatedFiles: jest.fn() }));
+jest.mock('./prepareFilesToUpload', () => ({ prepareFilesToUpload: jest.fn() }));
+jest.mock('../../../common/network/upload/upload.service', () => ({
+  uploadService: { createFileEntry: jest.fn(), uploadFile: jest.fn() },
+}));
+
+jest.mock('../../../../store/slices/drive', () => ({
+  driveActions: {
+    uploadFileStart: jest.fn(),
+    uploadFileFailed: jest.fn((payload) => ({ type: 'uploadFileFailed', payload })),
+    uploadFileFinished: jest.fn(() => ({ type: 'uploadFileFinished' })),
+  },
+}));
+
+jest.mock('../../../../store/slices/ui', () => ({
+  uiActions: {
+    setShowNotEnoughDeviceSpaceModal: jest.fn((value) => ({ type: 'setShowNotEnoughDeviceSpaceModal', payload: value })),
+    setShowEmptyFileNotAllowedModal: jest.fn((value) => ({ type: 'setShowEmptyFileNotAllowedModal', payload: value })),
+    setFileSizeExceededMessage: jest.fn((value) => ({ type: 'setFileSizeExceededMessage', payload: value })),
+  },
+}));
+
+jest.mock('../../../native/InternxtSignalingModule', () => ({ notifyParentChanged: jest.fn().mockResolvedValue(undefined) }));
+
+jest.mock('../../../ErrorService', () => ({
+  __esModule: true,
+  default: { reportError: (...args: unknown[]) => mockReportError(...args), castError: (error: Error) => mockCastError(error) },
+}));
+
+jest.mock('../../../AnalyticsService', () => ({ __esModule: true, default: { track: jest.fn() }, DriveAnalyticsEvent: {} }));
+jest.mock('../../../common', () => ({ logger: { error: jest.fn(), info: jest.fn() } }));
+
+import { driveActions } from '../../../../store/slices/drive';
+import { uiActions } from '../../../../store/slices/ui';
+import { FileSizeExceededError } from './fileSizeErrors';
+import { uploadSingleFile } from './uploadFileUtils';
+
+const buildUploadingFile = (overrides: Partial<UploadingFile> = {}): UploadingFile => ({
+  id: 1,
+  uuid: 'file-uuid',
+  uri: 'file:///tmp/file.txt',
+  name: 'video.mov',
+  type: 'mov',
+  parentId: 10,
+  parentUuid: 'destination-folder-uuid',
+  createdAt: '2024-01-01',
+  updatedAt: '2024-01-01',
+  size: 20 * 1024 * 1024,
+  progress: 0,
+  uploaded: false,
+  ...overrides,
+});
+
+const arrange = ({ hasDeviceSpace = true }: { hasDeviceSpace?: boolean } = {}) => {
+  mockCheckAvailableStorage.mockResolvedValue(hasDeviceSpace);
+  return {
+    file: buildUploadingFile(),
+    dispatch: jest.fn() as unknown as Dispatch<Action>,
+    uploadSuccess: jest.fn(),
+  };
+};
+
+describe('uploadSingleFile — device storage handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('when there is not enough device space, then it warns about storage and does not upload the file', async () => {
+    const { file, dispatch, uploadSuccess } = arrange({ hasDeviceSpace: false });
+    const uploadFile = jest.fn().mockResolvedValue(undefined);
+
+    await uploadSingleFile(file, dispatch, uploadFile, uploadSuccess);
+
+    expect(mockCheckAvailableStorage).toHaveBeenCalledWith(file.size, 2.2);
+    expect(uiActions.setShowNotEnoughDeviceSpaceModal).toHaveBeenCalledWith(true);
+    expect(uploadFile).not.toHaveBeenCalled();
+  });
+
+  test('when there is enough device space, then the upload proceeds normally', async () => {
+    const { file, dispatch, uploadSuccess } = arrange({ hasDeviceSpace: true });
+    const uploadFile = jest.fn().mockResolvedValue(undefined);
+
+    await uploadSingleFile(file, dispatch, uploadFile, uploadSuccess);
+
+    expect(uploadFile).toHaveBeenCalledWith(file, 'document');
+    expect(uploadSuccess).toHaveBeenCalledWith(file);
+    expect(uiActions.setShowNotEnoughDeviceSpaceModal).not.toHaveBeenCalled();
+  });
+
+  test('when the upload fails with a device I/O error, then it warns about storage instead of the generic error', async () => {
+    const { file, dispatch, uploadSuccess } = arrange();
+    const uploadFile = jest.fn().mockRejectedValue('Cannot convert argument of type class java.io.IOException');
+
+    await uploadSingleFile(file, dispatch, uploadFile, uploadSuccess);
+
+    expect(uiActions.setShowNotEnoughDeviceSpaceModal).toHaveBeenCalledWith(true);
+    expect(driveActions.uploadFileFailed).not.toHaveBeenCalled();
+  });
+
+  test('when the upload fails with an I/O error, then the original native error is reported for diagnosis', async () => {
+    const { file, dispatch, uploadSuccess } = arrange();
+    const nativeError = 'ENOSPC: no space left on device';
+    const uploadFile = jest.fn().mockRejectedValue(nativeError);
+
+    await uploadSingleFile(file, dispatch, uploadFile, uploadSuccess);
+
+    expect(mockReportError).toHaveBeenCalledWith(nativeError, { extra: { fileId: file.id } });
+  });
+
+  test('when the upload exceeds the plan limit, then it shows its size modal and not the storage one', async () => {
+    const { file, dispatch, uploadSuccess } = arrange();
+    const uploadFile = jest.fn().mockRejectedValue(new FileSizeExceededError());
+
+    await uploadSingleFile(file, dispatch, uploadFile, uploadSuccess);
+
+    expect(uiActions.setFileSizeExceededMessage).toHaveBeenCalled();
+    expect(uiActions.setShowNotEnoughDeviceSpaceModal).not.toHaveBeenCalled();
+  });
+
+  test('when the upload fails with a non-I/O error, then it is mapped as a generic error as before', async () => {
+    const { file, dispatch, uploadSuccess } = arrange();
+    const networkError = new Error('Network request failed');
+    const uploadFile = jest.fn().mockRejectedValue(networkError);
+
+    await expect(uploadSingleFile(file, dispatch, uploadFile, uploadSuccess)).rejects.toThrow('Network request failed');
+
+    expect(mockCastError).toHaveBeenCalledWith(networkError);
+    expect(driveActions.uploadFileFailed).toHaveBeenCalled();
+    expect(uiActions.setShowNotEnoughDeviceSpaceModal).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/drive/file/utils/uploadFileUtils.ts
+++ b/src/services/drive/file/utils/uploadFileUtils.ts
@@ -20,6 +20,7 @@ import analyticsService, { DriveAnalyticsEvent } from '../../../AnalyticsService
 import { logger } from '../../../common';
 import { uploadService } from '../../../common/network/upload/upload.service';
 import { notifyParentChanged } from '../../../native/InternxtSignalingModule';
+import { UPLOAD_FREE_SPACE_MULTIPLIER, isNativeIOError } from './deviceStorageErrors';
 import { EmptyFileNotAllowedError, isEmptyFilePlanError } from './emptyFileErrors';
 import { FileSizeExceededError, isFileSizeExceededError } from './fileSizeErrors';
 import { BucketNotFoundError } from './upload.errors';
@@ -239,6 +240,16 @@ export async function uploadSingleFile(
 
       await createEmptyFileEntry(bucketId, file);
     } else {
+      const hasDeviceSpace = await fileSystemService
+        .checkAvailableStorage(file.size, UPLOAD_FREE_SPACE_MULTIPLIER)
+        .catch(() => true);
+
+      if (!hasDeviceSpace) {
+        dispatch(uiActions.setShowNotEnoughDeviceSpaceModal(true));
+        dispatch(driveActions.uploadFileFinished());
+        return;
+      }
+
       await uploadFile(file, 'document');
     }
     uploadSuccess(file);
@@ -265,6 +276,10 @@ export async function uploadSingleFile(
       },
     });
     trackUploadError(file, err);
+    if (isNativeIOError(e)) {
+      dispatch(uiActions.setShowNotEnoughDeviceSpaceModal(true));
+      return;
+    }
     const castedError = errorService.castError(e, 'upload');
     dispatch(driveActions.uploadFileFailed({ errorMessage: castedError.message, id: file.id }));
     logger.error('File upload process failed: ', JSON.stringify(err));


### PR DESCRIPTION
Add a pre-flight free-space check (~2.2x file size) before copying/encrypting, and map native IOException/ENOSPC failures to the NotEnoughDeviceSpaceModal instead of the genericError. Reuses existing infrastructure with no new strings.