### PR TITLE
[PB-6628] bugfix/Duplicated local assets

### DIFF
--- a/src/screens/PhotosScreen/hooks/useBurstRepresentatives.ts
+++ b/src/screens/PhotosScreen/hooks/useBurstRepresentatives.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import useDebouncedValue from 'src/hooks/useDebouncedValue';
+import { logger } from 'src/services/common';
+import { BurstNativeModule } from 'src/services/photos/burst/BurstNativeModule';
+
+const BURST_LOOKUP_DEBOUNCE_MS = 400;
+
+/**
+ * Resolves which of the given assets are the representative photo of a burst group.
+ *
+ * @param assetIds - Ids of the currently loaded local assets to look up.
+ * @returns Ids of the assets that represent their burst group.
+ */
+export const useBurstRepresentatives = (assetIds: string[]): Set<string> => {
+  const [burstRepresentativeIdSet, setBurstRepresentativeIdSet] = useState<Set<string>>(new Set());
+  const debouncedAssetIds = useDebouncedValue(assetIds, BURST_LOOKUP_DEBOUNCE_MS);
+
+  useEffect(() => {
+    if (debouncedAssetIds.length === 0) {
+      return;
+    }
+    BurstNativeModule.getBurstRepresentativeIds(debouncedAssetIds)
+      .then((ids) => setBurstRepresentativeIdSet(new Set(ids)))
+      .catch((err) => logger.error(`[LocalAssets] getBurstRepresentativeIds failed: ${err}`));
+  }, [debouncedAssetIds]);
+
+  return burstRepresentativeIdSet;
+};

--- a/src/screens/PhotosScreen/hooks/useLocalAssets.spec.ts
+++ b/src/screens/PhotosScreen/hooks/useLocalAssets.spec.ts
@@ -278,6 +278,74 @@ describe('useLocalAssets', () => {
     expect(mockMediaLibrary.getAssetsAsync).toHaveBeenCalledTimes(2);
   });
 
+  test('when reload is called while the mount background pagination is still in flight, then the stale page is discarded instead of being appended after the reload', async () => {
+    const page1 = [makeAsset('a1'), makeAsset('a2')];
+    const reloadAssets = [makeAsset('a9')];
+    let resolveStalePage2: ((page: MediaLibrary.PagedInfo<MediaLibrary.Asset>) => void) | undefined;
+    const stalePage2 = new Promise<MediaLibrary.PagedInfo<MediaLibrary.Asset>>((resolve) => {
+      resolveStalePage2 = resolve;
+    });
+
+    mockMediaLibrary.getAssetsAsync
+      .mockResolvedValueOnce(makePage(page1, true, 'cursor-1')) // mount: first page
+      .mockImplementationOnce(() => stalePage2) // mount: background page 2, held pending
+      .mockResolvedValueOnce(makePage(reloadAssets, false)); // reload: fresh first page
+
+    const { result } = renderHook(() => useLocalAssets());
+
+    await act(async () => {
+      await Promise.resolve();
+    }); // first page applied, background load for page 2 now in flight
+
+    await act(async () => {
+      await result.current.reload();
+    }); // reload wins: resets assets to the fresh result while page 2 is still pending
+
+    expect(result.current.assets).toEqual(reloadAssets);
+
+    await act(async () => {
+      resolveStalePage2?.(makePage([makeAsset('a3')], false));
+      await flushPromises();
+    }); // the stale background loop resumes here — it must detect it was superseded and no-op
+
+    expect(result.current.assets).toEqual(reloadAssets);
+  });
+
+  test('when a reload is interrupted by a newer reload, then only the newer reload cleans up orphaned sync entries', async () => {
+    const mountAssets = [makeAsset('a1')];
+    let resolveInterruptedReloadPage: ((page: MediaLibrary.PagedInfo<MediaLibrary.Asset>) => void) | undefined;
+    const interruptedReloadPage = new Promise<MediaLibrary.PagedInfo<MediaLibrary.Asset>>((resolve) => {
+      resolveInterruptedReloadPage = resolve;
+    });
+
+    mockMediaLibrary.getAssetsAsync
+      .mockResolvedValueOnce(makePage(mountAssets, false)) // mount
+      .mockImplementationOnce(() => interruptedReloadPage) // first reload, held pending
+      .mockResolvedValueOnce(makePage([makeAsset('a9')], false)); // second reload
+
+    const { result } = renderHook(() => useLocalAssets());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    let firstReload: Promise<void> | undefined;
+    await act(async () => {
+      firstReload = result.current.reload(); // blocks on the held page
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      const secondReload = result.current.reload(); // supersedes the first one
+      resolveInterruptedReloadPage?.(makePage(mountAssets, true, 'cursor-1'));
+      await Promise.all([secondReload, firstReload]);
+    });
+
+    // the interrupted reload must not clean up with its incomplete id set
+    expect(mockPhotosLocalDB.cleanupOrphanedAssetSync).toHaveBeenCalledTimes(1);
+    expect(mockPhotosLocalDB.cleanupOrphanedAssetSync).toHaveBeenCalledWith(new Set(['a9']));
+  });
+
   test('when sync status changes and there are assets loaded, then synced ids refresh from the database', async () => {
     mockMediaLibrary.getAssetsAsync.mockResolvedValueOnce(makePage([makeAsset('a1')]));
     mockPhotosLocalDB.getSyncedEntries.mockResolvedValue(

--- a/src/screens/PhotosScreen/hooks/useLocalAssets.spec.ts
+++ b/src/screens/PhotosScreen/hooks/useLocalAssets.spec.ts
@@ -139,8 +139,9 @@ describe('useLocalAssets', () => {
   });
 
   test('when the app returns to the foreground and a recent photo was deleted while locked, then the deleted photo is removed from the gallery', async () => {
-    const firstLoad = [makeAsset('a1'), makeAsset('a2')];
-    const afterDelete = [makeAsset('a2')];
+    const RECENT_TIME = new Date('2026-07-01T10:00:00Z').getTime();
+    const firstLoad = [makeAsset('a1', RECENT_TIME), makeAsset('a2', RECENT_TIME - 1000)];
+    const afterDelete = [makeAsset('a2', RECENT_TIME - 1000)];
     mockMediaLibrary.getAssetsAsync
       .mockResolvedValueOnce(makePage(firstLoad))
       .mockResolvedValueOnce(makePage(afterDelete));
@@ -194,6 +195,69 @@ describe('useLocalAssets', () => {
     expect(result.current.assets[0]).toEqual(newPhoto);
     expect(result.current.assets).toContainEqual(existingAssets[0]);
     expect(result.current.assets).toContainEqual(existingAssets[1]);
+  });
+
+  test('when photos with corrupted creation times fall outside the head window, then they are not treated as locally deleted', async () => {
+    const RECENT_TIME = new Date('2026-07-01T10:00:00Z').getTime();
+    const recentPhoto = { ...makeAsset('recent', RECENT_TIME), modificationTime: RECENT_TIME } as MediaLibrary.Asset;
+    const corruptedTimePhoto = { ...makeAsset('whatsapp', 0), modificationTime: RECENT_TIME } as MediaLibrary.Asset;
+
+    mockMediaLibrary.getAssetsAsync
+      .mockResolvedValueOnce(makePage([recentPhoto, corruptedTimePhoto]))
+      .mockResolvedValueOnce(makePage([recentPhoto], true, 'cursor-1'));
+
+    let appStateCallback: ((state: string) => void) | undefined;
+    jest.spyOn(AppState, 'addEventListener').mockImplementation((_event, cb) => {
+      appStateCallback = cb as (state: string) => void;
+      return { remove: jest.fn() } as never;
+    });
+
+    const { result } = renderHook(() => useLocalAssets());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      appStateCallback?.('background');
+      appStateCallback?.('active');
+      await flushPromises();
+    });
+
+    expect(result.current.assets.find((a) => a.id === 'whatsapp')).toBeDefined();
+    expect(mockPhotosLocalDB.deleteAssetSync).not.toHaveBeenCalled();
+  });
+
+  test('when the head window creation times are unreliable, then no photos are dropped from the gallery', async () => {
+    const RECENT_TIME = new Date('2026-07-01T10:00:00Z').getTime();
+    const knownPhoto = { ...makeAsset('known', RECENT_TIME), modificationTime: RECENT_TIME } as MediaLibrary.Asset;
+    const corruptedA = { ...makeAsset('corrupted-1', 0), modificationTime: RECENT_TIME } as MediaLibrary.Asset;
+    const corruptedB = { ...makeAsset('corrupted-2', 0), modificationTime: RECENT_TIME } as MediaLibrary.Asset;
+
+    mockMediaLibrary.getAssetsAsync
+      .mockResolvedValueOnce(makePage([knownPhoto, corruptedA, corruptedB]))
+      .mockResolvedValueOnce(makePage([corruptedA, corruptedB], true, 'cursor-1'));
+
+    let appStateCallback: ((state: string) => void) | undefined;
+    jest.spyOn(AppState, 'addEventListener').mockImplementation((_event, cb) => {
+      appStateCallback = cb as (state: string) => void;
+      return { remove: jest.fn() } as never;
+    });
+
+    const { result } = renderHook(() => useLocalAssets());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      appStateCallback?.('background');
+      appStateCallback?.('active');
+      await flushPromises();
+    });
+
+    expect(result.current.assets.find((a) => a.id === 'known')).toBeDefined();
+    expect(mockPhotosLocalDB.deleteAssetSync).not.toHaveBeenCalled();
   });
 
   test('when the device is unlocked mid-gallery, then assets loaded beyond the first page are preserved without re-pagination', async () => {
@@ -287,26 +351,26 @@ describe('useLocalAssets', () => {
     });
 
     mockMediaLibrary.getAssetsAsync
-      .mockResolvedValueOnce(makePage(page1, true, 'cursor-1')) // mount: first page
-      .mockImplementationOnce(() => stalePage2) // mount: background page 2, held pending
-      .mockResolvedValueOnce(makePage(reloadAssets, false)); // reload: fresh first page
+      .mockResolvedValueOnce(makePage(page1, true, 'cursor-1'))
+      .mockImplementationOnce(() => stalePage2)
+      .mockResolvedValueOnce(makePage(reloadAssets, false));
 
     const { result } = renderHook(() => useLocalAssets());
 
     await act(async () => {
       await Promise.resolve();
-    }); // first page applied, background load for page 2 now in flight
+    });
 
     await act(async () => {
       await result.current.reload();
-    }); // reload wins: resets assets to the fresh result while page 2 is still pending
+    });
 
     expect(result.current.assets).toEqual(reloadAssets);
 
     await act(async () => {
       resolveStalePage2?.(makePage([makeAsset('a3')], false));
       await flushPromises();
-    }); // the stale background loop resumes here — it must detect it was superseded and no-op
+    });
 
     expect(result.current.assets).toEqual(reloadAssets);
   });
@@ -319,9 +383,9 @@ describe('useLocalAssets', () => {
     });
 
     mockMediaLibrary.getAssetsAsync
-      .mockResolvedValueOnce(makePage(mountAssets, false)) // mount
-      .mockImplementationOnce(() => interruptedReloadPage) // first reload, held pending
-      .mockResolvedValueOnce(makePage([makeAsset('a9')], false)); // second reload
+      .mockResolvedValueOnce(makePage(mountAssets, false))
+      .mockImplementationOnce(() => interruptedReloadPage)
+      .mockResolvedValueOnce(makePage([makeAsset('a9')], false));
 
     const { result } = renderHook(() => useLocalAssets());
 
@@ -331,17 +395,16 @@ describe('useLocalAssets', () => {
 
     let firstReload: Promise<void> | undefined;
     await act(async () => {
-      firstReload = result.current.reload(); // blocks on the held page
+      firstReload = result.current.reload();
       await Promise.resolve();
     });
 
     await act(async () => {
-      const secondReload = result.current.reload(); // supersedes the first one
+      const secondReload = result.current.reload();
       resolveInterruptedReloadPage?.(makePage(mountAssets, true, 'cursor-1'));
       await Promise.all([secondReload, firstReload]);
     });
 
-    // the interrupted reload must not clean up with its incomplete id set
     expect(mockPhotosLocalDB.cleanupOrphanedAssetSync).toHaveBeenCalledTimes(1);
     expect(mockPhotosLocalDB.cleanupOrphanedAssetSync).toHaveBeenCalledWith(new Set(['a9']));
   });

--- a/src/screens/PhotosScreen/hooks/useLocalAssets.ts
+++ b/src/screens/PhotosScreen/hooks/useLocalAssets.ts
@@ -1,16 +1,15 @@
 import * as MediaLibrary from 'expo-media-library';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AppState } from 'react-native';
-import useDebouncedValue from 'src/hooks/useDebouncedValue';
 import { logger } from 'src/services/common';
-import { BurstNativeModule } from 'src/services/photos/burst/BurstNativeModule';
 import { photosLocalDB } from 'src/services/photos/database/photosLocalDB';
 import { isPermissionActive } from 'src/services/photos/photoPermissionService';
-import { normalizeAssetCreationTime } from 'src/services/photos/utils/resolveAssetCreationTime';
 import { useAppSelector } from 'src/store/hooks';
+import { useBurstRepresentatives } from './useBurstRepresentatives';
+import { useLocalAssetsSyncStatus } from './useLocalAssetsSyncStatus';
+import { usePagedLocalAssets } from './usePagedLocalAssets';
 
-const PAGE_SIZE = 1000;
-const MEDIA_TYPES = [MediaLibrary.MediaType.photo, MediaLibrary.MediaType.video];
+const LIBRARY_CHANGE_DEBOUNCE_MS = 400;
 
 export interface LocalAssetsResult {
   assets: MediaLibrary.Asset[];
@@ -26,271 +25,94 @@ export interface LocalAssetsResult {
   reload: () => Promise<void>;
 }
 
+/**
+ * Local device timeline for the Photos screen.
+ *
+ * @returns The current local assets, their backup/sync status, and controls to page or reload.
+ */
 export const useLocalAssets = (): LocalAssetsResult => {
-  const [assets, setAssets] = useState<MediaLibrary.Asset[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [hasLoadedLocalAssetsOnce, setHasLoadedLocalAssetsOnce] = useState(false);
-  const [syncedIds, setSyncedIds] = useState<Set<string>>(new Set());
-  const [cloudDeletedIds, setCloudDeletedIds] = useState<Set<string>>(new Set());
   const [localDeletionDetectedCount, setLocalDeletionDetectedCount] = useState(0);
-  const [burstRepresentativeIdSet, setBurstRepresentativeIdSet] = useState<Set<string>>(new Set());
-  const [incompleteUploadBurstIdSet, setIncompleteUploadBurstIdSet] = useState<Set<string>>(new Set());
-
-  const cursorRef = useRef<string | undefined>(undefined);
-  const hasMoreRef = useRef(true);
-  const isLoadingMoreRef = useRef(false);
-  const activeLoadGenerationRef = useRef(0);
   const appStateRef = useRef(AppState.currentState);
-  const mediaLibrarySubscriptionRef = useRef<ReturnType<typeof MediaLibrary.addListener> | null>(null);
   const libraryChangeDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const syncStatus = useAppSelector((state) => state.photos.syncStatus);
   const uploadingAssetIds = useAppSelector((state) => state.photos.uploadingAssetIds);
-  const sessionUploadedAssets = useAppSelector((state) => state.photos.sessionUploadedAssets);
-  const isFetchingCloudHistory = useAppSelector((state) => state.photos.isFetchingCloudHistory);
   const permissionStatus = useAppSelector((state) => state.photos.permissionStatus);
   const isPhotosEnabled = isPermissionActive(permissionStatus);
 
   const uploadingIdSet = useMemo(() => new Set(uploadingAssetIds), [uploadingAssetIds]);
 
-  const fetchLocalPage = useCallback(async (after?: string): Promise<MediaLibrary.PagedInfo<MediaLibrary.Asset>> => {
-    const page = await MediaLibrary.getAssetsAsync({
-      first: PAGE_SIZE,
-      after,
-      mediaType: MEDIA_TYPES,
-      sortBy: [[MediaLibrary.SortBy.creationTime, false]],
-    });
-    return { ...page, assets: page.assets.map(normalizeAssetCreationTime) };
-  }, []);
-
-  const applyPage = useCallback(
-    (page: MediaLibrary.PagedInfo<MediaLibrary.Asset>, { replace }: { replace: boolean }) => {
-      setAssets((prev) => (replace ? page.assets : [...prev, ...page.assets]));
-      cursorRef.current = page.hasNextPage ? page.endCursor : undefined;
-      hasMoreRef.current = page.hasNextPage;
-    },
-    [],
-  );
-
-  const loadNextPage = useCallback(async () => {
-    if (isLoadingMoreRef.current || !hasMoreRef.current || !cursorRef.current) {
-      return;
-    }
-    const generation = activeLoadGenerationRef.current;
-    isLoadingMoreRef.current = true;
-    setIsLoading(true);
-    try {
-      const page = await fetchLocalPage(cursorRef.current);
-      if (activeLoadGenerationRef.current !== generation) {
-        return;
-      }
-      applyPage(page, { replace: false });
-    } finally {
-      isLoadingMoreRef.current = false;
-      setIsLoading(false);
-    }
-  }, [fetchLocalPage, applyPage]);
-
-  const loadAllRemainingPages = useCallback(
-    async (generation: number) => {
-      if (isLoadingMoreRef.current || !hasMoreRef.current || !cursorRef.current) {
-        return;
-      }
-      isLoadingMoreRef.current = true;
-      try {
-        while (hasMoreRef.current && cursorRef.current && activeLoadGenerationRef.current === generation) {
-          const page = await fetchLocalPage(cursorRef.current);
-          if (activeLoadGenerationRef.current !== generation) {
-            break;
-          }
-          applyPage(page, { replace: false });
-        }
-      } finally {
-        isLoadingMoreRef.current = false;
-      }
-    },
-    [fetchLocalPage, applyPage],
-  );
-
-  const refreshSyncStatusFromDB = useCallback(async () => {
-    if (assets.length === 0) {
-      return;
-    }
-    const assetIds = assets.map((a) => a.id);
-    await photosLocalDB.init();
-    const entries = await photosLocalDB.getSyncedEntries(assetIds);
-    const synced = new Set<string>();
-    const cloudDeleted = new Set<string>();
-    for (const [id, info] of entries) {
-      if (info.status === 'cloud_deleted' || info.status === 'deleted') {
-        cloudDeleted.add(id);
-      } else if (info.status === 'synced') {
-        synced.add(id);
-      } else if (info.status === 'error') {
-        // to not mark as synced, but still track as known asset
-        // leave this to fill if we add a Icon for error state in the future
-      }
-    }
-    setSyncedIds(synced);
-    setCloudDeletedIds(cloudDeleted);
-
-    const incompleteBursts = await photosLocalDB.getIncompleteBurstAssets();
-    setIncompleteUploadBurstIdSet(new Set(incompleteBursts.map((burst) => burst.assetId)));
-  }, [assets]);
+  const { assets, isLoading, hasLoadedLocalAssetsOnce, loadNextPage, reloadFromStart, reconcileHead, applyLibraryChange } =
+    usePagedLocalAssets(isPhotosEnabled);
 
   const assetIds = useMemo(() => assets.map((asset) => asset.id), [assets]);
-  const debouncedAssetIds = useDebouncedValue(assetIds, 400);
-  useEffect(() => {
-    if (debouncedAssetIds.length === 0) {
-      return;
+  const { syncedIds, cloudDeletedIds, incompleteUploadBurstIdSet } = useLocalAssetsSyncStatus(assetIds);
+  const burstRepresentativeIdSet = useBurstRepresentatives(assetIds);
+
+  const removeDeletedAssetsFromSyncDB = useCallback(async (deletedAssetIds: string[]) => {
+    await photosLocalDB.init();
+    await Promise.all(deletedAssetIds.map((id) => photosLocalDB.deleteAssetSync(id)));
+    setLocalDeletionDetectedCount((prev) => prev + 1);
+  }, []);
+
+  const reconcileWithDevice = useCallback(async () => {
+    const droppedAssetIds = await reconcileHead();
+    if (droppedAssetIds.length > 0) {
+      logger.info(
+        `[LocalAssets] Reconcile dropped ${droppedAssetIds.length} locally deleted assets: ${droppedAssetIds.join(', ')}`,
+      );
+      await removeDeletedAssetsFromSyncDB(droppedAssetIds);
     }
-    BurstNativeModule.getBurstRepresentativeIds(debouncedAssetIds)
-      .then((ids) => setBurstRepresentativeIdSet(new Set(ids)))
-      .catch((err) => logger.error(`[LocalAssets] getBurstRepresentativeIds failed: ${err}`));
-  }, [debouncedAssetIds]);
+  }, [reconcileHead, removeDeletedAssetsFromSyncDB]);
+
+  const handleIncrementalLibraryChange = useCallback(
+    async (event: MediaLibrary.MediaLibraryAssetsChangeEvent) => {
+      const { insertedAssets = [], deletedAssets = [], updatedAssets = [] } = event;
+      const deletedAssetIds = deletedAssets.map((a) => a.id);
+
+      applyLibraryChange({ inserted: insertedAssets, updated: updatedAssets, deletedIds: deletedAssetIds });
+
+      if (deletedAssetIds.length > 0) {
+        logger.info(`[LocalAssets] Library change: removing ${deletedAssetIds.length} deleted assets from asset_sync`);
+        await removeDeletedAssetsFromSyncDB(deletedAssetIds);
+      }
+    },
+    [applyLibraryChange, removeDeletedAssetsFromSyncDB],
+  );
 
   const hardReloadAndReconcile = useCallback(async () => {
-    const generation = ++activeLoadGenerationRef.current; // invalidate any in-flight pagination loop
-    cursorRef.current = undefined;
-    hasMoreRef.current = true;
-    isLoadingMoreRef.current = true;
-
-    const allIds = new Set<string>();
-    try {
-      let isFirstPage = true;
-      while (
-        activeLoadGenerationRef.current === generation &&
-        (isFirstPage || (hasMoreRef.current && cursorRef.current))
-      ) {
-        const page = await fetchLocalPage(isFirstPage ? undefined : cursorRef.current);
-        if (activeLoadGenerationRef.current !== generation) {
-          break;
-        }
-        applyPage(page, { replace: isFirstPage });
-        page.assets.forEach((a) => allIds.add(a.id));
-        isFirstPage = false;
-      }
-    } finally {
-      isLoadingMoreRef.current = false;
+    const deviceAssetIds = await reloadFromStart();
+    if (!deviceAssetIds) {
+      return;
     }
 
-    if (activeLoadGenerationRef.current !== generation) {
-      return; // superseded — cleaning up with a partial id set would drop valid asset_sync entries
-    }
-
-    logger.info(`[LocalAssets] Reloaded from start — ${allIds.size} total assets`);
+    logger.info(`[LocalAssets] Reloaded from start — ${deviceAssetIds.size} total assets`);
 
     await photosLocalDB.init();
-    const orphanedAssetsSyncRemovedCount = await photosLocalDB.cleanupOrphanedAssetSync(allIds);
+    const orphanedAssetsSyncRemovedCount = await photosLocalDB.cleanupOrphanedAssetSync(deviceAssetIds);
     if (orphanedAssetsSyncRemovedCount > 0) {
       logger.info(`[LocalAssets] Cleaned up ${orphanedAssetsSyncRemovedCount} orphaned asset_sync entries`);
       setLocalDeletionDetectedCount((prev) => prev + 1);
     }
-  }, [fetchLocalPage, applyPage]);
-
-  const applyIncrementalLibraryChange = useCallback(async (event: MediaLibrary.MediaLibraryAssetsChangeEvent) => {
-    const { insertedAssets = [], deletedAssets = [], updatedAssets = [] } = event;
-
-    const deletedAssetIds = deletedAssets.map((a) => a.id);
-    const deletedAssetIdSet = new Set(deletedAssetIds);
-    const updatedAssetMap = new Map(updatedAssets.map((a) => [a.id, a]));
-
-    setAssets((prevAssets) => {
-      const insertedAssetsNotAlreadyPresent = insertedAssets.filter((a) => !prevAssets.some((p) => p.id === a.id));
-      const nextAssets = prevAssets
-        .filter((a) => !deletedAssetIdSet.has(a.id))
-        .map((a) => updatedAssetMap.get(a.id) ?? a);
-
-      if (insertedAssetsNotAlreadyPresent.length > 0) {
-        logger.info(`[LocalAssets] Library change: prepending ${insertedAssetsNotAlreadyPresent.length} new assets`);
-      }
-
-      return [...insertedAssetsNotAlreadyPresent, ...nextAssets];
-    });
-
-    if (deletedAssetIds.length > 0) {
-      logger.info(`[LocalAssets] Library change: removing ${deletedAssetIds.length} deleted assets from asset_sync`);
-      await photosLocalDB.init();
-      await Promise.all(deletedAssetIds.map((id) => photosLocalDB.deleteAssetSync(id)));
-      setLocalDeletionDetectedCount((prev) => prev + 1);
-    }
-  }, []);
-
-  const reconcileOnForeground = useCallback(async () => {
-    const page = await fetchLocalPage();
-    if (page.assets.length === 0) {
-      return;
-    }
-
-    const freshIds = new Set(page.assets.map((a) => a.id));
-    const headMinTime = Math.min(...page.assets.map((a) => a.creationTime));
-
-    let droppedAssetsIds: string[] = [];
-    setAssets((prevAssets) => {
-      const newAssets = page.assets.filter((a) => !prevAssets.some((p) => p.id === a.id));
-      const droppedAssets = prevAssets.filter((a) => a.creationTime >= headMinTime && !freshIds.has(a.id));
-      droppedAssetsIds = droppedAssets.map((a) => a.id);
-      const preservedAssets = prevAssets.filter((a) => a.creationTime < headMinTime || freshIds.has(a.id));
-      if (newAssets.length > 0) {
-        logger.info(`[LocalAssets] Reconcile prepended ${newAssets.length} new assets`);
-      }
-      return [...newAssets, ...preservedAssets];
-    });
-
-    if (droppedAssetsIds.length > 0) {
-      logger.info(
-        `[LocalAssets] Reconcile dropped ${droppedAssetsIds.length} locally deleted assets: ${droppedAssetsIds.join(', ')}`,
-      );
-      await photosLocalDB.init();
-      await Promise.all(droppedAssetsIds.map((id) => photosLocalDB.deleteAssetSync(id)));
-      setLocalDeletionDetectedCount((prev) => prev + 1);
-    }
-
-    logger.info(`[LocalAssets] Reconciled on foreground — ${page.assets.length} fresh assets`);
-  }, [fetchLocalPage]);
-
-  useEffect(() => {
-    if (!isPhotosEnabled) {
-      setIsLoading(false);
-      setHasLoadedLocalAssetsOnce(true);
-      return;
-    }
-    const loadFirstPage = async () => {
-      try {
-        const page = await fetchLocalPage();
-        applyPage(page, { replace: true });
-        // Eagerly load all remaining pages in background — don't wait for scroll.
-        // Cloud items from history can extend the list far back in time, making
-        // onEndReached fire much later than the user runs out of local assets.
-        if (page.hasNextPage) {
-          loadAllRemainingPages(activeLoadGenerationRef.current);
-        }
-      } finally {
-        setIsLoading(false);
-        setHasLoadedLocalAssetsOnce(true);
-      }
-    };
-    loadFirstPage();
-  }, [isPhotosEnabled]);
+  }, [reloadFromStart]);
 
   useEffect(() => {
     const subscription = AppState.addEventListener('change', (nextState) => {
       if (isPhotosEnabled && appStateRef.current !== 'active' && nextState === 'active') {
-        reconcileOnForeground();
+        reconcileWithDevice();
       }
       appStateRef.current = nextState;
     });
     return () => subscription.remove();
-  }, [reconcileOnForeground, isPhotosEnabled]);
+  }, [reconcileWithDevice, isPhotosEnabled]);
 
   useEffect(() => {
     if (!isPhotosEnabled) {
       return;
     }
-    mediaLibrarySubscriptionRef.current = MediaLibrary.addListener((event) => {
+    const subscription = MediaLibrary.addListener((event) => {
       if (event.hasIncrementalChanges) {
         // iOS: we have the exact set of inserted/deleted/updated assets. Apply without a fetch.
-        applyIncrementalLibraryChange(event);
+        handleIncrementalLibraryChange(event);
       } else {
         // Android (empty event) or iOS large change:
         // debounce to coalesce rapid bursts before fetching.
@@ -299,37 +121,29 @@ export const useLocalAssets = (): LocalAssetsResult => {
         }
         libraryChangeDebounceRef.current = setTimeout(() => {
           libraryChangeDebounceRef.current = null;
-          reconcileOnForeground();
-        }, 400);
+          reconcileWithDevice();
+        }, LIBRARY_CHANGE_DEBOUNCE_MS);
       }
     });
 
     return () => {
-      mediaLibrarySubscriptionRef.current?.remove();
-      mediaLibrarySubscriptionRef.current = null;
+      subscription?.remove();
       if (libraryChangeDebounceRef.current) {
         clearTimeout(libraryChangeDebounceRef.current);
         libraryChangeDebounceRef.current = null;
       }
     };
-  }, [applyIncrementalLibraryChange, reconcileOnForeground, isPhotosEnabled]);
-
-  useEffect(() => {
-    refreshSyncStatusFromDB();
-  }, [refreshSyncStatusFromDB, syncStatus, sessionUploadedAssets, isFetchingCloudHistory]);
-
-  // Re-sort explicitly by the normalized value so the exposed order always matches what's shown.
-  const sortedAssets = useMemo(() => [...assets].sort((a, b) => b.creationTime - a.creationTime), [assets]);
+  }, [handleIncrementalLibraryChange, reconcileWithDevice, isPhotosEnabled]);
 
   return {
-    assets: sortedAssets,
+    assets,
     isLoading,
     hasLoadedLocalAssetsOnce,
     syncedIds,
     cloudDeletedIds,
     uploadingIdSet,
     burstRepresentativeIdSet,
-    incompleteUploadBurstIdSet: incompleteUploadBurstIdSet,
+    incompleteUploadBurstIdSet,
     localDeletionDetectedCount,
     loadNextPage,
     reload: hardReloadAndReconcile,

--- a/src/screens/PhotosScreen/hooks/useLocalAssets.ts
+++ b/src/screens/PhotosScreen/hooks/useLocalAssets.ts
@@ -39,6 +39,7 @@ export const useLocalAssets = (): LocalAssetsResult => {
   const cursorRef = useRef<string | undefined>(undefined);
   const hasMoreRef = useRef(true);
   const isLoadingMoreRef = useRef(false);
+  const activeLoadGenerationRef = useRef(0);
   const appStateRef = useRef(AppState.currentState);
   const mediaLibrarySubscriptionRef = useRef<ReturnType<typeof MediaLibrary.addListener> | null>(null);
   const libraryChangeDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -75,10 +76,14 @@ export const useLocalAssets = (): LocalAssetsResult => {
     if (isLoadingMoreRef.current || !hasMoreRef.current || !cursorRef.current) {
       return;
     }
+    const generation = activeLoadGenerationRef.current;
     isLoadingMoreRef.current = true;
     setIsLoading(true);
     try {
       const page = await fetchLocalPage(cursorRef.current);
+      if (activeLoadGenerationRef.current !== generation) {
+        return;
+      }
       applyPage(page, { replace: false });
     } finally {
       isLoadingMoreRef.current = false;
@@ -86,20 +91,26 @@ export const useLocalAssets = (): LocalAssetsResult => {
     }
   }, [fetchLocalPage, applyPage]);
 
-  const loadAllRemainingPages = useCallback(async () => {
-    if (isLoadingMoreRef.current || !hasMoreRef.current || !cursorRef.current) {
-      return;
-    }
-    isLoadingMoreRef.current = true;
-    try {
-      while (hasMoreRef.current && cursorRef.current) {
-        const page = await fetchLocalPage(cursorRef.current);
-        applyPage(page, { replace: false });
+  const loadAllRemainingPages = useCallback(
+    async (generation: number) => {
+      if (isLoadingMoreRef.current || !hasMoreRef.current || !cursorRef.current) {
+        return;
       }
-    } finally {
-      isLoadingMoreRef.current = false;
-    }
-  }, [fetchLocalPage, applyPage]);
+      isLoadingMoreRef.current = true;
+      try {
+        while (hasMoreRef.current && cursorRef.current && activeLoadGenerationRef.current === generation) {
+          const page = await fetchLocalPage(cursorRef.current);
+          if (activeLoadGenerationRef.current !== generation) {
+            break;
+          }
+          applyPage(page, { replace: false });
+        }
+      } finally {
+        isLoadingMoreRef.current = false;
+      }
+    },
+    [fetchLocalPage, applyPage],
+  );
 
   const refreshSyncStatusFromDB = useCallback(async () => {
     if (assets.length === 0) {
@@ -139,6 +150,7 @@ export const useLocalAssets = (): LocalAssetsResult => {
   }, [debouncedAssetIds]);
 
   const hardReloadAndReconcile = useCallback(async () => {
+    const generation = ++activeLoadGenerationRef.current; // invalidate any in-flight pagination loop
     cursorRef.current = undefined;
     hasMoreRef.current = true;
     isLoadingMoreRef.current = true;
@@ -146,14 +158,24 @@ export const useLocalAssets = (): LocalAssetsResult => {
     const allIds = new Set<string>();
     try {
       let isFirstPage = true;
-      while (isFirstPage || (hasMoreRef.current && cursorRef.current)) {
+      while (
+        activeLoadGenerationRef.current === generation &&
+        (isFirstPage || (hasMoreRef.current && cursorRef.current))
+      ) {
         const page = await fetchLocalPage(isFirstPage ? undefined : cursorRef.current);
+        if (activeLoadGenerationRef.current !== generation) {
+          break;
+        }
         applyPage(page, { replace: isFirstPage });
         page.assets.forEach((a) => allIds.add(a.id));
         isFirstPage = false;
       }
     } finally {
       isLoadingMoreRef.current = false;
+    }
+
+    if (activeLoadGenerationRef.current !== generation) {
+      return; // superseded — cleaning up with a partial id set would drop valid asset_sync entries
     }
 
     logger.info(`[LocalAssets] Reloaded from start — ${allIds.size} total assets`);
@@ -241,7 +263,7 @@ export const useLocalAssets = (): LocalAssetsResult => {
         // Cloud items from history can extend the list far back in time, making
         // onEndReached fire much later than the user runs out of local assets.
         if (page.hasNextPage) {
-          loadAllRemainingPages();
+          loadAllRemainingPages(activeLoadGenerationRef.current);
         }
       } finally {
         setIsLoading(false);

--- a/src/screens/PhotosScreen/hooks/useLocalAssetsSyncStatus.ts
+++ b/src/screens/PhotosScreen/hooks/useLocalAssetsSyncStatus.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import { photosLocalDB } from 'src/services/photos/database/photosLocalDB';
+import { useAppSelector } from 'src/store/hooks';
+
+export interface LocalAssetsSyncStatusResult {
+  syncedIds: Set<string>;
+  cloudDeletedIds: Set<string>;
+  incompleteUploadBurstIdSet: Set<string>;
+}
+
+/**
+ * Backup-status overlay for the local timeline, read from the local photos database.
+ *
+ * @param assetIds - Ids of the currently loaded local assets to look up.
+ * @returns Which of those ids are synced, cloud-deleted, or part of an incomplete burst upload.
+ */
+export const useLocalAssetsSyncStatus = (assetIds: string[]): LocalAssetsSyncStatusResult => {
+  const [syncedIds, setSyncedIds] = useState<Set<string>>(new Set());
+  const [cloudDeletedIds, setCloudDeletedIds] = useState<Set<string>>(new Set());
+  const [incompleteUploadBurstIdSet, setIncompleteUploadBurstIdSet] = useState<Set<string>>(new Set());
+
+  const syncStatus = useAppSelector((state) => state.photos.syncStatus);
+  const sessionUploadedAssets = useAppSelector((state) => state.photos.sessionUploadedAssets);
+  const isFetchingCloudHistory = useAppSelector((state) => state.photos.isFetchingCloudHistory);
+
+  useEffect(() => {
+    if (assetIds.length === 0) {
+      return;
+    }
+    const refreshFromDB = async () => {
+      await photosLocalDB.init();
+      const entries = await photosLocalDB.getSyncedEntries(assetIds);
+      const synced = new Set<string>();
+      const cloudDeleted = new Set<string>();
+      for (const [id, info] of entries) {
+        if (info.status === 'cloud_deleted' || info.status === 'deleted') {
+          cloudDeleted.add(id);
+        } else if (info.status === 'synced') {
+          synced.add(id);
+        } else if (info.status === 'error') {
+          // to not mark as synced, but still track as known asset
+          // leave this to fill if we add a Icon for error state in the future
+        }
+      }
+      setSyncedIds(synced);
+      setCloudDeletedIds(cloudDeleted);
+
+      const incompleteBursts = await photosLocalDB.getIncompleteBurstAssets();
+      setIncompleteUploadBurstIdSet(new Set(incompleteBursts.map((burst) => burst.assetId)));
+    };
+    refreshFromDB();
+  }, [assetIds, syncStatus, sessionUploadedAssets, isFetchingCloudHistory]);
+
+  return { syncedIds, cloudDeletedIds, incompleteUploadBurstIdSet };
+};

--- a/src/screens/PhotosScreen/hooks/usePagedLocalAssets.ts
+++ b/src/screens/PhotosScreen/hooks/usePagedLocalAssets.ts
@@ -1,0 +1,257 @@
+import * as MediaLibrary from 'expo-media-library';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { logger } from 'src/services/common';
+import {
+  isPlausibleAssetTimestamp,
+  normalizeAssetCreationTime,
+} from 'src/services/photos/utils/resolveAssetCreationTime';
+
+const PAGE_SIZE = 1000;
+const MEDIA_TYPES = [MediaLibrary.MediaType.photo, MediaLibrary.MediaType.video];
+
+export interface LocalLibraryChange {
+  inserted: MediaLibrary.Asset[];
+  updated: MediaLibrary.Asset[];
+  deletedIds: string[];
+}
+
+interface AssetEntry {
+  asset: MediaLibrary.Asset;
+  rawCreationTime: number;
+}
+
+interface LocalAssetsPage {
+  assetEntries: AssetEntry[];
+  hasNextPage: boolean;
+  endCursor: string | undefined;
+}
+
+export interface PagedLocalAssetsResult {
+  assets: MediaLibrary.Asset[];
+  isLoading: boolean;
+  hasLoadedLocalAssetsOnce: boolean;
+  loadNextPage: () => void;
+  reloadFromStart: () => Promise<Set<string> | undefined>;
+  reconcileHead: () => Promise<string[]>;
+  applyLibraryChange: (change: LocalLibraryChange) => void;
+}
+
+interface PaginationState {
+  runId: number;
+  cursor: string | undefined;
+  hasMore: boolean;
+  isRunning: boolean;
+}
+
+interface LoadRunOptions {
+  restart: boolean;
+  maxPages?: number;
+}
+
+/**
+ * Owns the collection of device photo/video assets and its pagination.
+ *
+ * @param isEnabled - Whether the device media library should be read at all.
+ * @returns The current assets plus controls to page, reload, and reconcile them.
+ */
+export const usePagedLocalAssets = (isEnabled: boolean): PagedLocalAssetsResult => {
+  const [assetMap, setAssetMap] = useState<Map<string, AssetEntry>>(new Map());
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasLoadedLocalAssetsOnce, setHasLoadedLocalAssetsOnce] = useState(false);
+  const paginationRef = useRef<PaginationState>({ runId: 0, cursor: undefined, hasMore: true, isRunning: false });
+
+  const fetchLocalPage = useCallback(async (after?: string): Promise<LocalAssetsPage> => {
+    const page = await MediaLibrary.getAssetsAsync({
+      first: PAGE_SIZE,
+      after,
+      mediaType: MEDIA_TYPES,
+      sortBy: [[MediaLibrary.SortBy.creationTime, false]],
+    });
+    return {
+      assetEntries: page.assets.map((asset) => ({
+        asset: normalizeAssetCreationTime(asset),
+        rawCreationTime: asset.creationTime,
+      })),
+      hasNextPage: page.hasNextPage,
+      endCursor: page.endCursor,
+    };
+  }, []);
+
+  /**
+   * Loads pages sequentially into the asset map.
+   *
+   * @param restart - Whether to discard the current cursor and load from the first page again.
+   * @param maxPages - Maximum number of pages to load in this run; unbounded when omitted.
+   * @returns The ids loaded by this run, or undefined when the run was superseded by a newer restart.
+   */
+  const runLoadPages = useCallback(
+    async ({ restart, maxPages }: LoadRunOptions): Promise<Set<string> | undefined> => {
+      const pagination = paginationRef.current;
+      if (restart) {
+        pagination.runId += 1;
+        pagination.cursor = undefined;
+        pagination.hasMore = true;
+      } else if (pagination.isRunning || !pagination.hasMore || !pagination.cursor) {
+        return undefined;
+      }
+      const runId = pagination.runId;
+      pagination.isRunning = true;
+      const loadedIds = new Set<string>();
+      let isFirstPage = restart;
+      let loadedPages = 0;
+      try {
+        while (
+          pagination.runId === runId &&
+          (isFirstPage || (pagination.hasMore && pagination.cursor !== undefined)) &&
+          (maxPages === undefined || loadedPages < maxPages)
+        ) {
+          const page = await fetchLocalPage(isFirstPage ? undefined : pagination.cursor);
+          if (pagination.runId !== runId) {
+            return undefined;
+          }
+          pagination.cursor = page.hasNextPage ? page.endCursor : undefined;
+          pagination.hasMore = page.hasNextPage;
+          const replace = isFirstPage; // captured: the updater may run after isFirstPage is mutated below
+          setAssetMap((prev) => {
+            const next = replace ? new Map<string, AssetEntry>() : new Map(prev);
+            for (const assetEntry of page.assetEntries) {
+              next.set(assetEntry.asset.id, assetEntry);
+            }
+            return next;
+          });
+          for (const assetEntry of page.assetEntries) {
+            loadedIds.add(assetEntry.asset.id);
+          }
+          isFirstPage = false;
+          loadedPages += 1;
+        }
+        return pagination.runId === runId ? loadedIds : undefined;
+      } finally {
+        if (pagination.runId === runId) {
+          pagination.isRunning = false;
+        }
+      }
+    },
+    [fetchLocalPage],
+  );
+
+  const loadNextPage = useCallback(async () => {
+    const pagination = paginationRef.current;
+    if (pagination.isRunning || !pagination.hasMore || !pagination.cursor) {
+      return;
+    }
+    setIsLoading(true);
+    try {
+      await runLoadPages({ restart: false, maxPages: 1 });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [runLoadPages]);
+
+  const reloadFromStart = useCallback(() => runLoadPages({ restart: true }), [runLoadPages]);
+
+  const reconcileHead = useCallback(async (): Promise<string[]> => {
+    const page = await fetchLocalPage();
+    if (page.assetEntries.length === 0) {
+      return [];
+    }
+
+    const freshIds = new Set(page.assetEntries.map((e) => e.asset.id));
+    const headMinRawTime = Math.min(...page.assetEntries.map((e) => e.rawCreationTime));
+    // Corrupted raw times (e.g. Android DATE_TAKEN = 0) sort outside the fetched pages,
+    // so an unreliable lower bound would falsely mark them as deleted. Skip windowing;
+    // the full reload catches real deletions.
+    const isWindowReliable = isPlausibleAssetTimestamp(headMinRawTime);
+
+    let droppedAssetIds: string[] = [];
+    setAssetMap((prev) => {
+      const next = new Map(prev);
+      const dropped: string[] = [];
+      if (isWindowReliable) {
+        for (const [id, assetEntry] of prev) {
+          if (assetEntry.rawCreationTime >= headMinRawTime && !freshIds.has(id)) {
+            next.delete(id);
+            dropped.push(id);
+          }
+        }
+      }
+      let prependedCount = 0;
+      for (const assetEntry of page.assetEntries) {
+        if (!next.has(assetEntry.asset.id)) {
+          prependedCount += 1;
+        }
+        next.set(assetEntry.asset.id, assetEntry);
+      }
+      if (prependedCount > 0) {
+        logger.info(`[LocalAssets] Reconcile prepended ${prependedCount} new assets`);
+      }
+      droppedAssetIds = dropped;
+      return next;
+    });
+
+    logger.info(`[LocalAssets] Reconciled head window — ${page.assetEntries.length} fresh assets`);
+    return droppedAssetIds;
+  }, [fetchLocalPage]);
+
+  const applyLibraryChange = useCallback(({ inserted, updated, deletedIds }: LocalLibraryChange) => {
+    setAssetMap((prev) => {
+      const next = new Map(prev);
+      for (const id of deletedIds) {
+        next.delete(id);
+      }
+      for (const asset of updated) {
+        if (next.has(asset.id)) {
+          next.set(asset.id, { asset, rawCreationTime: asset.creationTime });
+        }
+      }
+      let insertedCount = 0;
+      for (const asset of inserted) {
+        if (!next.has(asset.id)) {
+          insertedCount += 1;
+        }
+        next.set(asset.id, { asset, rawCreationTime: asset.creationTime });
+      }
+      if (insertedCount > 0) {
+        logger.info(`[LocalAssets] Library change: prepending ${insertedCount} new assets`);
+      }
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!isEnabled) {
+      setIsLoading(false);
+      setHasLoadedLocalAssetsOnce(true);
+      return;
+    }
+    const loadInitialPages = async () => {
+      try {
+        await runLoadPages({ restart: true, maxPages: 1 });
+      } finally {
+        setIsLoading(false);
+        setHasLoadedLocalAssetsOnce(true);
+      }
+      // Eagerly load all remaining pages in background — don't wait for scroll.
+      // Cloud items from history can extend the list far back in time, making
+      // onEndReached fire much later than the user runs out of local assets.
+      runLoadPages({ restart: false });
+    };
+    loadInitialPages();
+  }, [isEnabled]);
+
+  // Re-sort explicitly by the normalized value so the exposed order always matches what's shown.
+  const assets = useMemo(
+    () => [...assetMap.values()].map((e) => e.asset).sort((a, b) => b.creationTime - a.creationTime),
+    [assetMap],
+  );
+
+  return {
+    assets,
+    isLoading,
+    hasLoadedLocalAssetsOnce,
+    loadNextPage,
+    reloadFromStart,
+    reconcileHead,
+    applyLibraryChange,
+  };
+};


### PR DESCRIPTION
Fix duplicated and falsely deleted local Photos by splitting useLocalAssets and reworking pagination state.

  ## Summary

  - **`usePagedLocalAssets`**: new hook, extracted from `useLocalAssets`, owns device asset pagination. Assets are now keyed by id in a `Map`, so re-applying a page can never produce duplicates (the original bug). Also fixes assets with a corrupted creation time (e.g. WhatsApp, `DATE_TAKEN = 0`) being wrongly flagged as locally deleted during the foreground reconcile. Each asset now have a field with its raw creation time alongside itself in a single `AssetEntry`, and the reconcile window is measured against that raw value instead of the normalized one, skipping the drop pass entirely when the window's own lower bound is unreliable.
  - **`useLocalAssetsSyncStatus`**: new hook, extracted from `useLocalAssets`, owns the backup-status overlay read from the local photos database.
  - **`useBurstRepresentatives`**: new hook, extracted from `useLocalAssets`, resolves burst representative ids.
  - **`useLocalAssets`**: now just composes the three hooks above.