### PR TITLE
PB-6498] bugfix/Changed lock flow and persist photos device id

### DIFF
--- a/src/screens/PhotosScreen/index.tsx
+++ b/src/screens/PhotosScreen/index.tsx
@@ -119,7 +119,18 @@ const PhotosScreen = (): JSX.Element => {
 
   const handleSelectPress = useCallback(() => selection.enterSelectMode(), [selection]);
 
-  const handleEnableBackup = useCallback(() => setIsEnableBackupSheetOpen(true), []);
+  const handleEnableBackup = useCallback(() => {
+    if (!hasAccess) {
+      return;
+    }
+    setIsEnableBackupSheetOpen(true);
+  }, [hasAccess]);
+
+  useEffect(() => {
+    if (!hasAccess && isEnableBackupSheetOpen) {
+      setIsEnableBackupSheetOpen(false);
+    }
+  }, [hasAccess, isEnableBackupSheetOpen]);
 
   const handleSelectMorePhotos = useSelectMorePhotos(reloadLocal);
 
@@ -206,7 +217,7 @@ const PhotosScreen = (): JSX.Element => {
         dispatch(runBackupCycleThunk());
       }
 
-      if (!enabled) {
+      if (!enabled && hasAccess) {
         setIsEnableBackupSheetOpen(true);
       }
 
@@ -215,7 +226,7 @@ const PhotosScreen = (): JSX.Element => {
         lastViewedIdRef.current = null;
         timelineRef.current?.scrollToAssetId(id);
       }
-    }, [enabled]),
+    }, [enabled, hasAccess]),
   );
 
   return (

--- a/src/services/AsyncStorageService.ts
+++ b/src/services/AsyncStorageService.ts
@@ -9,7 +9,6 @@ const SENSITIVE_KEYS = [
   AsyncStorageKey.PhotosToken,
   AsyncStorageKey.User,
   AsyncStorageKey.ThemePreference,
-  AsyncStorageKey.PhotosDeviceId,
 ];
 
 class AsyncStorageService {
@@ -129,6 +128,9 @@ class AsyncStorageService {
         AsyncStorageKey.PhotosSettings,
         AsyncStorageKey.PhotosDiscoverSeen,
         AsyncStorageKey.PhotosDevicesCache,
+        AsyncStorageKey.PhotosAccessCache,
+        AsyncStorageKey.LastUpdatedAt,
+        AsyncStorageKey.IsDeletingAccount,
       ];
 
       await AsyncStorage.multiRemove(nonSensitiveKeys);

--- a/src/services/common/httpStatusCodes.ts
+++ b/src/services/common/httpStatusCodes.ts
@@ -1,6 +1,7 @@
 export const HTTP_BAD_REQUEST = 400;
 export const HTTP_UNAUTHORIZED = 401;
 export const HTTP_PAYMENT_REQUIRED = 402;
+export const HTTP_FORBIDDEN = 403;
 export const HTTP_NOT_FOUND = 404;
 export const HTTP_CONFLICT = 409;
 export const HTTP_QUOTA_EXCEEDED = 420;

--- a/src/services/photos/PhotoDeviceId.spec.ts
+++ b/src/services/photos/PhotoDeviceId.spec.ts
@@ -1,8 +1,11 @@
+import { AxiosResponseError } from '@internxt/sdk/dist/shared/types/errors';
 import * as Application from 'expo-application';
 import { Platform } from 'react-native';
+import asyncStorageService from 'src/services/AsyncStorageService';
 import secureStorageService from 'src/services/SecureStorageService';
 import { PhotoDeviceNameConflictError } from './errors';
 import { PhotoDeviceManager } from './PhotoDeviceId';
+import { photoDeviceIdentityStore } from './PhotoDeviceIdentityStore';
 import { photosDeviceService } from './photosDeviceService';
 
 jest.mock('expo-application', () => ({
@@ -28,6 +31,13 @@ jest.mock('src/services/SecureStorageService', () => ({
   },
 }));
 
+jest.mock('src/services/AsyncStorageService', () => ({
+  __esModule: true,
+  default: {
+    getUser: jest.fn(),
+  },
+}));
+
 jest.mock('./photosDeviceService', () => ({
   photosDeviceService: {
     getDevice: jest.fn(),
@@ -36,12 +46,26 @@ jest.mock('./photosDeviceService', () => ({
   },
 }));
 
+jest.mock('./PhotoDeviceIdentityStore', () => ({
+  PHOTOS_DEVICE_KEY: 'photos-device-key',
+  photoDeviceIdentityStore: {
+    getValidFor: jest.fn(),
+    save: jest.fn(),
+    clearAccount: jest.fn(),
+    clearAll: jest.fn(),
+  },
+}));
+
 const mockGetItem = secureStorageService.getItem as jest.Mock;
 const mockSetItem = secureStorageService.setItem as jest.Mock;
+const mockGetUser = asyncStorageService.getUser as jest.Mock;
 const mockGetDevice = photosDeviceService.getDevice as jest.Mock;
 const mockCreateDevice = photosDeviceService.createDevice as jest.Mock;
 const mockListDevices = photosDeviceService.listDevices as jest.Mock;
 const mockGetAndroidId = Application.getAndroidId as jest.Mock;
+const mockGetValidFor = photoDeviceIdentityStore.getValidFor as jest.Mock;
+const mockSaveIdentity = photoDeviceIdentityStore.save as jest.Mock;
+const mockClearAccount = photoDeviceIdentityStore.clearAccount as jest.Mock;
 
 const setPlatform = (os: 'android' | 'ios') =>
   Object.defineProperty(Platform, 'OS', { value: os, writable: true, configurable: true });
@@ -53,53 +77,84 @@ const makeDevice = (plainName: string) => ({
   status: 'EXISTS' as const,
 });
 
+const CURRENT_USER_EMAIL = 'user@internxt.com';
+
 beforeEach(() => {
   jest.clearAllMocks();
   mockSetItem.mockResolvedValue(undefined);
+  mockGetUser.mockResolvedValue({ email: CURRENT_USER_EMAIL });
+  mockGetValidFor.mockResolvedValue(null);
   setPlatform('android');
 });
 
-describe('PhotoDeviceManager.ensureDeviceFolder', () => {
-  describe('when a folder uuid is stored in secure storage', () => {
-    test('when the stored folder still exists, then it is returned without creating a new one', async () => {
-      mockGetItem.mockResolvedValue('folder-uuid-123');
-      mockGetDevice.mockResolvedValue(makeDevice('test-android-id'));
-
-      const result = await PhotoDeviceManager.ensureDeviceFolder();
-
-      expect(result).toEqual({ deviceId: 'folder-uuid-123', plainName: 'test-android-id', bucket: 'photos-bucket' });
-      expect(mockCreateDevice).not.toHaveBeenCalled();
-      expect(mockSetItem).not.toHaveBeenCalled();
+describe('PhotoDeviceManager.ensureDeviceFolder — stored identity', () => {
+  test('when a stored identity matches the current account email and device model, then the device folder is reused without creating a new one', async () => {
+    mockGetValidFor.mockResolvedValue({
+      deviceId: 'folder-uuid-123',
+      email: CURRENT_USER_EMAIL,
+      model: 'Internxt iPhone',
     });
+    mockGetDevice.mockResolvedValue(makeDevice('test-android-id'));
 
-    test('when the stored folder has been deleted on the backend, then a new one is created by device key', async () => {
-      mockGetItem.mockResolvedValue('folder-uuid-old');
-      mockGetDevice.mockResolvedValue({ ...makeDevice('test-android-id'), uuid: 'folder-uuid-old', status: 'DELETED' });
-      mockCreateDevice.mockResolvedValue(makeDevice('Internxt iPhone (test-android-id)'));
+    const result = await PhotoDeviceManager.ensureDeviceFolder();
 
-      const result = await PhotoDeviceManager.ensureDeviceFolder();
-
-      expect(result.deviceId).toBe('folder-uuid-123');
-      expect(mockCreateDevice).toHaveBeenCalledWith('Internxt iPhone (test-android-id)');
-      expect(mockSetItem).toHaveBeenCalledWith(expect.any(String), 'folder-uuid-123');
-    });
-
-    test('when the stored folder is not found on the backend, then a new one is created by device key', async () => {
-      mockGetItem.mockResolvedValue('folder-uuid-gone');
-      mockGetDevice.mockResolvedValue(null);
-      mockCreateDevice.mockResolvedValue(makeDevice('Internxt iPhone (test-android-id)'));
-
-      await PhotoDeviceManager.ensureDeviceFolder();
-
-      expect(mockCreateDevice).toHaveBeenCalledWith('Internxt iPhone (test-android-id)');
+    expect(result).toEqual({ deviceId: 'folder-uuid-123', plainName: 'test-android-id', bucket: 'photos-bucket' });
+    expect(mockCreateDevice).not.toHaveBeenCalled();
+    expect(mockGetValidFor).toHaveBeenCalledWith(CURRENT_USER_EMAIL, 'Internxt iPhone');
+    expect(mockSaveIdentity).toHaveBeenCalledWith({
+      deviceId: 'folder-uuid-123',
+      email: CURRENT_USER_EMAIL,
+      model: 'Internxt iPhone',
     });
   });
 
-  describe('when no folder uuid is stored on Android', () => {
-    beforeEach(() => {
-      setPlatform('android');
-      mockGetItem.mockResolvedValue(null);
+  test('when the store reports no identity valid for the current account/hardware, then it is treated as absent and a new device folder is created', async () => {
+    mockGetValidFor.mockResolvedValue(null);
+    mockCreateDevice.mockResolvedValue(makeDevice('Internxt iPhone (test-android-id)'));
+
+    const result = await PhotoDeviceManager.ensureDeviceFolder();
+
+    expect(mockCreateDevice).toHaveBeenCalledWith('Internxt iPhone (test-android-id)');
+    expect(result.deviceId).toBe('folder-uuid-123');
+  });
+
+  test('when the stored device has been deleted on the backend, then a new one is created by device key', async () => {
+    mockGetValidFor.mockResolvedValue({
+      deviceId: 'folder-uuid-old',
+      email: CURRENT_USER_EMAIL,
+      model: 'Internxt iPhone',
     });
+    mockGetDevice.mockResolvedValue({ ...makeDevice('test-android-id'), uuid: 'folder-uuid-old', status: 'DELETED' });
+    mockCreateDevice.mockResolvedValue(makeDevice('Internxt iPhone (test-android-id)'));
+
+    const result = await PhotoDeviceManager.ensureDeviceFolder();
+
+    expect(result.deviceId).toBe('folder-uuid-123');
+    expect(mockCreateDevice).toHaveBeenCalledWith('Internxt iPhone (test-android-id)');
+  });
+
+  test('when reusing a stored device returns 403, then the stored identity is cleared and a new device folder is created', async () => {
+    mockGetValidFor.mockResolvedValue({
+      deviceId: 'folder-uuid-other-user',
+      email: CURRENT_USER_EMAIL,
+      model: 'Internxt iPhone',
+    });
+    mockGetDevice.mockRejectedValue(
+      new AxiosResponseError('Forbidden', 'GET /photos/devices/:uuid', { status: 403 } as never),
+    );
+    mockCreateDevice.mockResolvedValue(makeDevice('Internxt iPhone (test-android-id)'));
+
+    const result = await PhotoDeviceManager.ensureDeviceFolder();
+
+    expect(mockClearAccount).toHaveBeenCalledWith(CURRENT_USER_EMAIL);
+    expect(mockCreateDevice).toHaveBeenCalledWith('Internxt iPhone (test-android-id)');
+    expect(result.deviceId).toBe('folder-uuid-123');
+  });
+});
+
+describe('PhotoDeviceManager.ensureDeviceFolder — no identity to reuse', () => {
+  describe('on Android', () => {
+    beforeEach(() => setPlatform('android'));
 
     test('when no folder exists yet, then a new device folder is created using the device name and the android hardware id', async () => {
       mockCreateDevice.mockResolvedValue(makeDevice('Internxt iPhone (test-android-id)'));
@@ -112,7 +167,11 @@ describe('PhotoDeviceManager.ensureDeviceFolder', () => {
         bucket: 'photos-bucket',
       });
       expect(mockCreateDevice).toHaveBeenCalledWith('Internxt iPhone (test-android-id)');
-      expect(mockSetItem).toHaveBeenCalledWith(expect.any(String), 'folder-uuid-123');
+      expect(mockSaveIdentity).toHaveBeenCalledWith({
+        deviceId: 'folder-uuid-123',
+        email: CURRENT_USER_EMAIL,
+        model: 'Internxt iPhone',
+      });
     });
 
     test('when creation returns 409, then the existing folder matching the android hardware id is adopted', async () => {
@@ -126,7 +185,11 @@ describe('PhotoDeviceManager.ensureDeviceFolder', () => {
         plainName: 'Internxt iPhone (test-android-id)',
         bucket: 'photos-bucket',
       });
-      expect(mockSetItem).toHaveBeenCalledWith(expect.any(String), 'folder-uuid-123');
+      expect(mockSaveIdentity).toHaveBeenCalledWith({
+        deviceId: 'folder-uuid-123',
+        email: CURRENT_USER_EMAIL,
+        model: 'Internxt iPhone',
+      });
     });
 
     test('when creation returns 409 and the remote device name has a different model but contains the same hardware id, then it is adopted anyway', async () => {
@@ -136,7 +199,6 @@ describe('PhotoDeviceManager.ensureDeviceFolder', () => {
       const result = await PhotoDeviceManager.ensureDeviceFolder();
 
       expect(result.plainName).toBe('Old Model Name (test-android-id)');
-      expect(mockSetItem).toHaveBeenCalledWith(expect.any(String), 'folder-uuid-123');
     });
 
     test('when creation returns 409 but no folder matches the android hardware id, then the error is rethrown', async () => {
@@ -154,11 +216,8 @@ describe('PhotoDeviceManager.ensureDeviceFolder', () => {
     });
   });
 
-  describe('when no folder uuid is stored on iOS', () => {
-    beforeEach(() => {
-      setPlatform('ios');
-      mockGetItem.mockResolvedValue(null);
-    });
+  describe('on iOS', () => {
+    beforeEach(() => setPlatform('ios'));
 
     test('when no folder exists yet, then a new device folder is created using the model name and the identifierForVendor', async () => {
       mockCreateDevice.mockResolvedValue(makeDevice('iPhone 15 (test-idfv)'));
@@ -176,7 +235,7 @@ describe('PhotoDeviceManager.ensureDeviceFolder', () => {
       const result = await PhotoDeviceManager.ensureDeviceFolder();
 
       expect(result.deviceId).toBe('folder-uuid-123');
-      expect(mockSetItem).toHaveBeenCalledWith(expect.any(String), 'folder-uuid-123');
+      expect(mockSaveIdentity).toHaveBeenCalled();
     });
   });
 
@@ -184,11 +243,10 @@ describe('PhotoDeviceManager.ensureDeviceFolder', () => {
     beforeEach(() => {
       setPlatform('android');
       mockGetAndroidId.mockReturnValue(null);
-      // mockGetItem: first call for PhotosDeviceId (null), second call for PhotosDeviceKey (null)
-      mockGetItem.mockResolvedValue(null);
     });
 
     test('when no device key is stored either, then a uuid is generated, persisted and used as device key', async () => {
+      mockGetItem.mockResolvedValue(null);
       mockCreateDevice.mockResolvedValue(makeDevice('Internxt iPhone (generated-uuid-fallback)'));
 
       await PhotoDeviceManager.ensureDeviceFolder();
@@ -198,9 +256,7 @@ describe('PhotoDeviceManager.ensureDeviceFolder', () => {
     });
 
     test('when a previously generated key is already stored, then it is reused without generating a new one', async () => {
-      mockGetItem
-        .mockResolvedValueOnce(null) // PhotosDeviceId
-        .mockResolvedValueOnce('previously-generated-key'); // PhotosDeviceKey
+      mockGetItem.mockResolvedValue('previously-generated-key');
       mockCreateDevice.mockResolvedValue(makeDevice('Internxt iPhone (previously-generated-key)'));
 
       await PhotoDeviceManager.ensureDeviceFolder();
@@ -213,8 +269,6 @@ describe('PhotoDeviceManager.ensureDeviceFolder', () => {
 
 describe('PhotoDeviceManager concurrent calls', () => {
   test('when ensureDeviceFolder is called twice before the first resolves, then the backend is only called once and both callers receive the same result', async () => {
-    mockGetItem.mockResolvedValue(null);
-
     let resolveCreate!: (device: ReturnType<typeof makeDevice>) => void;
     mockCreateDevice.mockReturnValue(
       new Promise((r) => {

--- a/src/services/photos/PhotoDeviceId.ts
+++ b/src/services/photos/PhotoDeviceId.ts
@@ -1,29 +1,32 @@
 import { PhotoDevice } from '@internxt/sdk/dist/drive/photos';
+import { AxiosResponseError } from '@internxt/sdk/dist/shared/types/errors';
 import * as Application from 'expo-application';
 import * as Device from 'expo-device';
 import { Platform } from 'react-native';
 import uuid from 'react-native-uuid';
+import asyncStorageService from 'src/services/AsyncStorageService';
 import { logger } from 'src/services/common';
+import { HTTP_FORBIDDEN } from 'src/services/common/httpStatusCodes';
 import secureStorageService from 'src/services/SecureStorageService';
-import { AsyncStorageKey } from 'src/types';
 import { PhotoDeviceNameConflictError } from './errors';
+import { PHOTOS_DEVICE_KEY, photoDeviceIdentityStore } from './PhotoDeviceIdentityStore';
 import { photosDeviceService } from './photosDeviceService';
 
 const TAG = '[PhotoDeviceManager]';
 
 export interface PhotoDeviceInfo {
   deviceId: string;
-  plainName: string; // device key used as backend name
+  plainName: string;
   bucket: string;
 }
 
 const getOrGenerateFallbackKey = async (): Promise<string> => {
-  const stored = await secureStorageService.getItem(AsyncStorageKey.PhotosDeviceKey);
+  const stored = await secureStorageService.getItem(PHOTOS_DEVICE_KEY);
   if (stored) {
     return stored;
   }
   const generated = uuid.v4() as string;
-  await secureStorageService.setItem(AsyncStorageKey.PhotosDeviceKey, generated);
+  await secureStorageService.setItem(PHOTOS_DEVICE_KEY, generated);
   logger.warn(TAG, `No stable device key available — generated fallback key=${generated}`);
   return generated;
 };
@@ -33,6 +36,8 @@ const getOrGenerateFallbackKey = async (): Promise<string> => {
  * - Android: androidId
  * - iOS: identifierForVendor
  * - Fallback: UUID generated once and persisted in SecureStorage
+ *
+ * @returns The device's unique identifier.
  */
 const getDeviceUniqueId = async (): Promise<string> => {
   if (Platform.OS === 'android') {
@@ -57,8 +62,6 @@ const buildDeviceKey = (uniqueId: string): string => {
   return displayName ? `${displayName} (${uniqueId})` : uniqueId;
 };
 
-const storeDevice = (uuid: string): Promise<void> => secureStorageService.setItem(AsyncStorageKey.PhotosDeviceId, uuid);
-
 const parseDeviceInfo = (device: PhotoDevice): PhotoDeviceInfo => ({
   deviceId: device.uuid,
   plainName: device.plainName,
@@ -67,13 +70,19 @@ const parseDeviceInfo = (device: PhotoDevice): PhotoDeviceInfo => ({
 
 /**
  * Ensures the current device has a folder in the Photos bucket.
- * - iOS: Keychain survives uninstall → uuid is recovered directly.
- * - Android: EncryptedSharedPreferences is wiped on uninstall, device is re-identified
- *   by androidId (stable hardware key); on a 409 the existing folder is adopted by key.
+ * - Same email + same model = reuse the folder.
+ * - Different email or different model = the stored identity is discarded, falls through to create.
  */
 class PhotoDeviceManagerService {
   private pendingDeviceFolder: Promise<PhotoDeviceInfo> | null = null;
 
+  /**
+   * Ensures the current device has a folder in the Photos bucket, creating one if needed.
+   * Concurrent calls while a resolution is in flight share the same result instead of
+   * triggering duplicate backend calls.
+   *
+   * @returns The resolved device folder info.
+   */
   ensureDeviceFolder(): Promise<PhotoDeviceInfo> {
     if (this.pendingDeviceFolder) {
       return this.pendingDeviceFolder;
@@ -84,26 +93,32 @@ class PhotoDeviceManagerService {
     return this.pendingDeviceFolder;
   }
 
+  /**
+   * Resolves the device folder: reuses a stored identity valid for the current account
+   * if one exists and still exists on the backend, otherwise creates a new folder.
+   *
+   * @returns The resolved device folder info.
+   */
   private async resolveDeviceFolder(): Promise<PhotoDeviceInfo> {
-    const storedUuid = await secureStorageService.getItem(AsyncStorageKey.PhotosDeviceId);
+    const currentEmail = (await asyncStorageService.getUser())?.email;
+    const currentModel = getDisplayName();
+    logger.info(TAG, `Resolving device folder for email=${currentEmail ?? 'unknown'} model="${currentModel}"`);
 
-    if (storedUuid) {
-      const existingDevice = await photosDeviceService.getDevice(storedUuid);
-      if (existingDevice?.status === 'EXISTS') {
-        logger.info(
-          TAG,
-          `Reusing device folder uuid=${existingDevice.uuid} key="${existingDevice.plainName}" bucket=${existingDevice.bucket}`,
-        );
-        return parseDeviceInfo(existingDevice);
+    const deviceIdentity = await photoDeviceIdentityStore.getValidFor(currentEmail, currentModel);
+    if (deviceIdentity) {
+      const reused = await this.tryReuseCandidate(deviceIdentity.deviceId, currentEmail, currentModel);
+      if (reused) {
+        return reused;
       }
-      logger.warn(TAG, `Stored uuid=${storedUuid} not found or DELETED — recreating by key`);
+    } else {
+      logger.info(TAG, 'No stored identity to reuse — creating device folder from scratch');
     }
 
     const uniqueId = await getDeviceUniqueId();
     const deviceKey = buildDeviceKey(uniqueId);
     try {
       const createdDevice = await photosDeviceService.createDevice(deviceKey);
-      await storeDevice(createdDevice.uuid);
+      await this.persistIdentity(createdDevice.uuid, currentEmail, currentModel);
       logger.info(
         TAG,
         `Created device folder uuid=${createdDevice.uuid} key="${createdDevice.plainName}" bucket=${createdDevice.bucket}`,
@@ -115,13 +130,73 @@ class PhotoDeviceManagerService {
         const devices = await photosDeviceService.listDevices();
         const device = devices.find((device) => device.plainName.includes(uniqueId) && device.status === 'EXISTS');
         if (device) {
-          await storeDevice(device.uuid);
+          await this.persistIdentity(device.uuid, currentEmail, currentModel);
           logger.info(TAG, `Adopted device folder uuid=${device.uuid} bucket=${device.bucket}`);
           return parseDeviceInfo(device);
         }
       }
       throw err;
     }
+  }
+
+  /**
+   * Attempts to reuse a candidate device folder uuid by checking it still exists on the
+   * backend. On success, re-persists the identity for the current account. On a 403,
+   * clears the stored identity for the current account.
+   *
+   * @param candidateUuid - Backend device folder uuid to verify and reuse.
+   * @param currentEmail - Email of the currently logged-in account, or undefined if unknown.
+   * @param currentModel - Display name of the current device, or null if unknown.
+   * @returns The reused device folder info, or null if the candidate can't be reused.
+   */
+  private async tryReuseCandidate(
+    candidateUuid: string,
+    currentEmail: string | undefined,
+    currentModel: string | null,
+  ): Promise<PhotoDeviceInfo | null> {
+    try {
+      const existingDevice = await photosDeviceService.getDevice(candidateUuid);
+      if (existingDevice?.status === 'EXISTS') {
+        await this.persistIdentity(existingDevice.uuid, currentEmail, currentModel);
+        logger.info(
+          TAG,
+          `Reusing device folder uuid=${existingDevice.uuid} key="${existingDevice.plainName}" bucket=${existingDevice.bucket}`,
+        );
+        return parseDeviceInfo(existingDevice);
+      }
+      logger.warn(TAG, `Candidate uuid=${candidateUuid} not found or DELETED — recreating by key`);
+      return null;
+    } catch (err) {
+      if (err instanceof AxiosResponseError && err.status === HTTP_FORBIDDEN) {
+        logger.warn(TAG, `getDevice 403 for uuid=${candidateUuid} — device belongs to another account, clearing`);
+        if (currentEmail) {
+          await photoDeviceIdentityStore.clearAccount(currentEmail);
+        }
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Saves the identity binding this device folder to the current account. No-op if
+   * there is no current account email to key the entry by.
+   *
+   * @param deviceId - Backend device folder uuid to persist.
+   * @param currentEmail - Email of the currently logged-in account, or undefined if unknown.
+   * @param currentModel - Display name of the current device, or null if unknown.
+   * @returns A promise that resolves once the identity has been persisted (or skipped).
+   */
+  private async persistIdentity(
+    deviceId: string,
+    currentEmail: string | undefined,
+    currentModel: string | null,
+  ): Promise<void> {
+    if (!currentEmail) {
+      logger.warn(TAG, `No current account email available — skipping identity persistence for uuid=${deviceId}`);
+      return;
+    }
+    await photoDeviceIdentityStore.save({ deviceId, email: currentEmail, model: currentModel ?? '' });
   }
 }
 

--- a/src/services/photos/PhotoDeviceIdentityStore.spec.ts
+++ b/src/services/photos/PhotoDeviceIdentityStore.spec.ts
@@ -1,0 +1,138 @@
+import secureStorageService from 'src/services/SecureStorageService';
+import { photoDeviceIdentityStore } from './PhotoDeviceIdentityStore';
+
+jest.mock('src/services/SecureStorageService', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
+const mockGetItem = secureStorageService.getItem as jest.Mock;
+const mockSetItem = secureStorageService.setItem as jest.Mock;
+const mockRemoveItem = secureStorageService.removeItem as jest.Mock;
+
+const identityA = { deviceId: 'folder-uuid-a', email: 'a@internxt.com', model: 'iPhone 15' };
+const identityB = { deviceId: 'folder-uuid-b', email: 'b@internxt.com', model: 'iPhone 15' };
+const identityC = { deviceId: 'folder-uuid-c', email: 'c@internxt.com', model: 'iPhone 15' };
+const identityD = { deviceId: 'folder-uuid-d', email: 'd@internxt.com', model: 'iPhone 15' };
+
+const setStoredEntries = (entries: unknown[]) => mockGetItem.mockResolvedValue(JSON.stringify(entries));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('PhotoDeviceIdentityStore.getValidFor', () => {
+  test('when the stored entry for this account matches the current model, then it is returned', async () => {
+    setStoredEntries([identityA]);
+
+    const result = await photoDeviceIdentityStore.getValidFor('a@internxt.com', 'iPhone 15');
+
+    expect(result).toEqual(identityA);
+  });
+
+  test('when there is no entry for the current account, then null is returned without touching other accounts', async () => {
+    setStoredEntries([identityB]);
+
+    const result = await photoDeviceIdentityStore.getValidFor('a@internxt.com', 'iPhone 15');
+
+    expect(result).toBeNull();
+    expect(mockSetItem).not.toHaveBeenCalled();
+    expect(mockRemoveItem).not.toHaveBeenCalled();
+  });
+
+  test('when the stored entry for this account has a different device model, then it is discarded and null is returned, leaving other accounts untouched', async () => {
+    setStoredEntries([identityA, identityB]);
+
+    const result = await photoDeviceIdentityStore.getValidFor('a@internxt.com', 'iPhone 16 Pro');
+
+    expect(result).toBeNull();
+    expect(mockSetItem).toHaveBeenCalledWith('photos-device-identity', JSON.stringify([identityB]));
+  });
+
+  test('when there is no current email, then null is returned without touching the stored entries', async () => {
+    setStoredEntries([identityA]);
+
+    const result = await photoDeviceIdentityStore.getValidFor(undefined, 'iPhone 15');
+
+    expect(result).toBeNull();
+    expect(mockSetItem).not.toHaveBeenCalled();
+    expect(mockRemoveItem).not.toHaveBeenCalled();
+  });
+
+  test('when a match is found, then it is promoted to the front as most recently used', async () => {
+    setStoredEntries([identityB, identityA]);
+
+    await photoDeviceIdentityStore.getValidFor('a@internxt.com', 'iPhone 15');
+
+    expect(mockSetItem).toHaveBeenCalledWith('photos-device-identity', JSON.stringify([identityA, identityB]));
+  });
+});
+
+describe('PhotoDeviceIdentityStore.save', () => {
+  test('when there is room, then the new identity is added to the front', async () => {
+    setStoredEntries([identityB]);
+
+    await photoDeviceIdentityStore.save(identityA);
+
+    expect(mockSetItem).toHaveBeenCalledWith('photos-device-identity', JSON.stringify([identityA, identityB]));
+  });
+
+  test('when the same account is saved again, then its previous entry is replaced, not duplicated', async () => {
+    setStoredEntries([identityA, identityB]);
+    const updatedIdentityA = { ...identityA, deviceId: 'folder-uuid-a-updated' };
+
+    await photoDeviceIdentityStore.save(updatedIdentityA);
+
+    expect(mockSetItem).toHaveBeenCalledWith('photos-device-identity', JSON.stringify([updatedIdentityA, identityB]));
+  });
+
+  test('when saving a 4th account, then the least recently used one is evicted', async () => {
+    setStoredEntries([identityC, identityB, identityA]);
+
+    await photoDeviceIdentityStore.save(identityD);
+
+    expect(mockSetItem).toHaveBeenCalledWith(
+      'photos-device-identity',
+      JSON.stringify([identityD, identityC, identityB]),
+    );
+  });
+});
+
+describe('PhotoDeviceIdentityStore.clearAccount', () => {
+  test('when clearing one account, then only its entry is removed', async () => {
+    setStoredEntries([identityA, identityB]);
+
+    await photoDeviceIdentityStore.clearAccount('a@internxt.com');
+
+    expect(mockSetItem).toHaveBeenCalledWith('photos-device-identity', JSON.stringify([identityB]));
+  });
+
+  test('when clearing the only remaining account, then the whole key is removed', async () => {
+    setStoredEntries([identityA]);
+
+    await photoDeviceIdentityStore.clearAccount('a@internxt.com');
+
+    expect(mockRemoveItem).toHaveBeenCalledWith('photos-device-identity');
+  });
+
+  test('when the account has no stored entry, then nothing is written', async () => {
+    setStoredEntries([identityB]);
+
+    await photoDeviceIdentityStore.clearAccount('a@internxt.com');
+
+    expect(mockSetItem).not.toHaveBeenCalled();
+    expect(mockRemoveItem).not.toHaveBeenCalled();
+  });
+});
+
+describe('PhotoDeviceIdentityStore.clearAll', () => {
+  test('when clearing all entries, then the whole key is removed', async () => {
+    await photoDeviceIdentityStore.clearAll();
+
+    expect(mockRemoveItem).toHaveBeenCalledWith('photos-device-identity');
+  });
+});

--- a/src/services/photos/PhotoDeviceIdentityStore.ts
+++ b/src/services/photos/PhotoDeviceIdentityStore.ts
@@ -1,0 +1,163 @@
+import { logger } from 'src/services/common';
+import secureStorageService from 'src/services/SecureStorageService';
+
+const TAG = '[PhotoDeviceIdentityStore]';
+
+const PHOTOS_DEVICE_IDENTITY_KEY = 'photos-device-identity';
+export const PHOTOS_DEVICE_KEY = 'photos-device-key';
+
+const MAX_ACCOUNTS = 3;
+
+export interface PhotoDeviceIdentity {
+  deviceId: string;
+  email: string;
+  model: string;
+}
+
+/**
+ * Persists the binding between a backend device folder and the account that created
+ * it, for up to MAX_ACCOUNTS accounts on this phone.
+ */
+class PhotoDeviceIdentityStore {
+  /**
+   * Saves or updates the identity for `deviceIdentity.email`.
+   * If the account is already stored, its previous entry is replaced. If
+   * saving pushes the store past MAX_ACCOUNTS, the least recently used entry is evicted.
+   *
+   * @param deviceIdentity - The device identity to persist.
+   * @returns A promise that resolves once the entry has been written.
+   */
+  async save(deviceIdentity: PhotoDeviceIdentity): Promise<void> {
+    const deviceIdentities = await this.readEntries();
+    const withoutCurrentAccount = deviceIdentities.filter((entry) => entry.email !== deviceIdentity.email);
+    const newDeviceIdentityEntries = [deviceIdentity, ...withoutCurrentAccount];
+    const updatedEntries = newDeviceIdentityEntries.slice(0, MAX_ACCOUNTS);
+
+    const evictedEntries = newDeviceIdentityEntries.slice(MAX_ACCOUNTS);
+    if (evictedEntries.length > 0) {
+      logger.info(
+        TAG,
+        `Saved identity for ${deviceIdentity.email} — evicted least recently used account(s): ${evictedEntries.map((e) => e.email).join(', ')}`,
+      );
+    } else {
+      logger.info(
+        TAG,
+        `Saved identity for ${deviceIdentity.email} deviceId=${deviceIdentity.deviceId} (${updatedEntries.length}/${MAX_ACCOUNTS} accounts cached)`,
+      );
+    }
+
+    await this.writeEntries(updatedEntries);
+  }
+
+  /**
+   * Returns the stored entry for `currentEmail` only if its model matches `currentModel`.
+   * - No entry for this email: returns null, nothing is changed.
+   * - Entry found but model doesn't match: that entry is discarded (other accounts' entries
+   *   are left untouched) and null is returned.
+   * - Entry found and matches: it's promoted to most-recently-used and returned.
+   * - `currentEmail` is undefined: returns null without touching anything.
+   *
+   * @param currentEmail - Email of the currently logged-in account, or undefined if unknown.
+   * @param currentModel - Display name of the current device, or null if unknown.
+   * @returns The matching identity, or null if there is none valid for this account/hardware.
+   */
+  async getValidFor(
+    currentEmail: string | undefined,
+    currentModel: string | null,
+  ): Promise<PhotoDeviceIdentity | null> {
+    if (!currentEmail) {
+      logger.warn(TAG, 'No current account email available — cannot validate stored identities');
+      return null;
+    }
+
+    const photoDeviceIdentities = await this.readEntries();
+    const currentIdentityIndex = photoDeviceIdentities.findIndex((entry) => entry.email === currentEmail);
+    if (currentIdentityIndex === -1) {
+      logger.info(
+        TAG,
+        `No stored identity for ${currentEmail} on this phone (${photoDeviceIdentities.length} other account(s) cached)`,
+      );
+      return null;
+    }
+
+    const currentIdentity = photoDeviceIdentities[currentIdentityIndex];
+    const restIdentities = photoDeviceIdentities.filter((_, i) => i !== currentIdentityIndex);
+
+    if (currentIdentity.model !== currentModel) {
+      logger.info(
+        TAG,
+        `Stored identity for ${currentEmail} has a different device model (stored="${currentIdentity.model}" current="${currentModel}") — discarding stale entry`,
+      );
+      await this.writeEntries(restIdentities);
+      return null;
+    }
+
+    logger.info(
+      TAG,
+      `Stored identity matches for ${currentEmail} deviceId=${currentIdentity.deviceId} model="${currentIdentity.model}" — promoting to most recently used`,
+    );
+    await this.writeEntries([currentIdentity, ...restIdentities]);
+    return currentIdentity;
+  }
+
+  /**
+   * Removes the stored entry for a single account, leaving the other accounts' entries intact.
+   *
+   * @param email - Email of the account whose entry should be removed.
+   * @returns A promise that resolves once the entry has been removed.
+   */
+  async clearAccount(email: string): Promise<void> {
+    const photoDeviceIdentities = await this.readEntries();
+    const updatedDeviceIdentities = photoDeviceIdentities.filter((entry) => entry.email !== email);
+    if (updatedDeviceIdentities.length !== photoDeviceIdentities.length) {
+      await this.writeEntries(updatedDeviceIdentities);
+    }
+  }
+
+  /**
+   * Wipes every stored entry for every account on this phone.
+   *
+   * @returns A promise that resolves once the storage key has been removed.
+   */
+  async clearAll(): Promise<void> {
+    await secureStorageService.removeItem(PHOTOS_DEVICE_IDENTITY_KEY);
+  }
+
+  /**
+   * Reads and parses the stored entries.
+   *
+   * @returns The stored identities, most recently used first, or an empty array if there are
+   * none or the stored value is corrupted.
+   */
+  private async readEntries(): Promise<PhotoDeviceIdentity[]> {
+    const storedDeviceIdentities = await secureStorageService.getItem(PHOTOS_DEVICE_IDENTITY_KEY);
+    if (!storedDeviceIdentities) {
+      return [];
+    }
+
+    try {
+      const parsedDeviceIdentities = JSON.parse(storedDeviceIdentities);
+      return Array.isArray(parsedDeviceIdentities) ? parsedDeviceIdentities : [];
+    } catch (error) {
+      logger.warn(TAG, 'Failed to parse stored identities, resetting', { error });
+      await this.clearAll();
+      return [];
+    }
+  }
+
+  /**
+   * Persists the given entries, or clears the storage key entirely if the list is empty.
+   *
+   * @param photoDeviceIdentities - The identities to persist, most recently used first.
+   * @returns A promise that resolves once the entries have been written.
+   */
+  private async writeEntries(photoDeviceIdentities: PhotoDeviceIdentity[]): Promise<void> {
+    if (photoDeviceIdentities.length === 0) {
+      await this.clearAll();
+      return;
+    }
+    await secureStorageService.setItem(PHOTOS_DEVICE_IDENTITY_KEY, JSON.stringify(photoDeviceIdentities));
+  }
+}
+
+export const photoDeviceIdentityStore = new PhotoDeviceIdentityStore();

--- a/src/store/slices/payments/index.spec.ts
+++ b/src/store/slices/payments/index.spec.ts
@@ -1,4 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit';
+import asyncStorageService from 'src/services/AsyncStorageService';
 import paymentService from 'src/services/PaymentService';
 import { AppDispatch } from 'src/store';
 import paymentsReducer, { paymentsSelectors, paymentsThunks } from './index';
@@ -52,6 +53,21 @@ describe('payments slice — loadFileLimitsThunk', () => {
     const store = makeStore();
     await store.dispatch(paymentsThunks.loadFileLimitsThunk());
     expect(store.getState().payments.photosAccess).toBeUndefined();
+  });
+
+  test('when a valid cached value exists, then it is used and the backend is not called', async () => {
+    mockPaymentService.getFileLimits.mockClear();
+    jest.spyOn(asyncStorageService, 'getItem').mockResolvedValue(
+      JSON.stringify({ photosAccess: true, cachedAt: Date.now() }),
+    );
+    const store = makeStore();
+
+    await store.dispatch(paymentsThunks.loadFileLimitsThunk());
+
+    expect(mockPaymentService.getFileLimits).not.toHaveBeenCalled();
+    expect(store.getState().payments.photosAccess).toBe(true);
+
+    jest.restoreAllMocks();
   });
 });
 

--- a/src/store/slices/photos/index.ts
+++ b/src/store/slices/photos/index.ts
@@ -212,7 +212,9 @@ export const checkPermissionRevocationThunk = createAsyncThunk<void, void, { sta
   'photos/checkPermissionRevocation',
   async (_, { getState, dispatch }) => {
     const { enabled } = getState().photos;
-    if (!enabled) return;
+    if (!enabled) {
+      return;
+    }
 
     const status = await photoPermissionService.getStatus();
     if (status === 'denied') {
@@ -287,7 +289,6 @@ export const runDiscoveryThunk = createAsyncThunk<void, void, { state: RootState
             duration: asset.duration,
             mediaType: asset.mediaType,
             isLivePhoto: asset.mediaSubtypes?.includes('livePhoto') ?? false,
-            // BURST:
             isBurst: burstIdSet.has(asset.id),
           }),
         ),
@@ -300,7 +301,6 @@ export const runDiscoveryThunk = createAsyncThunk<void, void, { state: RootState
             duration: asset.duration,
             mediaType: asset.mediaType,
             isLivePhoto: asset.mediaSubtypes?.includes('livePhoto') ?? false,
-            // BURST:
             isBurst: burstIdSet.has(asset.id),
           }),
         ),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -102,8 +102,6 @@ export enum AsyncStorageKey {
   ScreenProtectionEnabled = 'screenProtectionEnabled',
   PhotosSettings = 'photosSettings',
   PhotosDiscoverSeen = 'photosDiscoverSeen',
-  PhotosDeviceId = 'photos-device-id',
-  PhotosDeviceKey = 'photos-device-key',
   PhotosAccessCache = 'photosAccessCache',
   PhotosDevicesCache = 'photos-devices-cache',
 }


### PR DESCRIPTION
Fix duplicate Photos device folders after logout, uninstall, and reinstall on iOS and changed lock flow to not appear the enable backup modal if the user has not have the corresponding tier.

## Summary
- **`PhotosScreen/index.tsx:`**: handleEnableBackup now checks hasAccess before opening the enable-backup sheet
  lost while it's open — previously it could be opened/left open for an account that doesn't have Photos access.
- **`PhotoDeviceIdentityStore`**: new store that persists the binding between a backend device folder and the account that created it (up to 3 accounts), deliberately kept outside storage `SENSITIVE_KEYS` so it survives logout instead of being wiped every time.
- **`PhotoDeviceId.ts`**: on login, validates the stored identity against the current account email and device model.
- **`AsyncStorageService`**: removed `PhotosDeviceId`/`PhotosDeviceKey` from `SENSITIVE_KEYS`, since that identity is now managed by `PhotoDeviceIdentityStore`.
