### PR TITLE
[PB-6378] bugfix/Fix cloud deleted reconcile behaviour

### DIFF
--- a/src/screens/PhotosScreen/hooks/useLocalAssetsSyncStatus.ts
+++ b/src/screens/PhotosScreen/hooks/useLocalAssetsSyncStatus.ts
@@ -22,6 +22,7 @@ export const useLocalAssetsSyncStatus = (assetIds: string[]): LocalAssetsSyncSta
   const syncStatus = useAppSelector((state) => state.photos.syncStatus);
   const sessionUploadedAssets = useAppSelector((state) => state.photos.sessionUploadedAssets);
   const isFetchingCloudHistory = useAppSelector((state) => state.photos.isFetchingCloudHistory);
+  const cloudFetchRevision = useAppSelector((state) => state.photos.cloudFetchRevision);
 
   useEffect(() => {
     if (assetIds.length === 0) {
@@ -49,7 +50,7 @@ export const useLocalAssetsSyncStatus = (assetIds: string[]): LocalAssetsSyncSta
       setIncompleteUploadBurstIdSet(new Set(incompleteBursts.map((burst) => burst.assetId)));
     };
     refreshFromDB();
-  }, [assetIds, syncStatus, sessionUploadedAssets, isFetchingCloudHistory]);
+  }, [assetIds, syncStatus, sessionUploadedAssets, isFetchingCloudHistory, cloudFetchRevision]);
 
   return { syncedIds, cloudDeletedIds, incompleteUploadBurstIdSet };
 };

--- a/src/services/drive/folder/driveFolder.service.ts
+++ b/src/services/drive/folder/driveFolder.service.ts
@@ -60,8 +60,8 @@ class DriveFolderService {
     return this.sdk.storageV2.getFolderAncestors(folderUuid) as Promise<FolderAncestor[]>;
   }
 
-  public getFolderContentByUuid(folderUuid: string) {
-    const [contentPromise] = this.sdk.storageV2.getFolderContentByUuid({ folderUuid });
+  public getFolderContentByUuid(folderUuid: string, offset?: number, limit?: number) {
+    const [contentPromise] = this.sdk.storageV2.getFolderContentByUuid({ folderUuid, offset, limit });
     return contentPromise;
   }
 

--- a/src/services/photos/PhotoCloudBrowser.spec.ts
+++ b/src/services/photos/PhotoCloudBrowser.spec.ts
@@ -22,6 +22,8 @@ jest.mock('./database/photosLocalDB', () => ({
     upsertCloudAsset: jest.fn(),
     getCloudAssetRemoteIdsByDeviceAndMonth: jest.fn(),
     getSyncedRemoteIdsByCreationMonth: jest.fn(),
+    getCloudDeletedRemoteIdsByCreationMonth: jest.fn().mockResolvedValue(new Set()),
+    revertCloudDeleted: jest.fn(),
     markCloudDeleted: jest.fn(),
     deleteCloudAsset: jest.fn(),
     getCloudAssetMonthsByDevice: jest.fn(),
@@ -57,6 +59,8 @@ beforeEach(() => {
   mockPhotosLocalDB.upsertCloudAsset.mockResolvedValue(undefined);
   mockPhotosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth.mockResolvedValue(new Set());
   mockPhotosLocalDB.getSyncedRemoteIdsByCreationMonth.mockResolvedValue(new Set());
+  mockPhotosLocalDB.getCloudDeletedRemoteIdsByCreationMonth.mockResolvedValue(new Set());
+  mockPhotosLocalDB.revertCloudDeleted.mockResolvedValue(undefined);
   mockPhotosLocalDB.markCloudDeleted.mockResolvedValue(undefined);
   mockPhotosLocalDB.deleteCloudAsset.mockResolvedValue(undefined);
   mockPhotosLocalDB.getCloudAssetMonthsByDevice.mockResolvedValue([]);
@@ -411,6 +415,25 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     expect(mockPhotosLocalDB.markCloudDeleted).toHaveBeenCalledTimes(1);
     expect(mockPhotosLocalDB.markCloudDeleted).toHaveBeenCalledWith('synced-remote-uuid');
     expect(mockPhotosLocalDB.deleteCloudAsset).toHaveBeenCalledWith('synced-remote-uuid');
+  });
+
+  test('when an asset previously marked cloud_deleted is found in the cloud again, then it is reverted back to synced', async () => {
+    mockDeviceService.listDevices.mockResolvedValueOnce([makeDevice('d1-uuid', 'Internxt iPhone')]);
+    const year = makeFolder('y-uuid', '2024');
+    const month = makeFolder('m-uuid', '06');
+    const day = makeFolder('day-uuid', '15');
+    const file = makeFile('remote-uuid', 'IMG_0001');
+    mockPhotosLocalDB.getCloudDeletedRemoteIdsByCreationMonth.mockResolvedValue(new Set(['remote-uuid']));
+    mockFolderService.getFolderFolders
+      .mockResolvedValueOnce({ folders: [year] } as never)
+      .mockResolvedValueOnce({ folders: [month] } as never)
+      .mockResolvedValueOnce({ folders: [day] } as never);
+    mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
+
+    await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'd1-uuid' });
+
+    expect(mockPhotosLocalDB.revertCloudDeleted).toHaveBeenCalledWith(['remote-uuid']);
+    expect(mockPhotosLocalDB.markCloudDeleted).not.toHaveBeenCalled();
   });
 
   test('when the current device id does not match any device in Drive, then synced assets are reset to pending but other devices are still synced', async () => {

--- a/src/services/photos/PhotoCloudBrowser.ts
+++ b/src/services/photos/PhotoCloudBrowser.ts
@@ -34,15 +34,15 @@ const resolveBurstFields = (
 };
 
 const fetchAllPages = async <T>(fetcher: (offset: number) => Promise<T[]>): Promise<T[]> => {
-  const all: T[] = [];
+  const alltItems: T[] = [];
   let offset = 0;
   let batch: T[];
   do {
     batch = await fetcher(offset);
-    all.push(...batch);
+    alltItems.push(...batch);
     offset += PAGE_SIZE;
   } while (batch.length === PAGE_SIZE);
-  return all;
+  return alltItems;
 };
 
 class PhotoCloudBrowserService {
@@ -200,6 +200,17 @@ class PhotoCloudBrowserService {
     return count;
   }
 
+  /**
+   * Reconciles what the local DB believes is backed up for this device/month against what was
+   * found in Drive. Marks ids no longer found as `cloud_deleted`, and reverts
+   * previously `cloud_deleted` ids that are found again back to `synced`.
+   *
+   * @param params.deviceId - Device folder uuid being reconciled.
+   * @param params.year - Year of the month being reconciled.
+   * @param params.month - Month being reconciled (1-12).
+   * @param params.foundIds - Remote file ids found in Drive for this device/month in this pass.
+   * @param params.currentDeviceId - This device's own folder uuid, or undefined if unknown.
+   */
   private async reconcileCloudDeletions(params: {
     deviceId: string;
     year: number;
@@ -208,20 +219,70 @@ class PhotoCloudBrowserService {
     currentDeviceId: string | undefined;
   }): Promise<void> {
     const { deviceId, year, month, foundIds, currentDeviceId } = params;
+    const monthLabel = `${year}/${String(month).padStart(2, '0')}`;
     logger.info(
-      `[CloudBrowser] reconcileCloudDeletions — device=${deviceId} ${year}/${String(month).padStart(2, '0')}, foundIds=${[...foundIds].length}, currentDeviceId=${currentDeviceId ?? 'none'}`,
+      `[CloudBrowser] reconcileCloudDeletions — device=${deviceId} ${monthLabel}, foundIds=${[...foundIds].length}, currentDeviceId=${currentDeviceId ?? 'none'}`,
     );
+    const isCurrentDevice = !!currentDeviceId && deviceId === currentDeviceId;
+
+    const knownIds = await this.getKnownRemoteIds({ deviceId, year, month, isCurrentDevice });
+
+    const removedCount = await this.markMissingAsCloudDeleted({ knownIds, foundIds });
+    if (removedCount > 0) {
+      logger.info(`[CloudBrowser] Device "${deviceId}" ${monthLabel} — ${removedCount} file(s) cloud_deleted`);
+    }
+
+    const revertedIds = await this.revertReappearedCloudDeleted({ year, month, foundIds, isCurrentDevice });
+    if (revertedIds.length > 0) {
+      logger.info(
+        `[CloudBrowser] Device "${deviceId}" ${monthLabel} — ${revertedIds.length} file(s) reverted to synced (found in cloud again): ${revertedIds.join(', ')}`,
+      );
+    }
+  }
+
+  /**
+   * Returns the remote ids the local DB believes are backed up for this device/month: cached
+   * `cloud_asset` entries, plus — when `params.isCurrentDevice` is true — ids already `synced`
+   * in `asset_sync` with a matching creation month.
+   *
+   * @param params.deviceId - Device folder uuid being reconciled.
+   * @param params.year - Year of the month being reconciled.
+   * @param params.month - Month being reconciled (1-12).
+   * @param params.isCurrentDevice - Whether `params.deviceId` is this device's own folder uuid;
+   *   when true, `asset_sync` is also consulted.
+   * @returns The set of known remote file ids.
+   */
+  private async getKnownRemoteIds(params: {
+    deviceId: string;
+    year: number;
+    month: number;
+    isCurrentDevice: boolean;
+  }): Promise<Set<string>> {
+    const { deviceId, year, month, isCurrentDevice } = params;
     const knownFromCloud = await this.localDB.getCloudAssetRemoteIdsByDeviceAndMonth(deviceId, year, month);
     logger.info(
       `[CloudBrowser] reconcileCloudDeletions — knownFromCloud=${knownFromCloud.size} in local DB for device=${deviceId} ${year}/${String(month).padStart(2, '0')}`,
     );
     const knownIds = new Set(knownFromCloud);
 
-    if (currentDeviceId && deviceId === currentDeviceId) {
+    if (isCurrentDevice) {
       const knownFromSync = await this.localDB.getSyncedRemoteIdsByCreationMonth(year, month);
-      for (const id of knownFromSync) knownIds.add(id);
+      for (const id of knownFromSync) {
+        knownIds.add(id);
+      }
     }
+    return knownIds;
+  }
 
+  /**
+   * Marks ids present in `params.knownIds` but absent from `params.foundIds` as `cloud_deleted`.
+   *
+   * @param params.knownIds - Remote file ids the local DB believes are backed up.
+   * @param params.foundIds - Remote file ids found in Drive for this device/month in this pass.
+   * @returns The number of ids marked `cloud_deleted`.
+   */
+  private async markMissingAsCloudDeleted(params: { knownIds: Set<string>; foundIds: Set<string> }): Promise<number> {
+    const { knownIds, foundIds } = params;
     let removedCount = 0;
     for (const knownId of knownIds) {
       if (!foundIds.has(knownId)) {
@@ -230,11 +291,38 @@ class PhotoCloudBrowserService {
         removedCount++;
       }
     }
-    if (removedCount > 0) {
-      logger.info(
-        `[CloudBrowser] Device "${deviceId}" ${year}/${String(month).padStart(2, '0')} — ${removedCount} file(s) cloud_deleted`,
-      );
+    return removedCount;
+  }
+
+  /**
+   * Reverts ids already marked `cloud_deleted` back to `synced` if they appear in
+   * `params.foundIds` this pass. No-op unless `params.isCurrentDevice` is true — `asset_sync` is
+   * only meaningful locally, so other devices have nothing to revert.
+   *
+   * @param params.year - Year of the month being reconciled.
+   * @param params.month - Month being reconciled (1-12).
+   * @param params.foundIds - Remote file ids found in Drive for this device/month in this pass.
+   * @param params.isCurrentDevice - Whether the device being reconciled is this device's own
+   *   folder uuid.
+   * @returns The remote file ids that were reverted back to `synced`.
+   */
+  private async revertReappearedCloudDeleted(params: {
+    year: number;
+    month: number;
+    foundIds: Set<string>;
+    isCurrentDevice: boolean;
+  }): Promise<string[]> {
+    const { year, month, foundIds, isCurrentDevice } = params;
+    if (!isCurrentDevice) {
+      return [];
     }
+
+    const cloudDeletedIds = await this.localDB.getCloudDeletedRemoteIdsByCreationMonth(year, month);
+    const revertedIds = [...cloudDeletedIds].filter((id) => foundIds.has(id));
+    if (revertedIds.length > 0) {
+      await this.localDB.revertCloudDeleted(revertedIds);
+    }
+    return revertedIds;
   }
 
   private async purgeDeletedDevices(activeDevices: { uuid: string }[], onPurged?: () => void): Promise<void> {
@@ -423,8 +511,9 @@ class PhotoCloudBrowserService {
   }
 
   private async listFilesWithThumbnails(folderUuid: string): Promise<DriveFileData[]> {
-    const content = await this.folderService.getFolderContentByUuid(folderUuid);
-    return content.files;
+    return fetchAllPages((offset) =>
+      this.folderService.getFolderContentByUuid(folderUuid, offset, PAGE_SIZE).then((content) => content.files),
+    );
   }
 }
 

--- a/src/services/photos/database/photosLocalDB.ts
+++ b/src/services/photos/database/photosLocalDB.ts
@@ -426,6 +426,28 @@ class PhotosLocalDB {
     return new Set(rows.map((r) => r.remote_file_id));
   }
 
+  async getCloudDeletedRemoteIdsByCreationMonth(year: number, month: number): Promise<Set<string>> {
+    const startMs = new Date(year, month - 1, 1).getTime();
+    const endMs = new Date(year, month, 1).getTime();
+    const rows = await sqliteService.getAllAsync<{ remote_file_id: string }>(
+      DB_NAME,
+      assetSyncTable.statements.getCloudDeletedRemoteIdsByCreationMonth,
+      [startMs, endMs],
+    );
+    return new Set(rows.map((r) => r.remote_file_id));
+  }
+
+  async revertCloudDeleted(remoteFileIds: string[]): Promise<void> {
+    if (remoteFileIds.length === 0) {
+      return;
+    }
+    for (let i = 0; i < remoteFileIds.length; i += CHUNK_SIZE) {
+      const chunk = remoteFileIds.slice(i, i + CHUNK_SIZE);
+      const placeholders = chunk.map(() => '?').join(', ');
+      await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.revertCloudDeleted(placeholders), chunk);
+    }
+  }
+
   async markCloudDeleted(remoteFileId: string): Promise<void> {
     await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.markCloudDeleted, [remoteFileId]);
   }

--- a/src/services/photos/database/tables/asset_sync.ts
+++ b/src/services/photos/database/tables/asset_sync.ts
@@ -126,7 +126,7 @@ const statements = {
   `,
 
   getStatus: `
-    SELECT asset_id, status, remote_file_id, synced_at, error_message, attempt_count,
+    SELECT asset_id, status, remote_file_id, synced_at, deleted_at, error_message, attempt_count,
            created_at, last_attempt_at, modification_time,
            file_name, file_size, creation_time, width, height, duration, media_type,
            is_live_photo, paired_video_remote_file_id, paired_video_status,
@@ -142,6 +142,15 @@ const statements = {
       AND creation_time >= ?
       AND creation_time < ?;
   `,
+  getCloudDeletedRemoteIdsByCreationMonth: `
+    SELECT remote_file_id FROM ${TABLE_NAME}
+    WHERE status = 'cloud_deleted'
+      AND remote_file_id IS NOT NULL
+      AND creation_time >= ?
+      AND creation_time < ?;
+  `,
+  revertCloudDeleted: (placeholders: string) =>
+    `UPDATE ${TABLE_NAME} SET status = 'synced', deleted_at = NULL WHERE status = 'cloud_deleted' AND remote_file_id IN (${placeholders});`,
   getPendingAssets: `
     SELECT asset_id, status, remote_file_id, is_burst, burst_member_count FROM ${TABLE_NAME}
     WHERE status IN ('pending', 'pending_edit')
@@ -165,7 +174,7 @@ const statements = {
       status     = 'deleted',
       deleted_at = (unixepoch() * 1000);
   `,
-  markCloudDeleted: `UPDATE ${TABLE_NAME} SET status = 'cloud_deleted' WHERE remote_file_id = ?;`,
+  markCloudDeleted: `UPDATE ${TABLE_NAME} SET status = 'cloud_deleted', deleted_at = (unixepoch() * 1000) WHERE remote_file_id = ?;`,
   resetSyncedToPending: `
     UPDATE ${TABLE_NAME} SET
       status = 'pending',


### PR DESCRIPTION
 Fix photos being wrongly marked as deleted from the cloud due to truncated pagination

  ## Summary

  - **`PhotoCloudBrowser.ts`**: `listFilesWithThumbnails` was calling `getFolderContentByUuid` with no `offset`/`limit`, silently truncating any day folder with more than 50 files. Those extra files then looked "missing from cloud" and got wrongly marked `cloud_deleted`. Now paginates with `fetchAllPages`, same as the other folder listings. (It looks as though the endpoint that calls getFolderContentByUuid has changed, it used to fetch all the files from the folder, but now it seems not to)
  - **`PhotoCloudBrowser.ts`**: `reconcileCloudDeletions` was one-directional, it could mark `cloud_deleted` but never revert a false positive once found in the cloud again, so any mistake (from the bug above, or any future cause) stuck forever.
  - **`driveFolderService.ts`**: `getFolderContentByUuid` now accepts and forwards `offset`/`limit` to the SDK.
  - **`asset_sync.ts` / `photosLocalDB.ts`**: new `getCloudDeletedRemoteIdsByCreationMonth` + `revertCloudDeleted`.
  - **`useLocalAssetsSyncStatus.ts`**: now also depends on `cloudFetchRevision`, so the local timeline reflects reconciliation  results live, month by month, instead of only after the full sync pass finishes.
