### PR TITLE
[_] bugfix/fix cloud deleted status in preview

### DIFF
--- a/src/screens/PhotoPreviewScreen/hooks/useLiveBackupStatus.spec.ts
+++ b/src/screens/PhotoPreviewScreen/hooks/useLiveBackupStatus.spec.ts
@@ -117,18 +117,26 @@ describe('useLiveBackupStatus', () => {
     expect(result.current.progress).toBe(0);
   });
 
-  test('when the asset is cloud-deleted and completed during this session, then cloud-deleted is no longer reported', () => {
+  test('when the asset is cloud-deleted and was uploaded earlier in this session, then cloud-deleted is still reported', () => {
     photosState.sessionCompletedAssetIds = ['a1'];
 
     const { result } = renderHook(() => useLiveBackupStatus(makeLocalItem('a1', 'cloud-deleted')));
 
-    expect(result.current.isCloudDeleted).toBe(false);
+    expect(result.current.isCloudDeleted).toBe(true);
   });
 
-  test('when the asset is cloud-deleted and was not completed during this session, then cloud-deleted is reported', () => {
+  test('when the asset is cloud-deleted and not in the upload queue, then cloud-deleted is reported', () => {
     const { result } = renderHook(() => useLiveBackupStatus(makeLocalItem('a1', 'cloud-deleted')));
 
     expect(result.current.isCloudDeleted).toBe(true);
+  });
+
+  test('when the asset is cloud-deleted but is currently being re-uploaded, then cloud-deleted is not reported', () => {
+    photosState.uploadingAssetIds = ['a1'];
+
+    const { result } = renderHook(() => useLiveBackupStatus(makeLocalItem('a1', 'cloud-deleted')));
+
+    expect(result.current.isCloudDeleted).toBe(false);
   });
 
   test('when the snapshot says uploading but the queue no longer contains the asset, then it is shown as backed', () => {

--- a/src/screens/PhotoPreviewScreen/hooks/useLiveBackupStatus.ts
+++ b/src/screens/PhotoPreviewScreen/hooks/useLiveBackupStatus.ts
@@ -52,7 +52,7 @@ export const useLiveBackupStatus = (item: TimelinePhotoItem | undefined): LiveBa
 
   const snapshotState = item?.type === 'local' ? item.backupState : undefined;
   const isWaitingToUpload = snapshotState === 'not-backed' && !isInUploadQueue && !completedDuringSession;
-  const isCloudDeleted = snapshotState === 'cloud-deleted' && !isInUploadQueue && !completedDuringSession;
+  const isCloudDeleted = snapshotState === 'cloud-deleted' && !isInUploadQueue;
 
   useEffect(() => {
     if (!isBurst || !assetId || isInUploadQueue) {

--- a/src/store/slices/photos/index.ts
+++ b/src/store/slices/photos/index.ts
@@ -265,7 +265,9 @@ export const runDiscoveryThunk = createAsyncThunk<void, void, { state: RootState
   'photos/runDiscovery',
   async (_, { getState, dispatch }) => {
     const { enabled, syncStatus } = getState().photos;
-    if (!enabled || syncStatus === 'scanning') return;
+    if (!enabled || syncStatus === 'scanning' || PhotoUploadQueue.isCycleRunning()) {
+      return;
+    }
 
     logger.info('[Discovery] Starting discovery cycle');
     dispatch(photosSlice.actions.setSyncStatus('scanning'));


### PR DESCRIPTION
  - **`useLiveBackupStatus.ts`**:the cloud-deleted status was hidden for an asset that had already completed an upload earlier in the same session (`completedDuringSession`), even if it was later deleted from the cloud again and is now being re-uploaded. `isCloudDeleted` no longer looks at session history, only at whether the asset is currently in the upload queue.
  - **`photos/index.ts`**: `runDiscoveryThunk` only guarded against `syncStatus === 'scanning'`, not against an upload cycle already running (`PhotoUploadQueue.isCycleRunning()`). A second trigger (AppState `'active'`, focusing the Photos screen, etc.) could slip in during the window between `PhotoUploadQueue.beginCycle()` and the `setSyncStatus('uploading')` dispatch, reset `syncStatus` back to `'idle'`, and mask a real upload in progress. Combined with `isFetchingCloudHistory` running in parallel, the group header got stuck showing `fetching` instead of `uploading`.