### PR TITLE
[_] bugfix/Fix Photos discovery error

### DIFF
--- a/__mocks__/expo-sqlite.ts
+++ b/__mocks__/expo-sqlite.ts
@@ -1,9 +1,18 @@
-const mockDb = {
+const createMockStatement = () => ({
+  executeAsync: jest.fn().mockResolvedValue(undefined),
+  finalizeAsync: jest.fn().mockResolvedValue(undefined),
+});
+
+const createMockDb = () => ({
   execAsync: jest.fn().mockResolvedValue(undefined),
   runAsync: jest.fn().mockResolvedValue(undefined),
   getFirstAsync: jest.fn().mockResolvedValue(null),
   getAllAsync: jest.fn().mockResolvedValue([]),
-};
+  prepareAsync: jest.fn().mockResolvedValue(createMockStatement()),
+  withTransactionAsync: jest.fn().mockImplementation(async (task: () => Promise<void>) => task()),
+  closeAsync: jest.fn().mockResolvedValue(undefined),
+});
 
-export const openDatabaseAsync = jest.fn().mockResolvedValue(mockDb);
+export const openDatabaseAsync = jest.fn().mockImplementation(async () => createMockDb());
+export const deleteDatabaseAsync = jest.fn().mockResolvedValue(undefined);
 export const NativeDatabase = jest.fn();

--- a/src/screens/PhotosScreen/hooks/useLocalAssets.spec.ts
+++ b/src/screens/PhotosScreen/hooks/useLocalAssets.spec.ts
@@ -17,7 +17,7 @@ jest.mock('src/services/photos/database/photosLocalDB', () => ({
     init: jest.fn().mockResolvedValue(undefined),
     getSyncedEntries: jest.fn(),
     getIncompleteBurstAssets: jest.fn().mockResolvedValue([]),
-    deleteAssetSync: jest.fn().mockResolvedValue(undefined),
+    deleteAssetSyncBulk: jest.fn().mockResolvedValue(undefined),
     cleanupOrphanedAssetSync: jest.fn().mockResolvedValue(0),
   },
 }));
@@ -225,7 +225,7 @@ describe('useLocalAssets', () => {
     });
 
     expect(result.current.assets.find((a) => a.id === 'whatsapp')).toBeDefined();
-    expect(mockPhotosLocalDB.deleteAssetSync).not.toHaveBeenCalled();
+    expect(mockPhotosLocalDB.deleteAssetSyncBulk).not.toHaveBeenCalled();
   });
 
   test('when the head window creation times are unreliable, then no photos are dropped from the gallery', async () => {
@@ -257,7 +257,7 @@ describe('useLocalAssets', () => {
     });
 
     expect(result.current.assets.find((a) => a.id === 'known')).toBeDefined();
-    expect(mockPhotosLocalDB.deleteAssetSync).not.toHaveBeenCalled();
+    expect(mockPhotosLocalDB.deleteAssetSyncBulk).not.toHaveBeenCalled();
   });
 
   test('when the device is unlocked mid-gallery, then assets loaded beyond the first page are preserved without re-pagination', async () => {
@@ -481,7 +481,7 @@ describe('useLocalAssets', () => {
 
     expect(result.current.assets.find((a) => a.id === 'old')).toBeUndefined();
     expect(result.current.assets).toHaveLength(2);
-    expect(mockPhotosLocalDB.deleteAssetSync).toHaveBeenCalledWith('old');
+    expect(mockPhotosLocalDB.deleteAssetSyncBulk).toHaveBeenCalledWith(['old']);
     expect(result.current.localDeletionDetectedCount).toBe(1);
     // getAssetsAsync should NOT have been called for the incremental update
     expect(mockMediaLibrary.getAssetsAsync).toHaveBeenCalledTimes(1);
@@ -548,7 +548,7 @@ describe('useLocalAssets', () => {
 
     expect(result.current.assets.find((a) => a.id === 'a1')).toEqual(editedAsset);
     expect(result.current.localDeletionDetectedCount).toBe(0);
-    expect(mockPhotosLocalDB.deleteAssetSync).not.toHaveBeenCalled();
+    expect(mockPhotosLocalDB.deleteAssetSyncBulk).not.toHaveBeenCalled();
   });
 
   test('when the media library fires a non-incremental event, then it falls back to a head-window reconcile fetch', async () => {

--- a/src/screens/PhotosScreen/hooks/useLocalAssets.ts
+++ b/src/screens/PhotosScreen/hooks/useLocalAssets.ts
@@ -41,8 +41,15 @@ export const useLocalAssets = (): LocalAssetsResult => {
 
   const uploadingIdSet = useMemo(() => new Set(uploadingAssetIds), [uploadingAssetIds]);
 
-  const { assets, isLoading, hasLoadedLocalAssetsOnce, loadNextPage, reloadFromStart, reconcileHead, applyLibraryChange } =
-    usePagedLocalAssets(isPhotosEnabled);
+  const {
+    assets,
+    isLoading,
+    hasLoadedLocalAssetsOnce,
+    loadNextPage,
+    reloadFromStart,
+    reconcileHead,
+    applyLibraryChange,
+  } = usePagedLocalAssets(isPhotosEnabled);
 
   const assetIds = useMemo(() => assets.map((asset) => asset.id), [assets]);
   const { syncedIds, cloudDeletedIds, incompleteUploadBurstIdSet } = useLocalAssetsSyncStatus(assetIds);
@@ -50,7 +57,7 @@ export const useLocalAssets = (): LocalAssetsResult => {
 
   const removeDeletedAssetsFromSyncDB = useCallback(async (deletedAssetIds: string[]) => {
     await photosLocalDB.init();
-    await Promise.all(deletedAssetIds.map((id) => photosLocalDB.deleteAssetSync(id)));
+    await photosLocalDB.deleteAssetSyncBulk(deletedAssetIds);
     setLocalDeletionDetectedCount((prev) => prev + 1);
   }, []);
 

--- a/src/services/SqliteService.spec.ts
+++ b/src/services/SqliteService.spec.ts
@@ -1,0 +1,121 @@
+import * as SQLite from 'expo-sqlite';
+import sqliteService from './SqliteService';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockedOpenDatabaseAsync = SQLite.openDatabaseAsync as jest.Mock<any>;
+
+const getOpenedDb = async (callIndex: number) => mockedOpenDatabaseAsync.mock.results[callIndex].value;
+
+describe('SqliteService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('when two calls run against the same DB, then the second does not start until the first settles', async () => {
+    await sqliteService.open('photos_sync.db');
+    const db = await getOpenedDb(0);
+
+    const order: string[] = [];
+    let resolveFirst: () => void = () => undefined;
+    db.runAsync.mockImplementationOnce(async () => {
+      order.push('first-start');
+      await new Promise<void>((resolve) => {
+        resolveFirst = resolve;
+      });
+      order.push('first-end');
+    });
+    db.runAsync.mockImplementationOnce(async () => {
+      order.push('second-start');
+    });
+
+    const first = sqliteService.executeSql('photos_sync.db', 'UPDATE test SET a = 1');
+    const second = sqliteService.executeSql('photos_sync.db', 'UPDATE test SET a = 2');
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(order).toEqual(['first-start']);
+
+    resolveFirst();
+    await Promise.all([first, second]);
+
+    expect(order).toEqual(['first-start', 'first-end', 'second-start']);
+  });
+
+  test('when a queued call fails, then the next queued call for the same DB still runs', async () => {
+    await sqliteService.open('photos_sync.db');
+    const db = await getOpenedDb(0);
+
+    db.runAsync.mockRejectedValueOnce(new Error('boom'));
+    db.runAsync.mockResolvedValueOnce(undefined);
+
+    await expect(sqliteService.executeSql('photos_sync.db', 'BAD SQL')).rejects.toThrow('boom');
+    await expect(sqliteService.executeSql('photos_sync.db', 'GOOD SQL')).resolves.toBeDefined();
+  });
+
+  test('when calls target different DB names, then they are not serialized against each other', async () => {
+    await sqliteService.open('photos_sync.db');
+    await sqliteService.open('drive.db');
+    const photosDb = await getOpenedDb(0);
+    const driveDb = await getOpenedDb(1);
+
+    let releasePhotos: () => void = () => undefined;
+    photosDb.runAsync.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releasePhotos = resolve;
+        }),
+    );
+    driveDb.runAsync.mockResolvedValueOnce(undefined);
+
+    const photosCall = sqliteService.executeSql('photos_sync.db', 'UPDATE test SET a = 1');
+    await sqliteService.executeSql('drive.db', 'UPDATE test SET a = 2');
+
+    // The drive.db call completed even though the photos_sync.db call is still pending —
+    // proof the two DBs don't share a queue.
+    expect(driveDb.runAsync).toHaveBeenCalledTimes(1);
+
+    releasePhotos();
+    await photosCall;
+  });
+
+  test('when the database is closed, then its queue is cleared so a later call to the same name starts fresh', async () => {
+    await sqliteService.open('photos_sync.db');
+    await sqliteService.close('photos_sync.db');
+    await sqliteService.open('photos_sync.db');
+    const db = await getOpenedDb(1);
+
+    await expect(sqliteService.executeSql('photos_sync.db', 'SELECT 1')).resolves.toBeDefined();
+    expect(db.runAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test('when executeBulk runs, then it prepares the statement once and executes it once per row', async () => {
+    await sqliteService.open('photos_sync.db');
+    const db = await getOpenedDb(0);
+
+    await sqliteService.executeBulk('photos_sync.db', 'INSERT INTO asset_sync VALUES (?)', [['a'], ['b'], ['c']]);
+
+    expect(db.prepareAsync).toHaveBeenCalledTimes(1);
+    expect(db.withTransactionAsync).toHaveBeenCalledTimes(1);
+    const statement = await db.prepareAsync.mock.results[0].value;
+    expect(statement.executeAsync).toHaveBeenCalledTimes(3);
+    expect(statement.executeAsync).toHaveBeenNthCalledWith(1, ['a']);
+    expect(statement.executeAsync).toHaveBeenNthCalledWith(3, ['c']);
+    expect(statement.finalizeAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test('when executeBulk is called with an empty list, then it does not touch the database', async () => {
+    await sqliteService.open('photos_sync.db');
+    const db = await getOpenedDb(0);
+
+    await sqliteService.executeBulk('photos_sync.db', 'INSERT INTO asset_sync VALUES (?)', []);
+
+    expect(db.prepareAsync).not.toHaveBeenCalled();
+    expect(db.withTransactionAsync).not.toHaveBeenCalled();
+  });
+
+  test('when the database was never opened, then executeSql throws instead of touching a connection', async () => {
+    await expect(sqliteService.executeSql('unknown.db', 'SELECT 1')).rejects.toThrow(
+      'SQLiteService - database with name \'unknown.db\' not found',
+    );
+  });
+});

--- a/src/services/SqliteService.ts
+++ b/src/services/SqliteService.ts
@@ -4,9 +4,25 @@ type SQLiteDatabase = SQLite.SQLiteDatabase;
 
 class SQLiteService {
   private readonly pool: Record<string, SQLiteDatabase>;
+  private readonly queues: Record<string, Promise<unknown>>;
 
   constructor() {
     this.pool = {};
+    this.queues = {};
+  }
+
+  // expo-sqlite's single connection isn't safe under concurrent statement execution:
+  // concurrent runAsync/getAllAsync calls on the same SQLiteDatabase can race and throw
+  // "Cannot use shared object that was already released".
+  // Serialize per DB name so only one statement runs against a given connection at a time.
+  private enqueue<T>(name: string, task: () => Promise<T>): Promise<T> {
+    const previous = this.queues[name] ?? Promise.resolve();
+    const run = previous.then(task, task);
+    this.queues[name] = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
   }
 
   public async open(name: string) {
@@ -19,6 +35,7 @@ class SQLiteService {
       await this.pool[name].closeAsync();
       delete this.pool[name];
     }
+    delete this.queues[name];
   }
 
   public async delete(name: string) {
@@ -26,53 +43,84 @@ class SQLiteService {
       await this.pool[name].closeAsync();
       delete this.pool[name];
     }
+    delete this.queues[name];
     await SQLite.deleteDatabaseAsync(name);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public async executeSql(name: string, statement: string, params?: any[]) {
     if (!this.pool[name]) {
       this.throwDatabaseNotFound(name);
     }
 
-    const result = await this.pool[name].runAsync(statement, params || []);
-    return [result];
+    return this.enqueue(name, async () => {
+      const result = await this.pool[name].runAsync(statement, params || []);
+      return [result];
+    });
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public async getAllAsync<T>(name: string, statement: string, params?: any[]): Promise<T[]> {
     if (!this.pool[name]) {
       this.throwDatabaseNotFound(name);
     }
 
-    return await this.pool[name].getAllAsync<T>(statement, params || []);
+    return this.enqueue(name, () => this.pool[name].getAllAsync<T>(statement, params || []));
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public async getFirstAsync<T>(name: string, statement: string, params?: any[]): Promise<T | null> {
     if (!this.pool[name]) {
       this.throwDatabaseNotFound(name);
     }
 
-    return await this.pool[name].getFirstAsync<T>(statement, params || []);
+    return this.enqueue(name, () => this.pool[name].getFirstAsync<T>(statement, params || []));
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  /**
+   * Runs `statement` once per row of `paramsList` by preparing it a single time and reusing
+   * it, inside one transaction. Use for bulk writes of the same statement instead of firing
+   * one `executeSql` per row.
+   *
+   * @param name - DB name, as passed to `open`.
+   * @param statement - SQL with `?` placeholders, run once per entry in `paramsList`.
+   * @param paramsList - Bind params for each execution, in order. No-ops on an empty list.
+   */
+  public async executeBulk(name: string, statement: string, paramsList: any[][]): Promise<void> {
+    if (!this.pool[name]) {
+      this.throwDatabaseNotFound(name);
+    }
+    if (paramsList.length === 0) {
+      return;
+    }
+
+    return this.enqueue(name, () =>
+      this.pool[name].withTransactionAsync(async () => {
+        const prepared = await this.pool[name].prepareAsync(statement);
+        try {
+          for (const params of paramsList) {
+            await prepared.executeAsync(params);
+          }
+        } finally {
+          await prepared.finalizeAsync();
+        }
+      }),
+    );
+  }
+
   public async transaction(name: string, scope: (t: any) => void | Promise<void>) {
     if (!this.pool[name]) {
       this.throwDatabaseNotFound(name);
     }
 
-    await this.pool[name].withTransactionAsync(async () => {
-      const txWrapper = {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        executeSql: async (statement: string, params?: any[]) => {
-          return await this.pool[name].runAsync(statement, params || []);
-        },
-      };
+    return this.enqueue(name, () =>
+      this.pool[name].withTransactionAsync(async () => {
+        const txWrapper = {
+          executeSql: async (statement: string, params?: any[]) => {
+            return await this.pool[name].runAsync(statement, params || []);
+          },
+        };
 
-      await scope(txWrapper);
-    });
+        await scope(txWrapper);
+      }),
+    );
   }
 
   private throwDatabaseNotFound(name: string) {

--- a/src/services/photos/database/photosLocalDB.spec.ts
+++ b/src/services/photos/database/photosLocalDB.spec.ts
@@ -8,6 +8,7 @@ jest.mock('../../SqliteService', () => ({
     executeSql: jest.fn().mockResolvedValue(undefined),
     getAllAsync: jest.fn().mockResolvedValue([]),
     getFirstAsync: jest.fn().mockResolvedValue(null),
+    executeBulk: jest.fn().mockResolvedValue(undefined),
     transaction: jest.fn(),
   },
 }));
@@ -40,53 +41,74 @@ describe('photosLocalDB', () => {
     expect(mockSqlite.executeSql).not.toHaveBeenCalled();
   });
 
-  test('when a photo is marked as pending, then it never overwrites an already synced photo', async () => {
-    await photosLocalDB.markPending('asset-1');
+  test('when photos are marked as pending in bulk, then it never overwrites an already synced photo and all media info fields are passed', async () => {
+    await photosLocalDB.markPendingBulk([
+      { assetId: 'asset-1' },
+      {
+        assetId: 'asset-2',
+        mediaInfo: {
+          fileName: 'photo.jpg',
+          creationTime: 1714000000000,
+          width: 3024,
+          height: 4032,
+          duration: 0,
+          mediaType: 'photo',
+        },
+      },
+    ]);
 
-    expect(mockSqlite.executeSql).toHaveBeenCalledTimes(1);
-    const [, stmt, params] = mockSqlite.executeSql.mock.calls[0];
+    expect(mockSqlite.executeBulk).toHaveBeenCalledTimes(1);
+    const [dbName, stmt, paramsList] = mockSqlite.executeBulk.mock.calls[0];
+    expect(dbName).toBe('photos_sync.db');
     expect(stmt).toContain('\'pending\'');
     expect(stmt).toContain('ON CONFLICT');
     expect(stmt).toContain('status != \'synced\'');
-    expect(params).toEqual(['asset-1', null, null, null, null, null, null, 0, 0]);
+    expect(paramsList).toEqual([
+      ['asset-1', null, null, null, null, null, null, 0, 0],
+      ['asset-2', 'photo.jpg', 1714000000000, 3024, 4032, 0, 'photo', 0, 0],
+    ]);
+    expect(mockSqlite.executeSql).not.toHaveBeenCalled();
   });
 
-  test('when a photo is marked as pending with media info, then all media info fields are passed to the database', async () => {
-    await photosLocalDB.markPending('asset-1', {
-      fileName: 'photo.jpg',
-      creationTime: 1714000000000,
-      width: 3024,
-      height: 4032,
-      duration: 0,
-      mediaType: 'photo',
-    });
+  test('when markPendingBulk is called with no entries, then it still delegates to executeBulk, which no-ops on an empty list', async () => {
+    await photosLocalDB.markPendingBulk([]);
 
-    const [, , params] = mockSqlite.executeSql.mock.calls[0];
-    expect(params).toEqual(['asset-1', 'photo.jpg', 1714000000000, 3024, 4032, 0, 'photo', 0, 0]);
+    expect(mockSqlite.executeBulk).toHaveBeenCalledWith('photos_sync.db', expect.any(String), []);
   });
 
-  test('when a photo is marked as pending for edit, then the status is pending_edit and it never overwrites a non-synced photo', async () => {
-    await photosLocalDB.markPendingEdit('asset-1');
+  test('when edited photos are marked as pending in bulk, then the status is pending_edit, it never overwrites a non-synced photo, and media info fields are passed', async () => {
+    await photosLocalDB.markPendingEditBulk([
+      { assetId: 'asset-1' },
+      {
+        assetId: 'asset-2',
+        mediaInfo: {
+          fileName: 'video.mp4',
+          creationTime: 1714000000000,
+          width: 1920,
+          height: 1080,
+          duration: 30,
+          mediaType: 'video',
+        },
+      },
+    ]);
 
-    expect(mockSqlite.executeSql).toHaveBeenCalledTimes(1);
-    const [, stmt, params] = mockSqlite.executeSql.mock.calls[0];
+    expect(mockSqlite.executeBulk).toHaveBeenCalledTimes(1);
+    const [, stmt, paramsList] = mockSqlite.executeBulk.mock.calls[0];
     expect(stmt).toContain('\'pending_edit\'');
     expect(stmt).toContain('status = \'synced\'');
-    expect(params).toEqual(['asset-1', null, null, null, null, null, null, 0, 0]);
+    expect(paramsList).toEqual([
+      ['asset-1', null, null, null, null, null, null, 0, 0],
+      ['asset-2', 'video.mp4', 1714000000000, 1920, 1080, 30, 'video', 0, 0],
+    ]);
   });
 
-  test('when a photo is marked as pending for edit with media info, then all media info fields are passed to the database', async () => {
-    await photosLocalDB.markPendingEdit('asset-2', {
-      fileName: 'video.mp4',
-      creationTime: 1714000000000,
-      width: 1920,
-      height: 1080,
-      duration: 30,
-      mediaType: 'video',
-    });
+  test('when asset_sync rows are deleted in bulk, then one param row per asset id is passed to executeBulk', async () => {
+    await photosLocalDB.deleteAssetSyncBulk(['asset-1', 'asset-2', 'asset-3']);
 
-    const [, , params] = mockSqlite.executeSql.mock.calls[0];
-    expect(params).toEqual(['asset-2', 'video.mp4', 1714000000000, 1920, 1080, 30, 'video', 0, 0]);
+    expect(mockSqlite.executeBulk).toHaveBeenCalledTimes(1);
+    const [dbName, , paramsList] = mockSqlite.executeBulk.mock.calls[0];
+    expect(dbName).toBe('photos_sync.db');
+    expect(paramsList).toEqual([['asset-1'], ['asset-2'], ['asset-3']]);
   });
 
   test('when a file size is cached for an asset, then the file size and asset id are passed to the database', async () => {

--- a/src/services/photos/database/photosLocalDB.ts
+++ b/src/services/photos/database/photosLocalDB.ts
@@ -273,6 +273,18 @@ const rowToAssetSyncEntry = (row: AssetSyncRow): AssetSyncEntry => ({
   burstMemberCount: row.burst_member_count,
 });
 
+const toMarkPendingParams = (assetId: string, mediaInfo?: AssetMediaInfo) => [
+  assetId,
+  mediaInfo?.fileName ?? null,
+  mediaInfo?.creationTime ?? null,
+  mediaInfo?.width ?? null,
+  mediaInfo?.height ?? null,
+  mediaInfo?.duration ?? null,
+  mediaInfo?.mediaType ?? null,
+  mediaInfo?.isLivePhoto ? 1 : 0,
+  mediaInfo?.isBurst ? 1 : 0,
+];
+
 class PhotosLocalDB {
   private initPromise: Promise<void> | null = null;
 
@@ -291,32 +303,33 @@ class PhotosLocalDB {
     return this.initPromise;
   }
 
-  async markPending(assetId: string, mediaInfo?: AssetMediaInfo): Promise<void> {
-    await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.markPending, [
-      assetId,
-      mediaInfo?.fileName ?? null,
-      mediaInfo?.creationTime ?? null,
-      mediaInfo?.width ?? null,
-      mediaInfo?.height ?? null,
-      mediaInfo?.duration ?? null,
-      mediaInfo?.mediaType ?? null,
-      mediaInfo?.isLivePhoto ? 1 : 0,
-      mediaInfo?.isBurst ? 1 : 0,
-    ]);
+  /**
+   * Marks assets pending, in bulk (see `SqliteService.executeBulk`).
+   *
+   * @param entries - Asset id + media info pairs, one per asset to mark pending.
+   */
+  async markPendingBulk(entries: Array<{ assetId: string; mediaInfo?: AssetMediaInfo }>): Promise<void> {
+    await this.markBulk(assetSyncTable.statements.markPending, entries);
   }
 
-  async markPendingEdit(assetId: string, mediaInfo?: AssetMediaInfo): Promise<void> {
-    await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.markPendingEdit, [
-      assetId,
-      mediaInfo?.fileName ?? null,
-      mediaInfo?.creationTime ?? null,
-      mediaInfo?.width ?? null,
-      mediaInfo?.height ?? null,
-      mediaInfo?.duration ?? null,
-      mediaInfo?.mediaType ?? null,
-      mediaInfo?.isLivePhoto ? 1 : 0,
-      mediaInfo?.isBurst ? 1 : 0,
-    ]);
+  /**
+   * Same as `markPendingBulk`, but for assets that were edited after already syncing.
+   *
+   * @param entries - Asset id + media info pairs, one per edited asset to mark pending.
+   */
+  async markPendingEditBulk(entries: Array<{ assetId: string; mediaInfo?: AssetMediaInfo }>): Promise<void> {
+    await this.markBulk(assetSyncTable.statements.markPendingEdit, entries);
+  }
+
+  private async markBulk(
+    statement: string,
+    entries: Array<{ assetId: string; mediaInfo?: AssetMediaInfo }>,
+  ): Promise<void> {
+    await sqliteService.executeBulk(
+      DB_NAME,
+      statement,
+      entries.map(({ assetId, mediaInfo }) => toMarkPendingParams(assetId, mediaInfo)),
+    );
   }
 
   async markSynced(assetId: string, remoteFileId: string, modificationTime: number | null): Promise<void> {
@@ -506,8 +519,17 @@ class PhotosLocalDB {
     await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.markDeleted, [assetId]);
   }
 
-  async deleteAssetSync(assetId: string): Promise<void> {
-    await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.deleteById, [assetId]);
+  /**
+   * Removes `asset_sync` rows for locally-deleted assets, in bulk (see `SqliteService.executeBulk`).
+   *
+   * @param assetIds - Ids of the local assets to remove from `asset_sync`.
+   */
+  async deleteAssetSyncBulk(assetIds: string[]): Promise<void> {
+    await sqliteService.executeBulk(
+      DB_NAME,
+      assetSyncTable.statements.deleteById,
+      assetIds.map((assetId) => [assetId]),
+    );
   }
 
   async cleanupOrphanedAssetSync(localAssetIds: Set<string>): Promise<number> {
@@ -519,12 +541,7 @@ class PhotosLocalDB {
     if (orphanAssetsIds.length === 0) {
       return 0;
     }
-    for (let i = 0; i < orphanAssetsIds.length; i += CHUNK_SIZE) {
-      const orphanAssetsChunk = orphanAssetsIds.slice(i, i + CHUNK_SIZE);
-      await Promise.all(
-        orphanAssetsChunk.map((id) => sqliteService.executeSql(DB_NAME, assetSyncTable.statements.deleteById, [id])),
-      );
-    }
+    await this.deleteAssetSyncBulk(orphanAssetsIds);
     return orphanAssetsIds.length;
   }
 

--- a/src/store/slices/photos/index.spec.ts
+++ b/src/store/slices/photos/index.spec.ts
@@ -112,8 +112,8 @@ jest.mock('src/services/photos/database/photosLocalDB', () => ({
   photosLocalDB: {
     init: jest.fn().mockResolvedValue(undefined),
     getPendingAssets: jest.fn().mockResolvedValue([]),
-    markPending: jest.fn().mockResolvedValue(undefined),
-    markPendingEdit: jest.fn().mockResolvedValue(undefined),
+    markPendingBulk: jest.fn().mockResolvedValue(undefined),
+    markPendingEditBulk: jest.fn().mockResolvedValue(undefined),
     markSynced: jest.fn().mockResolvedValue(undefined),
     markSyncedLivePhoto: jest.fn().mockResolvedValue(undefined),
     markSyncedBurst: jest.fn().mockResolvedValue(undefined),
@@ -197,8 +197,8 @@ describe('photos slice', () => {
     mockDeduplicator.getAssetsToSync.mockResolvedValue({ newAssets: [], editedAssets: [] });
     mockPhotosLocalDB.init.mockResolvedValue(undefined);
     mockPhotosLocalDB.getPendingAssets.mockResolvedValue([]);
-    mockPhotosLocalDB.markPending.mockResolvedValue(undefined);
-    mockPhotosLocalDB.markPendingEdit.mockResolvedValue(undefined);
+    mockPhotosLocalDB.markPendingBulk.mockResolvedValue(undefined);
+    mockPhotosLocalDB.markPendingEditBulk.mockResolvedValue(undefined);
     mockPhotosLocalDB.markSynced.mockResolvedValue(undefined);
     mockPhotosLocalDB.markSyncedBurst.mockResolvedValue(undefined);
     mockPhotosLocalDB.markError.mockResolvedValue(undefined);
@@ -1726,7 +1726,7 @@ describe('photos slice', () => {
 
       expect(mockPhotosLocalDB.markSynced).toHaveBeenCalledWith('a1', 'remote-1', 12345);
       expect(store.getState().photos.uploadingAssetIds).toEqual([]);
-      expect(mockPhotosLocalDB.markPending).not.toHaveBeenCalled();
+      expect(mockPhotosLocalDB.markPendingBulk).not.toHaveBeenCalled();
     });
 
     test('when the upload succeeds, then the asset is not added to sessionCompletedAssetIds', async () => {

--- a/src/store/slices/photos/index.ts
+++ b/src/store/slices/photos/index.ts
@@ -281,31 +281,23 @@ export const runDiscoveryThunk = createAsyncThunk<void, void, { state: RootState
       const burstRepresentativeIds = await BurstNativeModule.getBurstRepresentativeIds(allPendingIds);
       const burstIdSet = new Set(burstRepresentativeIds);
 
+      const transformToPendingEntry = (asset: (typeof newAssets)[number]) => ({
+        assetId: asset.id,
+        mediaInfo: {
+          fileName: asset.filename,
+          creationTime: asset.creationTime,
+          width: asset.width,
+          height: asset.height,
+          duration: asset.duration,
+          mediaType: asset.mediaType,
+          isLivePhoto: asset.mediaSubtypes?.includes('livePhoto') ?? false,
+          isBurst: burstIdSet.has(asset.id),
+        },
+      });
+
       await Promise.all([
-        ...newAssets.map((asset) =>
-          photosLocalDB.markPending(asset.id, {
-            fileName: asset.filename,
-            creationTime: asset.creationTime,
-            width: asset.width,
-            height: asset.height,
-            duration: asset.duration,
-            mediaType: asset.mediaType,
-            isLivePhoto: asset.mediaSubtypes?.includes('livePhoto') ?? false,
-            isBurst: burstIdSet.has(asset.id),
-          }),
-        ),
-        ...editedAssets.map((asset) =>
-          photosLocalDB.markPendingEdit(asset.id, {
-            fileName: asset.filename,
-            creationTime: asset.creationTime,
-            width: asset.width,
-            height: asset.height,
-            duration: asset.duration,
-            mediaType: asset.mediaType,
-            isLivePhoto: asset.mediaSubtypes?.includes('livePhoto') ?? false,
-            isBurst: burstIdSet.has(asset.id),
-          }),
-        ),
+        photosLocalDB.markPendingBulk(newAssets.map(transformToPendingEntry)),
+        photosLocalDB.markPendingEditBulk(editedAssets.map(transformToPendingEntry)),
       ]);
       const localAssetIdSet = new Set(scannedAssets.map((a) => a.id));
       const orphanedAssetsSyncRemovedCount = await photosLocalDB.cleanupOrphanedAssetSync(localAssetIdSet);


### PR DESCRIPTION
`expo-sqlite`'s single native connection per DB isn't safe under concurrent statement execution, concurrent calls against the same connection can race and throw `Cannot use shared object that was already released`.
**Fix**: serialize all calls against a given DB connection through a queue in `SqliteService`, and write bulk updates through a single prepared statement (`executeBulk`) instead of firing one statement per row.

## Summary

  - **`SqliteService.ts`*: per-DB-name serialization queue (`enqueue`), so no two statements ever run concurrently against the same native connection. 
  - **`photosLocalDB.ts`**: new `markPendingBulk`, `markPendingEditBulk`, `deleteAssetSyncBulk` built on `executeBulk`.
  - **`store/slices/photos/index.ts`** (`runDiscoveryThunk`): uses the bulk methods instead of firing one write per asset.
  - **`useLocalAssets.ts`*: local deletion reconcile uses `deleteAssetSyncBulk` instead of one `deleteAssetSync` per id.
