### PR TITLE
[PB-6660] bugfix/recently uploaded photos are incorrectly shown as ‘pending upload’

### DIFF
--- a/src/services/photos/PhotoCloudBrowser.spec.ts
+++ b/src/services/photos/PhotoCloudBrowser.spec.ts
@@ -445,6 +445,7 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
 
     // Own device folder isn't among Drive's — reset synced assets to pending regardless.
     expect(mockPhotosLocalDB.resetSyncedToPending).toHaveBeenCalledTimes(1);
+    expect(mockPhotosLocalDB.resetSyncedToPending).toHaveBeenCalledWith(expect.any(Number));
     // But other (unrelated) devices are still walked so the "All devices" filter has their data.
     expect(mockFolderService.getFolderFolders).toHaveBeenCalledWith('d1-uuid', 0, 50);
   });
@@ -456,6 +457,7 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
 
     expect(mockFolderService.getFolderFolders).not.toHaveBeenCalled();
     expect(mockPhotosLocalDB.resetSyncedToPending).toHaveBeenCalledTimes(1);
+    expect(mockPhotosLocalDB.resetSyncedToPending).toHaveBeenCalledWith(expect.any(Number));
     expect(mockPhotosLocalDB.markCloudDeleted).not.toHaveBeenCalled();
   });
 
@@ -475,7 +477,7 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
 
     await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'd1-uuid' });
 
-    expect(mockPhotosLocalDB.getSyncedRemoteIdsByCreationMonth).toHaveBeenCalled();
+    expect(mockPhotosLocalDB.getSyncedRemoteIdsByCreationMonth).toHaveBeenCalledWith(2024, 6, expect.any(Number));
   });
 
   test('when a month known in the DB is no longer present in the cloud, then all its files are marked as cloud_deleted', async () => {
@@ -547,6 +549,31 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
     await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'd1-uuid' });
 
     expect(mockPhotosLocalDB.resetSyncedToPending).toHaveBeenCalledTimes(1);
+    expect(mockPhotosLocalDB.resetSyncedToPending).toHaveBeenCalledWith(expect.any(Number));
+    expect(mockPhotosLocalDB.markCloudDeleted).not.toHaveBeenCalled();
+  });
+
+  test('when the current device has no cloud history but every synced month was synced during this same cycle, then nothing is reset to pending', async () => {
+    mockDeviceService.listDevices.mockResolvedValueOnce([makeDevice('d1-uuid', 'Internxt iPhone')]);
+    mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
+    mockPhotosLocalDB.getCloudAssetMonthsByDevice.mockResolvedValue([]);
+    mockPhotosLocalDB.getSyncedMonths.mockResolvedValue([]);
+    mockFolderService.getFolderFolders.mockResolvedValueOnce({ folders: [] } as never);
+
+    await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'd1-uuid' });
+
+    expect(mockPhotosLocalDB.getSyncedMonths).toHaveBeenCalledWith(expect.any(Number));
+    expect(mockPhotosLocalDB.resetSyncedToPending).not.toHaveBeenCalled();
+  });
+
+  test('when the sync cycle is cancelled, then deleted-months reconciliation is skipped', async () => {
+    mockDeviceService.listDevices.mockResolvedValueOnce([makeDevice('d1-uuid', 'Internxt iPhone')]);
+    mockPhotosLocalDB.getCloudAssetMonthsByDevice.mockResolvedValue([{ year: 2024, month: 6 }]);
+    mockFolderService.getFolderFolders.mockResolvedValueOnce({ folders: [] } as never);
+
+    await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'd1-uuid', isCancelled: () => true });
+
+    expect(mockPhotosLocalDB.resetSyncedToPending).not.toHaveBeenCalled();
     expect(mockPhotosLocalDB.markCloudDeleted).not.toHaveBeenCalled();
   });
 

--- a/src/services/photos/PhotoCloudBrowser.ts
+++ b/src/services/photos/PhotoCloudBrowser.ts
@@ -81,6 +81,7 @@ class PhotoCloudBrowserService {
       month,
       onMonthFetched,
       currentDeviceId: undefined,
+      cycleStartedAt: Date.now(),
     });
   }
 
@@ -94,6 +95,7 @@ class PhotoCloudBrowserService {
     logger.info(
       `[CloudBrowser] syncAllHistory — currentDeviceId=${currentDeviceId ?? 'none'}, force=${force ?? false}`,
     );
+    const cycleStartedAt = Date.now();
     const devices = await this.listDeviceFolders();
     if (devices.length === 0) {
       logger.info('[CloudBrowser] No device folders found — skipping sync');
@@ -101,7 +103,7 @@ class PhotoCloudBrowserService {
         // Own device folder gone from cloud — every remote reference is stale. Reset synced
         // assets to pending (not cloud_deleted) so the next upload cycle restores the backup.
         await this.purgeDeletedDevices(devices, onMonthFetched);
-        await this.localDB.resetSyncedToPending();
+        await this.localDB.resetSyncedToPending(cycleStartedAt);
       }
       return;
     }
@@ -111,7 +113,7 @@ class PhotoCloudBrowserService {
       logger.info(
         `[CloudBrowser] Current device "${currentDeviceId}" not found among Drive's device folders — resetting synced assets to pending`,
       );
-      await this.localDB.resetSyncedToPending();
+      await this.localDB.resetSyncedToPending(cycleStartedAt);
     }
     logger.info(`[CloudBrowser] Syncing ${devices.length} device(s): ${devices.map((d) => d.uuid).join(', ')}`);
 
@@ -141,13 +143,19 @@ class PhotoCloudBrowserService {
             onMonthFetched,
             force,
             currentDeviceId,
+            cycleStartedAt,
           });
         }
       };
       await Promise.all(Array.from({ length: CONCURRENCY }, () => worker()));
     }
 
-    await this.reconcileDeletedMonths({ devices, discoveredMonths: months, currentDeviceId });
+    if (isCancelled?.()) {
+      logger.info('[CloudBrowser] Sync cancelled — skipping deleted-months reconciliation');
+      return;
+    }
+
+    await this.reconcileDeletedMonths({ devices, discoveredMonths: months, currentDeviceId, cycleStartedAt });
   }
 
   private async fetchMonthFromFolder(params: {
@@ -158,8 +166,9 @@ class PhotoCloudBrowserService {
     onMonthFetched?: () => void;
     force?: boolean;
     currentDeviceId: string | undefined;
+    cycleStartedAt: number;
   }): Promise<number> {
-    const { deviceId, monthFolderUuid, year, month, onMonthFetched, force, currentDeviceId } = params;
+    const { deviceId, monthFolderUuid, year, month, onMonthFetched, force, currentDeviceId, cycleStartedAt } = params;
     if (!force) {
       const cacheAge = await this.localDB.getCloudFetchCacheAge(deviceId, year, month);
       if (cacheAge !== null && Date.now() - cacheAge < CACHE_TTL_MS) return 0;
@@ -187,7 +196,7 @@ class PhotoCloudBrowserService {
       }
     }
 
-    await this.reconcileCloudDeletions({ deviceId, year, month, foundIds, currentDeviceId });
+    await this.reconcileCloudDeletions({ deviceId, year, month, foundIds, currentDeviceId, cycleStartedAt });
 
     if (count > 0) {
       logger.info(
@@ -210,6 +219,8 @@ class PhotoCloudBrowserService {
    * @param params.month - Month being reconciled (1-12).
    * @param params.foundIds - Remote file ids found in Drive for this device/month in this pass.
    * @param params.currentDeviceId - This device's own folder uuid, or undefined if unknown.
+   * @param params.cycleStartedAt - Timestamp (ms) captured before this sync cycle started
+   * observing the cloud
    */
   private async reconcileCloudDeletions(params: {
     deviceId: string;
@@ -217,15 +228,16 @@ class PhotoCloudBrowserService {
     month: number;
     foundIds: Set<string>;
     currentDeviceId: string | undefined;
+    cycleStartedAt: number;
   }): Promise<void> {
-    const { deviceId, year, month, foundIds, currentDeviceId } = params;
+    const { deviceId, year, month, foundIds, currentDeviceId, cycleStartedAt } = params;
     const monthLabel = `${year}/${String(month).padStart(2, '0')}`;
     logger.info(
       `[CloudBrowser] reconcileCloudDeletions — device=${deviceId} ${monthLabel}, foundIds=${[...foundIds].length}, currentDeviceId=${currentDeviceId ?? 'none'}`,
     );
     const isCurrentDevice = !!currentDeviceId && deviceId === currentDeviceId;
 
-    const knownIds = await this.getKnownRemoteIds({ deviceId, year, month, isCurrentDevice });
+    const knownIds = await this.getKnownRemoteIds({ deviceId, year, month, isCurrentDevice, cycleStartedAt });
 
     const removedCount = await this.markMissingAsCloudDeleted({ knownIds, foundIds });
     if (removedCount > 0) {
@@ -250,6 +262,8 @@ class PhotoCloudBrowserService {
    * @param params.month - Month being reconciled (1-12).
    * @param params.isCurrentDevice - Whether `params.deviceId` is this device's own folder uuid;
    *   when true, `asset_sync` is also consulted.
+   * @param params.cycleStartedAt - Timestamp (ms) captured before this sync cycle started
+   * observing the cloud
    * @returns The set of known remote file ids.
    */
   private async getKnownRemoteIds(params: {
@@ -257,8 +271,9 @@ class PhotoCloudBrowserService {
     year: number;
     month: number;
     isCurrentDevice: boolean;
+    cycleStartedAt: number;
   }): Promise<Set<string>> {
-    const { deviceId, year, month, isCurrentDevice } = params;
+    const { deviceId, year, month, isCurrentDevice, cycleStartedAt } = params;
     const knownFromCloud = await this.localDB.getCloudAssetRemoteIdsByDeviceAndMonth(deviceId, year, month);
     logger.info(
       `[CloudBrowser] reconcileCloudDeletions — knownFromCloud=${knownFromCloud.size} in local DB for device=${deviceId} ${year}/${String(month).padStart(2, '0')}`,
@@ -266,7 +281,7 @@ class PhotoCloudBrowserService {
     const knownIds = new Set(knownFromCloud);
 
     if (isCurrentDevice) {
-      const knownFromSync = await this.localDB.getSyncedRemoteIdsByCreationMonth(year, month);
+      const knownFromSync = await this.localDB.getSyncedRemoteIdsByCreationMonth(year, month, cycleStartedAt);
       for (const id of knownFromSync) {
         knownIds.add(id);
       }
@@ -347,8 +362,9 @@ class PhotoCloudBrowserService {
     devices: { uuid: string }[];
     discoveredMonths: { deviceId: string; year: number; month: number; monthFolderUuid: string }[];
     currentDeviceId: string | undefined;
+    cycleStartedAt: number;
   }): Promise<void> {
-    const { devices, discoveredMonths, currentDeviceId } = params;
+    const { devices, discoveredMonths, currentDeviceId, cycleStartedAt } = params;
     const discoveredSet = new Set(discoveredMonths.map((m) => `${m.deviceId}:${m.year}:${m.month}`));
     logger.info(
       `[CloudBrowser] reconcileDeletedMonths — ${devices.length} device(s) to reconcile: ${devices.map((d) => d.uuid).join(', ')}`,
@@ -363,13 +379,13 @@ class PhotoCloudBrowserService {
       const monthSet = new Set(cloudMonths.map((m) => `${m.year}:${m.month}`));
 
       if (currentDeviceId && deviceId === currentDeviceId) {
-        const syncedMonths = await this.localDB.getSyncedMonths();
+        const syncedMonths = await this.localDB.getSyncedMonths(cycleStartedAt);
         const isRecreatedDeviceFolder = cloudMonths.length === 0 && syncedMonths.length > 0;
         if (isRecreatedDeviceFolder) {
           logger.info(
             `[CloudBrowser] Device "${deviceId}" has no cloud history but local DB has synced months — resetting to pending for re-upload`,
           );
-          await this.localDB.resetSyncedToPending();
+          await this.localDB.resetSyncedToPending(cycleStartedAt);
           continue;
         }
         for (const m of syncedMonths) monthSet.add(`${m.year}:${m.month}`);
@@ -381,7 +397,14 @@ class PhotoCloudBrowserService {
           logger.info(
             `[CloudBrowser] Device "${deviceId}" ${year}/${String(month).padStart(2, '0')} — month no longer in cloud`,
           );
-          await this.reconcileCloudDeletions({ deviceId, year, month, foundIds: new Set(), currentDeviceId });
+          await this.reconcileCloudDeletions({
+            deviceId,
+            year,
+            month,
+            foundIds: new Set(),
+            currentDeviceId,
+            cycleStartedAt,
+          });
         }
       }
     }

--- a/src/services/photos/database/photosLocalDB.spec.ts
+++ b/src/services/photos/database/photosLocalDB.spec.ts
@@ -1049,4 +1049,36 @@ describe('photosLocalDB cloud asset methods', () => {
       ]);
     });
   });
+
+  describe('synced-before cutoff', () => {
+    test('when synced remote ids for a creation month are requested, then the cutoff is passed after the month range', async () => {
+      await photosLocalDB.getSyncedRemoteIdsByCreationMonth(2024, 6, 1714000000000);
+
+      expect(mockSqlite.getAllAsync).toHaveBeenCalledTimes(1);
+      const [dbName, stmt, params] = mockSqlite.getAllAsync.mock.calls[0];
+      expect(dbName).toBe('photos_sync.db');
+      expect(stmt).toContain('synced_at');
+      expect(params).toEqual([new Date(2024, 5, 1).getTime(), new Date(2024, 6, 1).getTime(), 1714000000000]);
+    });
+
+    test('when synced months are requested, then the cutoff is passed as the only parameter', async () => {
+      await photosLocalDB.getSyncedMonths(1714000000000);
+
+      expect(mockSqlite.getAllAsync).toHaveBeenCalledWith(
+        'photos_sync.db',
+        expect.stringContaining('synced_at'),
+        [1714000000000],
+      );
+    });
+
+    test('when synced assets are reset to pending, then the cutoff is passed as the only parameter', async () => {
+      await photosLocalDB.resetSyncedToPending(1714000000000);
+
+      expect(mockSqlite.executeSql).toHaveBeenCalledWith(
+        'photos_sync.db',
+        expect.stringContaining('synced_at'),
+        [1714000000000],
+      );
+    });
+  });
 });

--- a/src/services/photos/database/photosLocalDB.ts
+++ b/src/services/photos/database/photosLocalDB.ts
@@ -436,13 +436,13 @@ class PhotosLocalDB {
     }));
   }
 
-  async getSyncedRemoteIdsByCreationMonth(year: number, month: number): Promise<Set<string>> {
+  async getSyncedRemoteIdsByCreationMonth(year: number, month: number, syncedBefore: number): Promise<Set<string>> {
     const startMs = new Date(year, month - 1, 1).getTime();
     const endMs = new Date(year, month, 1).getTime();
     const rows = await sqliteService.getAllAsync<{ remote_file_id: string }>(
       DB_NAME,
       assetSyncTable.statements.getSyncedRemoteIdsByCreationMonth,
-      [startMs, endMs],
+      [startMs, endMs, syncedBefore],
     );
     return new Set(rows.map((r) => r.remote_file_id));
   }
@@ -473,8 +473,8 @@ class PhotosLocalDB {
     await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.markCloudDeleted, [remoteFileId]);
   }
 
-  async resetSyncedToPending(): Promise<void> {
-    await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.resetSyncedToPending);
+  async resetSyncedToPending(syncedBefore: number): Promise<void> {
+    await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.resetSyncedToPending, [syncedBefore]);
   }
 
   async getDistinctCloudAssetDeviceIds(): Promise<string[]> {
@@ -497,10 +497,11 @@ class PhotosLocalDB {
     );
   }
 
-  async getSyncedMonths(): Promise<{ year: number; month: number }[]> {
+  async getSyncedMonths(syncedBefore: number): Promise<{ year: number; month: number }[]> {
     return sqliteService.getAllAsync<{ year: number; month: number }>(
       DB_NAME,
       assetSyncTable.statements.getSyncedMonths,
+      [syncedBefore],
     );
   }
 

--- a/src/services/photos/database/tables/asset_sync.ts
+++ b/src/services/photos/database/tables/asset_sync.ts
@@ -140,7 +140,8 @@ const statements = {
     WHERE status = 'synced'
       AND remote_file_id IS NOT NULL
       AND creation_time >= ?
-      AND creation_time < ?;
+      AND creation_time < ?
+      AND (synced_at IS NULL OR synced_at < ?);
   `,
   getCloudDeletedRemoteIdsByCreationMonth: `
     SELECT remote_file_id FROM ${TABLE_NAME}
@@ -184,7 +185,8 @@ const statements = {
       burst_member_count = NULL,
       paired_video_remote_file_id = NULL,
       paired_video_status = NULL
-    WHERE status = 'synced';
+    WHERE status = 'synced'
+      AND (synced_at IS NULL OR synced_at < ?);
   `,
   resetErrorsToPending: `
     UPDATE ${TABLE_NAME}
@@ -204,7 +206,8 @@ const statements = {
     FROM ${TABLE_NAME}
     WHERE status = 'synced'
       AND creation_time IS NOT NULL
-      AND remote_file_id IS NOT NULL;
+      AND remote_file_id IS NOT NULL
+      AND (synced_at IS NULL OR synced_at < ?);
   `,
 
   getIncompleteBurstAssets: `


### PR DESCRIPTION
 Fix synced photos reverting to pending during the first backup cycle

## Summary

- **`PhotoCloudBrowser.ts`**: capture `cycleStartedAt` before `syncAllHistory` observes the cloud, and thread it through `fetchMonthFromFolder`, `reconcileCloudDeletions`, `getKnownRemoteIds`, and `reconcileDeletedMonths`. Assets the concurrent upload cycle marks `synced` after that cutoff are never reverted or marked `cloud_deleted` by a stale cloud snapshot.
- **`PhotoCloudBrowser.ts`**: skip `reconcileDeletedMonths` entirely when the sync cycle is cancelled in flight, avoiding false resets from a partially populated `cloud_asset` cache.
- **`asset_sync.ts`**: add a `synced_at` cutoff filter (`AND (synced_at IS NULL OR synced_at < ?)`) to `resetSyncedToPending`, `getSyncedMonths`, and `getSyncedRemoteIdsByCreationMonth`.
- **`photosLocalDB.ts`**: add a mandatory `syncedBefore` parameter to functions.