### PR TITLE
[PB-6700] feature/Generate thumbnails of raw photos assets

### DIFF
--- a/src/screens/PhotoPreviewScreen/components/PreviewPage.tsx
+++ b/src/screens/PhotoPreviewScreen/components/PreviewPage.tsx
@@ -1,12 +1,49 @@
 import { useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, Image, View, useWindowDimensions } from 'react-native';
+import { logger } from 'src/services/common';
 import { useTailwind } from 'tailwind-rn';
 import { VideoViewer } from '../../../components/photos/VideoViewer/VideoViewer';
 import { ImageViewer } from '../../../components/ui-kit/view/ImageViewer/ImageViewer';
 import { TimelinePhotoItem } from '../../PhotosScreen/types';
+import { useCloudThumbnailBackfill } from '../hooks/useCloudThumbnailBackfill';
 import { usePreviewSource } from '../hooks/usePreviewSource';
 
 const VIDEO_ACTIVATION_DELAY_MS = 200;
+
+interface ThumbnailFallbackProps {
+  itemId: string;
+  thumbnailUri: string | null;
+  isLoading: boolean;
+  mediaLabel: 'video' | 'photo';
+  containerClassName: string;
+}
+
+const ThumbnailFallback = ({
+  itemId,
+  thumbnailUri,
+  isLoading,
+  mediaLabel,
+  containerClassName,
+}: ThumbnailFallbackProps): JSX.Element => {
+  const tailwind = useTailwind();
+  return (
+    <View style={tailwind(containerClassName)}>
+      {thumbnailUri ? (
+        <Image
+          source={{ uri: thumbnailUri }}
+          style={tailwind('w-full h-full')}
+          resizeMode="contain"
+          onError={(e) =>
+            logger.error(
+              `[PreviewPage] ${mediaLabel} thumbnail failed to load — id: ${itemId}, uri: ${thumbnailUri}, error: ${e.nativeEvent.error}`,
+            )
+          }
+        />
+      ) : null}
+      {isLoading ? <ActivityIndicator style={tailwind('absolute')} color="white" size="large" /> : null}
+    </View>
+  );
+};
 
 interface PageContentProps {
   item: TimelinePhotoItem;
@@ -37,7 +74,6 @@ const PageContent = ({
   onVideoEnd,
   videoResetKey,
 }: PageContentProps): JSX.Element => {
-  const tailwind = useTailwind();
   if (item.mediaType === 'video') {
     if (uri && isActive) {
       return (
@@ -52,12 +88,13 @@ const PageContent = ({
       );
     }
     return (
-      <View style={tailwind('flex-1 bg-black justify-center items-center')}>
-        {thumbnailUri ? (
-          <Image source={{ uri: thumbnailUri }} style={tailwind('w-full h-full')} resizeMode="contain" />
-        ) : null}
-        {isLoading ? <ActivityIndicator style={tailwind('absolute')} color="white" size="large" /> : null}
-      </View>
+      <ThumbnailFallback
+        itemId={item.id}
+        thumbnailUri={thumbnailUri}
+        isLoading={isLoading}
+        mediaLabel="video"
+        containerClassName="flex-1 bg-black justify-center items-center"
+      />
     );
   }
 
@@ -66,12 +103,13 @@ const PageContent = ({
   }
 
   return (
-    <View style={tailwind('flex-1 justify-center items-center')}>
-      {thumbnailUri ? (
-        <Image source={{ uri: thumbnailUri }} style={tailwind('w-full h-full')} resizeMode="contain" />
-      ) : null}
-      {isLoading ? <ActivityIndicator style={tailwind('absolute')} color="white" size="large" /> : null}
-    </View>
+    <ThumbnailFallback
+      itemId={item.id}
+      thumbnailUri={thumbnailUri}
+      isLoading={isLoading}
+      mediaLabel="photo"
+      containerClassName="flex-1 justify-center items-center"
+    />
   );
 };
 
@@ -101,6 +139,7 @@ export const PreviewPage = ({
   const tailwind = useTailwind();
   const { width: screenWidth } = useWindowDimensions();
   const { uri, thumbnailUri, isLoading } = usePreviewSource(item, isScrubbing);
+  useCloudThumbnailBackfill(item, uri);
   const [isVideoActive, setIsVideoActive] = useState(false);
 
   useEffect(() => {

--- a/src/screens/PhotoPreviewScreen/context/PreviewThumbnailBackfillContext.tsx
+++ b/src/screens/PhotoPreviewScreen/context/PreviewThumbnailBackfillContext.tsx
@@ -1,0 +1,20 @@
+import { createContext, useContext } from 'react';
+import { BackfilledThumbnailRefs } from 'src/services/photos/PhotoThumbnailBackfillService';
+
+export interface PreviewThumbnailBackfillContextType {
+  onThumbnailBackfilled: (itemId: string, refs: BackfilledThumbnailRefs) => void;
+}
+
+export const PreviewThumbnailBackfillContext = createContext<PreviewThumbnailBackfillContextType | undefined>(
+  undefined,
+);
+
+export const usePreviewThumbnailBackfillContext = (): PreviewThumbnailBackfillContextType => {
+  const context = useContext(PreviewThumbnailBackfillContext);
+  if (!context) {
+    throw new Error(
+      'usePreviewThumbnailBackfillContext must be used within a PreviewThumbnailBackfillContext.Provider',
+    );
+  }
+  return context;
+};

--- a/src/screens/PhotoPreviewScreen/hooks/useCloudThumbnailBackfill.spec.ts
+++ b/src/screens/PhotoPreviewScreen/hooks/useCloudThumbnailBackfill.spec.ts
@@ -1,0 +1,141 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { createElement, PropsWithChildren } from 'react';
+import { PhotoThumbnailBackfillService } from 'src/services/photos/PhotoThumbnailBackfillService';
+import { useAppDispatch } from 'src/store/hooks';
+import { CloudPhotoItem, PhotoItem } from '../../PhotosScreen/types';
+import { PreviewThumbnailBackfillContext } from '../context/PreviewThumbnailBackfillContext';
+import { useCloudThumbnailBackfill } from './useCloudThumbnailBackfill';
+
+jest.mock('src/services/photos/PhotoThumbnailBackfillService', () => ({
+  PhotoThumbnailBackfillService: { backfillCloudThumbnail: jest.fn() },
+}));
+
+jest.mock('src/store/hooks', () => ({
+  useAppDispatch: jest.fn(),
+}));
+
+const incrementCloudFetchRevisionAction = { type: 'photos/incrementCloudFetchRevision' };
+
+jest.mock('src/store/slices/photos', () => ({
+  photosActions: { incrementCloudFetchRevision: jest.fn(() => incrementCloudFetchRevisionAction) },
+}));
+
+jest.mock('src/services/common', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const mockBackfillCloudThumbnail = PhotoThumbnailBackfillService.backfillCloudThumbnail as jest.Mock;
+const mockDispatch = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useAppDispatch as jest.Mock).mockReturnValue(mockDispatch);
+});
+
+const makeCloudItem = (overrides: Partial<CloudPhotoItem> = {}): CloudPhotoItem => ({
+  id: 'cloud-1',
+  type: 'cloud-only',
+  mediaType: 'photo',
+  fileName: 'photo.dng',
+  thumbnailPath: null,
+  thumbnailBucketId: null,
+  thumbnailBucketFile: null,
+  thumbnailType: null,
+  deviceId: 'device-1',
+  folderDate: 0,
+  uploadedAt: 0,
+  isFavorite: false,
+  ...overrides,
+});
+
+const backfilledRefs = {
+  thumbnailBucketId: 'bucket-1',
+  thumbnailBucketFile: 'file-1',
+  thumbnailType: 'JPEG',
+  thumbnailPath: '/local/thumb.jpg',
+};
+
+const makeWrapper =
+  (onThumbnailBackfilled: jest.Mock = jest.fn()) =>
+  ({ children }: PropsWithChildren): JSX.Element =>
+    createElement(PreviewThumbnailBackfillContext.Provider, { value: { onThumbnailBackfilled } }, children);
+
+describe('useCloudThumbnailBackfill', () => {
+  test('when the backfill succeeds, then onBackfilled is called with the new refs and the cloud fetch revision is incremented', async () => {
+    mockBackfillCloudThumbnail.mockResolvedValue(backfilledRefs);
+    const onBackfilled = jest.fn();
+    const item = makeCloudItem();
+
+    renderHook(() => useCloudThumbnailBackfill(item, '/local/full.dng'), { wrapper: makeWrapper(onBackfilled) });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(onBackfilled).toHaveBeenCalledWith('cloud-1', backfilledRefs);
+    expect(mockDispatch).toHaveBeenCalledWith(incrementCloudFetchRevisionAction);
+  });
+
+  test('when the backfill does not produce refs, then onBackfilled is not called and nothing is dispatched', async () => {
+    mockBackfillCloudThumbnail.mockResolvedValue(null);
+    const onBackfilled = jest.fn();
+    const item = makeCloudItem();
+
+    renderHook(() => useCloudThumbnailBackfill(item, '/local/full.dng'), { wrapper: makeWrapper(onBackfilled) });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(onBackfilled).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  test('when the item is local, then the backfill service is not called', async () => {
+    const item: PhotoItem = {
+      id: 'local-1',
+      type: 'local',
+      mediaType: 'photo',
+      createdAt: 0,
+      backupState: 'backed',
+    };
+
+    renderHook(() => useCloudThumbnailBackfill(item, '/local/full.jpg'), { wrapper: makeWrapper() });
+
+    expect(mockBackfillCloudThumbnail).not.toHaveBeenCalled();
+  });
+
+  test('when the uri is not ready yet, then the backfill service is not called', async () => {
+    const item = makeCloudItem();
+
+    renderHook(() => useCloudThumbnailBackfill(item, null), { wrapper: makeWrapper() });
+
+    expect(mockBackfillCloudThumbnail).not.toHaveBeenCalled();
+  });
+
+  test('when the item already has a thumbnail, then the backfill service is not called', async () => {
+    const item = makeCloudItem({ thumbnailBucketFile: 'existing-file-id' });
+
+    renderHook(() => useCloudThumbnailBackfill(item, '/local/full.dng'), { wrapper: makeWrapper() });
+
+    expect(mockBackfillCloudThumbnail).not.toHaveBeenCalled();
+  });
+
+  test('when rerendered with the same item, then the backfill is only attempted once', async () => {
+    mockBackfillCloudThumbnail.mockResolvedValue(backfilledRefs);
+    const item = makeCloudItem();
+
+    const { rerender } = renderHook(({ uri }) => useCloudThumbnailBackfill(item, uri), {
+      initialProps: { uri: '/local/full.dng' },
+      wrapper: makeWrapper(),
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    rerender({ uri: '/local/full.dng' });
+
+    expect(mockBackfillCloudThumbnail).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/screens/PhotoPreviewScreen/hooks/useCloudThumbnailBackfill.ts
+++ b/src/screens/PhotoPreviewScreen/hooks/useCloudThumbnailBackfill.ts
@@ -1,0 +1,44 @@
+import { useEffect, useRef } from 'react';
+import { logger } from 'src/services/common';
+import { PhotoThumbnailBackfillService } from 'src/services/photos/PhotoThumbnailBackfillService';
+import { useAppDispatch } from 'src/store/hooks';
+import { photosActions } from 'src/store/slices/photos';
+import { TimelinePhotoItem } from '../../PhotosScreen/types';
+import { usePreviewThumbnailBackfillContext } from '../context/PreviewThumbnailBackfillContext';
+
+/**
+ * Backfills a missing thumbnail for a cloud-only item once its full asset has finished
+ * downloading in the preview. Runs at most once per mounted preview page.
+ *
+ * @param item - Timeline item currently shown in the preview page.
+ * @param uri - Local URI of the already-downloaded full asset, or `null` while it's still loading.
+ */
+export const useCloudThumbnailBackfill = (item: TimelinePhotoItem, uri: string | null): void => {
+  const dispatch = useAppDispatch();
+  const { onThumbnailBackfilled } = usePreviewThumbnailBackfillContext();
+  const backfillAttempted = useRef<string | null>(null);
+
+  useEffect(() => {
+    // item.thumbnailBucketFile guards against re-firing after a *successful* backfill already
+    // updated the item; backfillAttempted guards against re-firing while a fetch is in flight or
+    // after a failed/null result, before the item itself has changed.
+    if (!uri || item.type !== 'cloud-only' || item.thumbnailBucketFile) {
+      return;
+    }
+    if (backfillAttempted.current === item.id) {
+      return;
+    }
+    backfillAttempted.current = item.id;
+
+    PhotoThumbnailBackfillService.backfillCloudThumbnail({ item, localUri: uri })
+      .then((refs) => {
+        if (refs) {
+          onThumbnailBackfilled(item.id, refs);
+          dispatch(photosActions.incrementCloudFetchRevision());
+        }
+      })
+      .catch((error) => {
+        logger.error(`[useCloudThumbnailBackfill] Unexpected error backfilling thumbnail for ${item.id}: ${error}`);
+      });
+  }, [item, uri, dispatch, onThumbnailBackfilled]);
+};

--- a/src/screens/PhotoPreviewScreen/hooks/usePreviewItems.spec.ts
+++ b/src/screens/PhotoPreviewScreen/hooks/usePreviewItems.spec.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react-native';
-import { PhotoItem } from '../../PhotosScreen/types';
+import { CloudPhotoItem, PhotoItem } from '../../PhotosScreen/types';
 import { usePreviewItems } from './usePreviewItems';
 
 const makeItem = (id: string, backupState: PhotoItem['backupState']): PhotoItem => ({
@@ -8,6 +8,22 @@ const makeItem = (id: string, backupState: PhotoItem['backupState']): PhotoItem 
   createdAt: 0,
   backupState,
   mediaType: 'photo',
+});
+
+const makeCloudItem = (id: string, overrides: Partial<CloudPhotoItem> = {}): CloudPhotoItem => ({
+  id,
+  type: 'cloud-only',
+  mediaType: 'photo',
+  fileName: 'photo.dng',
+  thumbnailPath: null,
+  thumbnailBucketId: null,
+  thumbnailBucketFile: null,
+  thumbnailType: null,
+  deviceId: 'device-1',
+  folderDate: 0,
+  uploadedAt: 0,
+  isFavorite: false,
+  ...overrides,
 });
 
 describe('usePreviewItems', () => {
@@ -53,5 +69,42 @@ describe('usePreviewItems', () => {
     const { result } = renderHook(() => usePreviewItems('a', items));
 
     expect(result.current.items).toEqual(items);
+  });
+
+  test('when markThumbnailBackfilled is called, then the matching cloud item gets the new thumbnail refs', () => {
+    const items = [makeCloudItem('a')];
+    const { result } = renderHook(() => usePreviewItems('a', items));
+
+    act(() =>
+      result.current.markThumbnailBackfilled('a', {
+        thumbnailBucketId: 'bucket-1',
+        thumbnailBucketFile: 'file-1',
+        thumbnailType: 'JPEG',
+        thumbnailPath: '/local/thumb.jpg',
+      }),
+    );
+
+    expect(result.current.items[0]).toMatchObject({
+      thumbnailBucketId: 'bucket-1',
+      thumbnailBucketFile: 'file-1',
+      thumbnailType: 'JPEG',
+      thumbnailPath: '/local/thumb.jpg',
+    });
+  });
+
+  test('when one cloud item is backfilled, then other items are left unchanged', () => {
+    const items = [makeCloudItem('a'), makeCloudItem('b')];
+    const { result } = renderHook(() => usePreviewItems('a', items));
+
+    act(() =>
+      result.current.markThumbnailBackfilled('a', {
+        thumbnailBucketId: 'bucket-1',
+        thumbnailBucketFile: 'file-1',
+        thumbnailType: 'JPEG',
+        thumbnailPath: '/local/thumb.jpg',
+      }),
+    );
+
+    expect((result.current.items[1] as CloudPhotoItem).thumbnailBucketFile).toBeNull();
   });
 });

--- a/src/screens/PhotoPreviewScreen/hooks/usePreviewItems.ts
+++ b/src/screens/PhotoPreviewScreen/hooks/usePreviewItems.ts
@@ -1,11 +1,31 @@
 import { useCallback, useMemo, useState } from 'react';
+import { BackfilledThumbnailRefs } from 'src/services/photos/PhotoThumbnailBackfillService';
 import { TimelinePhotoItem } from '../../PhotosScreen/types';
+
+const withBackedUpOverride = (item: TimelinePhotoItem, backedUpIds: Set<string>): TimelinePhotoItem => {
+  if (item.type === 'local' && backedUpIds.has(item.id)) {
+    return { ...item, backupState: 'backed' as const };
+  }
+  return item;
+};
+
+const withThumbnailBackfillOverride = (
+  item: TimelinePhotoItem,
+  backfilledThumbnails: Map<string, BackfilledThumbnailRefs>,
+): TimelinePhotoItem => {
+  const thumbnailRefs = backfilledThumbnails.get(item.id);
+  if (item.type === 'cloud-only' && thumbnailRefs) {
+    return { ...item, ...thumbnailRefs };
+  }
+  return item;
+};
 
 export interface UsePreviewItemsResult {
   items: TimelinePhotoItem[];
   currentIndex: number;
   setCurrentIndex: (index: number) => void;
   markAssetBackedUp: (id: string) => void;
+  markThumbnailBackfilled: (id: string, refs: BackfilledThumbnailRefs) => void;
 }
 
 export const usePreviewItems = (initialId: string, items: TimelinePhotoItem[]): UsePreviewItemsResult => {
@@ -19,20 +39,24 @@ export const usePreviewItems = (initialId: string, items: TimelinePhotoItem[]): 
   );
   const [currentIndex, setCurrentIndex] = useState(initialIndex);
   const [backedUpIds, setBackedUpIds] = useState<Set<string>>(new Set());
+  const [backfilledThumbnails, setBackfilledThumbnails] = useState<Map<string, BackfilledThumbnailRefs>>(new Map());
 
-  const overriddenItems = useMemo(
-    () =>
-      backedUpIds.size === 0
-        ? items
-        : items.map((item) =>
-            item.type === 'local' && backedUpIds.has(item.id) ? { ...item, backupState: 'backed' as const } : item,
-          ),
-    [items, backedUpIds],
-  );
+  const overriddenItems = useMemo(() => {
+    if (backedUpIds.size === 0 && backfilledThumbnails.size === 0) {
+      return items;
+    }
+    return items.map((item) =>
+      withThumbnailBackfillOverride(withBackedUpOverride(item, backedUpIds), backfilledThumbnails),
+    );
+  }, [items, backedUpIds, backfilledThumbnails]);
 
   const markAssetBackedUp = useCallback((id: string) => {
     setBackedUpIds((prev) => new Set(prev).add(id));
   }, []);
 
-  return { items: overriddenItems, currentIndex, setCurrentIndex, markAssetBackedUp };
+  const markThumbnailBackfilled = useCallback((id: string, refs: BackfilledThumbnailRefs) => {
+    setBackfilledThumbnails((prev) => new Map(prev).set(id, refs));
+  }, []);
+
+  return { items: overriddenItems, currentIndex, setCurrentIndex, markAssetBackedUp, markThumbnailBackfilled };
 };

--- a/src/screens/PhotoPreviewScreen/index.tsx
+++ b/src/screens/PhotoPreviewScreen/index.tsx
@@ -16,6 +16,7 @@ import { MetadataPanel } from './components/MetadataPanel';
 import { PreviewCarousel } from './components/PreviewCarousel';
 import { PreviewHeader } from './components/PreviewHeader';
 import { PreviewPager } from './components/PreviewPager';
+import { PreviewThumbnailBackfillContext } from './context/PreviewThumbnailBackfillContext';
 import { useLiveBackupStatus } from './hooks/useLiveBackupStatus';
 import { usePreviewItems } from './hooks/usePreviewItems';
 
@@ -23,7 +24,10 @@ type Props = RootStackScreenProps<'PhotoPreview'>;
 
 export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
   const { initialId, items: routeItems, onItemChanged, onCurrentItemChange } = route.params;
-  const { items, currentIndex, setCurrentIndex, markAssetBackedUp } = usePreviewItems(initialId, routeItems);
+  const { items, currentIndex, setCurrentIndex, markAssetBackedUp, markThumbnailBackfilled } = usePreviewItems(
+    initialId,
+    routeItems,
+  );
   const tailwind = useTailwind();
   const navigation = useNavigation();
 
@@ -153,24 +157,31 @@ export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
   const isSynced = !isWaitingToUpload && !isCloudDeleted && !isUploading;
   const isBurstIncomplete = currentItem?.type === 'local' && currentItem?.isBurstUploadIncomplete === true;
 
+  const thumbnailBackfillContextValue = useMemo(
+    () => ({ onThumbnailBackfilled: markThumbnailBackfilled }),
+    [markThumbnailBackfilled],
+  );
+
   return (
     <View style={tailwind('flex-1 bg-black')}>
       <StatusBar hidden />
       <GestureDetector gesture={swipeDownGesture}>
         <Animated.View style={[tailwind('flex-1'), swipeDownAnimatedStyle]}>
-          <PreviewPager
-            items={items}
-            initialIndex={currentIndex}
-            activeIndex={currentIndex}
-            isScrubbing={isScrubbing}
-            onIndexChange={setCurrentIndex}
-            onTap={handleTap}
-            onZoomChange={handleZoomChange}
-            onVideoPlay={handleVideoPlay}
-            onVideoPause={handleVideoPause}
-            onVideoEnd={handleVideoEnd}
-            videoResetKey={videoResetKey}
-          />
+          <PreviewThumbnailBackfillContext.Provider value={thumbnailBackfillContextValue}>
+            <PreviewPager
+              items={items}
+              initialIndex={currentIndex}
+              activeIndex={currentIndex}
+              isScrubbing={isScrubbing}
+              onIndexChange={setCurrentIndex}
+              onTap={handleTap}
+              onZoomChange={handleZoomChange}
+              onVideoPlay={handleVideoPlay}
+              onVideoPause={handleVideoPause}
+              onVideoEnd={handleVideoEnd}
+              videoResetKey={videoResetKey}
+            />
+          </PreviewThumbnailBackfillContext.Provider>
           <PreviewHeader
             visible={isUiVisible}
             item={currentItem}

--- a/src/screens/PhotosScreen/hooks/useCloudThumbnail.spec.ts
+++ b/src/screens/PhotosScreen/hooks/useCloudThumbnail.spec.ts
@@ -165,6 +165,29 @@ describe('useCloudThumbnail', () => {
     expect(mockPhotosLocalDB.setCloudThumbnailPath).not.toHaveBeenCalled();
   });
 
+  test('when the same item is backfilled with a thumbnail path after a reload, then the new path is shown without a new download', async () => {
+    const itemWithoutThumbnail = makeCloudItem({ id: 'remote-1', thumbnailPath: null, thumbnailBucketId: null, thumbnailBucketFile: null });
+    const itemWithBackfilledThumbnail = makeCloudItem({
+      id: 'remote-1',
+      thumbnailPath: '/backfilled/thumb.jpg',
+      thumbnailBucketId: 'bucket-1',
+      thumbnailBucketFile: 'file-1',
+    });
+
+    const { result, rerender } = renderHook(({ item }) => useCloudThumbnail(item), {
+      initialProps: { item: itemWithoutThumbnail },
+    });
+
+    expect(result.current.uri).toBeNull();
+
+    await act(async () => {
+      rerender({ item: itemWithBackfilledThumbnail });
+    });
+
+    expect(result.current.uri).toBe('/backfilled/thumb.jpg');
+    expect(mockDriveFileService.getThumbnail).not.toHaveBeenCalled();
+  });
+
   test('when the image fails to load, then the stale path is cleared from the database and uri becomes null', async () => {
     const item = makeCloudItem({
       thumbnailPath: '/stale/thumb.jpg',

--- a/src/screens/PhotosScreen/hooks/useCloudThumbnail.ts
+++ b/src/screens/PhotosScreen/hooks/useCloudThumbnail.ts
@@ -65,7 +65,7 @@ export const useCloudThumbnail = (item: CloudPhotoItem): { uri: string | null; o
     return () => {
       cancelled = true;
     };
-  }, [item.id, retryCount]);
+  }, [item.id, item.thumbnailPath, retryCount]);
 
   return { uri: localPath, onImageError };
 };

--- a/src/services/common/media/thumbnail.constants.spec.ts
+++ b/src/services/common/media/thumbnail.constants.spec.ts
@@ -1,0 +1,18 @@
+import { isThumbnailSupported } from './thumbnail.constants';
+
+describe('isThumbnailSupported', () => {
+  test('when the extension is a RAW photo format, then it is supported', () => {
+    expect(isThumbnailSupported('dng')).toBe(true);
+    expect(isThumbnailSupported('DNG')).toBe(true);
+  });
+
+  test('when the extension is a common image format, then it is supported', () => {
+    expect(isThumbnailSupported('jpg')).toBe(true);
+    expect(isThumbnailSupported('png')).toBe(true);
+    expect(isThumbnailSupported('heic')).toBe(true);
+  });
+
+  test('when the extension has no known thumbnail generator, then it is not supported', () => {
+    expect(isThumbnailSupported('zip')).toBe(false);
+  });
+});

--- a/src/services/common/media/thumbnail.constants.ts
+++ b/src/services/common/media/thumbnail.constants.ts
@@ -10,7 +10,10 @@ export const IMAGE_THUMBNAIL_EXTENSIONS = new Set<string>([
   FileExtension.JPEG,
   FileExtension.PNG,
   FileExtension.HEIC,
+  FileExtension.DNG,
 ]);
+
+export const RAW_IMAGE_THUMBNAIL_EXTENSIONS = new Set<string>([FileExtension.DNG]);
 export const VIDEO_THUMBNAIL_EXTENSIONS = new Set<string>([FileExtension.MP4, FileExtension.MOV, FileExtension.AVI]);
 export const PDF_THUMBNAIL_EXTENSIONS = new Set<string>([FileExtension.PDF]);
 

--- a/src/services/common/media/thumbnail.generation.spec.ts
+++ b/src/services/common/media/thumbnail.generation.spec.ts
@@ -16,6 +16,7 @@ jest.mock('expo-image-manipulator', () => ({
   },
   SaveFormat: { JPEG: 'jpeg' },
 }));
+jest.mock('../logger', () => ({ logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() } }));
 
 import {
   generateImageThumbnail,
@@ -29,6 +30,7 @@ const mocks = () => ({
   pdfGenerate: jest.requireMock('react-native-pdf-thumbnail').default.generate as jest.Mock,
   manipulate: jest.requireMock('expo-image-manipulator').ImageManipulator.manipulate as jest.Mock,
   stat: jest.requireMock('@dr.pogodin/react-native-fs').stat as jest.Mock,
+  loggerError: jest.requireMock('../logger').logger.error as jest.Mock,
 });
 
 beforeEach(() => {
@@ -157,5 +159,35 @@ describe('generateThumbnail', () => {
 
     expect(mocks().createThumbnail).toHaveBeenCalledTimes(1);
     expect(mocks().pdfGenerate).not.toHaveBeenCalled();
+  });
+
+  test('when extension is a RAW photo, then it routes through expo-image-manipulator instead of createThumbnail (AVFoundation can not decode RAW)', async () => {
+    await generateThumbnail('/var/mobile/Containers/Data/DCIM/IMG_5068.DNG', 'dng');
+
+    expect(mocks().manipulate).toHaveBeenCalledWith('file:///var/mobile/Containers/Data/DCIM/IMG_5068.DNG');
+    expect(mocks().createThumbnail).not.toHaveBeenCalled();
+    expect(mocks().pdfGenerate).not.toHaveBeenCalled();
+  });
+
+  test('when extension is a RAW photo and running on Android, then it also routes through expo-image-manipulator', async () => {
+    Platform.OS = 'android';
+
+    await generateThumbnail('/storage/emulated/0/DCIM/Camera/IMG_5068.dng', 'dng');
+
+    expect(mocks().manipulate).toHaveBeenCalledWith('file:///storage/emulated/0/DCIM/Camera/IMG_5068.dng');
+    expect(mocks().createThumbnail).not.toHaveBeenCalled();
+    expect(mocks().pdfGenerate).not.toHaveBeenCalled();
+  });
+
+  test('when generation fails, then the error is logged with the asset path and rethrown', async () => {
+    mocks().createThumbnail.mockRejectedValueOnce(new Error('Cannot Open'));
+
+    await expect(generateThumbnail('/var/mobile/Containers/Data/DCIM/IMG_0042.png', 'png')).rejects.toThrow(
+      'Cannot Open',
+    );
+
+    expect(mocks().loggerError).toHaveBeenCalledWith(
+      expect.stringContaining('/var/mobile/Containers/Data/DCIM/IMG_0042.png'),
+    );
   });
 });

--- a/src/services/common/media/thumbnail.generation.ts
+++ b/src/services/common/media/thumbnail.generation.ts
@@ -4,10 +4,12 @@ import { Platform } from 'react-native';
 import { createThumbnail } from 'react-native-create-thumbnail';
 import PdfThumbnail from 'react-native-pdf-thumbnail';
 
+import { logger } from '../logger';
 import { stripFileUri, toFileUri } from '../uri/uriHelpers';
 import {
   IMAGE_THUMBNAIL_EXTENSIONS,
   PDF_THUMBNAIL_QUALITY,
+  RAW_IMAGE_THUMBNAIL_EXTENSIONS,
   THUMBNAIL_JPEG_COMPRESS,
   THUMBNAIL_MAX_WIDTH,
   VIDEO_THUMBNAIL_DIR_SIZE,
@@ -17,7 +19,7 @@ import type { GeneratedThumbnail } from './thumbnail.types';
 
 const statSize = async (path: string): Promise<number> => Number((await RNFS.stat(path)).size);
 
-const generateImageThumbnailAndroid = async (sourcePath: string): Promise<GeneratedThumbnail> => {
+const generateImageThumbnailViaManipulator = async (sourcePath: string): Promise<GeneratedThumbnail> => {
   const imageManipulatorContext = ImageManipulator.manipulate(toFileUri(sourcePath));
   imageManipulatorContext.resize({ width: THUMBNAIL_MAX_WIDTH });
   const imageRef = await imageManipulatorContext.renderAsync();
@@ -43,7 +45,10 @@ const generateMediaThumbnail = async (sourcePath: string): Promise<GeneratedThum
 // instead of expo-image-manipulator: subsampled decode avoids loading the full bitmap
 // into memory, preventing jetsam kills in the share extension
 export const generateImageThumbnail = async (sourcePath: string): Promise<GeneratedThumbnail> =>
-  Platform.OS === 'android' ? generateImageThumbnailAndroid(sourcePath) : generateMediaThumbnail(sourcePath);
+  Platform.OS === 'android' ? generateImageThumbnailViaManipulator(sourcePath) : generateMediaThumbnail(sourcePath);
+
+export const generateRawImageThumbnail = (sourcePath: string): Promise<GeneratedThumbnail> =>
+  generateImageThumbnailViaManipulator(sourcePath);
 
 export const generateVideoThumbnail = (sourcePath: string): Promise<GeneratedThumbnail> =>
   generateMediaThumbnail(sourcePath);
@@ -56,7 +61,19 @@ export const generatePdfThumbnail = async (sourcePath: string): Promise<Generate
 
 export const generateThumbnail = async (sourcePath: string, extension: string): Promise<GeneratedThumbnail> => {
   const extensionLower = extension.toLowerCase();
-  if (IMAGE_THUMBNAIL_EXTENSIONS.has(extensionLower)) return generateImageThumbnail(sourcePath);
-  if (VIDEO_THUMBNAIL_EXTENSIONS.has(extensionLower)) return generateVideoThumbnail(sourcePath);
-  return generatePdfThumbnail(sourcePath);
+  try {
+    if (RAW_IMAGE_THUMBNAIL_EXTENSIONS.has(extensionLower)) {
+      return await generateRawImageThumbnail(sourcePath);
+    }
+    if (IMAGE_THUMBNAIL_EXTENSIONS.has(extensionLower)) {
+      return await generateImageThumbnail(sourcePath);
+    }
+    if (VIDEO_THUMBNAIL_EXTENSIONS.has(extensionLower)) {
+      return await generateVideoThumbnail(sourcePath);
+    }
+    return await generatePdfThumbnail(sourcePath);
+  } catch (error) {
+    logger.error(`[thumbnail.generation] Failed to generate thumbnail for ${sourcePath}: ${error}`);
+    throw error;
+  }
 };

--- a/src/services/photos/PhotoThumbnailBackfillService.spec.ts
+++ b/src/services/photos/PhotoThumbnailBackfillService.spec.ts
@@ -1,0 +1,175 @@
+import asyncStorageService from '@internxt-mobile/services/AsyncStorageService';
+import { CloudPhotoItem, PhotoItem } from 'src/screens/PhotosScreen/types';
+import fileSystemService from 'src/services/FileSystemService';
+import { PhotoThumbnailBackfillService } from './PhotoThumbnailBackfillService';
+import { uploadThumbnailForAsset } from './PhotoUploadService';
+import { photosLocalDB } from './database/photosLocalDB';
+
+jest.mock('./database/photosLocalDB', () => ({
+  photosLocalDB: { getCloudAssetById: jest.fn(), setCloudThumbnailRefs: jest.fn() },
+}));
+
+jest.mock('./PhotoUploadService', () => ({
+  uploadThumbnailForAsset: jest.fn(),
+}));
+
+jest.mock('src/lib/network', () => ({
+  getEnvironmentConfigFromUser: jest.fn().mockReturnValue({
+    bridgeUser: 'user',
+    bridgePass: 'user-id',
+    encryptionKey: 'mnemonic',
+    bucketId: 'drive-bucket',
+  }),
+}));
+
+jest.mock('src/services/FileSystemService', () => ({
+  __esModule: true,
+  default: {
+    getCacheDir: jest.fn(() => '/cache'),
+    ensureDir: jest.fn(),
+    moveFile: jest.fn(),
+    pathToUri: jest.fn((p: string) => `file://${p}`),
+  },
+}));
+
+jest.mock('@internxt-mobile/services/AsyncStorageService', () => ({
+  __esModule: true,
+  default: { getUser: jest.fn() },
+}));
+
+jest.mock('@internxt-mobile/services/common', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const mockGetCloudAssetById = photosLocalDB.getCloudAssetById as jest.Mock;
+const mockSetCloudThumbnailRefs = photosLocalDB.setCloudThumbnailRefs as jest.Mock;
+const mockUploadThumbnailForAsset = uploadThumbnailForAsset as jest.Mock;
+const mockGetUser = asyncStorageService.getUser as jest.Mock;
+const mockMoveFile = fileSystemService.moveFile as jest.Mock;
+
+const makeCloudItem = (overrides: Partial<CloudPhotoItem> = {}): CloudPhotoItem => ({
+  id: 'cloud-uuid-1',
+  type: 'cloud-only',
+  mediaType: 'photo',
+  fileName: 'IMG_5068.DNG',
+  thumbnailPath: null,
+  thumbnailBucketId: null,
+  thumbnailBucketFile: null,
+  thumbnailType: null,
+  deviceId: 'device-1',
+  folderDate: Date.now(),
+  uploadedAt: Date.now(),
+  isFavorite: false,
+  ...overrides,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetCloudAssetById.mockResolvedValue({ bucket: 'photos-bucket' });
+  mockGetUser.mockResolvedValue({
+    bridgeUser: 'user',
+    userId: 'user-id',
+    mnemonic: 'mnemonic',
+    bucket: 'drive-bucket',
+  });
+  mockUploadThumbnailForAsset.mockResolvedValue({
+    bucketId: 'photos-bucket',
+    bucketFile: 'thumb-file-id',
+    type: 'JPEG',
+    localPath: '/tmp/thumb.jpg',
+  });
+});
+
+describe('backfillCloudThumbnail', () => {
+  test('when the item already has a thumbnail, then nothing is uploaded', async () => {
+    const item = makeCloudItem({ thumbnailBucketFile: 'existing-file-id' });
+
+    const result = await PhotoThumbnailBackfillService.backfillCloudThumbnail({ item, localUri: '/cache/photo.dng' });
+
+    expect(result).toBeNull();
+    expect(mockUploadThumbnailForAsset).not.toHaveBeenCalled();
+  });
+
+  test('when the item is a local item, then nothing is uploaded', async () => {
+    const item: PhotoItem = {
+      id: 'local-1',
+      type: 'local',
+      mediaType: 'photo',
+      createdAt: Date.now(),
+      backupState: 'backed',
+    };
+
+    const result = await PhotoThumbnailBackfillService.backfillCloudThumbnail({ item, localUri: '/cache/photo.dng' });
+
+    expect(result).toBeNull();
+    expect(mockUploadThumbnailForAsset).not.toHaveBeenCalled();
+  });
+
+  test('when the file extension has no thumbnail generator, then nothing is uploaded', async () => {
+    const item = makeCloudItem({ fileName: 'archive.zip' });
+
+    const result = await PhotoThumbnailBackfillService.backfillCloudThumbnail({ item, localUri: '/cache/archive.zip' });
+
+    expect(result).toBeNull();
+    expect(mockUploadThumbnailForAsset).not.toHaveBeenCalled();
+  });
+
+  test('when the cloud asset has no bucket in the database, then nothing is uploaded', async () => {
+    mockGetCloudAssetById.mockResolvedValue({ bucket: null });
+    const item = makeCloudItem();
+
+    const result = await PhotoThumbnailBackfillService.backfillCloudThumbnail({ item, localUri: '/cache/photo.dng' });
+
+    expect(result).toBeNull();
+    expect(mockUploadThumbnailForAsset).not.toHaveBeenCalled();
+  });
+
+  test('when the thumbnail is generated and uploaded, then it is moved to a stable cache path, persisted in the database, and the new refs are returned', async () => {
+    const item = makeCloudItem();
+
+    const result = await PhotoThumbnailBackfillService.backfillCloudThumbnail({
+      item,
+      localUri: 'file:///cache/photo_preview/cloud-uuid-1.dng',
+    });
+
+    expect(result).toEqual({
+      thumbnailBucketId: 'photos-bucket',
+      thumbnailBucketFile: 'thumb-file-id',
+      thumbnailType: 'JPEG',
+      thumbnailPath: 'file:///cache/photo_thumbnail_backfill/cloud-uuid-1.jpg',
+    });
+    expect(mockUploadThumbnailForAsset).toHaveBeenCalledWith(
+      '/cache/photo_preview/cloud-uuid-1.dng',
+      'DNG',
+      'cloud-uuid-1',
+      expect.objectContaining({ bucketId: 'photos-bucket' }),
+      true,
+    );
+    expect(mockMoveFile).toHaveBeenCalledWith('/tmp/thumb.jpg', '/cache/photo_thumbnail_backfill/cloud-uuid-1.jpg');
+    expect(mockSetCloudThumbnailRefs).toHaveBeenCalledWith('cloud-uuid-1', {
+      bucketId: 'photos-bucket',
+      bucketFile: 'thumb-file-id',
+      type: 'JPEG',
+      localPath: 'file:///cache/photo_thumbnail_backfill/cloud-uuid-1.jpg',
+    });
+  });
+
+  test('when the upload fails, then nothing is persisted in the database', async () => {
+    mockUploadThumbnailForAsset.mockResolvedValue(null);
+    const item = makeCloudItem();
+
+    const result = await PhotoThumbnailBackfillService.backfillCloudThumbnail({ item, localUri: '/cache/photo.dng' });
+
+    expect(result).toBeNull();
+    expect(mockSetCloudThumbnailRefs).not.toHaveBeenCalled();
+  });
+
+  test('when an unexpected error is thrown, then it does not propagate', async () => {
+    mockGetUser.mockRejectedValue(new Error('storage unavailable'));
+    const item = makeCloudItem();
+
+    const result = await PhotoThumbnailBackfillService.backfillCloudThumbnail({ item, localUri: '/cache/photo.dng' });
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/services/photos/PhotoThumbnailBackfillService.ts
+++ b/src/services/photos/PhotoThumbnailBackfillService.ts
@@ -1,0 +1,95 @@
+import asyncStorageService from '@internxt-mobile/services/AsyncStorageService';
+import { logger } from '@internxt-mobile/services/common';
+import { isThumbnailSupported } from '@internxt-mobile/services/common/media/thumbnail.constants';
+import { stripFileUri } from '@internxt-mobile/services/common/uri/uriHelpers';
+import fileSystemService from '@internxt-mobile/services/FileSystemService';
+import { getEnvironmentConfigFromUser } from 'src/lib/network';
+import { TimelinePhotoItem } from 'src/screens/PhotosScreen/types';
+import { photosLocalDB } from './database/photosLocalDB';
+import { UploadCredentials, uploadThumbnailForAsset } from './PhotoUploadService';
+import { splitFileNameAndExtension } from './PhotoUploadService.utils';
+
+const getThumbnailCacheDir = () => fileSystemService.getCacheDir() + '/photo_thumbnail_backfill/';
+const thumbnailCachePathFor = (remoteFileId: string) => `${getThumbnailCacheDir()}${remoteFileId}.jpg`;
+
+export interface BackfilledThumbnailRefs {
+  thumbnailBucketId: string;
+  thumbnailBucketFile: string;
+  thumbnailType: string;
+  thumbnailPath: string | null;
+}
+
+/**
+ * Generates and uploads a thumbnail for a cloud-only asset that doesn't have one yet. Reuses an
+ * already-downloaded local copy of the file instead of downloading it again. No-op for local
+ * items or items that already have a thumbnail.
+ *
+ * @param params.item - Timeline item to backfill a thumbnail for.
+ * @param params.localUri - Local URI of the already-downloaded full asset.
+ * @returns The new thumbnail refs if one was generated, uploaded and persisted; `null` otherwise
+ * (already had one, unsupported extension, or the upload failed).
+ */
+const backfillCloudThumbnail = async ({
+  item,
+  localUri,
+}: {
+  item: TimelinePhotoItem;
+  localUri: string;
+}): Promise<BackfilledThumbnailRefs | null> => {
+  if (item.type !== 'cloud-only' || item.thumbnailBucketFile) {
+    return null;
+  }
+
+  const { fileExtension } = splitFileNameAndExtension(item.fileName);
+  if (!isThumbnailSupported(fileExtension)) {
+    return null;
+  }
+
+  const asset = await photosLocalDB.getCloudAssetById(item.id);
+  if (!asset?.bucket) {
+    logger.warn(`[PhotoThumbnailBackfillService] No bucket for cloud asset ${item.id}, skipping backfill`);
+    return null;
+  }
+
+  try {
+    const user = await asyncStorageService.getUser();
+    const { bridgeUser, bridgePass, encryptionKey } = getEnvironmentConfigFromUser(user);
+    const credentials: UploadCredentials = { bucketId: asset.bucket, bridgeUser, bridgePass, encryptionKey };
+
+    const localFilePath = stripFileUri(localUri);
+    const uploaded = await uploadThumbnailForAsset(localFilePath, fileExtension, item.id, credentials, true);
+    if (!uploaded) {
+      return null;
+    }
+
+    let cachedThumbnailUri: string | null = null;
+    if (uploaded.localPath) {
+      await fileSystemService.ensureDir(getThumbnailCacheDir());
+      const destPath = thumbnailCachePathFor(item.id);
+      await fileSystemService.moveFile(uploaded.localPath, destPath);
+      cachedThumbnailUri = fileSystemService.pathToUri(destPath);
+    }
+
+    const refs: BackfilledThumbnailRefs = {
+      thumbnailBucketId: uploaded.bucketId,
+      thumbnailBucketFile: uploaded.bucketFile,
+      thumbnailType: uploaded.type,
+      thumbnailPath: cachedThumbnailUri,
+    };
+
+    await photosLocalDB.setCloudThumbnailRefs(item.id, {
+      bucketId: refs.thumbnailBucketId,
+      bucketFile: refs.thumbnailBucketFile,
+      type: refs.thumbnailType,
+      localPath: refs.thumbnailPath,
+    });
+
+    logger.info(`[PhotoThumbnailBackfillService] Backfilled thumbnail for cloud asset ${item.id}`);
+    return refs;
+  } catch (error) {
+    logger.error(`[PhotoThumbnailBackfillService] Failed to backfill thumbnail for ${item.id}: ${error}`);
+    return null;
+  }
+};
+
+export const PhotoThumbnailBackfillService = { backfillCloudThumbnail };

--- a/src/services/photos/PhotoUploadService.ts
+++ b/src/services/photos/PhotoUploadService.ts
@@ -228,15 +228,25 @@ const cleanupTempFile = async (tempPath?: string): Promise<void> => {
   await fileSystemService.unlinkIfExists(tempPath);
 };
 
-const uploadThumbnailForAsset = async (
+export interface UploadedThumbnailRef {
+  bucketId: string;
+  bucketFile: string;
+  type: string;
+  /** Local path of the generated thumbnail file. Only set when `keepTempFile` is true. */
+  localPath?: string;
+}
+
+export const uploadThumbnailForAsset = async (
   localFilePath: string,
   fileExtension: string,
   fileUuid: string,
   credentials: UploadCredentials,
-): Promise<void> => {
-  if (!isThumbnailSupported(fileExtension)) return;
+  keepTempFile = false,
+): Promise<UploadedThumbnailRef | null> => {
+  if (!isThumbnailSupported(fileExtension)) return null;
 
   let thumbnailPath: string | undefined;
+  let succeeded = false;
   try {
     const thumbnail = await generateThumbnail(localFilePath, fileExtension);
     thumbnailPath = thumbnail.path;
@@ -260,10 +270,21 @@ const uploadThumbnailForAsset = async (
       bucketFile: thumbnailFileId,
       encryptVersion: EncryptionVersion.Aes03,
     });
+
+    succeeded = true;
+    return {
+      bucketId: credentials.bucketId,
+      bucketFile: thumbnailFileId,
+      type: thumbnail.type,
+      localPath: keepTempFile ? thumbnailPath : undefined,
+    };
   } catch (err) {
     logger.error(`Failed to upload thumbnail for file ${fileUuid} (ext=${fileExtension}, path=${localFilePath}):`, err);
+    return null;
   } finally {
-    await cleanupTempFile(thumbnailPath);
+    if (!keepTempFile || !succeeded) {
+      await cleanupTempFile(thumbnailPath);
+    }
   }
 };
 

--- a/src/services/photos/database/photosLocalDB.ts
+++ b/src/services/photos/database/photosLocalDB.ts
@@ -621,6 +621,19 @@ class PhotosLocalDB {
     await sqliteService.executeSql(DB_NAME, cloudAssetTable.statements.setThumbnailPath, [path, remoteFileId]);
   }
 
+  async setCloudThumbnailRefs(
+    remoteFileId: string,
+    refs: { bucketId: string; bucketFile: string; type: string; localPath: string | null },
+  ): Promise<void> {
+    await sqliteService.executeSql(DB_NAME, cloudAssetTable.statements.setThumbnailRefs, [
+      refs.bucketId,
+      refs.bucketFile,
+      refs.type,
+      refs.localPath,
+      remoteFileId,
+    ]);
+  }
+
   async deleteCloudAsset(remoteFileId: string): Promise<void> {
     await sqliteService.executeSql(DB_NAME, cloudAssetTable.statements.delete, [remoteFileId]);
   }

--- a/src/services/photos/database/tables/cloud_asset.ts
+++ b/src/services/photos/database/tables/cloud_asset.ts
@@ -138,6 +138,12 @@ const statements = {
     UPDATE ${TABLE_NAME} SET thumbnail_path = ? WHERE remote_file_id = ?;
   `,
 
+  setThumbnailRefs: `
+    UPDATE ${TABLE_NAME}
+    SET thumbnail_bucket_id = ?, thumbnail_bucket_file = ?, thumbnail_type = ?, thumbnail_path = ?
+    WHERE remote_file_id = ?;
+  `,
+
   delete: `DELETE FROM ${TABLE_NAME} WHERE remote_file_id = ?;`,
   deleteByDevice: `DELETE FROM ${TABLE_NAME} WHERE device_id = ?;`,
   getDistinctDeviceIds: `SELECT DISTINCT device_id FROM ${TABLE_NAME};`,

--- a/src/types/drive/file.ts
+++ b/src/types/drive/file.ts
@@ -91,4 +91,5 @@ export enum FileExtension {
   PNG = 'png',
   HEIC = 'heic',
   PDF = 'pdf',
+  DNG = 'dng',
 }


### PR DESCRIPTION
Fixed RAW (.DNG) photos with no thumbnail by regenerating and re-uploading them on preview open

  ## Summary

  - **`thumbnail.constants.ts`**, **`file.ts`**: added `FileExtension.DNG`.
  - **`thumbnail.generation.ts`**: RAW extensions now route through `expo-image-manipulator`  instead of `react-native-create-thumbnail`, which can't decode RAW at all.
  - **`PhotoUploadService.ts`**: `uploadThumbnailForAsset` exported and now returns the uploaded thumbnail refs instead of `void`, with a `keepTempFile` option so a caller can reuse the generated local file instead of it being deleted right after upload.
  - **`PhotoThumbnailBackfillService.ts`**: for assets already backed up before this fix and still missing a thumbnail, actually **generates a new thumbnail and uploads it**. Applies to any cloud-only item missing a thumbnail.
  - **`PreviewThumbnailBackfillContext.tsx`**,**`useCloudThumbnailBackfill.ts`** : triggers that regeneration from the preview screen. 
  - **`cloud_asset.ts`**, **`photosLocalDB.ts`**: new `setThumbnailRefs`/`setCloudThumbnailRefs` to persist `thumbnail_bucket_id/file/type` once the regenerated thumbnail is uploaded.
  - **Real-time UI update after regeneration**, two separate repaint bugs fixed:
    - **`useCloudThumbnail.ts`**: the grid wasn't repainting, its sync effect was missing `item.thumbnailPath` in its deps.
    - **`usePreviewItems.ts`**: the open preview/carousel wasn't repainting either, its `items` come from a frozen `route.params` snapshot, disconnected from the DB.
  - **`index.tsx`**, **`PreviewPage.tsx`**: wire the new callback from the regeneration hook up to `usePreviewItems`, via Context.
  - **`PreviewPage.tsx`**: extracted `ThumbnailFallback` to remove duplicated `<Image onError=...>` markup between the video and photo fallback branches.
