### PR TITLE
[_] feature/Added Photos thumbnail cache invalidation and refresh

### DIFF
--- a/src/screens/PhotoPreviewScreen/hooks/useCloudThumbnailBackfill.spec.ts
+++ b/src/screens/PhotoPreviewScreen/hooks/useCloudThumbnailBackfill.spec.ts
@@ -97,6 +97,7 @@ describe('useCloudThumbnailBackfill', () => {
       type: 'local',
       mediaType: 'photo',
       createdAt: 0,
+      modificationTime: 0,
       backupState: 'backed',
     };
 

--- a/src/screens/PhotoPreviewScreen/hooks/useLiveBackupStatus.spec.ts
+++ b/src/screens/PhotoPreviewScreen/hooks/useLiveBackupStatus.spec.ts
@@ -28,6 +28,7 @@ const makeLocalItem = (id: string, backupState: PhotoItem['backupState']): Photo
   id,
   type: 'local',
   createdAt: 1000,
+  modificationTime: 1000,
   backupState,
   mediaType: 'photo',
 });
@@ -176,6 +177,7 @@ describe('useLiveBackupStatus', () => {
       id: 'b1',
       type: 'local',
       createdAt: 1000,
+      modificationTime: 1000,
       backupState: 'not-backed',
       mediaType: 'photo',
       isBurst: true,
@@ -195,6 +197,7 @@ describe('useLiveBackupStatus', () => {
       id: 'b2',
       type: 'local',
       createdAt: 1000,
+      modificationTime: 1000,
       backupState: 'backed',
       mediaType: 'photo',
       isBurst: true,

--- a/src/screens/PhotoPreviewScreen/hooks/usePreviewItems.spec.ts
+++ b/src/screens/PhotoPreviewScreen/hooks/usePreviewItems.spec.ts
@@ -6,6 +6,7 @@ const makeItem = (id: string, backupState: PhotoItem['backupState']): PhotoItem 
   id,
   type: 'local',
   createdAt: 0,
+  modificationTime: 0,
   backupState,
   mediaType: 'photo',
 });

--- a/src/screens/PhotoPreviewScreen/hooks/usePreviewSource.spec.ts
+++ b/src/screens/PhotoPreviewScreen/hooks/usePreviewSource.spec.ts
@@ -19,6 +19,7 @@ const makeLocalItem = (overrides: Partial<PhotoItem> = {}): PhotoItem => ({
   uri: 'ph://ABCD-1234/L0/001',
   mediaType: 'photo',
   createdAt: Date.now(),
+  modificationTime: Date.now(),
   backupState: 'backed',
   ...overrides,
 });

--- a/src/screens/PhotosScreen/components/PhotoItem.spec.ts
+++ b/src/screens/PhotosScreen/components/PhotoItem.spec.ts
@@ -1,0 +1,31 @@
+import { PhotoItem as PhotoItemType } from '../types';
+import { localPhotoCellAreEqual } from './PhotoItem';
+
+const makeItem = (overrides: Partial<PhotoItemType> = {}): PhotoItemType => ({
+  id: 'asset-1',
+  type: 'local',
+  uri: 'ph://asset-1',
+  createdAt: 0,
+  modificationTime: 1000,
+  backupState: 'backed',
+  mediaType: 'photo',
+  ...overrides,
+});
+
+const makeProps = (item: PhotoItemType) => ({ item, isSelectMode: false, isSelected: false });
+
+describe('local photo cell memo comparator', () => {
+  test('when nothing changes, then the cell is not re-rendered', () => {
+    const prev = makeProps(makeItem());
+    const next = makeProps(makeItem());
+
+    expect(localPhotoCellAreEqual(prev, next)).toBe(true);
+  });
+
+  test('when only the modification time of a local photo changes, then the cell is re-rendered', () => {
+    const prev = makeProps(makeItem({ modificationTime: 1000 }));
+    const next = makeProps(makeItem({ modificationTime: 2000 }));
+
+    expect(localPhotoCellAreEqual(prev, next)).toBe(false);
+  });
+});

--- a/src/screens/PhotosScreen/components/PhotoItem.tsx
+++ b/src/screens/PhotosScreen/components/PhotoItem.tsx
@@ -157,10 +157,14 @@ const BurstBadge = ({ isBurstIncomplete }: { isBurstIncomplete?: boolean }): JSX
   );
 };
 
-const localPhotoCellAreEqual = (prev: CellProps & { item: PhotoItemType }, next: CellProps & { item: PhotoItemType }) =>
+export const localPhotoCellAreEqual = (
+  prev: CellProps & { item: PhotoItemType },
+  next: CellProps & { item: PhotoItemType },
+) =>
   prev.item.id === next.item.id &&
   prev.item.backupState === next.item.backupState &&
   prev.item.uri === next.item.uri &&
+  prev.item.modificationTime === next.item.modificationTime &&
   prev.item.mediaType === next.item.mediaType &&
   prev.item.duration === next.item.duration &&
   prev.item.isLivePhoto === next.item.isLivePhoto &&
@@ -205,7 +209,7 @@ const LocalPhotoCell = memo(
       <TouchableOpacity activeOpacity={0.85} style={containerStyle} onPress={handlePress} onLongPress={handleLongPress}>
         {/* recyclingKey clears the previous asset's bitmap immediately when FlashList reuses this cell */}
         <ExpoImage
-          source={{ uri: item.uri }}
+          source={{ uri: item.uri, cacheKey: `${item.id}-${item.modificationTime}` }}
           recyclingKey={item.id}
           style={[StyleSheet.absoluteFillObject, isCloudDeleted && styles.dimmed]}
           contentFit="cover"

--- a/src/screens/PhotosScreen/components/PhotosTimeline.tsx
+++ b/src/screens/PhotosScreen/components/PhotosTimeline.tsx
@@ -49,6 +49,7 @@ const SKELETON_GROUP: TimelineDateGroup = {
       id: `__skeleton_${i}__`,
       type: 'local' as const,
       createdAt: 0,
+      modificationTime: 0,
       backupState: 'loading' as PhotoBackupState,
       mediaType: 'photo' as const,
     })),

--- a/src/screens/PhotosScreen/hooks/usePhotoActionHandlers.spec.ts
+++ b/src/screens/PhotosScreen/hooks/usePhotoActionHandlers.spec.ts
@@ -41,6 +41,7 @@ const makeLocalBacked = (id = 'asset-1'): PhotoItem => ({
   id,
   type: 'local',
   createdAt: 0,
+  modificationTime: 0,
   backupState: 'backed',
   mediaType: 'photo',
   uri: `ph://${id}`,

--- a/src/screens/PhotosScreen/hooks/usePhotoActions.spec.ts
+++ b/src/screens/PhotosScreen/hooks/usePhotoActions.spec.ts
@@ -54,6 +54,7 @@ const makeLocalBacked = (id = 'asset-1'): PhotoItem => ({
   id,
   type: 'local',
   createdAt: 0,
+  modificationTime: 0,
   backupState: 'backed',
   mediaType: 'photo',
   uri: `ph://${id}`,

--- a/src/screens/PhotosScreen/hooks/usePhotoSelection.spec.ts
+++ b/src/screens/PhotosScreen/hooks/usePhotoSelection.spec.ts
@@ -6,6 +6,7 @@ const makeLocalItem = (id: string, backupState: PhotoBackupState = 'backed'): Ti
   id,
   type: 'local',
   createdAt: 0,
+  modificationTime: 0,
   backupState,
   mediaType: 'photo',
 });

--- a/src/screens/PhotosScreen/types.ts
+++ b/src/screens/PhotosScreen/types.ts
@@ -6,6 +6,7 @@ export interface PhotoItem {
   type: 'local';
   uri?: string;
   createdAt: number;
+  modificationTime: number;
   backupState: PhotoBackupState;
   mediaType: PhotoMediaType;
   duration?: string;

--- a/src/screens/PhotosScreen/utils/photoTimelineGroups.spec.ts
+++ b/src/screens/PhotosScreen/utils/photoTimelineGroups.spec.ts
@@ -41,6 +41,7 @@ const makePhotoItem = (overrides: Partial<PhotoItem> = {}): PhotoItem => ({
   type: 'local',
   uri: 'file:///photo.jpg',
   createdAt: new Date('2024-06-15T12:00:00').getTime(),
+  modificationTime: new Date('2024-06-15T12:00:00').getTime(),
   backupState: 'not-backed',
   mediaType: 'photo',
   ...overrides,
@@ -136,6 +137,12 @@ describe('local asset to photo item conversion', () => {
     const item = assetToPhotoItem(asset, new Set(), new Set());
     expect(item.mediaType).toBe('video');
     expect(item.duration).toBe('2:05');
+  });
+
+  test('when a device asset is converted to a timeline item, then its modification time is carried over', () => {
+    const asset = makeAsset({ modificationTime: new Date('2024-07-01T09:30:00').getTime() });
+    const item = assetToPhotoItem(asset, new Set(), new Set());
+    expect(item.modificationTime).toBe(new Date('2024-07-01T09:30:00').getTime());
   });
 
   test('when the asset is in the cloud-deleted set, then its backup state is cloud-deleted', () => {

--- a/src/screens/PhotosScreen/utils/photoTimelineGroups.ts
+++ b/src/screens/PhotosScreen/utils/photoTimelineGroups.ts
@@ -54,6 +54,7 @@ export const assetToPhotoItem = (
     type: 'local',
     uri: asset.uri,
     createdAt: asset.creationTime,
+    modificationTime: asset.modificationTime,
     backupState,
     mediaType: isVideo ? 'video' : 'photo',
     duration: isVideo ? formatVideoDuration(asset.duration) : undefined,

--- a/src/screens/PhotosScreen/utils/photoUtils.spec.ts
+++ b/src/screens/PhotosScreen/utils/photoUtils.spec.ts
@@ -6,6 +6,7 @@ const makeLocalItem = (overrides: Partial<PhotoItem> = {}): PhotoItem => ({
   type: 'local',
   uri: 'file:///photo.jpg',
   createdAt: Date.now(),
+  modificationTime: Date.now(),
   backupState: 'not-backed',
   mediaType: 'photo',
   ...overrides,

--- a/src/services/photos/PhotoActionsService.spec.ts
+++ b/src/services/photos/PhotoActionsService.spec.ts
@@ -66,6 +66,7 @@ const makeLocalBacked = (id = 'asset-1'): PhotoItem => ({
   uri: `ph://${id}`,
   mediaType: 'photo',
   createdAt: Date.now(),
+  modificationTime: Date.now(),
   backupState: 'backed',
 });
 
@@ -75,6 +76,7 @@ const makeLocalNotBacked = (id = 'asset-nb'): PhotoItem => ({
   uri: `ph://${id}`,
   mediaType: 'photo',
   createdAt: Date.now(),
+  modificationTime: Date.now(),
   backupState: 'not-backed',
 });
 

--- a/src/services/photos/PhotoAssetFetchService.spec.ts
+++ b/src/services/photos/PhotoAssetFetchService.spec.ts
@@ -57,6 +57,7 @@ const makeLocalItem = (overrides: Partial<PhotoItem> = {}): PhotoItem => ({
   uri: 'ph://ABCD-1234/L0/001',
   mediaType: 'photo',
   createdAt: Date.now(),
+  modificationTime: Date.now(),
   backupState: 'backed',
   ...overrides,
 });

--- a/src/services/photos/PhotoCloudBrowser.spec.ts
+++ b/src/services/photos/PhotoCloudBrowser.spec.ts
@@ -1,3 +1,4 @@
+import fileSystemService from '@internxt-mobile/services/FileSystemService';
 import { driveFolderService } from 'src/services/drive/folder/driveFolder.service';
 import { photosLocalDB } from './database/photosLocalDB';
 import { photoCloudBrowser } from './PhotoCloudBrowser';
@@ -31,23 +32,39 @@ jest.mock('./database/photosLocalDB', () => ({
     getDistinctCloudAssetDeviceIds: jest.fn().mockResolvedValue([]),
     deleteCloudAssetsByDevice: jest.fn(),
     resetSyncedToPending: jest.fn(),
+    getCachedThumbnailRefs: jest.fn(),
   },
+}));
+
+jest.mock('@internxt-mobile/services/FileSystemService', () => ({
+  __esModule: true,
+  default: { unlinkIfExists: jest.fn() },
 }));
 
 const mockFolderService = driveFolderService as jest.Mocked<typeof driveFolderService>;
 const mockDeviceService = photosDeviceService as jest.Mocked<typeof photosDeviceService>;
 const mockPhotosLocalDB = photosLocalDB as jest.Mocked<typeof photosLocalDB>;
+const mockFileSystemService = fileSystemService as jest.Mocked<typeof fileSystemService>;
 
 const makeFolder = (uuid: string, plainName: string) => ({ uuid, plainName, name: plainName }) as never;
-const makeFile = (uuid: string, plainName: string) =>
+const defaultThumbnails = [{ bucket_id: 'bucket-1', bucket_file: 'file-1', type: 'jpg' }];
+const makeFile = (uuid: string, plainName: string, thumbnails: unknown[] = defaultThumbnails) =>
   ({
     uuid,
     plainName,
     name: plainName,
     size: 1024,
     createdAt: '2024-06-15T12:00:00.000Z',
-    thumbnails: [{ bucket_id: 'bucket-1', bucket_file: 'file-1', type: 'jpg' }],
+    thumbnails,
   }) as never;
+
+const setupMonthFetch = (file: unknown) => {
+  mockFolderService.getFolderFolders
+    .mockResolvedValueOnce({ folders: [makeFolder('year-uuid', '2024')] })
+    .mockResolvedValueOnce({ folders: [makeFolder('month-uuid', '06')] })
+    .mockResolvedValueOnce({ folders: [makeFolder('day-uuid', '15')] });
+  mockFolderService.getFolderContentByUuid.mockResolvedValueOnce({ files: [file] } as never);
+};
 const makeDevice = (uuid: string, plainName: string, status: 'EXISTS' | 'TRASHED' | 'DELETED' = 'EXISTS') => ({
   uuid,
   plainName,
@@ -68,6 +85,8 @@ beforeEach(() => {
   mockPhotosLocalDB.getSyncedMonths.mockResolvedValue([]);
   mockPhotosLocalDB.getDistinctCloudAssetDeviceIds.mockResolvedValue([]);
   mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
+  mockPhotosLocalDB.getCachedThumbnailRefs.mockResolvedValue(new Map());
+  mockFileSystemService.unlinkIfExists.mockResolvedValue(true);
 });
 
 describe('PhotoCloudBrowser.listDeviceFolders', () => {
@@ -183,6 +202,73 @@ describe('PhotoCloudBrowser.fetchMonth', () => {
     });
 
     expect(mockPhotosLocalDB.upsertCloudAsset).not.toHaveBeenCalled();
+  });
+
+  test('when a cloud file has several thumbnails, then the most recently created one is used', async () => {
+    mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValueOnce(null);
+    setupMonthFetch(
+      makeFile('file-uuid', 'IMG_20240615_120000.jpg', [
+        { id: 1, bucket_id: 'bucket-1', bucket_file: 'old-thumb', type: 'jpg', createdAt: '2024-06-15T10:00:00Z' },
+        { id: 2, bucket_id: 'bucket-1', bucket_file: 'new-thumb', type: 'jpg', createdAt: '2024-06-16T10:00:00Z' },
+      ]),
+    );
+
+    await photoCloudBrowser.fetchMonth({ deviceId: 'd1-uuid', deviceFolderUuid: 'd1-uuid', year: 2024, month: 6 });
+
+    expect(mockPhotosLocalDB.upsertCloudAsset).toHaveBeenCalledWith(
+      expect.objectContaining({ thumbnailBucketFile: 'new-thumb' }),
+    );
+  });
+
+  test('when the thumbnails have no creation date, then the one with the highest identifier is used', async () => {
+    mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValueOnce(null);
+    setupMonthFetch(
+      makeFile('file-uuid', 'IMG_20240615_120000.jpg', [
+        { id: 5, bucket_id: 'bucket-1', bucket_file: 'thumb-5', type: 'jpg' },
+        { id: 9, bucket_id: 'bucket-1', bucket_file: 'thumb-9', type: 'jpg' },
+      ]),
+    );
+
+    await photoCloudBrowser.fetchMonth({ deviceId: 'd1-uuid', deviceFolderUuid: 'd1-uuid', year: 2024, month: 6 });
+
+    expect(mockPhotosLocalDB.upsertCloudAsset).toHaveBeenCalledWith(
+      expect.objectContaining({ thumbnailBucketFile: 'thumb-9' }),
+    );
+  });
+
+  test('when a cloud file has no thumbnails, then the thumbnail references are left empty', async () => {
+    mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValueOnce(null);
+    setupMonthFetch(makeFile('file-uuid', 'IMG_20240615_120000.jpg', []));
+
+    await photoCloudBrowser.fetchMonth({ deviceId: 'd1-uuid', deviceFolderUuid: 'd1-uuid', year: 2024, month: 6 });
+
+    expect(mockPhotosLocalDB.upsertCloudAsset).toHaveBeenCalledWith(
+      expect.objectContaining({ thumbnailBucketId: null, thumbnailBucketFile: null, thumbnailType: null }),
+    );
+  });
+
+  test('when a file thumbnail bucket file changes, then the old cached thumbnail file is deleted', async () => {
+    mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValueOnce(null);
+    mockPhotosLocalDB.getCachedThumbnailRefs.mockResolvedValueOnce(
+      new Map([['file-uuid', { thumbnailPath: '/cache/old-thumb.jpg', thumbnailBucketFile: 'old-thumb' }]]),
+    );
+    setupMonthFetch(makeFile('file-uuid', 'IMG_20240615_120000.jpg'));
+
+    await photoCloudBrowser.fetchMonth({ deviceId: 'd1-uuid', deviceFolderUuid: 'd1-uuid', year: 2024, month: 6 });
+
+    expect(mockFileSystemService.unlinkIfExists).toHaveBeenCalledWith('/cache/old-thumb.jpg');
+  });
+
+  test('when a file thumbnail bucket file is unchanged, then no cached thumbnail file is deleted', async () => {
+    mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValueOnce(null);
+    mockPhotosLocalDB.getCachedThumbnailRefs.mockResolvedValueOnce(
+      new Map([['file-uuid', { thumbnailPath: '/cache/thumb.jpg', thumbnailBucketFile: 'file-1' }]]),
+    );
+    setupMonthFetch(makeFile('file-uuid', 'IMG_20240615_120000.jpg'));
+
+    await photoCloudBrowser.fetchMonth({ deviceId: 'd1-uuid', deviceFolderUuid: 'd1-uuid', year: 2024, month: 6 });
+
+    expect(mockFileSystemService.unlinkIfExists).not.toHaveBeenCalled();
   });
 
   test('when a folder has two files, then the count returned is two', async () => {

--- a/src/services/photos/PhotoCloudBrowser.ts
+++ b/src/services/photos/PhotoCloudBrowser.ts
@@ -36,7 +36,7 @@ const pickLatestThumbnail = (thumbnails: ThumbnailWithCreatedAt[] | undefined): 
       return new Date(candidate.createdAt).getTime() > new Date(newest.createdAt).getTime() ? candidate : newest;
     }
     return candidate.id > newest.id ? candidate : newest;
-  });
+  }, thumbnails[0]);
 };
 
 const resolveBurstFields = (
@@ -557,19 +557,21 @@ class PhotoCloudBrowserService {
     }
 
     const cachedRefs = await this.localDB.getCachedThumbnailRefs(entriesWithThumbnail.map((entry) => entry.remoteFileId));
-    await Promise.all(
-      entriesWithThumbnail.map((entry) => {
+    const stalePaths = entriesWithThumbnail
+      .map((entry) => {
         const cached = cachedRefs.get(entry.remoteFileId);
         if (
           !cached?.thumbnailPath ||
           !cached.thumbnailBucketFile ||
           cached.thumbnailBucketFile === entry.thumbnailBucketFile
         ) {
-          return undefined;
+          return null;
         }
-        return fileSystemService.unlinkIfExists(cached.thumbnailPath);
-      }),
-    );
+        return cached.thumbnailPath;
+      })
+      .filter((path): path is string => path !== null);
+
+    await Promise.all(stalePaths.map((path) => fileSystemService.unlinkIfExists(path)));
   }
 
   private async findChildFolder(parentUuid: string, name: string): Promise<FetchPaginatedFolder | null> {

--- a/src/services/photos/PhotoCloudBrowser.ts
+++ b/src/services/photos/PhotoCloudBrowser.ts
@@ -1,5 +1,6 @@
+import fileSystemService from '@internxt-mobile/services/FileSystemService';
 import { DriveFileData } from '@internxt-mobile/types/drive/file';
-import { FetchPaginatedFolder } from '@internxt/sdk/dist/drive/storage/types';
+import { FetchPaginatedFolder, Thumbnail } from '@internxt/sdk/dist/drive/storage/types';
 import { logger } from 'src/services/common';
 import { driveFolderService } from 'src/services/drive/folder/driveFolder.service';
 import { buildBurstBaseSet, linkBurst } from './burst/BurstCloudLinker';
@@ -17,6 +18,26 @@ const CACHE_TTL_MS = 24 * HOUR_MS;
 const PAGE_SIZE = 50;
 const MIN_MONTH_NUMBER = 1;
 const MAX_MONTH_NUMBER = 12;
+
+// The SDK's Thumbnail type omits `createdAt`, need to add it
+type ThumbnailWithCreatedAt = Thumbnail & { createdAt?: string };
+
+/**
+ * Picks the most recently created thumbnail. A file can have several thumbnail entries (e.g.
+ * after an edited photo is re-uploaded and a new thumbnail is generated), and `id` is an
+ * autoincrement fallback for when `createdAt` isn't present on either candidate.
+ */
+const pickLatestThumbnail = (thumbnails: ThumbnailWithCreatedAt[] | undefined): ThumbnailWithCreatedAt | null => {
+  if (!thumbnails?.length) {
+    return null;
+  }
+  return thumbnails.reduce((newest, candidate) => {
+    if (candidate.createdAt && newest.createdAt) {
+      return new Date(candidate.createdAt).getTime() > new Date(newest.createdAt).getTime() ? candidate : newest;
+    }
+    return candidate.id > newest.id ? candidate : newest;
+  });
+};
 
 const resolveBurstFields = (
   baseName: string | null,
@@ -188,6 +209,8 @@ class PhotoCloudBrowserService {
 
       const plainNameIndex = this.buildPlainNameIndex(existingFiles);
       const entries = this.buildCloudAssetEntries({ files: existingFiles, plainNameIndex, deviceId, folderDate, now });
+
+      await this.evictStaleThumbnailCacheFiles(entries);
 
       for (const entry of entries) {
         foundIds.add(entry.remoteFileId);
@@ -466,7 +489,7 @@ class PhotoCloudBrowserService {
       const baseName = file.plainName ?? file.name;
       const type = file.type ?? '';
       const fileName = type ? `${baseName}.${type}` : baseName;
-      const thumb = file.thumbnails?.[0] ?? null;
+      const thumb = pickLatestThumbnail(file.thumbnails);
 
       let livePhotoRole: LivePhotoRole | null = null;
       let isLivePhoto = false;
@@ -520,6 +543,33 @@ class PhotoCloudBrowserService {
     }
 
     return entries;
+  }
+
+  /**
+   * Deletes cached thumbnail files that no longer match the file's current thumbnail bucket file
+   * (e.g. after an edited photo replaced its thumbnail on the server). The DB row itself is
+   * invalidated by the `upsertCloudAsset` upsert; this only reclaims the orphaned disk file.
+   */
+  private async evictStaleThumbnailCacheFiles(entries: CloudAssetEntry[]): Promise<void> {
+    const entriesWithThumbnail = entries.filter((entry) => entry.thumbnailBucketFile);
+    if (entriesWithThumbnail.length === 0) {
+      return;
+    }
+
+    const cachedRefs = await this.localDB.getCachedThumbnailRefs(entriesWithThumbnail.map((entry) => entry.remoteFileId));
+    await Promise.all(
+      entriesWithThumbnail.map((entry) => {
+        const cached = cachedRefs.get(entry.remoteFileId);
+        if (
+          !cached?.thumbnailPath ||
+          !cached.thumbnailBucketFile ||
+          cached.thumbnailBucketFile === entry.thumbnailBucketFile
+        ) {
+          return undefined;
+        }
+        return fileSystemService.unlinkIfExists(cached.thumbnailPath);
+      }),
+    );
   }
 
   private async findChildFolder(parentUuid: string, name: string): Promise<FetchPaginatedFolder | null> {

--- a/src/services/photos/PhotoThumbnailBackfillService.spec.ts
+++ b/src/services/photos/PhotoThumbnailBackfillService.spec.ts
@@ -96,6 +96,7 @@ describe('backfillCloudThumbnail', () => {
       type: 'local',
       mediaType: 'photo',
       createdAt: Date.now(),
+      modificationTime: Date.now(),
       backupState: 'backed',
     };
 

--- a/src/services/photos/database/photosLocalDB.spec.ts
+++ b/src/services/photos/database/photosLocalDB.spec.ts
@@ -627,6 +627,47 @@ describe('photosLocalDB cloud asset methods', () => {
     ]);
   });
 
+  test('when a cloud asset is upserted, then the cached thumbnail path is only kept if the thumbnail bucket file is unchanged', async () => {
+    await photosLocalDB.upsertCloudAsset({
+      remoteFileId: 'remote-1',
+      deviceId: 'device-1',
+      folderDate: 1718000000000,
+      fileName: 'photo.jpg',
+      fileSize: 2048,
+      fileId: 'bridge-file-1',
+      thumbnailPath: null,
+      thumbnailBucketId: 'bucket-1',
+      thumbnailBucketFile: 'file-1',
+      thumbnailType: 'jpg',
+      discoveredAt: 1718100000000,
+      uploadedAt: 1718200000000,
+      isFavorite: false,
+    });
+
+    const [, statement] = mockSqlite.executeSql.mock.calls[0];
+    expect(statement as string).toContain('cloud_asset.thumbnail_bucket_file IS NOT excluded.thumbnail_bucket_file');
+    expect(statement as string).toContain('THEN NULL');
+  });
+
+  test('when cached thumbnail refs are requested for a set of ids, then a map keyed by remote file id is returned', async () => {
+    mockSqlite.getAllAsync.mockResolvedValueOnce([
+      { remote_file_id: 'remote-1', thumbnail_path: '/local/thumb1.jpg', thumbnail_bucket_file: 'file-1' },
+      { remote_file_id: 'remote-2', thumbnail_path: null, thumbnail_bucket_file: null },
+    ]);
+
+    const refs = await photosLocalDB.getCachedThumbnailRefs(['remote-1', 'remote-2']);
+
+    expect(refs.get('remote-1')).toEqual({ thumbnailPath: '/local/thumb1.jpg', thumbnailBucketFile: 'file-1' });
+    expect(refs.get('remote-2')).toEqual({ thumbnailPath: null, thumbnailBucketFile: null });
+  });
+
+  test('when cached thumbnail refs are requested for an empty id list, then no query is made', async () => {
+    const refs = await photosLocalDB.getCachedThumbnailRefs([]);
+
+    expect(refs.size).toBe(0);
+    expect(mockSqlite.getAllAsync).not.toHaveBeenCalled();
+  });
+
   test('when all cloud assets are fetched, then each database row is mapped to a typed entry', async () => {
     mockSqlite.getAllAsync.mockResolvedValueOnce([
       {

--- a/src/services/photos/database/photosLocalDB.ts
+++ b/src/services/photos/database/photosLocalDB.ts
@@ -617,7 +617,7 @@ class PhotosLocalDB {
     return rows.map(rowToCloudAssetEntry);
   }
 
-  private buildInClausePlaceholders = (ids: string[]): string => ids.map(() => '?').join(', ');
+  private readonly buildInClausePlaceholders = (ids: string[]): string => ids.map(() => '?').join(', ');
 
   async getCachedThumbnailRefs(
     remoteFileIds: string[],

--- a/src/services/photos/database/photosLocalDB.ts
+++ b/src/services/photos/database/photosLocalDB.ts
@@ -386,7 +386,7 @@ class PhotosLocalDB {
 
     const results = await Promise.all(
       chunks.map((chunk) => {
-        const placeholders = chunk.map(() => '?').join(', ');
+        const placeholders = this.buildInClausePlaceholders(chunk);
         return sqliteService.getAllAsync<{
           asset_id: string;
           modification_time: number | null;
@@ -464,7 +464,7 @@ class PhotosLocalDB {
     }
     for (let i = 0; i < remoteFileIds.length; i += CHUNK_SIZE) {
       const chunk = remoteFileIds.slice(i, i + CHUNK_SIZE);
-      const placeholders = chunk.map(() => '?').join(', ');
+      const placeholders = this.buildInClausePlaceholders(chunk);
       await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.revertCloudDeleted(placeholders), chunk);
     }
   }
@@ -615,6 +615,44 @@ class PhotosLocalDB {
         ])
       : await sqliteService.getAllAsync<CloudAssetRow>(DB_NAME, cloudAssetTable.statements.getByRange, [from, to]);
     return rows.map(rowToCloudAssetEntry);
+  }
+
+  private buildInClausePlaceholders = (ids: string[]): string => ids.map(() => '?').join(', ');
+
+  async getCachedThumbnailRefs(
+    remoteFileIds: string[],
+  ): Promise<Map<string, { thumbnailPath: string | null; thumbnailBucketFile: string | null }>> {
+    const refs = new Map<string, { thumbnailPath: string | null; thumbnailBucketFile: string | null }>();
+    if (remoteFileIds.length === 0) {
+      return refs;
+    }
+
+    const chunks: string[][] = [];
+    for (let i = 0; i < remoteFileIds.length; i += CHUNK_SIZE) {
+      chunks.push(remoteFileIds.slice(i, i + CHUNK_SIZE));
+    }
+
+    const results = await Promise.all(
+      chunks.map((chunk) => {
+        const placeholders = this.buildInClausePlaceholders(chunk);
+        return sqliteService.getAllAsync<{
+          remote_file_id: string;
+          thumbnail_path: string | null;
+          thumbnail_bucket_file: string | null;
+        }>(DB_NAME, cloudAssetTable.statements.getThumbnailRefsInList(placeholders), chunk);
+      }),
+    );
+
+    for (const chunkRows of results) {
+      for (const row of chunkRows) {
+        refs.set(row.remote_file_id, {
+          thumbnailPath: row.thumbnail_path,
+          thumbnailBucketFile: row.thumbnail_bucket_file,
+        });
+      }
+    }
+
+    return refs;
   }
 
   async setCloudThumbnailPath(remoteFileId: string, path: string | null): Promise<void> {

--- a/src/services/photos/database/tables/cloud_asset.ts
+++ b/src/services/photos/database/tables/cloud_asset.ts
@@ -57,7 +57,12 @@ const statements = {
       file_name              = excluded.file_name,
       file_size              = excluded.file_size,
       file_id                = excluded.file_id,
-      thumbnail_path         = COALESCE(${TABLE_NAME}.thumbnail_path, excluded.thumbnail_path),
+      thumbnail_path         = CASE
+        WHEN excluded.thumbnail_bucket_file IS NOT NULL
+         AND ${TABLE_NAME}.thumbnail_bucket_file IS NOT excluded.thumbnail_bucket_file
+        THEN NULL
+        ELSE COALESCE(${TABLE_NAME}.thumbnail_path, excluded.thumbnail_path)
+      END,
       thumbnail_bucket_id    = excluded.thumbnail_bucket_id,
       thumbnail_bucket_file  = excluded.thumbnail_bucket_file,
       thumbnail_type         = excluded.thumbnail_type,
@@ -132,6 +137,12 @@ const statements = {
     SELECT ${COLUMNS}
     FROM ${TABLE_NAME}
     WHERE remote_file_id = ?;
+  `,
+
+  getThumbnailRefsInList: (placeholders: string) => `
+    SELECT remote_file_id, thumbnail_path, thumbnail_bucket_file
+    FROM ${TABLE_NAME}
+    WHERE remote_file_id IN (${placeholders});
   `,
 
   setThumbnailPath: `


### PR DESCRIPTION
Added thumbnail cache invalidation and refresh for local and cloud assets

  ## Summary

  - **`PhotosScreen/types.ts`, `photoTimelineGroups.ts`**: added `modificationTime` to `PhotoItem`, sourced from the same `MediaLibrary.Asset` field the sync layer already uses to detect edits.
  - **`PhotoItem.tsx`**: the grid's `ExpoImage` now keys its cache on `${id}-${modificationTime}` instead of just the URI (which iOS doesn't change on edit).
  - **`PhotoCloudBrowser.ts`**: picks the most recently created thumbnail instead of blindly using `thumbnails[0]`, and evicts the orphaned cached thumbnail file from disk when a file's thumbnail bucket changed.
  - **`cloud_asset.ts`**: the cloud asset upsert now nulls the cached `thumbnail_path` when `thumbnail_bucket_file` changed, so stale local caches get invalidated instead of persisted forever.
  - **`database/photosLocalDB.ts`**: new `getCachedThumbnailRefs` batch lookup, plus a shared `buildInClausePlaceholders` helper reused across the existing chunked queries.