### PR TITLE
[_]: address Sonar findings and repair auth credentials spec

### DIFF
--- a/android/app/src/main/java/com/internxt/cloud/documents/http/CallAwait.kt
+++ b/android/app/src/main/java/com/internxt/cloud/documents/http/CallAwait.kt
@@ -24,5 +24,7 @@ private fun Response.closeQuietly() {
     try {
         close()
     } catch (_: Throwable) {
+        // Intentionally empty: close() failures on an already-abandoned response are irrelevant
+        // and must not mask the coroutine's cancellation or original result.
     }
 }

--- a/android/app/src/test/java/com/internxt/cloud/documents/DocumentRowBuilderTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/DocumentRowBuilderTest.kt
@@ -9,6 +9,10 @@ import org.junit.Test
 
 class DocumentRowBuilderTest {
 
+    companion object {
+        private const val UPDATED_AT = "2026-01-11T00:00:00.000Z"
+    }
+
     @Test
     fun folderRowFields() {
         val folder = DriveFolder(
@@ -17,7 +21,7 @@ class DocumentRowBuilderTest {
             parentUuid = "parent-uuid",
             bucket = null,
             createdAt = null,
-            updatedAt = "2026-01-11T00:00:00.000Z",
+            updatedAt = UPDATED_AT,
         )
 
         val row = DocumentRowBuilder.folderRow(folder)
@@ -44,7 +48,7 @@ class DocumentRowBuilderTest {
             bucket = "bucket-id",
             folderUuid = "parent-uuid",
             createdAt = null,
-            updatedAt = "2026-01-11T00:00:00.000Z",
+            updatedAt = UPDATED_AT,
             fileId = "file-id-1",
         )
 
@@ -96,7 +100,7 @@ class DocumentRowBuilderTest {
 
     @Test
     fun parseIsoToMillisHandlesValidInput() {
-        assertEquals(1768089600000L, DocumentRowBuilder.parseIsoToMillis("2026-01-11T00:00:00.000Z"))
+        assertEquals(1768089600000L, DocumentRowBuilder.parseIsoToMillis(UPDATED_AT))
     }
 
     @Test

--- a/android/app/src/test/java/com/internxt/cloud/documents/DocumentRowCacheTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/DocumentRowCacheTest.kt
@@ -8,6 +8,13 @@ import org.junit.Test
 
 class DocumentRowCacheTest {
 
+    companion object {
+        private const val FOLDER_UUID = "folder-uuid"
+        private const val FILE_UUID = "file-uuid"
+        private const val FOLDER_DOC_ID = "f:$FOLDER_UUID"
+        private const val FILE_DOC_ID = "d:$FILE_UUID"
+    }
+
     private lateinit var cache: DocumentRowCache
 
     @Before
@@ -22,13 +29,13 @@ class DocumentRowCacheTest {
 
     @Test
     fun `when putAll receives listing rows, then they are retrievable by decoded uuid`() {
-        val folderRow = row("f:folder-uuid", "Documents")
-        val fileRow = row("d:file-uuid", "report.pdf")
+        val folderRow = row(FOLDER_DOC_ID, "Documents")
+        val fileRow = row(FILE_DOC_ID, "report.pdf")
 
         cache.putAll(listOf(folderRow, fileRow))
 
-        assertEquals(folderRow, cache["folder-uuid"])
-        assertEquals(fileRow, cache["file-uuid"])
+        assertEquals(folderRow, cache[FOLDER_UUID])
+        assertEquals(fileRow, cache[FILE_UUID])
     }
 
     @Test
@@ -49,33 +56,33 @@ class DocumentRowCacheTest {
 
     @Test
     fun `when put stores a row under a uuid, then a later put overwrites it`() {
-        cache.put("file-uuid", row("d:file-uuid", "old.pdf"))
-        val renamed = row("d:file-uuid", "new.pdf")
+        cache.put(FILE_UUID, row(FILE_DOC_ID, "old.pdf"))
+        val renamed = row(FILE_DOC_ID, "new.pdf")
 
-        cache.put("file-uuid", renamed)
+        cache.put(FILE_UUID, renamed)
 
-        assertEquals(renamed, cache["file-uuid"])
+        assertEquals(renamed, cache[FILE_UUID])
     }
 
     @Test
     fun `when evict removes a uuid, then only that entry is gone`() {
-        cache.putAll(listOf(row("d:file-uuid"), row("f:folder-uuid")))
+        cache.putAll(listOf(row(FILE_DOC_ID), row(FOLDER_DOC_ID)))
 
-        cache.evict("file-uuid")
+        cache.evict(FILE_UUID)
 
-        assertNull(cache["file-uuid"])
-        assertEquals(row("f:folder-uuid"), cache["folder-uuid"])
+        assertNull(cache[FILE_UUID])
+        assertEquals(row(FOLDER_DOC_ID), cache[FOLDER_UUID])
     }
 
     @Test
     fun `when evictAll receives stale rows, then their uuids are removed and others remain`() {
         val staying = row("d:kept-uuid")
-        cache.putAll(listOf(row("d:file-uuid"), row("f:folder-uuid"), staying))
+        cache.putAll(listOf(row(FILE_DOC_ID), row(FOLDER_DOC_ID), staying))
 
-        cache.evictAll(listOf(row("d:file-uuid"), row("f:folder-uuid")))
+        cache.evictAll(listOf(row(FILE_DOC_ID), row(FOLDER_DOC_ID)))
 
-        assertNull(cache["file-uuid"])
-        assertNull(cache["folder-uuid"])
+        assertNull(cache[FILE_UUID])
+        assertNull(cache[FOLDER_UUID])
         assertEquals(staying, cache["kept-uuid"])
     }
 

--- a/android/app/src/test/java/com/internxt/cloud/documents/MimeTypesTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/MimeTypesTest.kt
@@ -5,11 +5,16 @@ import org.junit.Test
 
 class MimeTypesTest {
 
+    companion object {
+        private const val APPLICATION_PDF = "application/pdf"
+        private const val IMAGE_JPEG = "image/jpeg"
+    }
+
     @Test
     fun mapsKnownExtensions() {
-        assertEquals("application/pdf", MimeTypes.fromExtension("pdf"))
-        assertEquals("image/jpeg", MimeTypes.fromExtension("jpg"))
-        assertEquals("image/jpeg", MimeTypes.fromExtension("jpeg"))
+        assertEquals(APPLICATION_PDF, MimeTypes.fromExtension("pdf"))
+        assertEquals(IMAGE_JPEG, MimeTypes.fromExtension("jpg"))
+        assertEquals(IMAGE_JPEG, MimeTypes.fromExtension("jpeg"))
         assertEquals("image/png", MimeTypes.fromExtension("png"))
         assertEquals("video/mp4", MimeTypes.fromExtension("mp4"))
         assertEquals("audio/mpeg", MimeTypes.fromExtension("mp3"))
@@ -22,14 +27,14 @@ class MimeTypesTest {
 
     @Test
     fun isCaseInsensitive() {
-        assertEquals("application/pdf", MimeTypes.fromExtension("PDF"))
-        assertEquals("image/jpeg", MimeTypes.fromExtension("JPG"))
-        assertEquals("image/jpeg", MimeTypes.fromExtension("Jpeg"))
+        assertEquals(APPLICATION_PDF, MimeTypes.fromExtension("PDF"))
+        assertEquals(IMAGE_JPEG, MimeTypes.fromExtension("JPG"))
+        assertEquals(IMAGE_JPEG, MimeTypes.fromExtension("Jpeg"))
     }
 
     @Test
     fun trimsWhitespace() {
-        assertEquals("application/pdf", MimeTypes.fromExtension("  pdf  "))
+        assertEquals(APPLICATION_PDF, MimeTypes.fromExtension("  pdf  "))
     }
 
     @Test

--- a/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientTest.kt
+++ b/android/app/src/test/java/com/internxt/cloud/documents/api/InternxtApiClientTest.kt
@@ -21,6 +21,9 @@ class InternxtApiClientTest {
         private const val PARENT_UUID = "parent-uuid"
         private const val BUCKET_ID = "bucket-id"
         private const val NEW_FOLDER_NAME = "New Folder"
+        private const val FILE_UUID_1 = "file-uuid-1"
+        private const val FOLDER_UUID_1 = "folder-uuid-1"
+        private const val MISSING_UUID = "missing-uuid"
     }
 
     @Before
@@ -58,7 +61,7 @@ class InternxtApiClientTest {
             {
               "files": [
                 {
-                  "uuid": "file-uuid-1",
+                  "uuid": "$FILE_UUID_1",
                   "plainName": "report.pdf",
                   "type": "pdf",
                   "size": 102400,
@@ -76,7 +79,7 @@ class InternxtApiClientTest {
 
         assertEquals(1, files.size)
         val file = files[0]
-        assertEquals("file-uuid-1", file.uuid)
+        assertEquals(FILE_UUID_1, file.uuid)
         assertEquals("report.pdf", file.plainName)
         assertEquals("pdf", file.type)
         assertEquals(102400L, file.size)
@@ -118,7 +121,7 @@ class InternxtApiClientTest {
         enqueueJson("", code = 404)
 
         assertThrows(InternxtApiException.NotFoundException::class.java) {
-            client.listFolderFiles("missing-uuid")
+            client.listFolderFiles(MISSING_UUID)
         }
     }
 
@@ -174,7 +177,7 @@ class InternxtApiClientTest {
             {
               "folders": [
                 {
-                  "uuid": "folder-uuid-1",
+                  "uuid": "$FOLDER_UUID_1",
                   "plainName": "Documents",
                   "parentUuid": "$PARENT_UUID",
                   "bucket": "$BUCKET_ID",
@@ -190,7 +193,7 @@ class InternxtApiClientTest {
 
         assertEquals(1, folders.size)
         val folder = folders[0]
-        assertEquals("folder-uuid-1", folder.uuid)
+        assertEquals(FOLDER_UUID_1, folder.uuid)
         assertEquals("Documents", folder.plainName)
         assertEquals(PARENT_UUID, folder.parentUuid)
         assertEquals(BUCKET_ID, folder.bucket)
@@ -227,7 +230,7 @@ class InternxtApiClientTest {
             {
               "files": [
                 {
-                  "uuid": "file-uuid-1",
+                  "uuid": "$FILE_UUID_1",
                   "plainName": "report.pdf",
                   "type": null,
                   "bucket": null,
@@ -258,7 +261,7 @@ class InternxtApiClientTest {
             {
               "files": [
                 {
-                  "uuid": "file-uuid-1",
+                  "uuid": "$FILE_UUID_1",
                   "plainName": "big.bin",
                   "size": "9999999999"
                 }
@@ -274,56 +277,56 @@ class InternxtApiClientTest {
 
     @Test
     fun getFolderHitsMetaEndpointAndReturnsParsedFolder() {
-        enqueueJson("""{"uuid":"folder-uuid-1","plainName":"Documents"}""")
+        enqueueJson("""{"uuid":"$FOLDER_UUID_1","plainName":"Documents"}""")
 
-        val folder = client.getFolder("folder-uuid-1")
+        val folder = client.getFolder(FOLDER_UUID_1)
 
-        assertEquals("folder-uuid-1", folder?.uuid)
+        assertEquals(FOLDER_UUID_1, folder?.uuid)
         assertEquals("Documents", folder?.plainName)
 
         val recorded = server.takeRequest()
         assertEquals("GET", recorded.method)
-        assertEquals("/folders/folder-uuid-1/meta", recorded.path)
+        assertEquals("/folders/$FOLDER_UUID_1/meta", recorded.path)
     }
 
     @Test
     fun getFolderReturnsNullWhenNotFound() {
         enqueueJson("", code = 404)
 
-        assertNull(client.getFolder("missing-uuid"))
+        assertNull(client.getFolder(MISSING_UUID))
     }
 
     @Test
     fun getFileHitsMetaEndpointAndReturnsParsedFile() {
-        enqueueJson("""{"uuid":"file-uuid-1","plainName":"report.pdf","type":"pdf","size":102400}""")
+        enqueueJson("""{"uuid":"$FILE_UUID_1","plainName":"report.pdf","type":"pdf","size":102400}""")
 
-        val file = client.getFile("file-uuid-1")
+        val file = client.getFile(FILE_UUID_1)
 
-        assertEquals("file-uuid-1", file?.uuid)
+        assertEquals(FILE_UUID_1, file?.uuid)
         assertEquals("report.pdf", file?.plainName)
         assertEquals(102400L, file?.size)
 
         val recorded = server.takeRequest()
         assertEquals("GET", recorded.method)
-        assertEquals("/files/file-uuid-1/meta", recorded.path)
+        assertEquals("/files/$FILE_UUID_1/meta", recorded.path)
     }
 
     @Test
     fun getFileReturnsNullWhenNotFound() {
         enqueueJson("", code = 404)
 
-        assertNull(client.getFile("missing-uuid"))
+        assertNull(client.getFile(MISSING_UUID))
     }
 
     @Test
     fun renameFilePutsPlainNameToMetaEndpoint() {
         enqueueJson("")
 
-        client.renameFile("file-uuid-1", "renamed.pdf")
+        client.renameFile(FILE_UUID_1, "renamed.pdf")
 
         val recorded = server.takeRequest()
         assertEquals("PUT", recorded.method)
-        assertEquals("/files/file-uuid-1/meta", recorded.path)
+        assertEquals("/files/$FILE_UUID_1/meta", recorded.path)
         assertEquals("renamed.pdf", JSONObject(recorded.body.readUtf8()).getString("plainName"))
     }
 
@@ -331,35 +334,35 @@ class InternxtApiClientTest {
     fun renameFolderPutsPlainNameToMetaEndpoint() {
         enqueueJson("")
 
-        client.renameFolder("folder-uuid-1", "Renamed")
+        client.renameFolder(FOLDER_UUID_1, "Renamed")
 
         val recorded = server.takeRequest()
         assertEquals("PUT", recorded.method)
-        assertEquals("/folders/folder-uuid-1/meta", recorded.path)
+        assertEquals("/folders/$FOLDER_UUID_1/meta", recorded.path)
         assertEquals("Renamed", JSONObject(recorded.body.readUtf8()).getString("plainName"))
     }
 
     @Test
     fun moveFilePatchesDestinationPayload() {
-        enqueueJson("""{"uuid":"file-uuid-1","folderUuid":"$PARENT_UUID"}""")
+        enqueueJson("""{"uuid":"$FILE_UUID_1","folderUuid":"$PARENT_UUID"}""")
 
-        client.moveFile("file-uuid-1", PARENT_UUID)
+        client.moveFile(FILE_UUID_1, PARENT_UUID)
 
         val recorded = server.takeRequest()
         assertEquals("PATCH", recorded.method)
-        assertEquals("/files/file-uuid-1", recorded.path)
+        assertEquals("/files/$FILE_UUID_1", recorded.path)
         assertEquals(PARENT_UUID, JSONObject(recorded.body.readUtf8()).getString("destinationFolder"))
     }
 
     @Test
     fun moveFolderPatchesDestinationPayload() {
-        enqueueJson("""{"uuid":"folder-uuid-1","parentUuid":"$PARENT_UUID"}""")
+        enqueueJson("""{"uuid":"$FOLDER_UUID_1","parentUuid":"$PARENT_UUID"}""")
 
-        client.moveFolder("folder-uuid-1", PARENT_UUID)
+        client.moveFolder(FOLDER_UUID_1, PARENT_UUID)
 
         val recorded = server.takeRequest()
         assertEquals("PATCH", recorded.method)
-        assertEquals("/folders/folder-uuid-1", recorded.path)
+        assertEquals("/folders/$FOLDER_UUID_1", recorded.path)
         assertEquals(PARENT_UUID, JSONObject(recorded.body.readUtf8()).getString("destinationFolder"))
     }
 
@@ -369,8 +372,8 @@ class InternxtApiClientTest {
 
         client.sendToTrash(
             listOf(
-                TrashItem("file-uuid-1", TrashItem.Type.FILE),
-                TrashItem("folder-uuid-1", TrashItem.Type.FOLDER),
+                TrashItem(FILE_UUID_1, TrashItem.Type.FILE),
+                TrashItem(FOLDER_UUID_1, TrashItem.Type.FOLDER),
             )
         )
 
@@ -379,9 +382,9 @@ class InternxtApiClientTest {
         assertEquals("/storage/trash/add", recorded.path)
         val items = JSONObject(recorded.body.readUtf8()).getJSONArray("items")
         assertEquals(2, items.length())
-        assertEquals("file-uuid-1", items.getJSONObject(0).getString("uuid"))
+        assertEquals(FILE_UUID_1, items.getJSONObject(0).getString("uuid"))
         assertEquals("file", items.getJSONObject(0).getString("type"))
-        assertEquals("folder-uuid-1", items.getJSONObject(1).getString("uuid"))
+        assertEquals(FOLDER_UUID_1, items.getJSONObject(1).getString("uuid"))
         assertEquals("folder", items.getJSONObject(1).getString("type"))
     }
 

--- a/ios/InternxtFileProvider/FileProviderEnumerator.swift
+++ b/ios/InternxtFileProvider/FileProviderEnumerator.swift
@@ -53,7 +53,7 @@ class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
     super.init()
   }
 
-  func invalidate() {}
+  func invalidate() { /* Nothing to cancel: enumeration Tasks are not retained, run to completion on their own, and the system ignores observer callbacks after invalidation. */ }
 
   func enumerateItems(for observer: NSFileProviderEnumerationObserver, startingAt page: NSFileProviderPage) {
     guard !isWorkingSet, FileProviderItemID.isDriveFolderContainer(enumeratedItemIdentifier) else {

--- a/ios/InternxtFileProvider/FileProviderExtension.swift
+++ b/ios/InternxtFileProvider/FileProviderExtension.swift
@@ -21,7 +21,7 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         // TODO: cleanup any resources
     }
 
-    func item(for identifier: NSFileProviderItemIdentifier, request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, Error?) -> Void) -> Progress {
+    func item(for identifier: NSFileProviderItemIdentifier, request _: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, Error?) -> Void) -> Progress {
         if identifier == .rootContainer {
             let rootItem = FileProviderItem.root(displayName: rootDisplayName)
             completionHandler(rootItem, nil)
@@ -52,7 +52,7 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         return progress
     }
 
-    func fetchContents(for itemIdentifier: NSFileProviderItemIdentifier, version requestedVersion: NSFileProviderItemVersion?, request: NSFileProviderRequest, completionHandler: @escaping (URL?, NSFileProviderItem?, Error?) -> Void) -> Progress {
+    func fetchContents(for itemIdentifier: NSFileProviderItemIdentifier, version _: NSFileProviderItemVersion?, request _: NSFileProviderRequest, completionHandler: @escaping (URL?, NSFileProviderItem?, Error?) -> Void) -> Progress {
         guard let decoded = FileProviderItemID.decode(itemIdentifier), decoded.kind == .file else {
             completionHandler(nil, nil, NSFileProviderError(.noSuchItem))
             return Progress()
@@ -79,7 +79,7 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         return progress
     }
 
-    func createItem(basedOn itemTemplate: NSFileProviderItem, fields: NSFileProviderItemFields, contents url: URL?, options: NSFileProviderCreateItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) -> Progress {
+    func createItem(basedOn itemTemplate: NSFileProviderItem, fields _: NSFileProviderItemFields, contents url: URL?, options _: NSFileProviderCreateItemOptions = [], request _: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) -> Progress {
         guard let driveAPI = DriveAPIFactory.make(), let networkFacade = NetworkFacadeFactory.make() else {
             completionHandler(nil, [], false, NSFileProviderError(.notAuthenticated))
             return Progress()
@@ -181,7 +181,7 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         return progress
     }
 
-    func modifyItem(_ item: NSFileProviderItem, baseVersion version: NSFileProviderItemVersion, changedFields: NSFileProviderItemFields, contents newContents: URL?, options: NSFileProviderModifyItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) -> Progress {
+    func modifyItem(_ item: NSFileProviderItem, baseVersion _: NSFileProviderItemVersion, changedFields: NSFileProviderItemFields, contents _: URL?, options _: NSFileProviderModifyItemOptions = [], request _: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) -> Progress {
         let shouldRename = changedFields.contains(.filename)
         let shouldMove = changedFields.contains(.parentItemIdentifier)
 
@@ -232,7 +232,7 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         return progress
     }
 
-    func deleteItem(identifier: NSFileProviderItemIdentifier, baseVersion version: NSFileProviderItemVersion, options: NSFileProviderDeleteItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (Error?) -> Void) -> Progress {
+    func deleteItem(identifier: NSFileProviderItemIdentifier, baseVersion _: NSFileProviderItemVersion, options _: NSFileProviderDeleteItemOptions = [], request _: NSFileProviderRequest, completionHandler: @escaping (Error?) -> Void) -> Progress {
         guard let driveAPI = DriveAPIFactory.make(), let trashAPI = DriveAPIFactory.makeTrash() else {
             completionHandler(NSFileProviderError(.notAuthenticated))
             return Progress()
@@ -257,7 +257,7 @@ class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         return progress
     }
 
-    func enumerator(for containerItemIdentifier: NSFileProviderItemIdentifier, request: NSFileProviderRequest) throws -> NSFileProviderEnumerator {
+    func enumerator(for containerItemIdentifier: NSFileProviderItemIdentifier, request _: NSFileProviderRequest) throws -> NSFileProviderEnumerator {
         return FileProviderEnumerator(enumeratedItemIdentifier: containerItemIdentifier)
     }
 }

--- a/ios/InternxtFileProvider/FileProviderItem.swift
+++ b/ios/InternxtFileProvider/FileProviderItem.swift
@@ -20,24 +20,28 @@ class FileProviderItem: NSObject, NSFileProviderItem {
   private let createdAt: String?
   private let sizeInBytes: String?
 
+  struct Metadata {
+    var fileExtension: String? = nil
+    var createdAt: String? = nil
+    var updatedAt: String? = nil
+    var sizeInBytes: String? = nil
+  }
+
   private init(
     identifier: NSFileProviderItemIdentifier,
     parent: NSFileProviderItemIdentifier,
     name: String,
     kind: DriveItemKind,
-    fileExtension: String?,
-    createdAt: String?,
-    updatedAt: String?,
-    sizeInBytes: String?
+    metadata: Metadata
   ) {
     self.identifier = identifier
     self.parent = parent
     self.name = name
     self.kind = kind
-    self.fileExtension = fileExtension
-    self.createdAt = createdAt
-    self.updatedAt = updatedAt
-    self.sizeInBytes = sizeInBytes
+    self.fileExtension = metadata.fileExtension
+    self.createdAt = metadata.createdAt
+    self.updatedAt = metadata.updatedAt
+    self.sizeInBytes = metadata.sizeInBytes
   }
 
   convenience init(folder: GetFolderFoldersResult, parent: NSFileProviderItemIdentifier) {
@@ -46,10 +50,7 @@ class FileProviderItem: NSObject, NSFileProviderItem {
       parent: parent,
       name: folder.plainName ?? folder.name,
       kind: .folder,
-      fileExtension: nil,
-      createdAt: folder.createdAt,
-      updatedAt: folder.updatedAt,
-      sizeInBytes: nil
+      metadata: Metadata(createdAt: folder.createdAt, updatedAt: folder.updatedAt)
     )
   }
 
@@ -59,10 +60,12 @@ class FileProviderItem: NSObject, NSFileProviderItem {
       parent: parent,
       name: file.plainName ?? file.name ?? file.uuid,
       kind: .file,
-      fileExtension: file.type,
-      createdAt: file.createdAt,
-      updatedAt: file.updatedAt,
-      sizeInBytes: file.size
+      metadata: Metadata(
+        fileExtension: file.type,
+        createdAt: file.createdAt,
+        updatedAt: file.updatedAt,
+        sizeInBytes: file.size
+      )
     )
   }
 
@@ -72,10 +75,7 @@ class FileProviderItem: NSObject, NSFileProviderItem {
       parent: parent,
       name: folder.plainName ?? folder.name,
       kind: .folder,
-      fileExtension: nil,
-      createdAt: folder.createdAt,
-      updatedAt: folder.updatedAt,
-      sizeInBytes: nil
+      metadata: Metadata(createdAt: folder.createdAt, updatedAt: folder.updatedAt)
     )
   }
 
@@ -85,10 +85,12 @@ class FileProviderItem: NSObject, NSFileProviderItem {
       parent: parent,
       name: file.plain_name,
       kind: .file,
-      fileExtension: file.type,
-      createdAt: file.createdAt,
-      updatedAt: file.updatedAt,
-      sizeInBytes: file.size
+      metadata: Metadata(
+        fileExtension: file.type,
+        createdAt: file.createdAt,
+        updatedAt: file.updatedAt,
+        sizeInBytes: file.size
+      )
     )
   }
 
@@ -100,10 +102,12 @@ class FileProviderItem: NSObject, NSFileProviderItem {
       parent: item.parentItemIdentifier,
       name: baseName,
       kind: decoded.kind,
-      fileExtension: newExtension,
-      createdAt: iso8601String(from: item.creationDate ?? nil),
-      updatedAt: iso8601String(from: item.contentModificationDate ?? nil),
-      sizeInBytes: (item.documentSize ?? nil)?.stringValue
+      metadata: Metadata(
+        fileExtension: newExtension,
+        createdAt: iso8601String(from: item.creationDate ?? nil),
+        updatedAt: iso8601String(from: item.contentModificationDate ?? nil),
+        sizeInBytes: (item.documentSize ?? nil)?.stringValue
+      )
     )
   }
 
@@ -129,10 +133,7 @@ class FileProviderItem: NSObject, NSFileProviderItem {
       parent: .rootContainer,
       name: displayName,
       kind: .folder,
-      fileExtension: nil,
-      createdAt: nil,
-      updatedAt: nil,
-      sizeInBytes: nil
+      metadata: Metadata()
     )
   }
 
@@ -142,10 +143,7 @@ class FileProviderItem: NSObject, NSFileProviderItem {
       parent: FileProviderItemID.parentIdentifier(folderUuid: folderMeta.parentUuid),
       name: folderMeta.plainName ?? folderMeta.name ?? identifier.rawValue,
       kind: .folder,
-      fileExtension: nil,
-      createdAt: folderMeta.createdAt,
-      updatedAt: folderMeta.updatedAt,
-      sizeInBytes: nil
+      metadata: Metadata(createdAt: folderMeta.createdAt, updatedAt: folderMeta.updatedAt)
     )
   }
 
@@ -155,10 +153,12 @@ class FileProviderItem: NSObject, NSFileProviderItem {
       parent: FileProviderItemID.parentIdentifier(folderUuid: fileMeta.folderUuid),
       name: fileMeta.plainName ?? fileMeta.name,
       kind: .file,
-      fileExtension: fileMeta.type,
-      createdAt: fileMeta.createdAt,
-      updatedAt: fileMeta.updatedAt,
-      sizeInBytes: fileMeta.size
+      metadata: Metadata(
+        fileExtension: fileMeta.type,
+        createdAt: fileMeta.createdAt,
+        updatedAt: fileMeta.updatedAt,
+        sizeInBytes: fileMeta.size
+      )
     )
   }
 

--- a/src/store/slices/auth/auth.syncNativeCredentials.spec.ts
+++ b/src/store/slices/auth/auth.syncNativeCredentials.spec.ts
@@ -5,6 +5,7 @@ jest.mock('../../../services/native/InternxtAuthCredentialsModule', () => ({
 
 jest.mock('@internxt-mobile/services/common', () => ({
   logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+  BaseLogger: jest.fn().mockImplementation(() => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() })),
   imageService: {},
   PROFILE_PICTURE_CACHE_KEY: 'profile-picture',
   SdkManager: { init: jest.fn(), setApiSecurity: jest.fn(), getInstance: jest.fn() },


### PR DESCRIPTION
- Document intentionally empty blocks (CallAwait closeQuietly catch, FileProviderEnumerator invalidate)
- Mark unused NSFileProviderReplicatedExtension parameters with `_` in FileProviderExtension
- Extract duplicated string literals into constants in Android DocumentRowBuilder, DocumentRowCache, MimeTypes and InternxtApiClient tests
- Mock BaseLogger in auth.syncNativeCredentials.spec so the suite runs again