### PR TITLE
[PB-6742]  bugfix/Improve timeline refresh after remove assets from mobile gallery

### DIFF
--- a/assets/lang/strings.ts
+++ b/assets/lang/strings.ts
@@ -229,7 +229,7 @@ const translations = {
           deletedFromCloud: 'Deleted from the cloud',
           backup: 'Backup',
           uploading: 'Uploading',
-          burstBadge: 'Burst',
+          burstBadge: 'BURST',
           burstIncomplete: 'Burst not fully backed up. Grant full Photos access to back up all burst photos.',
           burstPhotosUnit: 'photos',
           metadata: {
@@ -1239,7 +1239,7 @@ const translations = {
           deletedFromCloud: 'Eliminado de la nube',
           backup: 'Copia de seguridad',
           uploading: 'Subiendo',
-          burstBadge: 'Ráfaga',
+          burstBadge: 'BURST',
           burstIncomplete:
             'Ráfaga incompleta. Para respaldar todas las fotos de la ráfaga, concede acceso completo a Fotos.',
           burstPhotosUnit: 'fotos',

--- a/src/screens/PhotosScreen/hooks/useLocalAssets.spec.ts
+++ b/src/screens/PhotosScreen/hooks/useLocalAssets.spec.ts
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react-native';
 import * as MediaLibrary from 'expo-media-library';
 import { AppState } from 'react-native';
 import { photosLocalDB } from 'src/services/photos/database/photosLocalDB';
+import { photoCloudBrowser } from 'src/services/photos/PhotoCloudBrowser';
 import { useAppSelector } from 'src/store/hooks';
 import { useLocalAssets } from './useLocalAssets';
 
@@ -18,6 +19,12 @@ jest.mock('src/services/photos/database/photosLocalDB', () => ({
     getSyncedEntries: jest.fn(),
     getIncompleteBurstAssets: jest.fn().mockResolvedValue([]),
     deleteAssetSyncBulk: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock('src/services/photos/PhotoCloudBrowser', () => ({
+  photoCloudBrowser: {
+    deleteAssetSyncPreservingCloudVisibility: jest.fn().mockResolvedValue(undefined),
     cleanupOrphanedAssetSync: jest.fn().mockResolvedValue(0),
   },
 }));
@@ -28,6 +35,7 @@ jest.mock('src/store/hooks', () => ({
 
 const mockMediaLibrary = MediaLibrary as jest.Mocked<typeof MediaLibrary>;
 const mockPhotosLocalDB = photosLocalDB as jest.Mocked<typeof photosLocalDB>;
+const mockPhotoCloudBrowser = photoCloudBrowser as jest.Mocked<typeof photoCloudBrowser>;
 const mockUseAppSelector = useAppSelector as jest.Mock;
 const photosState = {
   syncStatus: 'idle',
@@ -35,6 +43,7 @@ const photosState = {
   sessionUploadedAssets: 0,
   isFetchingCloudHistory: false,
   permissionStatus: 'granted' as const,
+  deviceId: 'device-1' as string | null,
 };
 
 const makeAsset = (id: string, creationTime = 1000): MediaLibrary.Asset =>
@@ -55,6 +64,7 @@ beforeEach(() => {
     uploadingAssetIds: [],
     sessionUploadedAssets: 0,
     isFetchingCloudHistory: false,
+    deviceId: 'device-1',
   });
   mockUseAppSelector.mockImplementation((selector: (state: { photos: typeof photosState }) => unknown) =>
     selector({ photos: photosState }),
@@ -405,8 +415,8 @@ describe('useLocalAssets', () => {
       await Promise.all([secondReload, firstReload]);
     });
 
-    expect(mockPhotosLocalDB.cleanupOrphanedAssetSync).toHaveBeenCalledTimes(1);
-    expect(mockPhotosLocalDB.cleanupOrphanedAssetSync).toHaveBeenCalledWith(new Set(['a9']));
+    expect(mockPhotoCloudBrowser.cleanupOrphanedAssetSync).toHaveBeenCalledTimes(1);
+    expect(mockPhotoCloudBrowser.cleanupOrphanedAssetSync).toHaveBeenCalledWith(new Set(['a9']), 'device-1');
   });
 
   test('when sync status changes and there are assets loaded, then synced ids refresh from the database', async () => {
@@ -481,7 +491,7 @@ describe('useLocalAssets', () => {
 
     expect(result.current.assets.find((a) => a.id === 'old')).toBeUndefined();
     expect(result.current.assets).toHaveLength(2);
-    expect(mockPhotosLocalDB.deleteAssetSyncBulk).toHaveBeenCalledWith(['old']);
+    expect(mockPhotoCloudBrowser.deleteAssetSyncPreservingCloudVisibility).toHaveBeenCalledWith(['old'], 'device-1');
     expect(result.current.localDeletionDetectedCount).toBe(1);
     // getAssetsAsync should NOT have been called for the incremental update
     expect(mockMediaLibrary.getAssetsAsync).toHaveBeenCalledTimes(1);

--- a/src/screens/PhotosScreen/hooks/useLocalAssets.ts
+++ b/src/screens/PhotosScreen/hooks/useLocalAssets.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AppState } from 'react-native';
 import { logger } from 'src/services/common';
 import { photosLocalDB } from 'src/services/photos/database/photosLocalDB';
+import { photoCloudBrowser } from 'src/services/photos/PhotoCloudBrowser';
 import { isPermissionActive } from 'src/services/photos/photoPermissionService';
 import { useAppSelector } from 'src/store/hooks';
 import { useBurstRepresentatives } from './useBurstRepresentatives';
@@ -37,6 +38,7 @@ export const useLocalAssets = (): LocalAssetsResult => {
 
   const uploadingAssetIds = useAppSelector((state) => state.photos.uploadingAssetIds);
   const permissionStatus = useAppSelector((state) => state.photos.permissionStatus);
+  const deviceId = useAppSelector((state) => state.photos.deviceId);
   const isPhotosEnabled = isPermissionActive(permissionStatus);
 
   const uploadingIdSet = useMemo(() => new Set(uploadingAssetIds), [uploadingAssetIds]);
@@ -55,11 +57,14 @@ export const useLocalAssets = (): LocalAssetsResult => {
   const { syncedIds, cloudDeletedIds, incompleteUploadBurstIdSet } = useLocalAssetsSyncStatus(assetIds);
   const burstRepresentativeIdSet = useBurstRepresentatives(assetIds);
 
-  const removeDeletedAssetsFromSyncDB = useCallback(async (deletedAssetIds: string[]) => {
-    await photosLocalDB.init();
-    await photosLocalDB.deleteAssetSyncBulk(deletedAssetIds);
-    setLocalDeletionDetectedCount((prev) => prev + 1);
-  }, []);
+  const removeDeletedAssetsFromSyncDB = useCallback(
+    async (deletedAssetIds: string[]) => {
+      await photosLocalDB.init();
+      await photoCloudBrowser.deleteAssetSyncPreservingCloudVisibility(deletedAssetIds, deviceId);
+      setLocalDeletionDetectedCount((prev) => prev + 1);
+    },
+    [deviceId],
+  );
 
   const reconcileWithDevice = useCallback(async () => {
     const droppedAssetIds = await reconcileHead();
@@ -95,12 +100,12 @@ export const useLocalAssets = (): LocalAssetsResult => {
     logger.info(`[LocalAssets] Reloaded from start — ${deviceAssetIds.size} total assets`);
 
     await photosLocalDB.init();
-    const orphanedAssetsSyncRemovedCount = await photosLocalDB.cleanupOrphanedAssetSync(deviceAssetIds);
+    const orphanedAssetsSyncRemovedCount = await photoCloudBrowser.cleanupOrphanedAssetSync(deviceAssetIds, deviceId);
     if (orphanedAssetsSyncRemovedCount > 0) {
       logger.info(`[LocalAssets] Cleaned up ${orphanedAssetsSyncRemovedCount} orphaned asset_sync entries`);
       setLocalDeletionDetectedCount((prev) => prev + 1);
     }
-  }, [reloadFromStart]);
+  }, [reloadFromStart, deviceId]);
 
   useEffect(() => {
     const subscription = AppState.addEventListener('change', (nextState) => {

--- a/src/screens/PhotosScreen/types.ts
+++ b/src/screens/PhotosScreen/types.ts
@@ -26,6 +26,7 @@ export interface CloudPhotoItem {
   deviceId: string;
   /** Time of the cloud day-folder this asset was discovered in. Used for timeline day-grouping. */
   folderDate: number;
+  creationTimeApi?: number | null;
   fileName: string;
   isLivePhoto?: boolean;
   // uuid of the paired .mov cloud asset (for isLivePhoto and cloud-only)

--- a/src/screens/PhotosScreen/utils/photoTimelineGroups.spec.ts
+++ b/src/screens/PhotosScreen/utils/photoTimelineGroups.spec.ts
@@ -580,4 +580,69 @@ describe('merging cloud items into local groups', () => {
     const result = mergeCloudIntoGroups(localGroups, [cloudItem]);
     expect(new Date(result[0].id).getTime()).toBeGreaterThan(new Date(result[1].id).getTime());
   });
+
+  test('when a local photo at 09:00 and a cloud-only photo with creationTimeApi at 18:00 share the same day, then the cloud-only photo appears before the local one', () => {
+    const day = new Date('2024-06-15T00:00:00');
+    const localGroups = [
+      makeDateGroup({
+        id: day.toDateString(),
+        photos: [makePhotoItem({ id: 'local-morning', createdAt: new Date('2024-06-15T09:00:00').getTime() })],
+      }),
+    ];
+    const cloudItem = cloudEntryToPhotoItem(
+      makeCloudEntry({
+        remoteFileId: 'cloud-evening',
+        folderDate: day.getTime(),
+        creationTimeApi: new Date('2024-06-15T18:00:00').getTime(),
+      }),
+    );
+
+    const result = mergeCloudIntoGroups(localGroups, [cloudItem]);
+
+    expect(result[0].photos.map((p) => p.id)).toEqual(['cloud-evening', 'local-morning']);
+  });
+
+  test('when a legacy cloud-only photo has no creationTimeApi, then it falls back to folderDate and the order stays deterministic', () => {
+    const day = new Date('2024-06-15T00:00:00');
+    const localGroups = [
+      makeDateGroup({
+        id: day.toDateString(),
+        photos: [makePhotoItem({ id: 'local-noon', createdAt: new Date('2024-06-15T12:00:00').getTime() })],
+      }),
+    ];
+    // folderDate is midnight of the day — older than any local capture time within that day, so
+    // a legacy row with no creationTimeApi sorts after local items, not interleaved incorrectly.
+    const cloudItem = cloudEntryToPhotoItem(
+      makeCloudEntry({ remoteFileId: 'cloud-legacy', folderDate: day.getTime(), creationTimeApi: null }),
+    );
+
+    const result = mergeCloudIntoGroups(localGroups, [cloudItem]);
+
+    expect(result[0].photos.map((p) => p.id)).toEqual(['local-noon', 'cloud-legacy']);
+  });
+
+  test('when two cloud-only photos share the same creationTimeApi, then they are ordered by id', () => {
+    const day = new Date('2024-06-15T00:00:00');
+    const sameTime = new Date('2024-06-15T10:00:00').getTime();
+    const localGroups = [makeDateGroup({ id: day.toDateString(), photos: [] })];
+    const cloudItems = [
+      cloudEntryToPhotoItem(makeCloudEntry({ remoteFileId: 'b-remote', folderDate: day.getTime(), creationTimeApi: sameTime })),
+      cloudEntryToPhotoItem(makeCloudEntry({ remoteFileId: 'a-remote', folderDate: day.getTime(), creationTimeApi: sameTime })),
+    ];
+
+    const result = mergeCloudIntoGroups(localGroups, cloudItems);
+
+    expect(result[0].photos.map((p) => p.id)).toEqual(['a-remote', 'b-remote']);
+  });
+
+  test('when a day group has no cloud additions, then the same group reference is returned', () => {
+    const localGroups = [makeDateGroup()];
+    const otherDayCloudItem = cloudEntryToPhotoItem(
+      makeCloudEntry({ folderDate: new Date('2024-05-01T12:00:00').getTime() }),
+    );
+
+    const result = mergeCloudIntoGroups(localGroups, [otherDayCloudItem]);
+
+    expect(result.find((g) => g.id === localGroups[0].id)).toBe(localGroups[0]);
+  });
 });

--- a/src/screens/PhotosScreen/utils/photoTimelineGroups.ts
+++ b/src/screens/PhotosScreen/utils/photoTimelineGroups.ts
@@ -2,6 +2,7 @@ import * as MediaLibrary from 'expo-media-library';
 import { isVideoExtension } from 'src/services/drive/file/utils/exifHelpers';
 import { CloudAssetEntry } from 'src/services/photos/database/photosLocalDB';
 import { isLivePhotoAsset } from 'src/services/photos/livePhoto.constants';
+import { resolveAssetCreationTime } from 'src/services/photos/utils/resolveAssetCreationTime';
 import { PhotosDisabledReason, PhotoSyncStatus } from 'src/store/slices/photos';
 import { GroupSyncStatus } from '../components/GroupHeader/PhotosGroupHeader';
 import { TimelineDateGroup } from '../components/PhotosTimeline';
@@ -172,6 +173,7 @@ export const cloudEntryToPhotoItem = (entry: CloudAssetEntry): CloudPhotoItem =>
   thumbnailType: entry.thumbnailType,
   deviceId: entry.deviceId,
   folderDate: entry.folderDate,
+  creationTimeApi: entry.creationTimeApi,
   fileName: entry.fileName,
   isLivePhoto: entry.isLivePhoto,
   pairedVideoRemoteFileId: entry.pairedRemoteFileId ?? undefined,
@@ -180,6 +182,15 @@ export const cloudEntryToPhotoItem = (entry: CloudAssetEntry): CloudPhotoItem =>
   uploadedAt: entry.uploadedAt,
   isFavorite: entry.isFavorite ?? false,
 });
+
+const getTimelineItemTimestamp = (item: TimelinePhotoItem): number =>
+  item.type === 'cloud-only' ? (resolveAssetCreationTime(item.creationTimeApi, item.folderDate) ?? item.folderDate) : item.createdAt;
+
+const sortByRealTimeDesc = (photos: TimelinePhotoItem[]): TimelinePhotoItem[] =>
+  [...photos].sort((a, b) => {
+    const diff = getTimelineItemTimestamp(b) - getTimelineItemTimestamp(a);
+    return diff !== 0 ? diff : a.id.localeCompare(b.id);
+  });
 
 export const mergeCloudIntoGroups = (localGroups: PhotoDateGroup[], cloudItems: CloudPhotoItem[]): PhotoDateGroup[] => {
   if (cloudItems.length === 0) return localGroups;
@@ -204,13 +215,13 @@ export const mergeCloudIntoGroups = (localGroups: PhotoDateGroup[], cloudItems: 
     if (!extra) {
       return group; // no cloud additions — preserve reference so FlashList skips these cells
     }
-    return { ...group, photos: [...group.photos, ...extra] };
+    return { ...group, photos: sortByRealTimeDesc([...group.photos, ...extra]) };
   });
 
   for (const [key, photos] of cloudByKey) {
     if (processedKeys.has(key)) continue;
     const date = new Date(key);
-    result.push({ id: key, label: getDateLabel(date, now), photos });
+    result.push({ id: key, label: getDateLabel(date, now), photos: sortByRealTimeDesc(photos) });
   }
 
   return result.sort((a, b) => new Date(b.id).getTime() - new Date(a.id).getTime());

--- a/src/services/photos/PhotoCloudBrowser.spec.ts
+++ b/src/services/photos/PhotoCloudBrowser.spec.ts
@@ -33,6 +33,10 @@ jest.mock('./database/photosLocalDB', () => ({
     deleteCloudAssetsByDevice: jest.fn(),
     resetSyncedToPending: jest.fn(),
     getCachedThumbnailRefs: jest.fn(),
+    getStatus: jest.fn(),
+    getCloudAssetById: jest.fn(),
+    deleteAssetSyncBulk: jest.fn().mockResolvedValue(undefined),
+    getOrphanedAssetSyncIds: jest.fn().mockResolvedValue([]),
   },
 }));
 
@@ -70,6 +74,12 @@ const makeDevice = (uuid: string, plainName: string, status: 'EXISTS' | 'TRASHED
   plainName,
   bucket: 'photos-bucket',
   status,
+});
+
+afterEach(async () => {
+  // queueMonthBackfill fires fire-and-forget — drain it so a test's dangling backfill can't run
+  // during a later test and steal its mockResolvedValueOnce queue or its coalescing key.
+  await photoCloudBrowser.waitForPendingCloudIndexUpdates();
 });
 
 beforeEach(() => {
@@ -120,6 +130,404 @@ describe('PhotoCloudBrowser.listDeviceFolders', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].uuid).toBe('d1-uuid');
+  });
+});
+
+const makeAssetSyncEntry = (overrides: Record<string, unknown> = {}) =>
+  ({
+    assetId: 'asset-1',
+    status: 'synced',
+    remoteFileId: 'remote-1',
+    syncedAt: 1718000000000,
+    deletedAt: null,
+    errorMessage: null,
+    attemptCount: 0,
+    createdAt: 1717900000000,
+    lastAttemptAt: null,
+    modificationTime: null,
+    fileName: 'photo.jpg',
+    fileSize: 2048,
+    creationTime: new Date('2024-06-15T10:30:00Z').getTime(),
+    width: null,
+    height: null,
+    duration: null,
+    mediaType: null,
+    isLivePhoto: false,
+    pairedVideoRemoteFileId: null,
+    pairedVideoStatus: null,
+    isBurst: false,
+    burstId: null,
+    burstMemberRemoteFileIds: null,
+    burstMemberCount: null,
+    ...overrides,
+  }) as never;
+
+describe('PhotoCloudBrowser.recordSyncedAsset', () => {
+  test('when an asset just finished syncing, then it is recorded in the cloud index with the day it was taken and no discovery timestamp', async () => {
+    mockPhotosLocalDB.getStatus.mockResolvedValueOnce(makeAssetSyncEntry());
+
+    await photoCloudBrowser.recordSyncedAsset('asset-1', 'device-1');
+
+    expect(mockPhotosLocalDB.upsertCloudAsset).toHaveBeenCalledWith(
+      expect.objectContaining({
+        remoteFileId: 'remote-1',
+        deviceId: 'device-1',
+        folderDate: new Date(2024, 5, 15).getTime(),
+        fileName: 'photo.jpg',
+        fileSize: 2048,
+        discoveredAt: 0,
+        uploadedAt: 1718000000000,
+        isFavorite: false,
+        // Real local capture time, used as a proxy so the timeline can interleave this row
+        // correctly (BUGFIX_CROSS_PLATFORM_PHOTO_ORDER.md Parte 2) before any real Drive fetch
+        // converges creationTimeApi to Drive's own value.
+        creationTimeApi: new Date('2024-06-15T10:30:00Z').getTime(),
+      }),
+    );
+  });
+
+  test('when the synced asset has fresh thumbnail data, then the complete cloud entry also carries the real local capture time as creationTimeApi', async () => {
+    mockPhotosLocalDB.getStatus.mockResolvedValueOnce(
+      makeAssetSyncEntry({ thumbnailBucketId: 'thumb-bucket-1', thumbnailBucketFile: 'thumb-file-1' }),
+    );
+
+    await photoCloudBrowser.recordSyncedAsset('asset-1', 'device-1');
+
+    expect(mockPhotosLocalDB.upsertCloudAsset).toHaveBeenCalledWith(
+      expect.objectContaining({ creationTimeApi: new Date('2024-06-15T10:30:00Z').getTime() }),
+    );
+  });
+
+  test('when an asset just finished syncing, then a background refresh is kicked off so the thumbnail (missing from the minimal row) converges quickly', async () => {
+    mockPhotosLocalDB.getStatus.mockResolvedValueOnce(makeAssetSyncEntry());
+    const fetchMonthSpy = jest.spyOn(photoCloudBrowser, 'fetchMonth').mockResolvedValue(0);
+
+    await photoCloudBrowser.recordSyncedAsset('asset-1', 'device-1');
+
+    expect(fetchMonthSpy).toHaveBeenCalledWith({
+      deviceId: 'device-1',
+      deviceFolderUuid: 'device-1',
+      year: 2024,
+      month: 6,
+      force: true,
+      currentDeviceId: 'device-1',
+    });
+    fetchMonthSpy.mockRestore();
+  });
+
+  test('when the asset synced through any path — Live Photo, burst, replace, or a recovered duplicate — then it is still recorded, since this reads back asset_sync instead of depending on which upload path ran', async () => {
+    mockPhotosLocalDB.getStatus.mockResolvedValueOnce(makeAssetSyncEntry({ isLivePhoto: true }));
+
+    await photoCloudBrowser.recordSyncedAsset('asset-1', 'device-1');
+
+    expect(mockPhotosLocalDB.upsertCloudAsset).toHaveBeenCalled();
+  });
+
+  test('when no device id is known, then nothing is recorded', async () => {
+    await photoCloudBrowser.recordSyncedAsset('asset-1', null);
+
+    expect(mockPhotosLocalDB.getStatus).not.toHaveBeenCalled();
+    expect(mockPhotosLocalDB.upsertCloudAsset).not.toHaveBeenCalled();
+  });
+
+  test('when the asset has no remote file id yet, then nothing is recorded', async () => {
+    mockPhotosLocalDB.getStatus.mockResolvedValueOnce(makeAssetSyncEntry({ remoteFileId: null }));
+
+    await photoCloudBrowser.recordSyncedAsset('asset-1', 'device-1');
+
+    expect(mockPhotosLocalDB.upsertCloudAsset).not.toHaveBeenCalled();
+  });
+
+  test('when the synced asset has fresh thumbnail data from the upload, then a complete cloud entry is written without calling fetchMonth', async () => {
+    mockPhotosLocalDB.getStatus.mockResolvedValueOnce(
+      makeAssetSyncEntry({
+        thumbnailBucketId: 'thumb-bucket-1',
+        thumbnailBucketFile: 'thumb-file-1',
+        thumbnailType: 'jpg',
+        contentFileId: 'content-file-1',
+        bucket: 'bucket-1',
+      }),
+    );
+    const fetchMonthSpy = jest.spyOn(photoCloudBrowser, 'fetchMonth');
+
+    await photoCloudBrowser.recordSyncedAsset('asset-1', 'device-1');
+
+    expect(mockPhotosLocalDB.upsertCloudAsset).toHaveBeenCalledWith(
+      expect.objectContaining({
+        remoteFileId: 'remote-1',
+        deviceId: 'device-1',
+        thumbnailBucketId: 'thumb-bucket-1',
+        thumbnailBucketFile: 'thumb-file-1',
+        thumbnailType: 'jpg',
+        fileId: 'content-file-1',
+        bucket: 'bucket-1',
+        discoveredAt: 0,
+      }),
+    );
+    expect(fetchMonthSpy).not.toHaveBeenCalled();
+    fetchMonthSpy.mockRestore();
+  });
+
+  test('when the asset is a burst representative with fresh thumbnail data, then burstGroupId is the representative own remote file id, not the local burst id', async () => {
+    mockPhotosLocalDB.getStatus.mockResolvedValueOnce(
+      makeAssetSyncEntry({
+        thumbnailBucketId: 'thumb-bucket-1',
+        thumbnailBucketFile: 'thumb-file-1',
+        thumbnailType: 'jpg',
+        contentFileId: 'content-file-1',
+        bucket: 'bucket-1',
+        isBurst: true,
+        burstId: 'local-burst-asset-id',
+      }),
+    );
+
+    await photoCloudBrowser.recordSyncedAsset('asset-1', 'device-1');
+
+    expect(mockPhotosLocalDB.upsertCloudAsset).toHaveBeenCalledWith(
+      expect.objectContaining({ burstRole: 'representative', burstGroupId: 'remote-1' }),
+    );
+  });
+
+  test('when the asset is a Live Photo with fresh thumbnail data, then livePhotoRole and pairedRemoteFileId are set directly from asset_sync', async () => {
+    mockPhotosLocalDB.getStatus.mockResolvedValueOnce(
+      makeAssetSyncEntry({
+        thumbnailBucketId: 'thumb-bucket-1',
+        thumbnailBucketFile: 'thumb-file-1',
+        thumbnailType: 'jpg',
+        isLivePhoto: true,
+        pairedVideoRemoteFileId: 'paired-remote-1',
+      }),
+    );
+
+    await photoCloudBrowser.recordSyncedAsset('asset-1', 'device-1');
+
+    expect(mockPhotosLocalDB.upsertCloudAsset).toHaveBeenCalledWith(
+      expect.objectContaining({ livePhotoRole: 'photo', pairedRemoteFileId: 'paired-remote-1' }),
+    );
+  });
+
+  test('when a Live Photo has a thumbnail but no content file id yet, then a minimal entry is written and a backfill is queued instead of a null file id', async () => {
+    mockPhotosLocalDB.getStatus.mockResolvedValueOnce(
+      makeAssetSyncEntry({
+        thumbnailBucketId: 'thumb-bucket-1',
+        thumbnailBucketFile: 'thumb-file-1',
+        thumbnailType: 'jpg',
+        contentFileId: null,
+        bucket: null,
+        isLivePhoto: true,
+        pairedVideoRemoteFileId: 'paired-remote-1',
+      }),
+    );
+    const fetchMonthSpy = jest.spyOn(photoCloudBrowser, 'fetchMonth').mockResolvedValueOnce(0);
+
+    await photoCloudBrowser.recordSyncedAsset('asset-1', 'device-1');
+
+    expect(mockPhotosLocalDB.upsertCloudAsset).toHaveBeenCalledWith(expect.objectContaining({ fileId: null }));
+    expect(fetchMonthSpy).toHaveBeenCalled();
+    fetchMonthSpy.mockRestore();
+  });
+
+  test('when the cloud entry already has a favorite mark, then a direct write from this device does not clear it', async () => {
+    mockPhotosLocalDB.getStatus.mockResolvedValueOnce(
+      makeAssetSyncEntry({
+        thumbnailBucketId: 'thumb-bucket-1',
+        thumbnailBucketFile: 'thumb-file-1',
+        thumbnailType: 'jpg',
+        contentFileId: 'content-file-1',
+        bucket: 'bucket-1',
+      }),
+    );
+    mockPhotosLocalDB.getCloudAssetById.mockResolvedValueOnce({ isFavorite: true } as never);
+
+    await photoCloudBrowser.recordSyncedAsset('asset-1', 'device-1');
+
+    expect(mockPhotosLocalDB.upsertCloudAsset).toHaveBeenCalledWith(expect.objectContaining({ isFavorite: true }));
+  });
+
+  test('when there is no fresh thumbnail data but a complete cloud entry already exists, then nothing is written and no backfill is queued', async () => {
+    mockPhotosLocalDB.getStatus.mockResolvedValueOnce(makeAssetSyncEntry());
+    mockPhotosLocalDB.getCloudAssetById.mockResolvedValueOnce({ thumbnailBucketId: 'thumb-bucket-1' } as never);
+    const fetchMonthSpy = jest.spyOn(photoCloudBrowser, 'fetchMonth');
+
+    await photoCloudBrowser.recordSyncedAsset('asset-1', 'device-1');
+
+    expect(mockPhotosLocalDB.upsertCloudAsset).not.toHaveBeenCalled();
+    expect(fetchMonthSpy).not.toHaveBeenCalled();
+    fetchMonthSpy.mockRestore();
+  });
+
+  test('when there is no fresh thumbnail data and no existing complete entry, then the minimal entry is written and a backfill is queued', async () => {
+    mockPhotosLocalDB.getStatus.mockResolvedValueOnce(makeAssetSyncEntry());
+    mockPhotosLocalDB.getCloudAssetById.mockResolvedValueOnce(null);
+    const fetchMonthSpy = jest.spyOn(photoCloudBrowser, 'fetchMonth').mockResolvedValue(0);
+
+    await photoCloudBrowser.recordSyncedAsset('asset-1', 'device-1');
+
+    expect(mockPhotosLocalDB.upsertCloudAsset).toHaveBeenCalledWith(
+      expect.objectContaining({ remoteFileId: 'remote-1', thumbnailBucketId: undefined }),
+    );
+    expect(fetchMonthSpy).toHaveBeenCalledWith({
+      deviceId: 'device-1',
+      deviceFolderUuid: 'device-1',
+      year: 2024,
+      month: 6,
+      force: true,
+      currentDeviceId: 'device-1',
+    });
+    fetchMonthSpy.mockRestore();
+  });
+});
+
+describe('PhotoCloudBrowser month backfill coalescing', () => {
+  test('when a second backfill is queued for the same device/month while the first is still in flight, then only one extra fetchMonth call runs (not one per asset)', async () => {
+    let resolveFirstFetch!: (count: number) => void;
+    const firstFetch = new Promise<number>((resolve) => {
+      resolveFirstFetch = resolve;
+    });
+    const fetchMonthSpy = jest
+      .spyOn(photoCloudBrowser, 'fetchMonth')
+      .mockReturnValueOnce(firstFetch)
+      .mockResolvedValueOnce(1);
+
+    mockPhotosLocalDB.getStatus.mockResolvedValueOnce(makeAssetSyncEntry({ assetId: 'asset-1', remoteFileId: 'remote-1' }));
+    mockPhotosLocalDB.getCloudAssetById.mockResolvedValueOnce(null);
+    await photoCloudBrowser.recordSyncedAsset('asset-1', 'device-1');
+
+    mockPhotosLocalDB.getStatus.mockResolvedValueOnce(makeAssetSyncEntry({ assetId: 'asset-2', remoteFileId: 'remote-2' }));
+    mockPhotosLocalDB.getCloudAssetById.mockResolvedValueOnce(null);
+    await photoCloudBrowser.recordSyncedAsset('asset-2', 'device-1');
+
+    // The second call arrived while the first fetchMonth was still in flight — it must not
+    // trigger a second Drive call, only mark the key for a trailing re-run.
+    expect(fetchMonthSpy).toHaveBeenCalledTimes(1);
+
+    resolveFirstFetch(0);
+    await photoCloudBrowser.waitForPendingCloudIndexUpdates();
+
+    // Exactly one coalesced re-run happened after the first call settled — not a second full
+    // fetchMonth per queued asset.
+    expect(fetchMonthSpy).toHaveBeenCalledTimes(2);
+    fetchMonthSpy.mockRestore();
+  });
+
+  test('when no backfill was queued while the first one was in flight, then no trailing re-run happens', async () => {
+    const fetchMonthSpy = jest.spyOn(photoCloudBrowser, 'fetchMonth').mockResolvedValue(0);
+
+    mockPhotosLocalDB.getStatus.mockResolvedValueOnce(makeAssetSyncEntry());
+    mockPhotosLocalDB.getCloudAssetById.mockResolvedValueOnce(null);
+    await photoCloudBrowser.recordSyncedAsset('asset-1', 'device-1');
+    await photoCloudBrowser.waitForPendingCloudIndexUpdates();
+
+    expect(fetchMonthSpy).toHaveBeenCalledTimes(1);
+    fetchMonthSpy.mockRestore();
+  });
+});
+
+describe('PhotoCloudBrowser.deleteAssetSyncPreservingCloudVisibility', () => {
+  test('when the cloud index has no entry for the backed-up photo, then a minimal cloud entry is created before the sync row is removed', async () => {
+    mockPhotosLocalDB.getStatus.mockResolvedValueOnce(makeAssetSyncEntry());
+    mockPhotosLocalDB.getCloudAssetById.mockResolvedValueOnce(null);
+
+    await photoCloudBrowser.deleteAssetSyncPreservingCloudVisibility(['asset-1'], 'device-1');
+
+    expect(mockPhotosLocalDB.upsertCloudAsset).toHaveBeenCalledWith(
+      expect.objectContaining({ remoteFileId: 'remote-1', deviceId: 'device-1', fileName: 'photo.jpg' }),
+    );
+    expect(mockPhotosLocalDB.deleteAssetSyncBulk).toHaveBeenCalledWith(['asset-1']);
+  });
+
+  test('when the cloud index already has the photo, then no extra entry is created', async () => {
+    mockPhotosLocalDB.getStatus.mockResolvedValueOnce(makeAssetSyncEntry());
+    mockPhotosLocalDB.getCloudAssetById.mockResolvedValueOnce({
+      remoteFileId: 'remote-1',
+      deviceId: 'device-1',
+      folderDate: 1,
+      fileName: 'x',
+    } as never);
+
+    await photoCloudBrowser.deleteAssetSyncPreservingCloudVisibility(['asset-1'], 'device-1');
+
+    expect(mockPhotosLocalDB.upsertCloudAsset).not.toHaveBeenCalled();
+    expect(mockPhotosLocalDB.deleteAssetSyncBulk).toHaveBeenCalledWith(['asset-1']);
+  });
+
+  test('when the cloud index already has the photo but it may only be a thumbnail-less minimal row, then a background refresh is still kicked off', async () => {
+    mockPhotosLocalDB.getStatus.mockResolvedValueOnce(makeAssetSyncEntry());
+    mockPhotosLocalDB.getCloudAssetById.mockResolvedValueOnce({
+      remoteFileId: 'remote-1',
+      deviceId: 'device-1',
+      folderDate: 1,
+      fileName: 'x',
+    } as never);
+    const fetchMonthSpy = jest.spyOn(photoCloudBrowser, 'fetchMonth').mockResolvedValue(0);
+
+    await photoCloudBrowser.deleteAssetSyncPreservingCloudVisibility(['asset-1'], 'device-1');
+
+    expect(fetchMonthSpy).toHaveBeenCalledWith({
+      deviceId: 'device-1',
+      deviceFolderUuid: 'device-1',
+      year: 2024,
+      month: 6,
+      force: true,
+      currentDeviceId: 'device-1',
+    });
+    fetchMonthSpy.mockRestore();
+  });
+
+  test('when the deleted asset was never backed up, then nothing is added to the cloud index', async () => {
+    mockPhotosLocalDB.getStatus.mockResolvedValueOnce(makeAssetSyncEntry({ status: 'pending', remoteFileId: null }));
+
+    await photoCloudBrowser.deleteAssetSyncPreservingCloudVisibility(['asset-1'], 'device-1');
+
+    expect(mockPhotosLocalDB.upsertCloudAsset).not.toHaveBeenCalled();
+    expect(mockPhotosLocalDB.deleteAssetSyncBulk).toHaveBeenCalledWith(['asset-1']);
+  });
+
+  test('when no device id is known, then the sync row is still removed but cloud visibility is not touched', async () => {
+    await photoCloudBrowser.deleteAssetSyncPreservingCloudVisibility(['asset-1'], null);
+
+    expect(mockPhotosLocalDB.getStatus).not.toHaveBeenCalled();
+    expect(mockPhotosLocalDB.deleteAssetSyncBulk).toHaveBeenCalledWith(['asset-1']);
+  });
+
+  test('when a minimal entry is created, then a background refresh of that day is kicked off to fill in real thumbnails', async () => {
+    mockPhotosLocalDB.getStatus.mockResolvedValueOnce(makeAssetSyncEntry());
+    mockPhotosLocalDB.getCloudAssetById.mockResolvedValueOnce(null);
+    const fetchMonthSpy = jest.spyOn(photoCloudBrowser, 'fetchMonth').mockResolvedValue(0);
+
+    await photoCloudBrowser.deleteAssetSyncPreservingCloudVisibility(['asset-1'], 'device-1');
+
+    expect(fetchMonthSpy).toHaveBeenCalledWith({
+      deviceId: 'device-1',
+      deviceFolderUuid: 'device-1',
+      year: 2024,
+      month: 6,
+      force: true,
+      currentDeviceId: 'device-1',
+    });
+    fetchMonthSpy.mockRestore();
+  });
+});
+
+describe('PhotoCloudBrowser.cleanupOrphanedAssetSync', () => {
+  test('when there are orphaned asset_sync entries, then they are removed and the count reflects it', async () => {
+    mockPhotosLocalDB.getOrphanedAssetSyncIds.mockResolvedValueOnce(['asset-2']);
+    mockPhotosLocalDB.getStatus.mockResolvedValueOnce(makeAssetSyncEntry({ assetId: 'asset-2' }));
+    mockPhotosLocalDB.getCloudAssetById.mockResolvedValueOnce(null);
+
+    const removedCount = await photoCloudBrowser.cleanupOrphanedAssetSync(new Set(['asset-1']), 'device-1');
+
+    expect(removedCount).toBe(1);
+    expect(mockPhotosLocalDB.deleteAssetSyncBulk).toHaveBeenCalledWith(['asset-2']);
+  });
+
+  test('when there are no orphaned asset_sync entries, then nothing is deleted', async () => {
+    mockPhotosLocalDB.getOrphanedAssetSyncIds.mockResolvedValueOnce([]);
+
+    const removedCount = await photoCloudBrowser.cleanupOrphanedAssetSync(new Set(['asset-1']), 'device-1');
+
+    expect(removedCount).toBe(0);
+    expect(mockPhotosLocalDB.deleteAssetSyncBulk).not.toHaveBeenCalled();
   });
 });
 
@@ -344,6 +752,29 @@ describe('PhotoCloudBrowser.syncAllHistory', () => {
 
     expect(mockPhotosLocalDB.getCloudFetchCacheAge.mock.calls[0]).toEqual(['d1-uuid', 2024, 3]);
     expect(mockPhotosLocalDB.getCloudFetchCacheAge.mock.calls[1]).toEqual(['d1-uuid', 2023, 6]);
+  });
+
+  test('when the current device and another device both have months to sync, then the current device is checked first', async () => {
+    mockDeviceService.listDevices.mockResolvedValueOnce([
+      makeDevice('other-uuid', 'Internxt iPad'),
+      makeDevice('current-uuid', 'Internxt iPhone'),
+    ]);
+    const otherYear = makeFolder('other-y-uuid', '2024');
+    const otherMonth = makeFolder('other-m-uuid', '01');
+    const currentYear = makeFolder('current-y-uuid', '2024');
+    const currentMonth = makeFolder('current-m-uuid', '01');
+    mockPhotosLocalDB.getCloudFetchCacheAge.mockResolvedValue(null);
+    mockFolderService.getFolderFolders
+      .mockResolvedValueOnce({ folders: [otherYear] } as never)
+      .mockResolvedValueOnce({ folders: [currentYear] } as never)
+      .mockResolvedValueOnce({ folders: [otherMonth] } as never)
+      .mockResolvedValueOnce({ folders: [currentMonth] } as never)
+      .mockResolvedValue({ folders: [] } as never);
+
+    await photoCloudBrowser.syncAllHistory({ currentDeviceId: 'current-uuid' });
+
+    expect(mockPhotosLocalDB.getCloudFetchCacheAge.mock.calls[0]).toEqual(['current-uuid', 2024, 1]);
+    expect(mockPhotosLocalDB.getCloudFetchCacheAge.mock.calls[1]).toEqual(['other-uuid', 2024, 1]);
   });
 
   test('when isCancelled returns true, then fewer months are fetched than discovered', async () => {

--- a/src/services/photos/PhotoCloudBrowser.ts
+++ b/src/services/photos/PhotoCloudBrowser.ts
@@ -5,7 +5,7 @@ import { logger } from 'src/services/common';
 import { driveFolderService } from 'src/services/drive/folder/driveFolder.service';
 import { buildBurstBaseSet, linkBurst } from './burst/BurstCloudLinker';
 import { isBurstMemberPlainName } from './burst/burst.constants';
-import { BurstRole, CloudAssetEntry, LivePhotoRole, photosLocalDB } from './database/photosLocalDB';
+import { AssetSyncEntry, BurstRole, CloudAssetEntry, LivePhotoRole, photosLocalDB } from './database/photosLocalDB';
 import {
   getPairedVideoPlainNameFromPhoto,
   getPhotoPlainNameFromPairedVideo,
@@ -67,14 +67,290 @@ const fetchAllPages = async <T>(fetcher: (offset: number) => Promise<T[]>): Prom
 };
 
 class PhotoCloudBrowserService {
+  private readonly cloudIndexUpdateSubscribers = new Set<() => void>();
+
+  private readonly inFlightMonthBackfills = new Map<string, Promise<number>>();
+  private readonly pendingMonthBackfillReruns = new Set<string>();
+
   constructor(
     private readonly folderService: typeof driveFolderService,
     private readonly localDB: typeof photosLocalDB,
   ) {}
 
+  subscribeToCloudIndexUpdates(callback: () => void): () => void {
+    this.cloudIndexUpdateSubscribers.add(callback);
+    return () => {
+      this.cloudIndexUpdateSubscribers.delete(callback);
+    };
+  }
+
+  /** Resolves once every queued month backfill (see `queueMonthBackfill`), including trailing re-runs, has settled. */
+  async waitForPendingCloudIndexUpdates(): Promise<void> {
+    while (this.inFlightMonthBackfills.size > 0) {
+      await Promise.all(this.inFlightMonthBackfills.values());
+    }
+  }
+
+  private notifyCloudIndexUpdated(): void {
+    this.cloudIndexUpdateSubscribers.forEach((callback) => {
+      try {
+        callback();
+      } catch (error) {
+        logger.error('[CloudBrowser] Cloud index update subscriber failed', { error });
+      }
+    });
+  }
+
   async listDeviceFolders(): Promise<{ uuid: string }[]> {
     const devices = await photosDeviceService.listDevices();
     return devices.filter((device) => device.status === 'EXISTS').map((device) => ({ uuid: device.uuid }));
+  }
+
+  /**
+   * Writes a `cloud_asset` row for a just-synced asset directly, without fetching Drive. Always
+   * called after `asset_sync` is marked synced, regardless of which upload/replace path produced
+   * it. Maps whatever `asset_sync` already knows (thumbnail, content refs, burst/Live Photo
+   * pairing); fields it doesn't have preserve the value already in `cloud_asset`, if any. Queues
+   * a background backfill whenever the thumbnail or content refs (`contentFileId`/`bucket`) are
+   * still missing, so the row converges without waiting for the month's TTL. No-op if there's no
+   * fresh thumbnail data and a complete row already exists for this asset.
+   *
+   * @param assetId - Local asset id whose `asset_sync` row was just marked synced.
+   * @param deviceId - This device's folder uuid, or null if unknown (no-op in that case).
+   */
+  async recordSyncedAsset(assetId: string, deviceId: string | null): Promise<void> {
+    if (!deviceId) {
+      logger.info(`[CloudBrowser] recordSyncedAsset skipped — assetId=${assetId}, no deviceId`);
+      return;
+    }
+    const assetEntry = await this.localDB.getStatus(assetId);
+    if (!assetEntry?.remoteFileId) {
+      logger.info(`[CloudBrowser] recordSyncedAsset skipped — assetId=${assetId}, no remoteFileId in asset_sync`);
+      return;
+    }
+
+    const existing = await this.localDB.getCloudAssetById(assetEntry.remoteFileId);
+
+    if (!assetEntry.thumbnailBucketId && existing?.thumbnailBucketId) {
+      logger.info(
+        `[CloudBrowser] recordSyncedAsset skipped — remoteFileId=${assetEntry.remoteFileId} already complete in cloud index`,
+      );
+      return;
+    }
+
+    const entry = this.buildCloudAssetEntry(assetEntry, deviceId, existing);
+    if (assetEntry.thumbnailBucketId) {
+      // Must run before the upsert — it reads the thumbnail_bucket_file still in cloud_asset.
+      await this.evictStaleThumbnailCacheFiles([entry]);
+    }
+    await this.localDB.upsertCloudAsset(entry);
+
+    const hasFullContentRefs = !!(assetEntry.contentFileId && assetEntry.bucket);
+    if (assetEntry.thumbnailBucketId && hasFullContentRefs) {
+      logger.info(
+        `[CloudBrowser] Recorded synced asset in cloud index (complete, no fetch) — remoteFileId=${assetEntry.remoteFileId}`,
+      );
+      return;
+    }
+
+    logger.info(
+      `[CloudBrowser] Recorded synced asset in cloud index (${assetEntry.thumbnailBucketId ? 'content refs pending' : 'thumbnail pending'}) — remoteFileId=${assetEntry.remoteFileId}`,
+    );
+    this.queueMonthBackfill(deviceId, assetEntry.creationTime, 'after upload');
+  }
+
+  /**
+   * Fires a `fetchMonth({force: true})` in the background for the month containing
+   * `creationTimeMs`. Coalesces with any backfill already in flight for the same device/month
+   * (see `inFlightMonthBackfills`) instead of starting a redundant one.
+   *
+   * @param deviceId - Device folder uuid whose month should be re-fetched.
+   * @param creationTimeMs - Creation time (ms) of the asset that triggered this backfill; used
+   *   only to resolve which year/month to fetch. No-op if null.
+   * @param context - Short label included in log lines to distinguish callers (e.g. "after upload").
+   */
+  private queueMonthBackfill(deviceId: string, creationTimeMs: number | null, context: string): void {
+    if (!creationTimeMs) {
+      return;
+    }
+    const date = new Date(creationTimeMs);
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1;
+    const key = `${deviceId}:${year}:${month}`;
+
+    if (this.inFlightMonthBackfills.has(key)) {
+      this.pendingMonthBackfillReruns.add(key);
+      logger.info(
+        `[CloudBrowser] Backfill ${context} — device=${deviceId} ${year}/${month} already in flight, scheduled a re-run after it`,
+      );
+      return;
+    }
+
+    const backfill = this.fetchMonth({
+      deviceId,
+      deviceFolderUuid: deviceId,
+      year,
+      month,
+      force: true,
+      currentDeviceId: deviceId,
+    })
+      .then((count) => {
+        logger.info(
+          `[CloudBrowser] Backfill ${context} — device=${deviceId} ${year}/${month}, ${count} file(s) upserted`,
+        );
+        if (count > 0) {
+          this.notifyCloudIndexUpdated();
+        }
+        return count;
+      })
+      .catch((err: unknown) => {
+        logger.warn(`[CloudBrowser] Backfill ${context} failed for ${deviceId} ${year}/${month}: ${err}`);
+        return 0;
+      })
+      .finally(() => {
+        this.inFlightMonthBackfills.delete(key);
+        if (this.pendingMonthBackfillReruns.delete(key)) {
+          this.queueMonthBackfill(deviceId, creationTimeMs, context);
+        }
+      });
+
+    this.inFlightMonthBackfills.set(key, backfill);
+  }
+
+  /**
+   * Builds a `cloud_asset` row from an `asset_sync` entry, mapping over whatever this call
+   * already knows (thumbnail/content refs, burst/Live Photo pairing) and leaving the rest null.
+   * Safe to write partially — `upsertCloudAsset`'s COALESCE semantics preserve any field a
+   * previous real fetch already populated instead of overwriting it with null.
+   *
+   * @param entry - The `asset_sync` row to build from.
+   * @param deviceId - This device's folder uuid.
+   * @param existing - The current `cloud_asset` row for this remoteFileId, if any — used to carry
+   *   over fields this call can't determine (currently `isFavorite`).
+   * @returns The corresponding `cloud_asset` row, ready to upsert.
+   */
+  private buildCloudAssetEntry(
+    entry: AssetSyncEntry,
+    deviceId: string,
+    existing?: CloudAssetEntry | null,
+  ): CloudAssetEntry {
+    const folderDate = entry.creationTime
+      ? (() => {
+          const d = new Date(entry.creationTime as number);
+          return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+        })()
+      : 0;
+    return {
+      remoteFileId: entry.remoteFileId as string,
+      deviceId,
+      folderDate,
+      fileName: entry.fileName ?? entry.assetId,
+      fileSize: entry.fileSize,
+      fileId: entry.contentFileId,
+      bucket: entry.bucket,
+      thumbnailPath: null,
+      thumbnailBucketId: entry.thumbnailBucketId,
+      thumbnailBucketFile: entry.thumbnailBucketFile,
+      thumbnailType: entry.thumbnailType,
+      // Local capture time, used as a proxy until a real fetch overwrites it with Drive's own value.
+      creationTimeApi: entry.creationTime,
+      ...this.buildLivePhotoAndBurstFields(entry),
+      discoveredAt: 0,
+      uploadedAt: entry.syncedAt ?? Date.now(),
+      isFavorite: existing?.isFavorite ?? false,
+    };
+  }
+
+  /**
+   * Derives the Live Photo/burst pairing fields shared by both direct-write `cloud_asset`
+   * builders. `entry.isLivePhoto`/`entry.isBurst` and their pairing ids are known from
+   * `asset_sync` regardless of whether the thumbnail/content refs are present.
+   *
+   * @param entry - The `asset_sync` row to derive pairing from.
+   * @returns `isLivePhoto`, `livePhotoRole`, `pairedRemoteFileId`, `burstRole`, `burstGroupId`.
+   */
+  private buildLivePhotoAndBurstFields(
+    entry: AssetSyncEntry,
+  ): Pick<CloudAssetEntry, 'isLivePhoto' | 'livePhotoRole' | 'pairedRemoteFileId' | 'burstRole' | 'burstGroupId'> {
+    return {
+      isLivePhoto: entry.isLivePhoto,
+      livePhotoRole: entry.isLivePhoto ? 'photo' : undefined,
+      pairedRemoteFileId: entry.isLivePhoto ? entry.pairedVideoRemoteFileId : undefined,
+      burstRole: entry.isBurst ? 'representative' : undefined,
+      // entry.remoteFileId, not entry.burstId (a different, local id) — see BurstCloudLinker.linkBurst.
+      burstGroupId: entry.isBurst ? (entry.remoteFileId ?? undefined) : undefined,
+    };
+  }
+
+  private async preserveCloudVisibilityForOrphans(entries: AssetSyncEntry[], deviceId: string): Promise<void> {
+    const monthsToBackfill = new Map<string, number>();
+    for (const entry of entries) {
+      if (!entry.remoteFileId) {
+        logger.info(
+          `[CloudBrowser] deleteAssetSyncPreservingCloudVisibility — assetId=${entry.assetId} skipped, never had a remote backup`,
+        );
+        continue;
+      }
+      const existing = await this.localDB.getCloudAssetById(entry.remoteFileId);
+      logger.info(
+        `[CloudBrowser] deleteAssetSyncPreservingCloudVisibility — assetId=${entry.assetId}, remoteFileId=${entry.remoteFileId}, hasExistingCloudRow=${!!existing}`,
+      );
+      if (!existing) {
+        await this.localDB.upsertCloudAsset(this.buildCloudAssetEntry(entry, deviceId));
+        logger.info(
+          `[CloudBrowser] Synthesized cloud entry before local delete — remoteFileId=${entry.remoteFileId}, fileName=${entry.fileName ?? 'unknown'}`,
+        );
+      }
+      if (entry.creationTime) {
+        const date = new Date(entry.creationTime);
+        monthsToBackfill.set(`${date.getFullYear()}:${date.getMonth() + 1}`, entry.creationTime);
+      }
+    }
+    for (const creationTimeMs of monthsToBackfill.values()) {
+      this.queueMonthBackfill(deviceId, creationTimeMs, 'after local delete');
+    }
+  }
+
+  /**
+   * Removes `asset_sync` rows for locally-deleted assets that had a remote backup but no
+   * `cloud_asset` row yet (upload happened inside the cloud-sync TTL window, or on a build
+   * predating this fix) — without this, the asset would vanish from the timeline entirely
+   * instead of surfacing as cloud-only. Inserts a minimal `cloud_asset` row synchronously
+   * (from data already in `asset_sync`, so it works offline) and kicks off a best-effort
+   * background refresh of the asset's day-folder to fill in real thumbnails/pairing.
+   *
+   * @param assetIds - Ids of the local assets to remove from `asset_sync`.
+   * @param deviceId - This device's folder uuid, or null if unknown (skips the cloud-visibility
+   *   preservation — the rows are still deleted).
+   */
+  async deleteAssetSyncPreservingCloudVisibility(assetIds: string[], deviceId: string | null): Promise<void> {
+    if (assetIds.length === 0) {
+      return;
+    }
+    if (deviceId) {
+      const entries = (await Promise.all(assetIds.map((id) => this.localDB.getStatus(id)))).filter(
+        (e): e is AssetSyncEntry => e !== null,
+      );
+      await this.preserveCloudVisibilityForOrphans(entries, deviceId);
+    }
+    await this.localDB.deleteAssetSyncBulk(assetIds);
+  }
+
+  /**
+   * Removes `asset_sync` rows for assets no longer present on the device, preserving cloud
+   * visibility for any that had a remote backup (see `deleteAssetSyncPreservingCloudVisibility`).
+   *
+   * @param localAssetIds - Ids of the assets currently on the device.
+   * @param deviceId - This device's folder uuid, or null if unknown.
+   * @returns The number of `asset_sync` rows removed.
+   */
+  async cleanupOrphanedAssetSync(localAssetIds: Set<string>, deviceId: string | null): Promise<number> {
+    const orphanAssetsIds = await this.localDB.getOrphanedAssetSyncIds(localAssetIds);
+    if (orphanAssetsIds.length === 0) {
+      return 0;
+    }
+    await this.deleteAssetSyncPreservingCloudVisibility(orphanAssetsIds, deviceId);
+    return orphanAssetsIds.length;
   }
 
   async fetchMonth(params: {
@@ -83,17 +359,27 @@ class PhotoCloudBrowserService {
     year: number;
     month: number;
     onMonthFetched?: () => void;
+    force?: boolean;
+    currentDeviceId?: string;
   }): Promise<number> {
-    const { deviceId, deviceFolderUuid, year, month, onMonthFetched } = params;
-    const cacheAge = await this.localDB.getCloudFetchCacheAge(deviceId, year, month);
-    if (cacheAge !== null && Date.now() - cacheAge < CACHE_TTL_MS) return 0;
+    const { deviceId, deviceFolderUuid, year, month, onMonthFetched, force, currentDeviceId } = params;
+    if (!force) {
+      const cacheAge = await this.localDB.getCloudFetchCacheAge(deviceId, year, month);
+      if (cacheAge !== null && Date.now() - cacheAge < CACHE_TTL_MS) {
+        return 0;
+      }
+    }
 
     const yearFolder = await this.findChildFolder(deviceFolderUuid, String(year));
-    if (!yearFolder) return 0;
+    if (!yearFolder) {
+      return 0;
+    }
 
     const monthStr = String(month).padStart(2, '0');
     const monthFolder = await this.findChildFolder(yearFolder.uuid, monthStr);
-    if (!monthFolder) return 0;
+    if (!monthFolder) {
+      return 0;
+    }
 
     return this.fetchMonthFromFolder({
       deviceId,
@@ -101,7 +387,8 @@ class PhotoCloudBrowserService {
       year,
       month,
       onMonthFetched,
-      currentDeviceId: undefined,
+      force,
+      currentDeviceId,
       cycleStartedAt: Date.now(),
     });
   }
@@ -141,6 +428,16 @@ class PhotoCloudBrowserService {
     await this.purgeDeletedDevices(devices, onMonthFetched);
 
     const months = await this.discoverAvailableMonths(devices);
+
+    // Own device's most recent months first: workers pull from the front of this array, so a
+    // manual refresh surfaces the user's own recent changes without waiting behind other devices.
+    months.sort((a, b) => {
+      const aOwn = a.deviceId === currentDeviceId ? 0 : 1;
+      const bOwn = b.deviceId === currentDeviceId ? 0 : 1;
+      if (aOwn !== bOwn) return aOwn - bOwn;
+      if (a.year !== b.year) return b.year - a.year;
+      return b.month - a.month;
+    });
 
     if (months.length === 0) {
       logger.info('[CloudBrowser] Discovery found no months in cloud');
@@ -556,7 +853,9 @@ class PhotoCloudBrowserService {
       return;
     }
 
-    const cachedRefs = await this.localDB.getCachedThumbnailRefs(entriesWithThumbnail.map((entry) => entry.remoteFileId));
+    const cachedRefs = await this.localDB.getCachedThumbnailRefs(
+      entriesWithThumbnail.map((entry) => entry.remoteFileId),
+    );
     const stalePaths = entriesWithThumbnail
       .map((entry) => {
         const cached = cachedRefs.get(entry.remoteFileId);

--- a/src/services/photos/PhotoUploadService.spec.ts
+++ b/src/services/photos/PhotoUploadService.spec.ts
@@ -118,7 +118,7 @@ beforeEach(() => {
   mockUploadFile.mockResolvedValueOnce('bucket-file-id').mockResolvedValueOnce('thumb-bucket-file-id');
 
   mockCheckFileExistence.mockResolvedValue({ existentFiles: [] });
-  mockCreateFileEntry.mockResolvedValue({ uuid: 'drive-file-uuid' });
+  mockCreateFileEntry.mockResolvedValue({ uuid: 'drive-file-uuid', createdAt: '2024-06-15T12:30:00.000Z' });
   mockReplaceFileEntry.mockResolvedValue(undefined);
 
   mockIsThumbnailSupported.mockReturnValue(true);
@@ -156,6 +156,19 @@ describe('PhotoUploadService.upload', () => {
     expect(result.photoUuid).toBe('drive-file-uuid');
   });
 
+  test('when uploading a supported image, then the thumbnail ref and content fileId/bucket already computed are returned so the caller can skip a Drive fetch', async () => {
+    const result = await PhotoUploadService.upload(makeAsset(), DEVICE_ID, PHOTOS_BUCKET);
+
+    expect(result.thumbnail).toEqual({
+      bucketId: PHOTOS_BUCKET,
+      bucketFile: 'thumb-bucket-file-id',
+      type: 'JPEG',
+      localPath: undefined,
+    });
+    expect(result.contentFileId).toBe('bucket-file-id');
+    expect(result.bucketId).toBe(PHOTOS_BUCKET);
+  });
+
   test('when the photo already exists in Drive, then its existing uuid is returned without uploading again', async () => {
     mockCheckFileExistence.mockResolvedValue({ existentFiles: [{ uuid: 'existing-uuid' }] });
 
@@ -164,6 +177,15 @@ describe('PhotoUploadService.upload', () => {
     expect(result.photoUuid).toBe('existing-uuid');
     expect(mockUploadFile).not.toHaveBeenCalled();
     expect(mockCreateFileEntry).not.toHaveBeenCalled();
+  });
+
+  test('when the photo already exists in Drive, then no thumbnail/content refs are returned — the caller falls back to a fetch-based backfill', async () => {
+    mockCheckFileExistence.mockResolvedValue({ existentFiles: [{ uuid: 'existing-uuid' }] });
+
+    const result = await PhotoUploadService.upload(makeAsset(), DEVICE_ID, PHOTOS_BUCKET);
+
+    expect(result.thumbnail).toBeUndefined();
+    expect(result.contentFileId).toBeUndefined();
   });
 
   test('when the network layer throws an abort error, then the abort error propagates with its name intact and is not wrapped', async () => {
@@ -279,6 +301,19 @@ describe('PhotoUploadService.replace', () => {
   test('when replacing an asset, then the existing remote file id is returned', async () => {
     const result = await PhotoUploadService.replace(makeAsset(), 'existing-remote-id', DEVICE_ID, PHOTOS_BUCKET);
     expect(result.photoUuid).toBe('existing-remote-id');
+  });
+
+  test('when replacing an asset, then the new thumbnail ref and content fileId/bucket are returned so the caller can write a complete cloud_asset row without a fetch', async () => {
+    const result = await PhotoUploadService.replace(makeAsset(), 'existing-remote-id', DEVICE_ID, PHOTOS_BUCKET);
+
+    expect(result.thumbnail).toEqual({
+      bucketId: PHOTOS_BUCKET,
+      bucketFile: 'thumb-bucket-file-id',
+      type: 'JPEG',
+      localPath: undefined,
+    });
+    expect(result.contentFileId).toBe('bucket-file-id');
+    expect(result.bucketId).toBe(PHOTOS_BUCKET);
   });
 
   test('when thumbnail generation fails during a replace, then the replace still returns the existing remote file id', async () => {

--- a/src/services/photos/PhotoUploadService.ts
+++ b/src/services/photos/PhotoUploadService.ts
@@ -54,6 +54,14 @@ export interface PhotoUploadResult {
   photoUuid: string;
   pairedVideoUuid?: string;
   burst?: { burstId: string; memberUuids: string[] };
+  /**
+   * Thumbnail/content refs already computed by this upload/replace call. Undefined whenever
+   * this call didn't generate them itself (e.g. the `FileAlreadyExistsError` recovery path, or a
+   * failed thumbnail upload).
+   */
+  thumbnail?: UploadedThumbnailRef;
+  contentFileId?: string;
+  bucketId?: string;
 }
 
 /**
@@ -372,7 +380,8 @@ const uploadPairedVideo = async (params: {
  * @param params.credentials - Encryption key and bridge credentials for the upload.
  * @param params.onProgress - Called with the upload progress ratio (0-1).
  * @param params.signal - Aborts the upload when triggered.
- * @returns UUID of the replaced or newly created Drive entry.
+ * @returns UUID of the replaced or newly created Drive entry, plus the content/thumbnail refs
+ *   this call generated — `thumbnail` is always populated, since a replace always regenerates it.
  */
 const replaceRemoteFile = async (params: {
   localFilePath: string;
@@ -388,7 +397,7 @@ const replaceRemoteFile = async (params: {
   credentials: UploadCredentials;
   onProgress?: (ratio: number) => void;
   signal?: AbortSignal;
-}): Promise<string> => {
+}): Promise<{ photoUuid: string; contentFileId: string; bucketId: string; thumbnail: UploadedThumbnailRef | null }> => {
   const {
     localFilePath,
     thumbnailSource,
@@ -424,9 +433,10 @@ const replaceRemoteFile = async (params: {
   }
 
   let photoUuid = existingRemoteFileId;
+  let thumbnail: UploadedThumbnailRef | null;
   try {
     await uploadService.replaceFileEntry(existingRemoteFileId, { fileId, size: fileSize });
-    await uploadThumbnailForAsset(thumbnailSource, fileExtension, existingRemoteFileId, credentials);
+    thumbnail = await uploadThumbnailForAsset(thumbnailSource, fileExtension, existingRemoteFileId, credentials);
   } catch (replaceError) {
     if (!isDeletedOrTrashedError(replaceError)) {
       logger.error(`Failed to replace file entry for ${existingRemoteFileId}:`, replaceError);
@@ -443,11 +453,11 @@ const replaceRemoteFile = async (params: {
       modificationTime: modificationIso,
       creationTime: creationIso,
     });
-    await uploadThumbnailForAsset(thumbnailSource, fileExtension, driveFile.uuid, credentials);
+    thumbnail = await uploadThumbnailForAsset(thumbnailSource, fileExtension, driveFile.uuid, credentials);
     photoUuid = driveFile.uuid;
   }
 
-  return photoUuid;
+  return { photoUuid, contentFileId: fileId, bucketId, thumbnail };
 };
 
 export const PhotoUploadService = {
@@ -502,7 +512,7 @@ export const PhotoUploadService = {
             signal,
           });
 
-          await uploadThumbnailForAsset(asset.uri, fileExtension, photoUuid, credentials);
+          const thumbnail = await uploadThumbnailForAsset(asset.uri, fileExtension, photoUuid, credentials);
 
           const pairedVideoUuid = await uploadPairedVideo({
             videoLocalPath,
@@ -515,7 +525,12 @@ export const PhotoUploadService = {
             signal,
           });
 
-          return { photoUuid, pairedVideoUuid: pairedVideoUuid ?? undefined };
+          return {
+            photoUuid,
+            pairedVideoUuid: pairedVideoUuid ?? undefined,
+            thumbnail: thumbnail ?? undefined,
+            bucketId: credentials.bucketId,
+          };
         } finally {
           await cleanupTempFile(photoLocalPath);
           await cleanupTempFile(videoLocalPath);
@@ -570,7 +585,7 @@ export const PhotoUploadService = {
         creationTime: creationIso,
       });
 
-      await uploadThumbnailForAsset(thumbnailSource, fileExtension, photoUuid, credentials);
+      const thumbnail = await uploadThumbnailForAsset(thumbnailSource, fileExtension, photoUuid, credentials);
 
       logger.info(`[PhotoUploadService] BURST block reached — assetId=${asset.id} plainName=${plainName}`);
       const burst = await uploadBurstMembersIfBurst({
@@ -585,7 +600,13 @@ export const PhotoUploadService = {
         onEvent,
       });
 
-      return { photoUuid, ...(burst ? { burst } : {}) };
+      return {
+        photoUuid,
+        ...(burst ? { burst } : {}),
+        thumbnail: thumbnail ?? undefined,
+        contentFileId: fileId,
+        bucketId,
+      };
     } finally {
       await cleanupTempFile(tempPath);
     }
@@ -633,7 +654,12 @@ export const PhotoUploadService = {
             bridgePass,
           };
 
-          const photoUuid = await replaceRemoteFile({
+          const {
+            photoUuid,
+            contentFileId,
+            bucketId,
+            thumbnail,
+          } = await replaceRemoteFile({
             localFilePath: photoLocalPath,
             thumbnailSource: asset.uri,
             existingRemoteFileId,
@@ -660,7 +686,13 @@ export const PhotoUploadService = {
             signal,
           });
 
-          return { photoUuid, pairedVideoUuid: pairedVideoUuid ?? undefined };
+          return {
+            photoUuid,
+            pairedVideoUuid: pairedVideoUuid ?? undefined,
+            thumbnail: thumbnail ?? undefined,
+            contentFileId,
+            bucketId,
+          };
         } finally {
           await cleanupTempFile(photoLocalPath);
           await cleanupTempFile(videoLocalPath);
@@ -682,7 +714,12 @@ export const PhotoUploadService = {
     const credentials: UploadCredentials = { bucketId: photosBucket, encryptionKey, bridgeUser, bridgePass };
 
     try {
-      const photoUuid = await replaceRemoteFile({
+      const {
+        photoUuid,
+        contentFileId,
+        bucketId,
+        thumbnail,
+      } = await replaceRemoteFile({
         localFilePath,
         thumbnailSource: thumbnailUri ?? localFilePath,
         existingRemoteFileId,
@@ -710,7 +747,13 @@ export const PhotoUploadService = {
         onEvent,
       });
 
-      return { photoUuid, ...(burst ? { burst } : {}) };
+      return {
+        photoUuid,
+        ...(burst ? { burst } : {}),
+        thumbnail: thumbnail ?? undefined,
+        contentFileId,
+        bucketId,
+      };
     } finally {
       await cleanupTempFile(tempPath);
     }

--- a/src/services/photos/database/photosLocalDB.spec.ts
+++ b/src/services/photos/database/photosLocalDB.spec.ts
@@ -26,10 +26,39 @@ describe('photosLocalDB', () => {
     await photosLocalDB.init();
 
     expect(mockSqlite.open).toHaveBeenCalledWith('photos_sync.db');
-    expect(mockSqlite.executeSql).toHaveBeenCalledTimes(8);
+    // 8 create table/index statements + 5 `ALTER TABLE asset_sync ADD COLUMN` migration
+    // statements (migrateAssetSyncColumns — additive columns for installs predating them).
+    expect(mockSqlite.executeSql).toHaveBeenCalledTimes(13);
     const statements = mockSqlite.executeSql.mock.calls.map(([, stmt]) => stmt as string);
     expect(statements.some((s) => s.includes('CREATE TABLE IF NOT EXISTS asset_sync'))).toBe(true);
     expect(statements.some((s) => s.includes('CREATE TABLE IF NOT EXISTS cloud_asset'))).toBe(true);
+    expect(statements.some((s) => s.includes('ALTER TABLE asset_sync ADD COLUMN thumbnail_bucket_id'))).toBe(true);
+  });
+
+  test('when the ALTER TABLE migration finds a column that already exists, then the duplicate column error is swallowed', async () => {
+    mockSqlite.executeSql.mockImplementation(async (_name, stmt) => {
+      if (typeof stmt === 'string' && stmt.includes('ALTER TABLE asset_sync ADD COLUMN')) {
+        throw new Error('duplicate column name: thumbnail_bucket_id');
+      }
+      return [];
+    });
+
+    await expect(photosLocalDB.init()).resolves.toBeUndefined();
+
+    mockSqlite.executeSql.mockResolvedValue([]); // restore the default for later tests
+  });
+
+  test('when the ALTER TABLE migration fails for a reason other than a duplicate column, then it rethrows', async () => {
+    mockSqlite.executeSql.mockImplementation(async (_name, stmt) => {
+      if (typeof stmt === 'string' && stmt.includes('ALTER TABLE asset_sync ADD COLUMN')) {
+        throw new Error('disk I/O error');
+      }
+      return [];
+    });
+
+    await expect(photosLocalDB.init()).rejects.toThrow('disk I/O error');
+
+    mockSqlite.executeSql.mockResolvedValue([]); // restore the default for later tests
   });
 
   test('when the database is initialized a second time, then no database calls are made', async () => {
@@ -111,6 +140,14 @@ describe('photosLocalDB', () => {
     expect(paramsList).toEqual([['asset-1'], ['asset-2'], ['asset-3']]);
   });
 
+  test('when getting orphaned asset_sync ids, then only the ones missing from the given local set are returned', async () => {
+    mockSqlite.getAllAsync.mockResolvedValueOnce([{ asset_id: 'asset-1' }, { asset_id: 'asset-2' }]);
+
+    const orphanIds = await photosLocalDB.getOrphanedAssetSyncIds(new Set(['asset-1']));
+
+    expect(orphanIds).toEqual(['asset-2']);
+  });
+
   test('when a file size is cached for an asset, then the file size and asset id are passed to the database', async () => {
     await photosLocalDB.cacheAssetFileSize('asset-3', 204800);
 
@@ -127,14 +164,36 @@ describe('photosLocalDB', () => {
     const [, stmt, params] = mockSqlite.executeSql.mock.calls[0];
     expect(stmt).toContain('\'synced\'');
     expect(stmt).toContain('unixepoch()');
-    expect(params).toEqual(['asset-1', 'remote-file-id', 1714000000]);
+    expect(params).toEqual(['asset-1', 'remote-file-id', 1714000000, null, null, null, null, null]);
   });
 
   test('when a photo is marked as synced without a modification time, then the modification time is stored as null', async () => {
     await photosLocalDB.markSynced('asset-1', 'remote-file-id', null);
 
     const [, , params] = mockSqlite.executeSql.mock.calls[0];
-    expect(params).toEqual(['asset-1', 'remote-file-id', null]);
+    expect(params).toEqual(['asset-1', 'remote-file-id', null, null, null, null, null, null]);
+  });
+
+  test('when a photo is marked as synced with thumbnail refs from the upload, then they are persisted', async () => {
+    await photosLocalDB.markSynced('asset-1', 'remote-file-id', 1714000000, {
+      thumbnailBucketId: 'bucket-1',
+      thumbnailBucketFile: 'thumb-file-1',
+      thumbnailType: 'jpg',
+      contentFileId: 'content-file-1',
+      bucket: 'bucket-1',
+    });
+
+    const [, , params] = mockSqlite.executeSql.mock.calls[0];
+    expect(params).toEqual([
+      'asset-1',
+      'remote-file-id',
+      1714000000,
+      'bucket-1',
+      'thumb-file-1',
+      'jpg',
+      'content-file-1',
+      'bucket-1',
+    ]);
   });
 
   test('when a photo upload fails without an error message, then it is marked as failed with a null message', async () => {
@@ -517,6 +576,15 @@ describe('photosLocalDB cloud asset methods', () => {
     const result = await photosLocalDB.getCloudAssetById('non-existent');
 
     expect(result).toBeNull();
+  });
+
+  test('when known cloud asset remote ids are looked up for a device/month, then rows with discoveredAt 0 are excluded from the query', async () => {
+    mockSqlite.getAllAsync.mockResolvedValueOnce([]);
+
+    await photosLocalDB.getCloudAssetRemoteIdsByDeviceAndMonth('device-1', 2024, 6);
+
+    const [, stmt] = mockSqlite.getAllAsync.mock.calls[0];
+    expect(stmt).toContain('discovered_at != 0');
   });
 
   test('when a cloud asset is upserted, then all its fields are passed to the database', async () => {

--- a/src/services/photos/database/photosLocalDB.ts
+++ b/src/services/photos/database/photosLocalDB.ts
@@ -98,9 +98,16 @@ export interface AssetSyncEntry {
   burstId: string | null;
   burstMemberRemoteFileIds: string[] | null;
   burstMemberCount: number | null;
+  /** Thumbnail/content refs captured straight from the upload that produced this asset — present
+   * only when this device generated them itself (see PhotoCloudBrowser.recordSyncedAsset). */
+  thumbnailBucketId: string | null;
+  thumbnailBucketFile: string | null;
+  thumbnailType: string | null;
+  contentFileId: string | null;
+  bucket: string | null;
 }
 
-interface AssetSyncRow {
+export interface AssetSyncRow {
   asset_id: string;
   status: AssetSyncStatus;
   remote_file_id: string | null;
@@ -125,6 +132,11 @@ interface AssetSyncRow {
   burst_id: string | null;
   burst_member_remote_file_ids: string | null;
   burst_member_count: number | null;
+  thumbnail_bucket_id: string | null;
+  thumbnail_bucket_file: string | null;
+  thumbnail_type: string | null;
+  content_file_id: string | null;
+  bucket: string | null;
 }
 
 export interface SyncedAssetInfo {
@@ -271,7 +283,30 @@ const rowToAssetSyncEntry = (row: AssetSyncRow): AssetSyncEntry => ({
   burstId: row.burst_id,
   burstMemberRemoteFileIds: row.burst_member_remote_file_ids ? JSON.parse(row.burst_member_remote_file_ids) : null,
   burstMemberCount: row.burst_member_count,
+  thumbnailBucketId: row.thumbnail_bucket_id,
+  thumbnailBucketFile: row.thumbnail_bucket_file,
+  thumbnailType: row.thumbnail_type,
+  contentFileId: row.content_file_id,
+  bucket: row.bucket,
 });
+
+/** Thumbnail/content refs captured from a successful upload/replace call, passed to markSynced*
+ * so recordSyncedAsset can later write a complete cloud_asset row without fetching Drive. */
+export interface SyncedThumbnailRefs {
+  thumbnailBucketId?: string;
+  thumbnailBucketFile?: string;
+  thumbnailType?: string;
+  contentFileId?: string;
+  bucket?: string;
+}
+
+const toThumbnailRefParams = (refs?: SyncedThumbnailRefs): (string | null)[] => [
+  refs?.thumbnailBucketId ?? null,
+  refs?.thumbnailBucketFile ?? null,
+  refs?.thumbnailType ?? null,
+  refs?.contentFileId ?? null,
+  refs?.bucket ?? null,
+];
 
 const toMarkPendingParams = (assetId: string, mediaInfo?: AssetMediaInfo) => [
   assetId,
@@ -292,6 +327,7 @@ class PhotosLocalDB {
     this.initPromise ??= (async () => {
       await sqliteService.open(DB_NAME);
       await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.createTable);
+      await this.migrateAssetSyncColumns();
       await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.createIndex);
       await sqliteService.executeSql(DB_NAME, cloudAssetTable.statements.createTable);
       await sqliteService.executeSql(DB_NAME, cloudAssetTable.statements.createIndexCreated);
@@ -301,6 +337,21 @@ class PhotosLocalDB {
       await sqliteService.executeSql(DB_NAME, cloudAssetTable.statements.createIndexBurstGroup);
     })();
     return this.initPromise;
+  }
+
+  /**
+   * Adds the thumbnail columns to `asset_sync`.
+   */
+  private async migrateAssetSyncColumns(): Promise<void> {
+    for (const statement of assetSyncTable.migrateAddColumns) {
+      try {
+        await sqliteService.executeSql(DB_NAME, statement);
+      } catch (err) {
+        if (!String(err).includes('duplicate column name')) {
+          throw err;
+        }
+      }
+    }
   }
 
   /**
@@ -332,11 +383,17 @@ class PhotosLocalDB {
     );
   }
 
-  async markSynced(assetId: string, remoteFileId: string, modificationTime: number | null): Promise<void> {
+  async markSynced(
+    assetId: string,
+    remoteFileId: string,
+    modificationTime: number | null,
+    thumbnailRefs?: SyncedThumbnailRefs,
+  ): Promise<void> {
     await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.markSynced, [
       assetId,
       remoteFileId,
       modificationTime,
+      ...toThumbnailRefParams(thumbnailRefs),
     ]);
   }
 
@@ -346,6 +403,7 @@ class PhotosLocalDB {
     modificationTime: number | null,
     pairedVideoRemoteFileId: string | null,
     pairedVideoStatus: PairedVideoStatus,
+    thumbnailRefs?: SyncedThumbnailRefs,
   ): Promise<void> {
     await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.markSyncedLivePhoto, [
       assetId,
@@ -353,6 +411,7 @@ class PhotosLocalDB {
       modificationTime,
       pairedVideoRemoteFileId,
       pairedVideoStatus,
+      ...toThumbnailRefParams(thumbnailRefs),
     ]);
   }
 
@@ -533,17 +592,20 @@ class PhotosLocalDB {
     );
   }
 
-  async cleanupOrphanedAssetSync(localAssetIds: Set<string>): Promise<number> {
-    const allsyncedAssets = await sqliteService.getAllAsync<{ asset_id: string }>(
+  /**
+   * Ids of `asset_sync` rows tracked locally whose asset is no longer on the device
+   * (`localAssetIds`). Read-only — callers decide what to do with the diff (see
+   * `PhotoCloudBrowser.deleteAssetSyncPreservingCloudVisibility`, which preserves cloud
+   * visibility for any orphan that had a remote backup before removing its row).
+   *
+   * @param localAssetIds - Ids of the assets currently on the device.
+   */
+  async getOrphanedAssetSyncIds(localAssetIds: Set<string>): Promise<string[]> {
+    const allSyncedAssets = await sqliteService.getAllAsync<{ asset_id: string }>(
       DB_NAME,
       assetSyncTable.statements.getAllTrackedAssetIds,
     );
-    const orphanAssetsIds = allsyncedAssets.filter((a) => !localAssetIds.has(a.asset_id)).map((a) => a.asset_id);
-    if (orphanAssetsIds.length === 0) {
-      return 0;
-    }
-    await this.deleteAssetSyncBulk(orphanAssetsIds);
-    return orphanAssetsIds.length;
+    return allSyncedAssets.filter((a) => !localAssetIds.has(a.asset_id)).map((a) => a.asset_id);
   }
 
   async reset(): Promise<void> {
@@ -699,6 +761,7 @@ class PhotosLocalDB {
     burstId: string,
     memberUuids: string[],
     memberCount: number | null,
+    thumbnailRefs?: SyncedThumbnailRefs,
   ): Promise<void> {
     await sqliteService.executeSql(DB_NAME, assetSyncTable.statements.markSyncedBurst, [
       assetId,
@@ -707,6 +770,7 @@ class PhotosLocalDB {
       burstId,
       JSON.stringify(memberUuids),
       memberCount,
+      ...toThumbnailRefParams(thumbnailRefs),
     ]);
   }
 

--- a/src/services/photos/database/tables/asset_sync.ts
+++ b/src/services/photos/database/tables/asset_sync.ts
@@ -27,7 +27,13 @@ const statements = {
       is_burst                    INTEGER NOT NULL DEFAULT 0,
       burst_id                    TEXT,
       burst_member_remote_file_ids TEXT,
-      burst_member_count          INTEGER
+      burst_member_count          INTEGER,
+      -- Captured from the upload/replace call itself (see migrateAddColumns below for existing installs).
+      thumbnail_bucket_id         TEXT,
+      thumbnail_bucket_file       TEXT,
+      thumbnail_type              TEXT,
+      content_file_id             TEXT,
+      bucket                      TEXT
     );
   `,
   createIndex: `CREATE INDEX IF NOT EXISTS idx_asset_sync_status ON ${TABLE_NAME}(status);`,
@@ -68,20 +74,27 @@ const statements = {
   `,
 
   markSynced: `
-    INSERT INTO ${TABLE_NAME} (asset_id, status, remote_file_id, synced_at, last_attempt_at, modification_time)
-    VALUES (?, 'synced', ?, (unixepoch() * 1000), (unixepoch() * 1000), ?)
+    INSERT INTO ${TABLE_NAME} (asset_id, status, remote_file_id, synced_at, last_attempt_at, modification_time,
+                               thumbnail_bucket_id, thumbnail_bucket_file, thumbnail_type, content_file_id, bucket)
+    VALUES (?, 'synced', ?, (unixepoch() * 1000), (unixepoch() * 1000), ?, ?, ?, ?, ?, ?)
     ON CONFLICT(asset_id) DO UPDATE SET
-      status            = 'synced',
-      remote_file_id    = excluded.remote_file_id,
-      synced_at         = excluded.synced_at,
-      last_attempt_at   = excluded.last_attempt_at,
-      modification_time = excluded.modification_time;
+      status                 = 'synced',
+      remote_file_id         = excluded.remote_file_id,
+      synced_at              = excluded.synced_at,
+      last_attempt_at        = excluded.last_attempt_at,
+      modification_time      = excluded.modification_time,
+      thumbnail_bucket_id    = COALESCE(excluded.thumbnail_bucket_id, ${TABLE_NAME}.thumbnail_bucket_id),
+      thumbnail_bucket_file  = COALESCE(excluded.thumbnail_bucket_file, ${TABLE_NAME}.thumbnail_bucket_file),
+      thumbnail_type         = COALESCE(excluded.thumbnail_type, ${TABLE_NAME}.thumbnail_type),
+      content_file_id        = COALESCE(excluded.content_file_id, ${TABLE_NAME}.content_file_id),
+      bucket                 = COALESCE(excluded.bucket, ${TABLE_NAME}.bucket);
   `,
 
   markSyncedLivePhoto: `
     INSERT INTO ${TABLE_NAME} (asset_id, status, remote_file_id, synced_at, last_attempt_at, modification_time,
-                               is_live_photo, paired_video_remote_file_id, paired_video_status)
-    VALUES (?, 'synced', ?, (unixepoch() * 1000), (unixepoch() * 1000), ?, 1, ?, ?)
+                               is_live_photo, paired_video_remote_file_id, paired_video_status,
+                               thumbnail_bucket_id, thumbnail_bucket_file, thumbnail_type, content_file_id, bucket)
+    VALUES (?, 'synced', ?, (unixepoch() * 1000), (unixepoch() * 1000), ?, 1, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(asset_id) DO UPDATE SET
       status                      = 'synced',
       remote_file_id              = excluded.remote_file_id,
@@ -90,14 +103,20 @@ const statements = {
       modification_time           = excluded.modification_time,
       is_live_photo               = 1,
       paired_video_remote_file_id = excluded.paired_video_remote_file_id,
-      paired_video_status         = excluded.paired_video_status;
+      paired_video_status         = excluded.paired_video_status,
+      thumbnail_bucket_id         = COALESCE(excluded.thumbnail_bucket_id, ${TABLE_NAME}.thumbnail_bucket_id),
+      thumbnail_bucket_file       = COALESCE(excluded.thumbnail_bucket_file, ${TABLE_NAME}.thumbnail_bucket_file),
+      thumbnail_type              = COALESCE(excluded.thumbnail_type, ${TABLE_NAME}.thumbnail_type),
+      content_file_id             = COALESCE(excluded.content_file_id, ${TABLE_NAME}.content_file_id),
+      bucket                      = COALESCE(excluded.bucket, ${TABLE_NAME}.bucket);
   `,
 
   // BURST: marks a burst representative as synced with its member uuids (iOS only).
   markSyncedBurst: `
     INSERT INTO ${TABLE_NAME} (asset_id, status, remote_file_id, synced_at, last_attempt_at, modification_time,
-                               is_burst, burst_id, burst_member_remote_file_ids, burst_member_count)
-    VALUES (?, 'synced', ?, (unixepoch() * 1000), (unixepoch() * 1000), ?, 1, ?, ?, ?)
+                               is_burst, burst_id, burst_member_remote_file_ids, burst_member_count,
+                               thumbnail_bucket_id, thumbnail_bucket_file, thumbnail_type, content_file_id, bucket)
+    VALUES (?, 'synced', ?, (unixepoch() * 1000), (unixepoch() * 1000), ?, 1, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(asset_id) DO UPDATE SET
       status                       = 'synced',
       remote_file_id               = excluded.remote_file_id,
@@ -107,7 +126,12 @@ const statements = {
       is_burst                     = 1,
       burst_id                     = excluded.burst_id,
       burst_member_remote_file_ids = excluded.burst_member_remote_file_ids,
-      burst_member_count           = excluded.burst_member_count;
+      burst_member_count           = excluded.burst_member_count,
+      thumbnail_bucket_id          = COALESCE(excluded.thumbnail_bucket_id, ${TABLE_NAME}.thumbnail_bucket_id),
+      thumbnail_bucket_file        = COALESCE(excluded.thumbnail_bucket_file, ${TABLE_NAME}.thumbnail_bucket_file),
+      thumbnail_type               = COALESCE(excluded.thumbnail_type, ${TABLE_NAME}.thumbnail_type),
+      content_file_id              = COALESCE(excluded.content_file_id, ${TABLE_NAME}.content_file_id),
+      bucket                       = COALESCE(excluded.bucket, ${TABLE_NAME}.bucket);
   `,
 
   markError: `
@@ -130,7 +154,8 @@ const statements = {
            created_at, last_attempt_at, modification_time,
            file_name, file_size, creation_time, width, height, duration, media_type,
            is_live_photo, paired_video_remote_file_id, paired_video_status,
-           is_burst, burst_id, burst_member_remote_file_ids, burst_member_count
+           is_burst, burst_id, burst_member_remote_file_ids, burst_member_count,
+           thumbnail_bucket_id, thumbnail_bucket_file, thumbnail_type, content_file_id, bucket
     FROM ${TABLE_NAME} WHERE asset_id = ?;
   `,
   getSyncedInList: (placeholders: string) =>
@@ -241,4 +266,13 @@ const statements = {
   `,
 };
 
-export default { TABLE_NAME, statements };
+// Adds the thumbnail/content columns to existing installs. See photosLocalDB.migrateAssetSyncColumns.
+const migrateAddColumns = [
+  `ALTER TABLE ${TABLE_NAME} ADD COLUMN thumbnail_bucket_id TEXT;`,
+  `ALTER TABLE ${TABLE_NAME} ADD COLUMN thumbnail_bucket_file TEXT;`,
+  `ALTER TABLE ${TABLE_NAME} ADD COLUMN thumbnail_type TEXT;`,
+  `ALTER TABLE ${TABLE_NAME} ADD COLUMN content_file_id TEXT;`,
+  `ALTER TABLE ${TABLE_NAME} ADD COLUMN bucket TEXT;`,
+];
+
+export default { TABLE_NAME, statements, migrateAddColumns };

--- a/src/services/photos/database/tables/cloud_asset.ts
+++ b/src/services/photos/database/tables/cloud_asset.ts
@@ -56,26 +56,27 @@ const statements = {
       folder_date            = excluded.folder_date,
       file_name              = excluded.file_name,
       file_size              = excluded.file_size,
-      file_id                = excluded.file_id,
+      file_id                = COALESCE(excluded.file_id, ${TABLE_NAME}.file_id),
       thumbnail_path         = CASE
         WHEN excluded.thumbnail_bucket_file IS NOT NULL
          AND ${TABLE_NAME}.thumbnail_bucket_file IS NOT excluded.thumbnail_bucket_file
         THEN NULL
         ELSE COALESCE(${TABLE_NAME}.thumbnail_path, excluded.thumbnail_path)
       END,
-      thumbnail_bucket_id    = excluded.thumbnail_bucket_id,
-      thumbnail_bucket_file  = excluded.thumbnail_bucket_file,
-      thumbnail_type         = excluded.thumbnail_type,
-      discovered_at          = excluded.discovered_at,
-      plain_name             = excluded.plain_name,
-      extension              = excluded.extension,
-      bucket                 = excluded.bucket,
-      folder_uuid            = excluded.folder_uuid,
-      creation_time_api      = excluded.creation_time_api,
-      modification_time      = excluded.modification_time,
-      updated_at             = excluded.updated_at,
-      status                 = excluded.status,
-      encrypt_version        = excluded.encrypt_version,
+      thumbnail_bucket_id    = COALESCE(excluded.thumbnail_bucket_id, ${TABLE_NAME}.thumbnail_bucket_id),
+      thumbnail_bucket_file  = COALESCE(excluded.thumbnail_bucket_file, ${TABLE_NAME}.thumbnail_bucket_file),
+      thumbnail_type         = COALESCE(excluded.thumbnail_type, ${TABLE_NAME}.thumbnail_type),
+      -- 0 = unconfirmed by a real listing; never regress an already-confirmed row back to it.
+      discovered_at          = CASE WHEN excluded.discovered_at = 0 THEN ${TABLE_NAME}.discovered_at ELSE excluded.discovered_at END,
+      plain_name             = COALESCE(excluded.plain_name, ${TABLE_NAME}.plain_name),
+      extension              = COALESCE(excluded.extension, ${TABLE_NAME}.extension),
+      bucket                 = COALESCE(excluded.bucket, ${TABLE_NAME}.bucket),
+      folder_uuid            = COALESCE(excluded.folder_uuid, ${TABLE_NAME}.folder_uuid),
+      creation_time_api      = COALESCE(excluded.creation_time_api, ${TABLE_NAME}.creation_time_api),
+      modification_time      = COALESCE(excluded.modification_time, ${TABLE_NAME}.modification_time),
+      updated_at             = COALESCE(excluded.updated_at, ${TABLE_NAME}.updated_at),
+      status                 = COALESCE(excluded.status, ${TABLE_NAME}.status),
+      encrypt_version        = COALESCE(excluded.encrypt_version, ${TABLE_NAME}.encrypt_version),
       is_live_photo          = excluded.is_live_photo,
       live_photo_role        = excluded.live_photo_role,
       paired_remote_file_id  = excluded.paired_remote_file_id,
@@ -160,9 +161,11 @@ const statements = {
   getDistinctDeviceIds: `SELECT DISTINCT device_id FROM ${TABLE_NAME};`,
   reset: `DELETE FROM ${TABLE_NAME};`,
 
+  // discovered_at != 0 excludes rows written directly (not yet confirmed by a real Drive
+  // listing) from cloud-deletion reconciliation, so a stale snapshot can't mark them deleted.
   getRemoteIdsByDeviceAndMonth: `
     SELECT remote_file_id FROM ${TABLE_NAME}
-    WHERE device_id = ? AND folder_date >= ? AND folder_date < ?;
+    WHERE device_id = ? AND folder_date >= ? AND folder_date < ? AND discovered_at != 0;
   `,
 
   getLatestDiscoveredAt: `

--- a/src/store/slices/photos/index.spec.ts
+++ b/src/store/slices/photos/index.spec.ts
@@ -95,6 +95,9 @@ jest.mock('src/services/photos/PhotoCloudBrowser', () => ({
   photoCloudBrowser: {
     listDeviceFolders: jest.fn().mockResolvedValue([]),
     syncAllHistory: jest.fn().mockResolvedValue(undefined),
+    cleanupOrphanedAssetSync: jest.fn().mockResolvedValue(0),
+    recordSyncedAsset: jest.fn().mockResolvedValue(undefined),
+    subscribeToCloudIndexUpdates: jest.fn().mockReturnValue(jest.fn()),
   },
 }));
 
@@ -217,6 +220,9 @@ describe('photos slice', () => {
     mockPhotoSyncManifestService.restoreManifest.mockResolvedValue(null);
     mockCloudBrowser.listDeviceFolders.mockResolvedValue([]);
     mockCloudBrowser.syncAllHistory.mockResolvedValue(undefined);
+    mockCloudBrowser.cleanupOrphanedAssetSync.mockResolvedValue(0);
+    mockCloudBrowser.recordSyncedAsset.mockResolvedValue(undefined);
+    mockCloudBrowser.subscribeToCloudIndexUpdates.mockReturnValue(jest.fn());
     // Prevent checkPermissionRevocationThunk from overwriting permissionStatus with undefined
     mockPermissionService.getStatus.mockResolvedValue('granted');
     mockHasPhotosFeatureAccess.mockReturnValue(true);
@@ -1824,7 +1830,13 @@ describe('photos slice', () => {
 
       await store.dispatch(uploadAssetsManuallyThunk({ assetIds: ['a1'], signal: makeSignal() })).unwrap();
 
-      expect(mockPhotosLocalDB.markSynced).toHaveBeenCalledWith('a1', 'remote-1', 12345);
+      expect(mockPhotosLocalDB.markSynced).toHaveBeenCalledWith('a1', 'remote-1', 12345, {
+        thumbnailBucketId: undefined,
+        thumbnailBucketFile: undefined,
+        thumbnailType: undefined,
+        contentFileId: undefined,
+        bucket: undefined,
+      });
       expect(store.getState().photos.uploadingAssetIds).toEqual([]);
       expect(mockPhotosLocalDB.markPendingBulk).not.toHaveBeenCalled();
     });

--- a/src/store/slices/photos/index.ts
+++ b/src/store/slices/photos/index.ts
@@ -114,6 +114,7 @@ const persistPhotosSettings = async (state: PhotosState): Promise<void> => {
 };
 
 let unsubscribeNetworkRecovery: (() => void) | null = null;
+let unsubscribeCloudIndexUpdates: (() => void) | null = null;
 
 export const hydratePhotosStateThunk = createAsyncThunk<void, void, { state: RootState }>(
   'photos/setState',
@@ -129,6 +130,11 @@ export const hydratePhotosStateThunk = createAsyncThunk<void, void, { state: Roo
         logger.info('[Photos] Network recovered — resuming backup cycle');
         dispatch(runBackupCycleThunk());
       }
+    });
+
+    unsubscribeCloudIndexUpdates?.();
+    unsubscribeCloudIndexUpdates = photoCloudBrowser.subscribeToCloudIndexUpdates(() => {
+      dispatch(photosSlice.actions.incrementCloudFetchRevision());
     });
 
     await photosLocalDB.init();
@@ -301,7 +307,10 @@ export const runDiscoveryThunk = createAsyncThunk<void, void, { state: RootState
         photosLocalDB.markPendingEditBulk(editedAssets.map(transformToPendingEntry)),
       ]);
       const localAssetIdSet = new Set(scannedAssets.map((a) => a.id));
-      const orphanedAssetsSyncRemovedCount = await photosLocalDB.cleanupOrphanedAssetSync(localAssetIdSet);
+      const orphanedAssetsSyncRemovedCount = await photoCloudBrowser.cleanupOrphanedAssetSync(
+        localAssetIdSet,
+        getState().photos.deviceId,
+      );
       if (orphanedAssetsSyncRemovedCount > 0) {
         logger.info(
           `[Discovery] Removed ${orphanedAssetsSyncRemovedCount} asset_sync entries for locally deleted assets`,

--- a/src/store/slices/photos/thunks/upload.ts
+++ b/src/store/slices/photos/thunks/upload.ts
@@ -4,12 +4,13 @@ import { Platform } from 'react-native';
 import { AbortError } from 'src/network/errors';
 import { networkMonitorService, NetworkState, NetworkStateType } from 'src/services/NetworkMonitorService';
 import { HTTP_QUOTA_EXCEEDED } from 'src/services/common/httpStatusCodes';
+import { photoCloudBrowser } from 'src/services/photos/PhotoCloudBrowser';
 import { PhotoAssetScanner } from 'src/services/photos/PhotoAssetScanner';
 import { photoSyncManifestService } from 'src/services/photos/PhotoSyncManifestService';
 import { AssetUploadJob, PhotoUploadQueue } from 'src/services/photos/PhotoUploadQueue';
 import { PhotoUploadEvent, PhotoUploadResult, uploadSingleFile } from 'src/services/photos/PhotoUploadService';
 import { retryIncompleteBursts } from 'src/services/photos/burst/BurstUploadHandler';
-import { AssetSyncStatus, photosLocalDB } from 'src/services/photos/database/photosLocalDB';
+import { AssetSyncStatus, photosLocalDB, SyncedThumbnailRefs } from 'src/services/photos/database/photosLocalDB';
 import { isPermissionActive } from 'src/services/photos/photoPermissionService';
 import { logger } from '../../../../services/common';
 import { RootState } from '../../../index';
@@ -59,8 +60,19 @@ export const completeSyncForAsset = async (
   assetId: string,
   result: PhotoUploadResult,
   modificationTime: number,
+  deviceId: string | null,
 ): Promise<void> => {
   const status = result.burst ? null : await photosLocalDB.getStatus(assetId);
+
+  // Undefined fields here fall back to their existing asset_sync value (COALESCE in
+  // markSynced*'s SQL), not overwritten with null.
+  const thumbnailRefs: SyncedThumbnailRefs = {
+    thumbnailBucketId: result.thumbnail?.bucketId,
+    thumbnailBucketFile: result.thumbnail?.bucketFile,
+    thumbnailType: result.thumbnail?.type,
+    contentFileId: result.contentFileId,
+    bucket: result.bucketId,
+  };
 
   if (result.burst) {
     await photosLocalDB.markSyncedBurst(
@@ -70,12 +82,13 @@ export const completeSyncForAsset = async (
       result.burst.burstId,
       result.burst.memberUuids,
       result.burst.memberUuids.length,
+      thumbnailRefs,
     );
   } else if (status?.isBurst) {
     // BURST: representative detected in discovery (is_burst=1) but exportBurstMembers returned 0
     // members — most likely limited photo access ("Selected Photos"). Mark synced with
     // memberCount=null so the retry pass re-attempts member export on the next upload cycle.
-    await photosLocalDB.markSyncedBurst(assetId, result.photoUuid, modificationTime, assetId, [], null);
+    await photosLocalDB.markSyncedBurst(assetId, result.photoUuid, modificationTime, assetId, [], null, thumbnailRefs);
   } else if (result.pairedVideoUuid !== undefined) {
     await photosLocalDB.markSyncedLivePhoto(
       assetId,
@@ -83,12 +96,19 @@ export const completeSyncForAsset = async (
       modificationTime,
       result.pairedVideoUuid,
       'synced',
+      thumbnailRefs,
     );
   } else if (status?.isLivePhoto) {
-    await photosLocalDB.markSyncedLivePhoto(assetId, result.photoUuid, modificationTime, null, 'error');
+    await photosLocalDB.markSyncedLivePhoto(assetId, result.photoUuid, modificationTime, null, 'error', thumbnailRefs);
   } else {
-    await photosLocalDB.markSynced(assetId, result.photoUuid, modificationTime);
+    await photosLocalDB.markSynced(assetId, result.photoUuid, modificationTime, thumbnailRefs);
   }
+
+  // Always runs, regardless of which branch above wrote asset_sync — see recordSyncedAsset's
+  // docstring for why this replaced threading cloud-index data through every upload path.
+  await photoCloudBrowser
+    .recordSyncedAsset(assetId, deviceId)
+    .catch((err) => logger.warn(`[Upload] Failed to record cloud_asset entry for ${assetId}: ${err}`));
 };
 
 const hasRemainingAssets = async (isIOS: boolean): Promise<boolean> => {
@@ -108,8 +128,9 @@ const finishAssetUpload = async (
   assetId: string,
   result: PhotoUploadResult,
   modificationTime: number,
+  deviceId: string | null,
 ): Promise<void> => {
-  await completeSyncForAsset(assetId, result, modificationTime);
+  await completeSyncForAsset(assetId, result, modificationTime, deviceId);
   dispatch(photosSlice.actions.removeUploadingAssetId(assetId));
   dispatch(photosSlice.actions.incrementTotalAssetsUploaded());
 };
@@ -119,8 +140,9 @@ const finishAssetUploadInCycle = async (
   assetId: string,
   result: PhotoUploadResult,
   modificationTime: number,
+  deviceId: string | null,
 ): Promise<void> => {
-  await finishAssetUpload(dispatch, assetId, result, modificationTime);
+  await finishAssetUpload(dispatch, assetId, result, modificationTime, deviceId);
   dispatch(photosSlice.actions.markAssetUploadCompleted(assetId));
 };
 
@@ -275,7 +297,7 @@ export const runUploadThunk = createAsyncThunk<void, { bypassEnabled?: boolean }
         },
         onAssetDone: async (assetId, result, modificationTime) => {
           lastDispatchedUploadProgressStep.delete(assetId);
-          await finishAssetUploadInCycle(dispatch, assetId, result, modificationTime);
+          await finishAssetUploadInCycle(dispatch, assetId, result, modificationTime, deviceId);
           dispatch(photosSlice.actions.incrementSessionUploadedAssets());
           photoSyncManifestService
             .maybeUploadManifest(deviceId, photosBucket)
@@ -378,7 +400,7 @@ export const uploadAssetsManuallyThunk = createAsyncThunk<
         dispatch(photosSlice.actions.setAssetUploadProgress({ assetId, progress: ratio }));
       },
       onAssetDone: async (assetId, result, modificationTime) => {
-        await finishAssetUpload(dispatch, assetId, result, modificationTime);
+        await finishAssetUpload(dispatch, assetId, result, modificationTime, deviceId);
       },
       onAssetError: async (assetId, error) => {
         const errorOutcome = await handleAssetUploadError(dispatch, assetId, error);


### PR DESCRIPTION
Write cloud_asset directly from upload data instead of waiting for the next sync, in order to have the drive data instantly.

## Summary

- **`PhotoCloudBrowser.ts`**: uploading a photo never wrote anything to `cloud_asset` before, it relied entirely on the next `syncAllHistory` pass to populate it, so deleting the photo locally in that window could make it vanish from the timeline instead of showing as cloud-only. New `recordSyncedAsset` writes `cloud_asset` directly from data the upload already produced (thumbnail, content refs, burst/Live Photo pairing), with a background backfill only for whatever's still missing (e.g. `contentFileId`/`bucket`, which the iOS Live Photo upload path never returns). Concurrent backfills for the same device/month coalesce into a single in-flight `fetchMonth` plus one trailing re-run instead of one per asset.
- **`database/tables/cloud_asset.ts`**: the upsert now `COALESCE`s every column a direct write might not know against the existing row, so a partial write never regresses data a real Drive fetch already confirmed. `discovered_at` uses a `CASE` (can't be `NULL`) to the same effect, and rows are excluded from cloud-deletion reconciliation while unconfirmed (`discovered_at = 0`).
- **`database/tables/asset_sync.ts`** / **`photosLocalDB.ts`**: `asset_sync` added `thumbnail_bucket_id/file/type`, `content_file_id`, `bucket`, captured from the upload/replace call. Real `ALTER TABLE` migration for existing installs 
- **`PhotoUploadService.ts`** / **`thunks/upload.ts`**: `PhotoUploadResult` threads the thumbnail refs it already computed up to `completeSyncForAsset`, which persists them.
- **`utils/photoTimelineGroups.ts`**: cloud-only items were concatenated after local items within a day group instead of interleaved by real capture time, now sorted together by `creationTimeApi`.
- **`store/slices/photos/index.ts`**: subscribes to `PhotoCloudBrowser`'s new update notification so a background backfill reloads the timeline once it converges.