### PR TITLE
[PB-6742] bugfix/Login screen navigation

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -93,8 +93,8 @@ android {
         applicationId 'com.internxt.cloud'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 127
-        versionName "1.10.1"
+        versionCode 128
+        versionName "1.10.11"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
     }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -93,8 +93,8 @@ android {
         applicationId 'com.internxt.cloud'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 128
-        versionName "1.10.11"
+        versionCode 129
+        versionName "1.10.2"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
     }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
   <string name="app_name">Internxt</string>
   <string name="expo_system_ui_user_interface_style" translatable="false">automatic</string>
-  <string name="expo_runtime_version">1.10.1</string>
+  <string name="expo_runtime_version">1.10.11</string>
   <string name="expo_splash_screen_resize_mode" translatable="false">contain</string>
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
   <string name="app_name">Internxt</string>
   <string name="expo_system_ui_user_interface_style" translatable="false">automatic</string>
-  <string name="expo_runtime_version">1.10.11</string>
+  <string name="expo_runtime_version">1.10.2</string>
   <string name="expo_splash_screen_resize_mode" translatable="false">contain</string>
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
 </resources>

--- a/ios/Internxt/Info.plist
+++ b/ios/Internxt/Info.plist
@@ -23,7 +23,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.10.11</string>
+    <string>1.10.2</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/ios/Internxt/Info.plist
+++ b/ios/Internxt/Info.plist
@@ -23,7 +23,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.10.1</string>
+    <string>1.10.11</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/ios/Internxt/Supporting/Expo.plist
+++ b/ios/Internxt/Supporting/Expo.plist
@@ -9,7 +9,7 @@
     <key>EXUpdatesLaunchWaitMs</key>
     <integer>0</integer>
     <key>EXUpdatesRuntimeVersion</key>
-    <string>1.10.11</string>
+    <string>1.10.2</string>
     <key>EXUpdatesURL</key>
     <string>https://u.expo.dev/680f4feb-6315-4a50-93ec-36dcd0b831d2</string>
   </dict>

--- a/ios/Internxt/Supporting/Expo.plist
+++ b/ios/Internxt/Supporting/Expo.plist
@@ -9,7 +9,7 @@
     <key>EXUpdatesLaunchWaitMs</key>
     <integer>0</integer>
     <key>EXUpdatesRuntimeVersion</key>
-    <string>1.10.1</string>
+    <string>1.10.11</string>
     <key>EXUpdatesURL</key>
     <string>https://u.expo.dev/680f4feb-6315-4a50-93ec-36dcd0b831d2</string>
   </dict>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drive-mobile",
-  "version": "v1.10.1",
+  "version": "v1.10.11",
   "private": true,
   "license": "GNU",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drive-mobile",
-  "version": "v1.10.11",
+  "version": "v1.10.2",
   "private": true,
   "license": "GNU",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -249,13 +249,7 @@ function AppContent(): JSX.Element {
                     onClose={onChangeProfilePictureModalClosed}
                   />
                   <LanguageModal isOpen={isLanguageModalOpen} onClose={onLanguageModalClosed} />
-                  <SignOutModal
-                    onSignedOut={() => {
-                      if (navigationRef.isReady()) {
-                        navigationRef.reset({ index: 0, routes: [{ name: 'SignIn' }] });
-                      }
-                    }}
-                  />
+                  <SignOutModal />
                 </Portal.Host>
               </DriveContextProvider>
             ) : (

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlass, XCircle } from 'phosphor-react-native';
+import { MagnifyingGlassIcon, XCircleIcon } from 'phosphor-react-native';
 import { createRef, useState } from 'react';
 import { StyleProp, TextInput, TouchableOpacity, View, ViewStyle } from 'react-native';
 import { useTailwind } from 'tailwind-rn';
@@ -50,7 +50,7 @@ export function SearchInput(props: SearchInputProps): JSX.Element {
           <View style={tailwind('flex-row items-center')}>
             {!isFocused && (
               <View style={tailwind('pl-3')}>
-                <MagnifyingGlass color={getColor('text-gray-40')} size={18} />
+                <MagnifyingGlassIcon color={getColor('text-gray-40')} size={18} />
               </View>
             )}
 
@@ -62,8 +62,14 @@ export function SearchInput(props: SearchInputProps): JSX.Element {
               value={props.value}
               style={[
                 styles.fontWeight.regular,
-                tailwind('text-base pl-3 h-9 flex-1'),
-                { marginBottom: 2, color: getColor('text-gray-100') },
+                tailwind('pl-3 h-9 flex-1'),
+                {
+                  fontSize: 16,
+                  color: getColor('text-gray-100'),
+                  paddingVertical: 0,
+                  textAlignVertical: 'center',
+                  includeFontPadding: false,
+                },
               ]}
               placeholder={props.placeholder || ''}
               placeholderTextColor={getColor('text-gray-80')}
@@ -72,7 +78,7 @@ export function SearchInput(props: SearchInputProps): JSX.Element {
             {!!props.value && (
               <TouchableOpacity onPress={onClearButtonPressed}>
                 <View style={tailwind('py-1.5 px-3 items-center justify-center')}>
-                  <XCircle weight="fill" color={getColor('text-gray-40')} size={24} />
+                  <XCircleIcon weight="fill" color={getColor('text-gray-40')} size={24} />
                 </View>
               </TouchableOpacity>
             )}

--- a/src/components/modals/SignOutModal/index.tsx
+++ b/src/components/modals/SignOutModal/index.tsx
@@ -13,11 +13,7 @@ import LoadingSpinner from '../../LoadingSpinner';
 import UserProfilePicture from '../../UserProfilePicture';
 import CenterModal from '../CenterModal';
 
-interface SignOutModalProps {
-  readonly onSignedOut: () => void;
-}
-
-function SignOutModal({ onSignedOut }: SignOutModalProps): JSX.Element {
+function SignOutModal(): JSX.Element {
   const tailwind = useTailwind();
   const dispatch = useAppDispatch();
   const userFullName = useAppSelector(authSelectors.userFullName);
@@ -41,7 +37,6 @@ function SignOutModal({ onSignedOut }: SignOutModalProps): JSX.Element {
     await dispatch(authThunks.signOutThunk({ reason: 'manual' }));
     isSigningOutRef.current = false;
     setIsSigningOut(false);
-    onSignedOut();
     onClosed();
   };
 

--- a/src/navigation/AppStackNavigator.tsx
+++ b/src/navigation/AppStackNavigator.tsx
@@ -1,0 +1,51 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { Platform } from 'react-native';
+
+import { LargeShareUploadScreen } from '../screens/LargeShareUpload/LargeShareUploadScreen';
+import { DeactivatedAccountScreen } from '../screens/DeactivatedAccountScreen';
+import DebugScreen from '../screens/DebugScreen';
+import { TrashScreen } from '../screens/common/TrashScreen';
+import { DrivePreviewScreen } from '../screens/drive/DrivePreviewScreen';
+import { PhotoPreviewScreen } from '../screens/PhotoPreviewScreen';
+import { SettingsNavigator } from './SettingsNavigator';
+import AuthenticatedNavigator from './TabExplorerNavigator';
+import ShareExtensionView from '../shareExtension/ShareExtensionView.android';
+import { RootStackParamList } from '../types/navigation';
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+export default function AppStackNavigator(): JSX.Element {
+  return (
+    <Stack.Navigator initialRouteName="TabExplorer" screenOptions={{ headerShown: false, gestureEnabled: true }}>
+      <Stack.Screen name="Debug" component={DebugScreen} />
+      <Stack.Screen name="DeactivatedAccount" component={DeactivatedAccountScreen} />
+      <Stack.Screen name="TabExplorer" component={AuthenticatedNavigator} />
+      <Stack.Screen name="Trash" component={TrashScreen} />
+      <Stack.Screen name="Settings" component={SettingsNavigator} />
+      <Stack.Screen
+        name="DrivePreview"
+        component={DrivePreviewScreen}
+        options={{ animation: 'slide_from_bottom', gestureEnabled: false }}
+      />
+      <Stack.Screen
+        name="PhotoPreview"
+        component={PhotoPreviewScreen}
+        options={{ animation: 'slide_from_bottom', gestureEnabled: false }}
+      />
+      {Platform.OS === 'android' && (
+        <Stack.Screen
+          name="AndroidShare"
+          component={ShareExtensionView}
+          options={{ animation: 'slide_from_bottom', gestureEnabled: false }}
+        />
+      )}
+      {Platform.OS === 'ios' && (
+        <Stack.Screen
+          name="LargeShareUpload"
+          component={LargeShareUploadScreen}
+          options={{ animation: 'slide_from_bottom', gestureEnabled: false }}
+        />
+      )}
+    </Stack.Navigator>
+  );
+}

--- a/src/navigation/AuthStackNavigator.tsx
+++ b/src/navigation/AuthStackNavigator.tsx
@@ -1,0 +1,27 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { Platform } from 'react-native';
+
+import SignInScreen from '../screens/SignInScreen';
+import WebLoginScreen from '../screens/WebLoginScreen';
+import DebugScreen from '../screens/DebugScreen';
+import ShareExtensionView from '../shareExtension/ShareExtensionView.android';
+import { RootStackParamList } from '../types/navigation';
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+export default function AuthStackNavigator(): JSX.Element {
+  return (
+    <Stack.Navigator initialRouteName="SignIn" screenOptions={{ headerShown: false, gestureEnabled: true }}>
+      <Stack.Screen name="Debug" component={DebugScreen} />
+      <Stack.Screen name="SignIn" component={SignInScreen} />
+      <Stack.Screen name="WebLogin" component={WebLoginScreen} />
+      {Platform.OS === 'android' && (
+        <Stack.Screen
+          name="AndroidShare"
+          component={ShareExtensionView}
+          options={{ animation: 'slide_from_bottom', gestureEnabled: false }}
+        />
+      )}
+    </Stack.Navigator>
+  );
+}

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -1,26 +1,14 @@
 import { NavigationContainerRef } from '@react-navigation/native';
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { Platform, View } from 'react-native';
-import { LargeShareUploadScreen } from '../screens/LargeShareUpload/LargeShareUploadScreen';
+import { View } from 'react-native';
 
-import SignInScreen from '../screens/SignInScreen';
-import WebLoginScreen from '../screens/WebLoginScreen';
 import { useAppSelector } from '../store/hooks';
 import { RootStackParamList } from '../types/navigation';
-import AuthenticatedNavigator from './TabExplorerNavigator';
 
 import { useDeepLinks } from '../hooks/useDeepLinks';
-import { DeactivatedAccountScreen } from '../screens/DeactivatedAccountScreen';
-import DebugScreen from '../screens/DebugScreen';
-import { TrashScreen } from '../screens/common/TrashScreen';
-import { DrivePreviewScreen } from '../screens/drive/DrivePreviewScreen';
-import { PhotoPreviewScreen } from '../screens/PhotoPreviewScreen';
-import { SettingsNavigator } from './SettingsNavigator';
-import ShareExtensionView from '../shareExtension/ShareExtensionView.android';
 import { useIosPendingShareHandoff } from '../shareExtension/hooks/useIosPendingShareHandoff';
 import { useAndroidShareIntent } from '../shareExtension/useAndroidShareIntent';
-
-const Stack = createNativeStackNavigator<RootStackParamList>();
+import AppStackNavigator from './AppStackNavigator';
+import AuthStackNavigator from './AuthStackNavigator';
 
 type Props = {
   navigationContainerRef?: NavigationContainerRef<RootStackParamList>;
@@ -35,43 +23,7 @@ function AppNavigator({ navigationContainerRef }: Readonly<Props>): JSX.Element 
 
   if (isLoggedIn == null) return <View />;
 
-  const initialRouteName: keyof RootStackParamList = isLoggedIn ? 'TabExplorer' : 'SignIn';
-
-  return (
-    <Stack.Navigator initialRouteName={initialRouteName} screenOptions={{ headerShown: false, gestureEnabled: true }}>
-      <Stack.Screen name="Debug" component={DebugScreen} />
-      <Stack.Screen name="SignIn" component={SignInScreen} />
-      <Stack.Screen name="WebLogin" component={WebLoginScreen} />
-      <Stack.Screen name="DeactivatedAccount" component={DeactivatedAccountScreen} />
-      <Stack.Screen name="TabExplorer" component={AuthenticatedNavigator} />
-      <Stack.Screen name="Trash" component={TrashScreen} />
-      <Stack.Screen name="Settings" component={SettingsNavigator} />
-      <Stack.Screen
-        name="DrivePreview"
-        component={DrivePreviewScreen}
-        options={{ animation: 'slide_from_bottom', gestureEnabled: false }}
-      />
-      <Stack.Screen
-        name="PhotoPreview"
-        component={PhotoPreviewScreen}
-        options={{ animation: 'slide_from_bottom', gestureEnabled: false }}
-      />
-      {Platform.OS === 'android' && (
-        <Stack.Screen
-          name="AndroidShare"
-          component={ShareExtensionView}
-          options={{ animation: 'slide_from_bottom', gestureEnabled: false }}
-        />
-      )}
-      {Platform.OS === 'ios' && (
-        <Stack.Screen
-          name="LargeShareUpload"
-          component={LargeShareUploadScreen}
-          options={{ animation: 'slide_from_bottom', gestureEnabled: false }}
-        />
-      )}
-    </Stack.Navigator>
-  );
+  return isLoggedIn ? <AppStackNavigator /> : <AuthStackNavigator />;
 }
 
 export default AppNavigator;

--- a/src/navigation/TabExplorerNavigator.tsx
+++ b/src/navigation/TabExplorerNavigator.tsx
@@ -5,7 +5,6 @@ import { BottomTabBarProps } from '@react-navigation/bottom-tabs/lib/typescript/
 import { useEffect } from 'react';
 import { AppState, AppStateStatus, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { authThunks } from 'src/store/slices/auth';
 import { runBackupCycleThunk } from 'src/store/slices/photos';
 import { storageThunks } from 'src/store/slices/storage';
 import { useTailwind } from 'tailwind-rn';
@@ -60,7 +59,6 @@ export default function TabExplorerNavigator(props: RootStackScreenProps<'TabExp
       } catch {
         const isDeletingAccount = await asyncStorageService.getItem(AsyncStorageKey.IsDeletingAccount);
         if (isDeletingAccount) {
-          dispatch(authThunks.signOutThunk({ reason: 'manual' }));
           props.navigation.replace('DeactivatedAccount');
         }
       }

--- a/src/screens/DeactivatedAccountScreen/DeactivatedAccountScreen.tsx
+++ b/src/screens/DeactivatedAccountScreen/DeactivatedAccountScreen.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { RootStackScreenProps } from '../../types/navigation';
 import InternxtLogo from '../../../assets/logo.svg';
 import AppScreen from '../../components/AppScreen';
 import AppButton from '../../components/AppButton';
@@ -12,12 +11,15 @@ import { Dimensions, Linking, View } from 'react-native';
 import AppVersionWidget from 'src/components/AppVersionWidget';
 import { LinearGradient } from 'expo-linear-gradient';
 import appService from 'src/services/AppService';
+import { useAppDispatch } from 'src/store/hooks';
+import { authThunks } from 'src/store/slices/auth';
 
-export function DeactivatedAccountScreen({ navigation }: RootStackScreenProps<'DeactivatedAccount'>): JSX.Element {
+export function DeactivatedAccountScreen(): JSX.Element {
   const tailwind = useTailwind();
+  const dispatch = useAppDispatch();
 
   const handleGoToSignIn = () => {
-    navigation.replace('SignIn');
+    dispatch(authThunks.signOutThunk({ reason: 'manual' }));
   };
   const handleGoToSignUp = async () => {
     const webAuthUrl = appService.urls.webAuth.signup;

--- a/src/screens/PhotoPreviewScreen/index.tsx
+++ b/src/screens/PhotoPreviewScreen/index.tsx
@@ -1,6 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 import strings from 'assets/lang/strings';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { StatusBar, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, { runOnJS, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
@@ -53,9 +53,18 @@ export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
     }
   }, []);
 
-  const handleSwipeDown = useCallback(() => {
+  const hasClosedRef = useRef(false);
+  const closePreview = useCallback(() => {
+    if (hasClosedRef.current) {
+      return;
+    }
+    hasClosedRef.current = true;
     navigation.goBack();
   }, [navigation]);
+
+  const handleSwipeDown = useCallback(() => {
+    closePreview();
+  }, [closePreview]);
 
   const exitVideoMode = useCallback(() => {
     setHasVideoStarted(false);
@@ -63,17 +72,13 @@ export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
     setIsUiVisible(true);
   }, [resetVideoPlayer]);
 
-  const closePreviewScreen = useCallback(() => {
-    navigation.goBack();
-  }, [navigation]);
-
   const handleClose = useCallback(() => {
     if (hasVideoStarted) {
       exitVideoMode();
     } else {
-      closePreviewScreen();
+      closePreview();
     }
-  }, [hasVideoStarted, exitVideoMode, closePreviewScreen]);
+  }, [hasVideoStarted, exitVideoMode, closePreview]);
 
   const handleVideoPlay = useCallback(() => {
     setHasVideoStarted(true);
@@ -132,8 +137,8 @@ export const PhotoPreviewScreen = ({ route }: Props): JSX.Element => {
     }, [onItemChanged]),
     onAfterTrash: useCallback(async () => {
       await onItemChanged?.();
-      navigation.goBack();
-    }, [onItemChanged, navigation]),
+      closePreview();
+    }, [onItemChanged, closePreview]),
     onAfterRestore: useCallback(
       async (restoredItems: TimelinePhotoItem[]) => {
         for (const restoredItem of restoredItems) {

--- a/src/screens/PhotosScreen/components/MoreActionsBottomSheet.tsx
+++ b/src/screens/PhotosScreen/components/MoreActionsBottomSheet.tsx
@@ -38,7 +38,6 @@ interface ActionRowProps {
   isLast?: boolean;
 }
 
-const SEPARATOR_COLOR = '#f9f9fc';
 const SLIDE_DISTANCE = 600;
 
 const ActionRow = ({ icon, label, onPress, isDestructive, isLast }: ActionRowProps): JSX.Element => {
@@ -51,7 +50,12 @@ const ActionRow = ({ icon, label, onPress, isDestructive, isLast }: ActionRowPro
       style={[tailwind('flex-row items-center px-4'), styles.row]}
       hitSlop={{ top: 2, bottom: 2 }}
     >
-      <View style={[styles.rowInner, !isLast && { borderBottomColor: SEPARATOR_COLOR, borderBottomWidth: 1 }]}>
+      <View
+        style={[
+          styles.rowInner,
+          !isLast && { borderBottomColor: getColor('border-gray-10'), borderBottomWidth: StyleSheet.hairlineWidth },
+        ]}
+      >
         <View style={styles.iconContainer}>{icon}</View>
         <AppText
           medium
@@ -206,7 +210,12 @@ const MoreActionsBottomSheet = ({
             <View style={[tailwind('bg-gray-20'), { width: 48, height: 4, borderRadius: 2, marginTop: 8 }]} />
           </View>
 
-          <View style={[styles.rowInner, { borderBottomColor: SEPARATOR_COLOR, borderBottomWidth: 1 }]}>
+          <View
+            style={[
+              styles.rowInner,
+              { borderBottomColor: getColor('border-gray-10'), borderBottomWidth: StyleSheet.hairlineWidth },
+            ]}
+          >
             <CaretLeftIcon size={24} color={getColor('text-primary')} />
             <AppText medium style={tailwind('text-base text-primary ml-1')}>
               {actionStrings.back}

--- a/src/screens/SignInScreen/index.tsx
+++ b/src/screens/SignInScreen/index.tsx
@@ -69,7 +69,6 @@ function SignInScreen(): JSX.Element {
   return (
     <AppScreen
       safeAreaTop
-      safeAreaBottom
       style={[tailwind('h-full px-6'), { backgroundColor: isDark ? 'transparent' : getColor('bg-surface') }]}
     >
       {isDark ? (

--- a/src/screens/WebLoginScreen/index.tsx
+++ b/src/screens/WebLoginScreen/index.tsx
@@ -48,16 +48,16 @@ function WebLoginScreen({ route, navigation }: RootStackScreenProps<'WebLogin'>)
           privateKey,
         });
 
-        await dispatch(
-          authThunks.signInThunk({
-            user: result.user,
-            token: result.token,
-            newToken: result.newToken,
-          }),
-        ).unwrap();
-
         setLoadingState('success');
-        setTimeout(() => navigation.replace('TabExplorer', { screen: 'Home' }), 800);
+        setTimeout(() => {
+          dispatch(
+            authThunks.signInThunk({
+              user: result.user,
+              token: result.token,
+              newToken: result.newToken,
+            }),
+          );
+        }, 800);
       } catch (error) {
         const castedError = errorService.castError(error);
         setLoadingState('error');

--- a/src/screens/drive/DriveFolderScreen/DriveFolderScreenHeader.tsx
+++ b/src/screens/drive/DriveFolderScreen/DriveFolderScreenHeader.tsx
@@ -133,7 +133,7 @@ export const DriveFolderScreenHeader: React.FC<DriveFolderScreenHeaderProps> = (
           onFocusChange={handleSearchInputFocusChange}
         />
       </Animated.View>
-      <Animated.View
+      {/* <Animated.View
         style={[
           tailwind('overflow-hidden px-4'),
           { height: globalSearchButtonHeight, opacity: globalSearchButtonOpacity },
@@ -144,7 +144,7 @@ export const DriveFolderScreenHeader: React.FC<DriveFolderScreenHeaderProps> = (
             {strings.screens.drive.searchInAllFolders}
           </AppText>
         </TouchableOpacity>
-      </Animated.View>
+      </Animated.View> */}
 
       <View style={[tailwind('flex-row justify-between items-center px-4')]}>
         <TouchableOpacity onPress={onSortButtonPress}>

--- a/src/screens/drive/DriveFolderScreen/search/GlobalSearchModal.tsx
+++ b/src/screens/drive/DriveFolderScreen/search/GlobalSearchModal.tsx
@@ -6,16 +6,8 @@ import { DriveListType } from '@internxt-mobile/types/drive/ui';
 import { useNavigation } from '@react-navigation/native';
 import { ArrowLeft, MagnifyingGlass } from 'phosphor-react-native';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import {
-  ActivityIndicator,
-  KeyboardAvoidingView,
-  Modal,
-  Platform,
-  SafeAreaView,
-  TextInput,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { ActivityIndicator, KeyboardAvoidingView, Modal, Platform, TextInput, TouchableOpacity, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import AppText from 'src/components/AppText';
 import DriveList from 'src/components/drive/lists/DriveList/DriveList';
 import useGetColor from 'src/hooks/useColor';
@@ -39,6 +31,7 @@ interface GlobalSearchModalProps {
 export const GlobalSearchModal: React.FC<GlobalSearchModalProps> = ({ visible, onClose, onItemPress }) => {
   const tailwind = useTailwind();
   const getColor = useGetColor();
+  const insets = useSafeAreaInsets();
   const [inputRef, setInputRef] = useState<TextInput | null>(null);
   const [isNavigating, setIsNavigating] = useState(false);
   const navigation = useNavigation<DriveScreenProps<'DriveFolder'>['navigation']>();
@@ -273,8 +266,19 @@ export const GlobalSearchModal: React.FC<GlobalSearchModalProps> = ({ visible, o
   };
 
   return (
-    <Modal visible={visible} animationType="slide" presentationStyle="fullScreen">
-      <SafeAreaView style={[tailwind('flex-1'), { backgroundColor: getColor('bg-surface') }]}>
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="fullScreen"
+      statusBarTranslucent
+      navigationBarTranslucent
+    >
+      <View
+        style={[
+          tailwind('flex-1'),
+          { backgroundColor: getColor('bg-surface'), paddingTop: insets.top, paddingBottom: insets.bottom },
+        ]}
+      >
         <KeyboardAvoidingView style={tailwind('flex-1')} behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
           {/* Header */}
           <View style={tailwind('flex-row items-center px-4 py-3 border-b border-gray-5')}>
@@ -299,9 +303,19 @@ export const GlobalSearchModal: React.FC<GlobalSearchModalProps> = ({ visible, o
                 onChangeText={updateQuery}
                 placeholder={strings.modals.GlobalSearchModal.searchPlaceholder}
                 placeholderTextColor={getColor('text-gray-40')}
-                style={[tailwind('flex-1 ml-2 text-base'), { color: getColor('text-gray-100') }]}
+                style={[
+                  tailwind('flex-1 ml-2'),
+                  {
+                    fontSize: 16,
+                    color: getColor('text-gray-100'),
+                    paddingVertical: 0,
+                    textAlignVertical: 'center',
+                    includeFontPadding: false,
+                  },
+                ]}
                 autoCapitalize="none"
                 autoCorrect={false}
+                spellCheck={false}
                 returnKeyType="search"
                 editable={!isNavigating}
               />
@@ -363,7 +377,7 @@ export const GlobalSearchModal: React.FC<GlobalSearchModalProps> = ({ visible, o
             renderEmptyState()
           )}
         </KeyboardAvoidingView>
-      </SafeAreaView>
+      </View>
     </Modal>
   );
 };

--- a/src/store/slices/photos/index.spec.ts
+++ b/src/store/slices/photos/index.spec.ts
@@ -104,6 +104,12 @@ jest.mock('src/store/slices/storage', () => ({
   },
 }));
 
+jest.mock('src/services/AppService', () => ({
+  ...jest.requireActual('src/services/AppService'),
+  __esModule: true,
+  default: { isPhotosEnabled: true },
+}));
+
 jest.mock('./selectors', () => ({
   hasPhotosFeatureAccess: jest.fn().mockReturnValue(true),
 }));


### PR DESCRIPTION
## Summary

  - **Login no longer stays reachable after signing in.** `RootNavigator` mounted a single `Stack.Navigator` with every screen at once; after login, `WebLoginScreen`  only did a `replace`, so `SignIn` stayed underneath in the history and swipe-back / Android back returned to it while logged in.
  - **Photos preview sometimes closed to the Home tab instead of Photos.** Deleting an asset from the preview auto-closed it (`navigation.goBack()`);, if the user also closed the preview manually, the second `goBack()` had nothing left to pop and landed on the bottom tab navigator, which defaults to `backBehavior: 'firstRoute'  (`Home`).

  ## Changes

  - **`src/navigation/AuthStackNavigator.tsx`/`src/navigation/AppStackNavigator.tsx`**: split the single root stack into a login stack and an app stack.
  - **`src/navigation/RootNavigator.tsx`** : now only picks which of the two stacks to mount, based on `state.auth.loggedIn`. Logging in unmounts the auth stack entirely (no history to go back to) and logging out unmounts the app stack.
  - **`src/screens/WebLoginScreen/index.tsx`** : removed the manual `navigation.replace('TabExplorer', ...)`, the stack swap is now driven by `signInThunk`.
  - **`src/components/modals/SignOutModal/index.tsx`** / **`src/App.tsx`**: removed the manual `navigationRef.reset(...)` on sign-out. Now logging out unmounts the app stack automatically.
  - **`src/screens/PhotoPreviewScreen/index.tsx`**: centralized every way of closing the preview into a single  `closePreview()` guarded by a ref, so only the first call actually pops the screen.