### PR TITLE
fix(ios): sync File Provider credentials on session restore and bump to 1.11.1

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -95,8 +95,8 @@ android {
         applicationId 'com.internxt.cloud'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 130
-        versionName "1.11.0"
+        versionCode 131
+        versionName "1.11.1"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
         buildConfigField "String", "INTERNXT_CLIENT_NAME", "\"${packageJson.name}\""

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
   <string name="app_name">Internxt</string>
   <string name="documents_provider_label">Internxt Drive</string>
   <string name="expo_system_ui_user_interface_style" translatable="false">automatic</string>
-  <string name="expo_runtime_version">1.11.0</string>
+  <string name="expo_runtime_version">1.11.1</string>
   <string name="expo_splash_screen_resize_mode" translatable="false">contain</string>
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
   <string name="upload_notification_channel_name">Internxt uploads</string>

--- a/ios/Internxt/Info.plist
+++ b/ios/Internxt/Info.plist
@@ -23,7 +23,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.11.0</string>
+    <string>1.11.1</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/ios/Internxt/SharedAuthKeychain.swift
+++ b/ios/Internxt/SharedAuthKeychain.swift
@@ -29,30 +29,16 @@ enum SharedAuthKeychain {
 
   static func read(_ sharedKey: String) -> Data? {
     guard let accessGroup = accessGroup else { return nil }
-    var result: AnyObject?
-    let query: [String: Any] = [
-      kSecClass as String: kSecClassGenericPassword,
-      kSecAttrService as String: service,
-      kSecAttrGeneric as String: Data(sharedKey.utf8),
-      kSecAttrAccount as String: Data(sharedKey.utf8),
-      kSecAttrAccessGroup as String: accessGroup,
-      kSecMatchLimit as String: kSecMatchLimitOne,
-      kSecReturnData as String: true,
-    ]
-    guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
-          let data = result as? Data else { return nil }
-    return data
+    return copyData(matching: query(for: sharedKey, accessGroup: accessGroup))
   }
 
   static func write(_ value: Data, for sharedKey: String) {
     guard let accessGroup = accessGroup else { return }
-    delete(sharedKey)
-    let query: [String: Any] = [
-      kSecClass as String: kSecClassGenericPassword,
-      kSecAttrService as String: service,
-      kSecAttrGeneric as String: Data(sharedKey.utf8),
-      kSecAttrAccount as String: Data(sharedKey.utf8),
-      kSecAttrAccessGroup as String: accessGroup,
+    let existing = read(sharedKey)
+    if existing == value { return }
+
+    let query = Self.query(for: sharedKey, accessGroup: accessGroup)
+    let attributes: [String: Any] = [
       // These credentials are read by the File Provider extension in the
       // background with no UI, so a user-authentication gate (SecAccessControl /
       // .userPresence) is intentionally NOT used — it would block every
@@ -62,7 +48,14 @@ enum SharedAuthKeychain {
       kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
       kSecValueData as String: value,
     ]
-    SecItemAdd(query as CFDictionary, nil)
+
+    let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+    if updateStatus == errSecSuccess { return }
+
+    if updateStatus != errSecItemNotFound {
+      delete(sharedKey)
+    }
+    SecItemAdd(query.merging(attributes) { $1 } as CFDictionary, nil)
   }
 
   static func write(_ value: String, for sharedKey: String) {
@@ -71,14 +64,7 @@ enum SharedAuthKeychain {
 
   static func delete(_ sharedKey: String) {
     guard let accessGroup = accessGroup else { return }
-    let query: [String: Any] = [
-      kSecClass as String: kSecClassGenericPassword,
-      kSecAttrService as String: service,
-      kSecAttrGeneric as String: Data(sharedKey.utf8),
-      kSecAttrAccount as String: Data(sharedKey.utf8),
-      kSecAttrAccessGroup as String: accessGroup,
-    ]
-    SecItemDelete(query as CFDictionary)
+    SecItemDelete(query(for: sharedKey, accessGroup: accessGroup) as CFDictionary)
   }
 
   static func clearAll() {
@@ -86,18 +72,45 @@ enum SharedAuthKeychain {
   }
 
   static func readPrivate(_ privateKey: String) -> Data? {
-    var result: AnyObject?
-    let query: [String: Any] = [
+    readPrivateRaw(privateKey) ?? readPrivateChunked(privateKey)
+  }
+
+  private static func readPrivateChunked(_ privateKey: String) -> Data? {
+    guard let countData = readPrivateRaw("\(privateKey)_chunks"),
+          let count = Int(String(decoding: countData, as: UTF8.self)),
+          count > 0 else { return nil }
+    var joined = Data()
+    for index in 0..<count {
+      guard let chunk = readPrivateRaw("\(privateKey)_chunk_\(index)") else { return nil }
+      joined.append(chunk)
+    }
+    return joined
+  }
+
+  private static func readPrivateRaw(_ privateKey: String) -> Data? {
+    copyData(matching: query(for: privateKey))
+  }
+
+  private static func query(for key: String, accessGroup: String? = nil) -> [String: Any] {
+    var query: [String: Any] = [
       kSecClass as String: kSecClassGenericPassword,
       kSecAttrService as String: service,
-      kSecAttrGeneric as String: Data(privateKey.utf8),
-      kSecAttrAccount as String: Data(privateKey.utf8),
-      kSecMatchLimit as String: kSecMatchLimitOne,
-      kSecReturnData as String: true,
+      kSecAttrGeneric as String: Data(key.utf8),
+      kSecAttrAccount as String: Data(key.utf8),
     ]
-    guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
-          let data = result as? Data else { return nil }
-    return data
+    if let accessGroup = accessGroup {
+      query[kSecAttrAccessGroup as String] = accessGroup
+    }
+    return query
+  }
+
+  private static func copyData(matching query: [String: Any]) -> Data? {
+    var readQuery = query
+    readQuery[kSecMatchLimit as String] = kSecMatchLimitOne
+    readQuery[kSecReturnData as String] = true
+    var result: AnyObject?
+    guard SecItemCopyMatching(readQuery as CFDictionary, &result) == errSecSuccess else { return nil }
+    return result as? Data
   }
 
   static func syncFromPrivateKeychain() {
@@ -106,10 +119,7 @@ enum SharedAuthKeychain {
     syncThemePreference()
 
     let isAuthenticated = readPrivate("photosToken") != nil
-    guard isAuthenticated else {
-      clearAll()
-      return
-    }
+    guard isAuthenticated else { return }
 
     copyFromPrivate(privateKey: "photosToken", sharedKey: photosTokenKey)
     copyFromPrivate(privateKey: "xUser_mnemonic", sharedKey: mnemonicKey, isJSONEncoded: true)

--- a/ios/Internxt/Supporting/Expo.plist
+++ b/ios/Internxt/Supporting/Expo.plist
@@ -9,7 +9,7 @@
     <key>EXUpdatesLaunchWaitMs</key>
     <integer>0</integer>
     <key>EXUpdatesRuntimeVersion</key>
-    <string>1.11.0</string>
+    <string>1.11.1</string>
     <key>EXUpdatesURL</key>
     <string>https://u.expo.dev/680f4feb-6315-4a50-93ec-36dcd0b831d2</string>
   </dict>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drive-mobile",
-  "version": "v1.11.0",
+  "version": "v1.11.1",
   "private": true,
   "license": "GNU",
   "scripts": {

--- a/src/store/slices/auth/auth.syncNativeCredentials.spec.ts
+++ b/src/store/slices/auth/auth.syncNativeCredentials.spec.ts
@@ -45,6 +45,7 @@ jest.mock('../../../services/AsyncStorageService', () => ({
 jest.mock('../../../services/AuthService', () => ({
   __esModule: true,
   default: {
+    authTokenHasExpired: jest.fn().mockReturnValue(false),
     emitLoginEvent: jest.fn(),
     emitLogoutEvent: jest.fn(),
     signout: jest.fn().mockResolvedValue(undefined),
@@ -58,7 +59,7 @@ jest.mock('../../../services/UserService', () => ({ __esModule: true, default: {
 
 import authService from '../../../services/AuthService';
 import { clearCredentials, setCredentials } from '../../../services/native/InternxtAuthCredentialsModule';
-import { refreshTokensThunk, signInThunk, signOutThunk } from './index';
+import { refreshTokensThunk, signInThunk, signOutThunk, silentSignInThunk } from './index';
 
 const setCredentialsMock = setCredentials as jest.Mock;
 const clearCredentialsMock = clearCredentials as jest.Mock;
@@ -83,7 +84,7 @@ describe('auth thunks native credentials handoff', () => {
     jest.clearAllMocks();
   });
 
-  it('when the login completes, then the wrapper receives the new token', async () => {
+  test('when the login completes, then the wrapper receives the new token', async () => {
     await runThunk(signInThunk({ user, token: 'access-token', newToken: 'login-new-token' }));
 
     expect(setCredentialsMock).toHaveBeenCalledWith(
@@ -91,7 +92,7 @@ describe('auth thunks native credentials handoff', () => {
     );
   });
 
-  it('when the token is refreshed in the foreground, then the wrapper receives the refreshed token', async () => {
+  test('when the token is refreshed in the foreground, then the wrapper receives the refreshed token', async () => {
     refreshAuthTokenMock.mockResolvedValue({ token: 'access-2', newToken: 'refreshed-new-token' });
     getAuthCredentialsMock.mockResolvedValue({
       credentials: { accessToken: 'access-2', photosToken: 'refreshed-new-token', user },
@@ -102,7 +103,19 @@ describe('auth thunks native credentials handoff', () => {
     expect(setCredentialsMock).toHaveBeenCalledWith(expect.objectContaining({ bearerToken: 'refreshed-new-token' }));
   });
 
-  it('when the logout completes, then clearCredentials is invoked', async () => {
+  test('when an existing session is restored at startup, then the wrapper receives the stored token', async () => {
+    getAuthCredentialsMock.mockResolvedValue({
+      credentials: { accessToken: 'access-3', photosToken: 'stored-new-token', user },
+    });
+
+    await runThunk(silentSignInThunk());
+
+    expect(setCredentialsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ bearerToken: 'stored-new-token', driveBaseUrl: 'https://drive' }),
+    );
+  });
+
+  test('when the logout completes, then clearCredentials is invoked', async () => {
     await runThunk(signOutThunk({ reason: 'manual' }));
 
     expect(clearCredentialsMock).toHaveBeenCalledTimes(1);

--- a/src/store/slices/auth/index.ts
+++ b/src/store/slices/auth/index.ts
@@ -110,6 +110,8 @@ export const silentSignInThunk = createAsyncThunk<void, void, { state: RootState
         newToken: credentials.photosToken,
       });
 
+      await syncNativeCredentials(credentials.photosToken, credentials.user);
+
       dispatch(
         authActions.setSignInData({
           token: credentials.accessToken,


### PR DESCRIPTION
Users updating from a pre-File-Provider version with an active session never got Files.app configured until they logged out and back in:

- SharedAuthKeychain: read tokens stored in chunks by SecureStore (large JWTs never exist under the plain key), stop wiping the shared items when the private read fails (logout clears them explicitly), and write in place (update/add) so the extension never hits the delete-then-add gap.
- silentSignInThunk now pushes native credentials on session restore, so the domain is registered and stabilized on first launch after an update; devices already broken self-heal without re-login.
- Bump version to 1.11.1 (Android versionCode 131) across package.json, build.gradle, strings.xml, Info.plist and Expo.plist.